### PR TITLE
feat: add allocation sampling profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD 17)
 option(MI_SECURE            "Use security mitigations (like meta data guard pages, allocation randomization, double-free mitigation, and free-list corruption detection)" OFF)
 option(MI_SECURE_FULL       "Use full security mitigations including guard pages at the end of each mimalloc page (may be expensive)" OFF)
 option(MI_PADDING           "Enable padding to detect heap block overflow (always on in DEBUG or SECURE mode, or with Valgrind/ASAN)" OFF)
+option(MI_PPROF             "Enable the allocation sampling profiler" ON)
 option(MI_OVERRIDE          "Override the standard malloc interface (i.e. define entry points for 'malloc', 'free', etc)" ON)
 option(MI_XMALLOC           "Enable abort() call on memory allocation failure by default" OFF)
 option(MI_SHOW_ERRORS       "Show error and warning messages by default (only enabled by default in DEBUG mode)" OFF)
@@ -72,6 +73,7 @@ set(mi_sources
     src/options.c
     src/os.c
     src/page.c
+    src/profile.c
     src/random.c
     src/segment.c
     src/segment-map.c
@@ -87,6 +89,12 @@ if(MI_EXTRA_CPPDEFS)
  set(mi_defines ${MI_EXTRA_CPPDEFS})
 else()
  set(mi_defines "")
+endif()
+
+if(MI_PPROF)
+  list(APPEND mi_defines MI_PPROF=1)
+else()
+  list(APPEND mi_defines MI_PPROF=0)
 endif()
 
 # pass git revision as a define
@@ -760,6 +768,15 @@ if (MI_BUILD_TESTS)
     endif()
     add_test(NAME test-${TEST_NAME} COMMAND mimalloc-test-${TEST_NAME})
   endforeach()
+
+  if(MI_PPROF)
+    add_executable(mimalloc-test-profile test/test-profile.c)
+    target_compile_definitions(mimalloc-test-profile PRIVATE ${mi_defines})
+    target_compile_options(mimalloc-test-profile PRIVATE ${mi_cflags})
+    target_include_directories(mimalloc-test-profile PRIVATE include)
+    target_link_libraries(mimalloc-test-profile PRIVATE mimalloc-static ${mi_libraries})
+    add_test(NAME test-profile COMMAND mimalloc-test-profile)
+  endif()
 
   # dynamic override test
   if(MI_BUILD_SHARED AND NOT (MI_TRACK_ASAN OR MI_DEBUG_TSAN OR MI_DEBUG_UBSAN) AND NOT (APPLE AND MI_USE_CXX))

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -431,6 +431,11 @@ typedef enum mi_option_e {
   mi_option_target_segments_per_thread, // experimental (=0)
   mi_option_generic_collect,            // collect heaps every N (=10000) generic allocation calls
   mi_option_allow_thp,                  // allow transparent huge pages? (=1) (on Android =0 by default). Set to 0 to disable THP for the process.
+  mi_option_prof,
+  mi_option_prof_sample_rate,
+  mi_option_prof_bt_max,
+  mi_option_prof_accum,
+  mi_option_prof_seed,
   _mi_option_last,
   // legacy option names
   mi_option_large_os_pages = mi_option_allow_large_os_pages,
@@ -504,6 +509,8 @@ mi_decl_nodiscard mi_decl_export mi_decl_restrict void* mi_heap_alloc_new_n(mi_h
 #ifdef __cplusplus
 }
 #endif
+
+#include "mimalloc/profile.h"
 
 // ---------------------------------------------------------------------------------------------
 // Implement the C++ std::allocator interface for use in STL containers.

--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -285,6 +285,12 @@ mi_msecs_t  _mi_clock_start(void);
 void*       _mi_page_malloc_zero(mi_heap_t* heap, mi_page_t* page, size_t size, bool zero, size_t* usable) mi_attr_noexcept;  // called from `_mi_malloc_generic`
 void*       _mi_page_malloc(mi_heap_t* heap, mi_page_t* page, size_t size) mi_attr_noexcept;                  // called from `_mi_heap_malloc_aligned`
 void*       _mi_page_malloc_zeroed(mi_heap_t* heap, mi_page_t* page, size_t size) mi_attr_noexcept;           // called from `_mi_heap_malloc_aligned`
+#if MI_PPROF
+void        _mi_prof_on_alloc(mi_heap_t* heap, mi_page_t* page, void* p, size_t size);
+void        _mi_prof_on_free(mi_page_t* page, void* p);
+void        _mi_prof_on_free_collect(mi_page_t* page, mi_block_t* head);
+void        _mi_prof_on_realloc_in_place(mi_page_t* page, void* p, size_t size);
+#endif
 void*       _mi_heap_malloc_zero(mi_heap_t* heap, size_t size, bool zero) mi_attr_noexcept;
 void*       _mi_heap_malloc_zero_ex(mi_heap_t* heap, size_t size, bool zero, size_t huge_alignment, size_t* usable) mi_attr_noexcept;     // called from `_mi_heap_malloc_aligned`
 void*       _mi_heap_realloc_zero(mi_heap_t* heap, void* p, size_t newsize, bool zero, size_t* usable_pre, size_t* usable_post) mi_attr_noexcept;

--- a/include/mimalloc/profile.h
+++ b/include/mimalloc/profile.h
@@ -1,0 +1,21 @@
+/* Public, allocation-only sampling profiler API. */
+#pragma once
+#ifndef MIMALLOC_PROFILE_H
+#define MIMALLOC_PROFILE_H
+
+#include "mimalloc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+mi_decl_nodiscard mi_decl_export bool mi_prof_start(size_t sample_rate) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_prof_start_seeded(size_t sample_rate, uint64_t seed) mi_attr_noexcept;
+mi_decl_export void mi_prof_stop(void) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_prof_is_enabled(void) mi_attr_noexcept;
+mi_decl_export void mi_prof_debug_stats(size_t* records, size_t* bytes) mi_attr_noexcept;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/mimalloc/types.h
+++ b/include/mimalloc/types.h
@@ -317,6 +317,7 @@ typedef uintptr_t mi_thread_free_t;
 //   at least one block that will be added, or as already been added, to
 //   the owning heap `thread_delayed_free` list. This guarantees that pages
 //   will be freed correctly even if only other threads free blocks.
+struct mi_prof_record_s;
 typedef struct mi_page_s {
   // "owned" by the segment
   uint32_t              slice_count;       // slices in this page (0 if not a page)
@@ -330,7 +331,8 @@ typedef struct mi_page_s {
   uint16_t              reserved;          // number of blocks reserved in memory
   mi_page_flags_t       flags;             // `in_full` and `has_aligned` flags (8 bits)
   uint8_t               free_is_zero:1;    // `true` if the blocks in the free list are zero initialized
-  uint8_t               retire_expire:7;   // expiration count for retired blocks
+  uint8_t               has_metadata:1;    // `true` if profiler records are attached to this page
+  uint8_t               retire_expire:6;   // expiration count for retired blocks
 
   mi_block_t*           free;              // list of available free blocks (`malloc` allocates from this list)
   mi_block_t*           local_free;        // list of deferred free blocks by this thread (migrates to `free`)
@@ -352,7 +354,7 @@ typedef struct mi_page_s {
   struct mi_page_s*     prev;              // previous page owned by this thread with the same `block_size`
 
   // 64-bit 11 words, 32-bit 13 words, (+2 for secure)
-  void* padding[1];
+  struct mi_prof_record_s* metadata;       // sampled live allocation records, or NULL
 } mi_page_t;
 
 
@@ -623,6 +625,13 @@ typedef struct mi_segments_tld_s {
   mi_stats_t*         stats;        // points to tld stats
 } mi_segments_tld_t;
 
+typedef struct mi_profiler_tld_s {
+  size_t   bytes_since_sample;
+  size_t   next_threshold;
+  uint64_t random;
+  uint64_t generation;
+} mi_profiler_tld_t;
+
 // Thread local data
 struct mi_tld_s {
   unsigned long long  heartbeat;     // monotonic heartbeat count
@@ -631,6 +640,7 @@ struct mi_tld_s {
   mi_heap_t*          heaps;         // list of heaps in this thread (so we can abandon all when the thread terminates)
   mi_segments_tld_t   segments;      // segment tld
   mi_stats_t          stats;         // statistics
+  mi_profiler_tld_t   profiler;      // allocation sampling profiler state
 };
 
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -111,6 +111,9 @@ extern inline void* _mi_page_malloc_zero(mi_heap_t* heap, mi_page_t* page, size_
     #endif
   #endif
 
+  #if MI_PPROF
+  _mi_prof_on_alloc(heap, page, block, size - MI_PADDING_SIZE);
+  #endif
   return block;
 }
 
@@ -277,6 +280,9 @@ void* mi_expand(void* p, size_t newsize) mi_attr_noexcept {
   const mi_page_t* const page = mi_validate_ptr_page(p,"mi_expand");  
   const size_t size = _mi_usable_size(p,page);
   if (newsize > size) return NULL;
+  #if MI_PPROF
+  _mi_prof_on_realloc_in_place((mi_page_t*)page, p, newsize);
+  #endif
   return p; // it fits
   #endif
 }
@@ -303,6 +309,9 @@ void* _mi_heap_realloc_zero(mi_heap_t* heap, void* p, size_t newsize, bool zero,
     // mi_track_resize(p,size,newsize)
     // if (newsize < size) { mi_track_mem_noaccess((uint8_t*)p + newsize, size - newsize); }
     if (usable_post!=NULL) { *usable_post = mi_page_usable_block_size(page); }
+    #if MI_PPROF
+    _mi_prof_on_realloc_in_place((mi_page_t*)page, p, newsize);
+    #endif
     return p;  // reallocation still fits and not more than 50% waste
   }
   void* newp = mi_heap_umalloc(heap,newsize,usable_post);

--- a/src/free.c
+++ b/src/free.c
@@ -33,6 +33,9 @@ static inline void mi_free_block_local(mi_page_t* page, mi_block_t* block, bool 
   MI_UNUSED(was_guarded);
   // checks  
   if mi_unlikely(mi_check_is_double_free(page, block)) return;
+  #if MI_PPROF
+  _mi_prof_on_free(page, block);
+  #endif
   if (!was_guarded) { mi_check_padding(page, block); }
   if (track_stats) { mi_stat_free(page, block); }
   #if (MI_DEBUG>0) && !MI_TRACK_ENABLED  && !MI_TSAN

--- a/src/init.c
+++ b/src/init.c
@@ -20,6 +20,7 @@ const mi_page_t _mi_page_empty = {
   0,       // reserved capacity
   { 0 },   // flags
   false,   // is_zero
+  false,   // has profiler metadata
   0,       // retire_expire
   NULL,    // free
   NULL,    // local_free
@@ -33,8 +34,8 @@ const mi_page_t _mi_page_empty = {
   #endif
   MI_ATOMIC_VAR_INIT(0), // xthread_free
   MI_ATOMIC_VAR_INIT(0), // xheap
-  NULL, NULL
-  , { 0 }  // padding
+  NULL, NULL,
+  NULL      // metadata
 };
 
 #define MI_PAGE_EMPTY() ((mi_page_t*)&_mi_page_empty)
@@ -140,7 +141,8 @@ mi_decl_cache_align static const mi_tld_t tld_empty = {
   false,
   NULL, NULL,
   { MI_SEGMENT_SPAN_QUEUES_EMPTY, 0, 0, 0, 0, 0, &mi_subproc_default, tld_empty_stats }, // segments
-  { sizeof(mi_stats_t), MI_STAT_VERSION, MI_STATS_NULL }       // stats
+  { sizeof(mi_stats_t), MI_STAT_VERSION, MI_STATS_NULL },      // stats
+  { 0, 0, 0, 0 }                                               // profiler
 };
 
 mi_threadid_t _mi_thread_id(void) mi_attr_noexcept {
@@ -158,7 +160,8 @@ static mi_decl_cache_align mi_tld_t tld_main = {
   0, false,
   &_mi_heap_main, & _mi_heap_main,
   { MI_SEGMENT_SPAN_QUEUES_EMPTY, 0, 0, 0, 0, 0, &mi_subproc_default, &tld_main.stats }, // segments
-  { sizeof(mi_stats_t), MI_STAT_VERSION, MI_STATS_NULL }       // stats
+  { sizeof(mi_stats_t), MI_STAT_VERSION, MI_STATS_NULL },      // stats
+  { 0, 0, 0, 0 }                                               // profiler
 };
 
 mi_decl_cache_align mi_heap_t _mi_heap_main = {

--- a/src/options.c
+++ b/src/options.c
@@ -170,6 +170,11 @@ static mi_option_desc_t options[_mi_option_last] =
   { 10000, UNINIT, MI_OPTION(generic_collect) },          // collect heaps every N (=10000) generic allocation calls
   { MI_DEFAULT_ALLOW_THP,
          UNINIT, MI_OPTION(allow_thp) }                 // allow transparent huge pages?
+  ,{ 0, UNINIT, MI_OPTION(prof) }
+  ,{ 524288, UNINIT, MI_OPTION(prof_sample_rate) }
+  ,{ 32, UNINIT, MI_OPTION(prof_bt_max) }
+  ,{ 0, UNINIT, MI_OPTION(prof_accum) }
+  ,{ 0, UNINIT, MI_OPTION(prof_seed) }
 };
 
 static void mi_option_init(mi_option_desc_t* desc);

--- a/src/page.c
+++ b/src/page.c
@@ -214,6 +214,9 @@ static void _mi_page_thread_free_collect(mi_page_t* page)
 
   // return if the list is empty
   if (head == NULL) return;
+  #if MI_PPROF
+  _mi_prof_on_free_collect(page, head);
+  #endif
 
   // find the tail -- also to get a proper count (without data races)
   size_t max_count = page->capacity; // cannot collect more than capacity

--- a/src/profile.c
+++ b/src/profile.c
@@ -85,7 +85,7 @@ static void prof_free_record(mi_page_t* page, void* p) {
   rec->next = prof_free; prof_free = rec;
 }
 
-bool mi_prof_start_seeded(size_t sample_rate, uint64_t seed) {
+bool mi_prof_start_seeded(size_t sample_rate, uint64_t seed) mi_attr_noexcept {
   if (sample_rate == 0) sample_rate = (size_t)mi_option_get(mi_option_prof_sample_rate);
   if (sample_rate == 0) sample_rate = 524288;
   mi_lock_acquire(&prof_lock);
@@ -94,10 +94,10 @@ bool mi_prof_start_seeded(size_t sample_rate, uint64_t seed) {
   mi_lock_release(&prof_lock);
   return started;
 }
-bool mi_prof_start(size_t sample_rate) { return mi_prof_start_seeded(sample_rate, (uint64_t)mi_option_get(mi_option_prof_seed)); }
-bool mi_prof_is_enabled(void) { return mi_atomic_load_relaxed(&prof_enabled); }
-void mi_prof_debug_stats(size_t* records, size_t* bytes) { mi_lock_acquire(&prof_lock); if (records) *records=prof_records; if (bytes) *bytes=prof_bytes; mi_lock_release(&prof_lock); }
-void mi_prof_stop(void) {
+bool mi_prof_start(size_t sample_rate) mi_attr_noexcept { return mi_prof_start_seeded(sample_rate, (uint64_t)mi_option_get(mi_option_prof_seed)); }
+bool mi_prof_is_enabled(void) mi_attr_noexcept { return mi_atomic_load_relaxed(&prof_enabled); }
+void mi_prof_debug_stats(size_t* records, size_t* bytes) mi_attr_noexcept { mi_lock_acquire(&prof_lock); if (records) *records=prof_records; if (bytes) *bytes=prof_bytes; mi_lock_release(&prof_lock); }
+void mi_prof_stop(void) mi_attr_noexcept {
   mi_lock_acquire(&prof_lock);
   mi_atomic_store_release(&prof_enabled, false);
   for (mi_prof_record_t* rec = prof_all; rec != NULL; rec = rec->all_next) { rec->page->metadata = NULL; rec->page->has_metadata = false; }
@@ -132,9 +132,9 @@ void _mi_prof_on_realloc_in_place(mi_page_t* page, void* p, size_t size) {
 }
 
 #else
-bool mi_prof_start(size_t sample_rate) { MI_UNUSED(sample_rate); return false; }
-bool mi_prof_start_seeded(size_t sample_rate, uint64_t seed) { MI_UNUSED(sample_rate); MI_UNUSED(seed); return false; }
-void mi_prof_stop(void) { }
-bool mi_prof_is_enabled(void) { return false; }
-void mi_prof_debug_stats(size_t* records, size_t* bytes) { if (records) *records=0; if (bytes) *bytes=0; }
+bool mi_prof_start(size_t sample_rate) mi_attr_noexcept { MI_UNUSED(sample_rate); return false; }
+bool mi_prof_start_seeded(size_t sample_rate, uint64_t seed) mi_attr_noexcept { MI_UNUSED(sample_rate); MI_UNUSED(seed); return false; }
+void mi_prof_stop(void) mi_attr_noexcept { }
+bool mi_prof_is_enabled(void) mi_attr_noexcept { return false; }
+void mi_prof_debug_stats(size_t* records, size_t* bytes) mi_attr_noexcept { if (records) *records=0; if (bytes) *bytes=0; }
 #endif

--- a/src/profile.c
+++ b/src/profile.c
@@ -1,0 +1,140 @@
+/* Allocation sampling profiler.  Its records never use mimalloc: the arena
+   below is backed directly by _mi_os_alloc so profiler bookkeeping cannot
+   recursively enter the allocator. */
+#include "mimalloc.h"
+#include "mimalloc/internal.h"
+
+#if MI_PPROF
+
+#define MI_PROF_CHUNK_SIZE (64*1024)
+
+typedef struct mi_prof_chunk_s {
+  struct mi_prof_chunk_s* next;
+  mi_memid_t memid;
+  size_t size;
+  size_t used;
+} mi_prof_chunk_t;
+
+typedef struct mi_prof_record_s {
+  struct mi_prof_record_s* next;
+  struct mi_prof_record_s* all_next;
+  void* ptr;
+  mi_page_t* page;
+  size_t size;
+} mi_prof_record_t;
+
+static mi_lock_t prof_lock = MI_LOCK_INITIALIZER;
+static _Atomic(bool) prof_enabled = false;
+static mi_prof_chunk_t* prof_chunks;
+static mi_prof_record_t* prof_all;
+static mi_prof_record_t* prof_free;
+static size_t prof_records;
+static size_t prof_bytes;
+static size_t prof_rate = 524288;
+static uint64_t prof_seed;
+static uint64_t prof_generation;
+
+static uint64_t prof_random(mi_profiler_tld_t* tld) {
+  uint64_t x = tld->random;
+  if (x == 0) x = prof_seed ^ (uintptr_t)tld ^ UINT64_C(0x9E3779B97F4A7C15);
+  x ^= x >> 12; x ^= x << 25; x ^= x >> 27;
+  tld->random = x;
+  return x * UINT64_C(2685821657736338717);
+}
+
+static size_t prof_threshold(mi_profiler_tld_t* tld) {
+  size_t rate = prof_rate;
+  size_t value = (size_t)(prof_random(tld) % (rate * 2));
+  if (value < 1) value = 1;
+  if (value > rate * 64) value = rate * 64;
+  return value;
+}
+
+static mi_prof_record_t* prof_record_alloc(void) {
+  if (prof_free != NULL) { mi_prof_record_t* rec = prof_free; prof_free = rec->next; return rec; }
+  mi_prof_chunk_t* chunk = prof_chunks;
+  const size_t align = sizeof(void*) - 1;
+  if (chunk == NULL || chunk->used + sizeof(mi_prof_record_t) + align > chunk->size) {
+    mi_memid_t memid;
+    void* p = _mi_os_alloc(MI_PROF_CHUNK_SIZE, &memid);
+    if (p == NULL) return NULL;
+    chunk = (mi_prof_chunk_t*)p;
+    chunk->next = prof_chunks; chunk->memid = memid; chunk->size = MI_PROF_CHUNK_SIZE; chunk->used = sizeof(*chunk);
+    prof_chunks = chunk;
+  }
+  uintptr_t start = ((uintptr_t)chunk + chunk->used + align) & ~(uintptr_t)align;
+  chunk->used = start - (uintptr_t)chunk + sizeof(mi_prof_record_t);
+  return (mi_prof_record_t*)start;
+}
+
+static void prof_remove_all(mi_prof_record_t* rec) {
+  mi_prof_record_t** cur = &prof_all;
+  while (*cur != rec) cur = &(*cur)->all_next;
+  *cur = rec->all_next;
+}
+
+static void prof_free_record(mi_page_t* page, void* p) {
+  mi_prof_record_t** cur = (mi_prof_record_t**)&page->metadata;
+  while (*cur != NULL && (*cur)->ptr != p) cur = &(*cur)->next;
+  if (*cur == NULL) return;
+  mi_prof_record_t* rec = *cur;
+  *cur = rec->next;
+  if (page->metadata == NULL) page->has_metadata = false;
+  prof_remove_all(rec);
+  prof_records--; prof_bytes -= rec->size;
+  rec->next = prof_free; prof_free = rec;
+}
+
+bool mi_prof_start_seeded(size_t sample_rate, uint64_t seed) {
+  if (sample_rate == 0) sample_rate = (size_t)mi_option_get(mi_option_prof_sample_rate);
+  if (sample_rate == 0) sample_rate = 524288;
+  mi_lock_acquire(&prof_lock);
+  bool started = !mi_atomic_load_relaxed(&prof_enabled);
+  if (started) { prof_rate = sample_rate; prof_seed = seed; prof_generation++; mi_atomic_store_release(&prof_enabled, true); }
+  mi_lock_release(&prof_lock);
+  return started;
+}
+bool mi_prof_start(size_t sample_rate) { return mi_prof_start_seeded(sample_rate, (uint64_t)mi_option_get(mi_option_prof_seed)); }
+bool mi_prof_is_enabled(void) { return mi_atomic_load_relaxed(&prof_enabled); }
+void mi_prof_debug_stats(size_t* records, size_t* bytes) { mi_lock_acquire(&prof_lock); if (records) *records=prof_records; if (bytes) *bytes=prof_bytes; mi_lock_release(&prof_lock); }
+void mi_prof_stop(void) {
+  mi_lock_acquire(&prof_lock);
+  mi_atomic_store_release(&prof_enabled, false);
+  for (mi_prof_record_t* rec = prof_all; rec != NULL; rec = rec->all_next) { rec->page->metadata = NULL; rec->page->has_metadata = false; }
+  mi_prof_chunk_t* chunk = prof_chunks;
+  while (chunk != NULL) { mi_prof_chunk_t* next = chunk->next; _mi_os_free(chunk, chunk->size, chunk->memid); chunk = next; }
+  prof_chunks=NULL; prof_all=NULL; prof_free=NULL; prof_records=0; prof_bytes=0;
+  mi_lock_release(&prof_lock);
+}
+void _mi_prof_on_alloc(mi_heap_t* heap, mi_page_t* page, void* p, size_t size) {
+  if mi_likely(!mi_atomic_load_relaxed(&prof_enabled)) return;
+  mi_lock_acquire(&prof_lock);
+  if (!mi_atomic_load_relaxed(&prof_enabled)) { mi_lock_release(&prof_lock); return; }
+  mi_profiler_tld_t* tld = &heap->tld->profiler;
+  if (tld->generation != prof_generation) { tld->bytes_since_sample = 0; tld->next_threshold = 0; tld->random = 0; tld->generation = prof_generation; }
+  tld->bytes_since_sample += size;
+  if (tld->next_threshold == 0) tld->next_threshold = prof_threshold(tld);
+  if (tld->bytes_since_sample < tld->next_threshold) { mi_lock_release(&prof_lock); return; }
+  tld->bytes_since_sample = 0; tld->next_threshold = prof_threshold(tld);
+  mi_prof_record_t* rec = prof_record_alloc();
+  if (rec != NULL) { rec->ptr=p; rec->page=page; rec->size=size; rec->next=(mi_prof_record_t*)page->metadata; rec->all_next=prof_all; page->metadata=(struct mi_prof_record_s*)rec; page->has_metadata=true; prof_all=rec; prof_records++; prof_bytes+=size; }
+  mi_lock_release(&prof_lock);
+}
+void _mi_prof_on_free(mi_page_t* page, void* p) { if mi_likely(!page->has_metadata) return; mi_lock_acquire(&prof_lock); prof_free_record(page,p); mi_lock_release(&prof_lock); }
+void _mi_prof_on_free_collect(mi_page_t* page, mi_block_t* head) { if mi_likely(!page->has_metadata) return; mi_lock_acquire(&prof_lock); for (mi_block_t* b=head; b != NULL && page->has_metadata; b=mi_block_next(page,b)) prof_free_record(page,b); mi_lock_release(&prof_lock); }
+void _mi_prof_on_realloc_in_place(mi_page_t* page, void* p, size_t size) {
+  if mi_likely(!page->has_metadata) return;
+  mi_lock_acquire(&prof_lock);
+  for (mi_prof_record_t* rec = (mi_prof_record_t*)page->metadata; rec != NULL; rec = rec->next) {
+    if (rec->ptr == p) { prof_bytes = prof_bytes - rec->size + size; rec->size = size; break; }
+  }
+  mi_lock_release(&prof_lock);
+}
+
+#else
+bool mi_prof_start(size_t sample_rate) { MI_UNUSED(sample_rate); return false; }
+bool mi_prof_start_seeded(size_t sample_rate, uint64_t seed) { MI_UNUSED(sample_rate); MI_UNUSED(seed); return false; }
+void mi_prof_stop(void) { }
+bool mi_prof_is_enabled(void) { return false; }
+void mi_prof_debug_stats(size_t* records, size_t* bytes) { if (records) *records=0; if (bytes) *bytes=0; }
+#endif

--- a/src/static.c
+++ b/src/static.c
@@ -31,6 +31,7 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "options.c"
 #include "os.c"
 #include "page.c"           // includes page-queue.c
+#include "profile.c"
 #include "random.c"
 #include "segment.c"
 #include "segment-map.c"

--- a/test/test-profile.c
+++ b/test/test-profile.c
@@ -1,0 +1,65 @@
+#include <assert.h>
+#include <stdio.h>
+#include "mimalloc/profile.h"
+
+static void profile_worker(void) {
+  for (size_t i = 0; i < 100000; i++) {
+    void* p = mi_malloc(32);
+    assert(p != NULL);
+    mi_free(p);
+  }
+}
+
+#ifdef _WIN32
+#include <windows.h>
+static DWORD WINAPI profile_thread(void* arg) { (void)arg; profile_worker(); return 0; }
+static void profile_threads(void) {
+  HANDLE threads[4];
+  for (size_t i = 0; i < 4; i++) threads[i] = CreateThread(NULL, 0, profile_thread, NULL, 0, NULL);
+  WaitForMultipleObjects(4, threads, TRUE, INFINITE);
+  for (size_t i = 0; i < 4; i++) CloseHandle(threads[i]);
+}
+#else
+#include <pthread.h>
+static void* profile_thread(void* arg) { (void)arg; profile_worker(); return NULL; }
+static void profile_threads(void) {
+  pthread_t threads[4];
+  for (size_t i = 0; i < 4; i++) assert(pthread_create(&threads[i], NULL, profile_thread, NULL) == 0);
+  for (size_t i = 0; i < 4; i++) assert(pthread_join(threads[i], NULL) == 0);
+}
+#endif
+
+int main(void) {
+  enum { count = 1000, size = 512 };
+  void* blocks[count];
+  size_t records = 0, bytes = 0;
+  assert(mi_prof_start_seeded(4096, 17));
+  assert(!mi_prof_start(4096));
+  for (size_t i = 0; i < count; i++) blocks[i] = mi_malloc(size);
+  mi_prof_debug_stats(&records, &bytes);
+  assert(records >= 60 && records <= 190);
+  assert(bytes >= records * size);
+  for (size_t i = 0; i < count; i++) mi_free(blocks[i]);
+  mi_prof_debug_stats(&records, &bytes);
+  assert(records == 0 && bytes == 0);
+  mi_prof_stop();
+  assert(!mi_prof_is_enabled());
+  assert(mi_prof_start_seeded(1, 23));
+  void* p = mi_malloc(128);
+  mi_prof_debug_stats(&records, &bytes);
+  assert(records == 1 && bytes == 128);
+  assert(mi_realloc(p, 96) == p);
+  mi_prof_debug_stats(&records, &bytes);
+  assert(records == 1 && bytes == 96);
+  mi_free(p);
+  mi_prof_debug_stats(&records, &bytes);
+  assert(records == 0 && bytes == 0);
+  mi_prof_stop();
+  assert(mi_prof_start_seeded(1, 31));
+  profile_threads();
+  mi_prof_debug_stats(&records, &bytes);
+  assert(records == 0 && bytes == 0);
+  mi_prof_stop();
+  puts("profile tests passed");
+  return 0;
+}


### PR DESCRIPTION
Closes #5

## Summary
- add the Phase 1 C allocation sampler with per-page records backed only by raw OS allocations
- add start/stop/debug public APIs, deterministic seeded sampling, free/realloc accounting, and OFF-build stubs
- add sampling, lifecycle, in-place realloc, and 4x100k concurrent cleanup tests

## Local validation
- MI_PPROF=ON focused C tests plus reduced static/dynamic stress
- MI_PPROF=OFF build
- MI_DEBUG_FULL profile test