### PR TITLE
ci: add cached Linux development loop

### DIFF
--- a/.clud/docker-build/soldr/Dockerfile
+++ b/.clud/docker-build/soldr/Dockerfile
@@ -1,0 +1,56 @@
+# managed-by: clud (docker_build_soldr.py)
+ARG RUST_VERSION=1.94.1
+FROM rust:${RUST_VERSION}-trixie
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        bash ca-certificates curl git pkg-config build-essential cmake ninja-build \
+        libssl-dev clang lld zstd \
+ && rm -rf /var/lib/apt/lists/*
+
+# Toolchain caches live in named volumes so cold rebuilds amortize
+# across `clud tool run docker-build` invocations.
+ENV HOME=/root \
+    CARGO_HOME=/cargo-home \
+    CARGO_TARGET_DIR=/target \
+    RUSTUP_HOME=/rustup-home \
+    CARGO_CHEF_LOCAL_DIR=/cargo-chef \
+    SOLDR_TRUST_MODE=permissive \
+    CARGO_TERM_COLOR=always \
+    PATH=/cargo-home/bin:/usr/local/cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Seed the toolchain into the same paths that later become named
+# volumes. Docker copies this image content into a fresh named volume
+# on first mount, so the first `docker exec` does not re-download Rust.
+ARG RUST_VERSION=1.94.1
+RUN mkdir -p /target /cargo-home /rustup-home /cargo-chef /root/.soldr /src \
+ && rustup default "${RUST_VERSION}" \
+ && rustup component add rustfmt clippy
+
+# Bake soldr into the helper image instead of installing it during the
+# first command. Keep its persistent daemon/cache state in /root/.soldr,
+# which cmd_up mounts as a named volume.
+ARG SOLDR_VERSION=0.8.0
+RUN mkdir -p /opt/soldr-bin \
+ && curl -fsSL \
+        "https://github.com/zackees/soldr/releases/download/v${SOLDR_VERSION}/soldr-v${SOLDR_VERSION}-x86_64-unknown-linux-gnu.tar.zst" \
+    | zstd -d --stdout \
+    | tar -xf - -C /opt/soldr-bin \
+ && for bin in soldr soldr-clang-shim cargo-chef crgx; do \
+        [ -f "/opt/soldr-bin/$bin" ] && cp "/opt/soldr-bin/$bin" "/usr/local/bin/$bin" && chmod +x "/usr/local/bin/$bin"; \
+    done \
+ && soldr --version
+
+# The soldr release currently ships its Rust cache integration but not the
+# zccache CLI used by CMake's compiler launcher. Keep that executable in the
+# image while its cache/daemon state remains on the named soldr volume.
+ARG ZCCACHE_VERSION=1.12.17
+RUN curl -fsSL \
+        "https://github.com/zackees/zccache/releases/download/${ZCCACHE_VERSION}/zccache-v${ZCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar -xz -C /opt/soldr-bin \
+ && find /opt/soldr-bin -type f -name 'zccache*' -exec cp {} /usr/local/bin/ \; \
+ && chmod +x /usr/local/bin/zccache* \
+ && zccache --version
+
+WORKDIR /src
+CMD ["bash", "-l"]

--- a/.clud/docker-build/soldr/entry.sh
+++ b/.clud/docker-build/soldr/entry.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# managed-by: clud (docker_build_soldr.py)
+# Idle entry script — the tool execs `docker run` directly for one-shot
+# commands; this script is here so `clud tool run docker/docker_build_soldr.py up`
+# has a long-running PID inside the container to attach against.
+set -euo pipefail
+exec tail -f /dev/null

--- a/.clud/docker-build/soldr/stack.toml
+++ b/.clud/docker-build/soldr/stack.toml
@@ -1,0 +1,19 @@
+# managed-by: clud (docker_build_soldr.py)
+[stack]
+name = "soldr"
+image_tag_base = "clud-docker-build-soldr"
+
+[volumes]
+target = "/target"
+cargo_home = "/cargo-home"
+rustup_home = "/rustup-home"
+cargo_chef = "/cargo-chef"
+soldr_home = "/root/.soldr"
+
+[env]
+HOME = "/root"
+CARGO_HOME = "/cargo-home"
+CARGO_TARGET_DIR = "/target"
+RUSTUP_HOME = "/rustup-home"
+CARGO_CHEF_LOCAL_DIR = "/cargo-chef"
+SOLDR_TRUST_MODE = "permissive"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Notes:
 
 ## Building
 
+For a fast Windows-hosted Linux C/Rust development loop using Docker named
+volumes, see [docs/dev-loop.md](docs/dev-loop.md).
+
 The C library builds exactly like upstream mimalloc:
 
 ```

--- a/ci/dev_linux.py
+++ b/ci/dev_linux.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Fast, volume-backed Linux build/test loop for Docker Desktop developers."""
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCKER_BUILD = ["clud", "tool", "run", "docker/docker-build.py", "soldr", str(ROOT)]
+C_TEST = (
+    "cmake -S /src -B /target/c-build -G Ninja -DMI_PPROF=ON "
+    "-DCMAKE_C_COMPILER_LAUNCHER=zccache && cmake --build /target/c-build && "
+    "ctest --test-dir /target/c-build --output-on-failure -E 'test-stress.*' && "
+    "threads=$(nproc); [ \"$threads\" -le 4 ] || threads=4; "
+    "/target/c-build/mimalloc-test-stress \"$threads\" 50 50 && "
+    "/target/c-build/mimalloc-test-stress-dynamic \"$threads\" 50 50"
+)
+
+
+def run_tool(args: list[str], *, capture: bool = False) -> str:
+    env = os.environ.copy()
+    env["MSYS_NO_PATHCONV"] = "1"
+    completed = subprocess.run(DOCKER_BUILD + args, cwd=ROOT, env=env, text=True,
+                               stdout=subprocess.PIPE if capture else None,
+                               stderr=subprocess.STDOUT if capture else None)
+    if completed.returncode:
+        if capture and completed.stdout:
+            print(completed.stdout, end="", file=sys.stderr)
+        raise subprocess.CalledProcessError(completed.returncode, completed.args)
+    return completed.stdout or ""
+
+
+def c_test(extra: list[str], *, capture: bool = False) -> str:
+    command = C_TEST
+    if extra:
+        command += " " + " ".join(extra)
+    # `clud tool run` consumes a standalone `--`; docker-build's `run`
+    # parser accepts the command directly as its remainder instead.
+    return run_tool(["run", "bash", "-lc", command], capture=capture)
+
+
+def rust_test(extra: list[str]) -> None:
+    if not (ROOT / "rust" / "Cargo.toml").is_file():
+        print("rust workspace not present yet (see #4)")
+        return
+    command = "cd /src/rust && soldr cargo test"
+    if extra:
+        command += " " + " ".join(extra)
+    run_tool(["run", "bash", "-lc", command])
+
+
+def timed(label: str, action):
+    start = time.monotonic()
+    output = action()
+    return label, time.monotonic() - start, output
+
+
+def container_id() -> str:
+    return subprocess.check_output(
+        ["docker", "ps", "-q", "-f", "name=^clud-docker-build-soldr-" + project_key() + "$"],
+        cwd=ROOT, text=True).strip()
+
+
+def marker_toggle() -> None:
+    alloc = ROOT / "src" / "alloc.c"
+    marker = "// dev-loop-bench-marker\n"
+    text = alloc.read_text(encoding="utf-8")
+    alloc.write_text(text[:-len(marker)] if text.endswith(marker) else text + marker,
+                     encoding="utf-8")
+
+
+def bench(reuse: bool = False) -> None:
+    results: list[tuple[str, float, str]] = []
+    if not reuse:
+        run_tool(["clean"])
+    run_tool(["up"])
+    initial_container = container_id()
+    initial_label = "reused C build + ctest" if reuse else "cold C build + ctest"
+    results.append(timed(initial_label, lambda: c_test([], capture=True)))
+    for i in range(1, 4):
+        results.append(timed(f"warm no-op {i}", lambda: c_test([], capture=True)))
+    marker_toggle()
+    results.append(timed("single edit", lambda: c_test([], capture=True)))
+    if (ROOT / "rust" / "Cargo.toml").is_file():
+        rust_test([])
+        results.append(timed("rust warm no-op", lambda: run_tool(
+            ["run", "bash", "-lc", "cd /src/rust && soldr cargo test"], capture=True)))
+
+    warm = [seconds for name, seconds, _ in results if name.startswith("warm no-op")]
+    checks = {
+        "warm median <= 60 s": statistics.median(warm) <= 60,
+        "single edit <= 60 s": next(seconds for name, seconds, _ in results if name == "single edit") <= 60,
+        "ninja reported no work": all("no work to do" in output.lower() for name, _, output in results if name.startswith("warm no-op")),
+        "container reused across warm runs": bool(initial_container) and container_id() == initial_container,
+        "warm runs did not rebuild the image": all(
+            "step 1/" not in output.lower() and "writing image" not in output.lower()
+            for name, _, output in results if name.startswith("warm no-op")),
+        "compiler launcher is zccache": "zccache" in run_tool(["run", "bash", "-lc", "grep CMAKE_C_COMPILER_LAUNCHER /target/c-build/CMakeCache.txt"], capture=True),
+        "source bind is read-only": subprocess.run(["docker", "exec", "clud-docker-build-soldr-" + project_key(), "touch", "/src/.probe"], cwd=ROOT).returncode != 0,
+    }
+    fs = run_tool(["run", "bash", "-lc", "df -T /target | tail -1"], capture=True).lower()
+    checks["target is not a host filesystem"] = not any(kind in fs for kind in ("9p", "fuse", "virtiofs"))
+    print("| phase | seconds |\n| --- | ---: |")
+    for name, seconds, _ in results:
+        print(f"| {name} | {seconds:.2f} |")
+    for name, ok in checks.items():
+        print(f"{'PASS' if ok else 'FAIL'}: {name}")
+    run_tool(["run", "bash", "-lc", "zccache --help 2>&1 | head -20"], capture=False)
+    if not all(checks.values()):
+        raise SystemExit("dev loop benchmark failed")
+
+
+def project_key() -> str:
+    import hashlib
+    return hashlib.blake2b(str(ROOT.resolve()).encode(), digest_size=6).hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("c-test", "rust-test"):
+        p = sub.add_parser(name)
+        p.add_argument("args", nargs=argparse.REMAINDER)
+    bench_parser = sub.add_parser("bench")
+    bench_parser.add_argument("--reuse", action="store_true",
+                              help="keep the current named volumes (restart validation)")
+    for name in ("shell", "doctor", "clean"):
+        sub.add_parser(name)
+    args = parser.parse_args()
+    if args.command == "c-test": c_test(args.args)
+    elif args.command == "rust-test": rust_test(args.args)
+    elif args.command == "bench": bench(args.reuse)
+    else: run_tool([args.command])
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -1,0 +1,52 @@
+# Fast local Linux build loop
+
+On Windows, run the C and Rust test loops through `python ci/dev_linux.py`.
+The source tree is a live, read-only Docker bind mount: its NTFS mtimes are
+shared with the container and remain stable across container restarts. Build
+trees and caches are Docker named volumes. Do not build into a host bind mount:
+writing build output through that layer is what causes the costly mtime and
+filesystem translation problems.
+
+```powershell
+python ci/dev_linux.py doctor
+python ci/dev_linux.py c-test
+python ci/dev_linux.py rust-test
+python ci/dev_linux.py bench
+python ci/dev_linux.py bench --reuse  # verify volumes after docker stop/start
+```
+
+`bench` is the acceptance check. It measures a cold run, three warm no-op C
+runs, and one source edit. It fails when the warm median exceeds 60 seconds,
+the edit exceeds 60 seconds, or the volume/no-op/cache invariants are absent.
+The local C profile runs CTest's API tests and both upstream stress binaries
+with at most four threads (their supported CLI arguments), matching the Docker
+Desktop CPU allocation. Native CI remains responsible for the unmodified full
+CTest suite.
+
+Use PowerShell. Git Bash requires `MSYS_NO_PATHCONV=1`. Docker Desktop must use
+the WSL2 backend and have at least four CPUs and 8 GiB available. `doctor`
+checks container/host clock skew; over one second makes comparisons between
+host-stamped source files and VM-stamped build output appear stale. A branch
+switch also rewrites source mtimes; run `git restore-mtime` if the cache
+matters. zccache hashes contents, so an mtime-driven rebuild should remain a
+cache-hit path rather than a full recompilation.
+
+For a cold-start recovery, run `python ci/dev_linux.py clean`, then
+`python ci/dev_linux.py c-test`. `clean` deliberately removes the Docker
+container and named volumes, so it should not be part of normal iteration.
+Use `bench --reuse` after restarting the named container to verify that volumes
+survive without deliberately wiping them first.
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| warm no-op takes minutes | host/VM clock skew over 1 s | Run `doctor`; enable Docker Desktop clock=host. |
+| everything rebuilds after a branch switch | checkout rewrote mtimes | Run `git restore-mtime`. |
+| every run builds an image | container reuse was bypassed | Use the script; only `up` builds images. |
+| first run each session is cold | container/volumes were recreated | Restart the named container; do not run `clean`. |
+| `docker: invalid working directory` | MSYS path conversion | Use PowerShell or set `MSYS_NO_PATHCONV=1`. |
+| C compilation misses cache | launcher was omitted | Reconfigure with `CMAKE_C_COMPILER_LAUNCHER=zccache`. |
+| Ninja rebuilds a fixed subset | generated outputs are retouched | Run `ninja -d explain -n` in `/target/c-build`. |
+
+If Docker Desktop is unavailable, the documented fallback is a host-side soldr
+cross-build followed by a slim Linux runtime container. It is slower because
+the build runs on the Windows filesystem; run the Docker recovery tool first.


### PR DESCRIPTION
Closes #10\n\nAdds the named-volume Docker development loop, benchmark with a 60-second fail-fast gate, restart validation, zccache-backed C launcher, and developer documentation.\n\nLocal verification:\n- python ci/dev_linux.py doctor\n- python ci/dev_linux.py bench\n- docker stop/start + python ci/dev_linux.py bench --reuse\n\nThe developer profile runs API CTest coverage plus both upstream stress binaries at the detected container CPU cap; native CI retains the full upstream CTest suite.