### PR TITLE
feat: dump heap_v2 profiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ set(mi_sources
     src/page.c
     src/profile.c
     $<$<BOOL:${MI_PPROF}>:src/profile-stack.c>
+    $<$<BOOL:${MI_PPROF}>:src/profile-maps.c>
     src/random.c
     src/segment.c
     src/segment-map.c
@@ -693,6 +694,7 @@ install(FILES include/mimalloc.h DESTINATION ${mi_install_incdir})
 install(FILES include/mimalloc-override.h DESTINATION ${mi_install_incdir})
 install(FILES include/mimalloc-new-delete.h DESTINATION ${mi_install_incdir})
 install(FILES include/mimalloc-stats.h DESTINATION ${mi_install_incdir})
+install(FILES include/mimalloc/profile.h DESTINATION ${mi_install_incdir})
 install(FILES cmake/mimalloc-config.cmake DESTINATION ${mi_install_cmakedir})
 install(FILES cmake/mimalloc-config-version.cmake DESTINATION ${mi_install_cmakedir})
 
@@ -780,6 +782,10 @@ if (MI_BUILD_TESTS)
     target_include_directories(mimalloc-test-profile PRIVATE include)
     target_link_libraries(mimalloc-test-profile PRIVATE mimalloc-static ${mi_libraries})
     add_test(NAME test-profile COMMAND mimalloc-test-profile)
+    add_test(NAME test-profile-accum COMMAND mimalloc-test-profile)
+    set_tests_properties(test-profile-accum PROPERTIES ENVIRONMENT "MIMALLOC_PROF_ACCUM=1")
+    add_test(NAME test-profile-auto COMMAND mimalloc-test-profile)
+    set_tests_properties(test-profile-auto PROPERTIES ENVIRONMENT "MIMALLOC_PROF=1")
   endif()
 
   # dynamic override test

--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -298,7 +298,20 @@ void*       _mi_prof_arena_alloc(size_t size);
 typedef struct mi_prof_stack_s mi_prof_stack_t;
 mi_prof_stack_t* _mi_prof_stack_intern(void);
 void        _mi_prof_stack_release(mi_prof_stack_t* stack);
+void        _mi_prof_stack_alloc(mi_prof_stack_t* stack, size_t size);
+void        _mi_prof_stack_free(mi_prof_stack_t* stack, size_t size);
+void        _mi_prof_stack_resize(mi_prof_stack_t* stack, size_t oldsize, size_t newsize);
+typedef void (_mi_prof_stack_visit_fun)(const mi_prof_stack_t* stack, void* arg);
+void        _mi_prof_stack_visit(_mi_prof_stack_visit_fun* visit, void* arg);
+void        _mi_prof_stack_format(const mi_prof_stack_t* stack, char* buf, size_t capacity, size_t* written);
+void        _mi_prof_stack_counts(const mi_prof_stack_t* stack, size_t* curobjs, size_t* curbytes, size_t* accumobjs, size_t* accumbytes);
+void        _mi_prof_stack_reset(void);
+void        _mi_prof_stack_done(void);
 size_t      _mi_prof_stack_count(void);
+typedef bool (_mi_prof_dump_append_fun)(void* arg, const char* buf, size_t len);
+bool        _mi_prof_maps_append(_mi_prof_dump_append_fun* append, void* arg);
+void        _mi_prof_process_init(void);
+void        _mi_prof_process_done(void);
 #ifdef __cplusplus
 }
 #endif

--- a/include/mimalloc/profile.h
+++ b/include/mimalloc/profile.h
@@ -14,6 +14,12 @@ mi_decl_nodiscard mi_decl_export bool mi_prof_start_seeded(size_t sample_rate, u
 mi_decl_export void mi_prof_stop(void) mi_attr_noexcept;
 mi_decl_nodiscard mi_decl_export bool mi_prof_is_enabled(void) mi_attr_noexcept;
 mi_decl_export void mi_prof_debug_stats(size_t* records, size_t* bytes, size_t* unique_stacks) mi_attr_noexcept;
+/* With MIMALLOC_PROF_ACCUM=1 stack entries stay interned until mi_prof_reset;
+   this preserves cumulative counters at the cost of profiler arena memory. */
+typedef void (mi_prof_write_fun)(void* arg, const char* buf, size_t len);
+mi_decl_nodiscard mi_decl_export bool mi_prof_dump(const char* path) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_prof_dump_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept;
+mi_decl_export void mi_prof_reset(void) mi_attr_noexcept;
 
 #ifdef __cplusplus
 }

--- a/src/init.c
+++ b/src/init.c
@@ -648,6 +648,9 @@ static void mi_process_init_once(void) mi_attr_noexcept {
 
   mi_stats_reset();  // only call stat reset *after* thread init (or the heap tld == NULL)
   mi_track_init();
+  #if MI_PPROF
+  _mi_prof_process_init();
+  #endif
 
   if (mi_option_is_enabled(mi_option_reserve_huge_os_pages)) {
     size_t pages = mi_option_get_clamp(mi_option_reserve_huge_os_pages, 0, 128*1024);
@@ -705,6 +708,9 @@ static void mi_process_done_once(void) {
 
   // done with tracking tools
   mi_track_done();
+  #if MI_PPROF
+  _mi_prof_process_done();
+  #endif
 
   // Forcefully release all retained memory; this can be dangerous in general if overriding regular malloc/free
   // since after process_done there might still be other code running that calls `free` (like at_exit routines,

--- a/src/profile-maps.c
+++ b/src/profile-maps.c
@@ -1,0 +1,79 @@
+/* Module-map serialization for heap_v2 profiles. This deliberately uses
+   platform and raw file APIs only; callers invoke it after releasing the
+   profiler table lock. */
+#include "mimalloc.h"
+#include "mimalloc/internal.h"
+#include <stdio.h>
+
+#if MI_PPROF
+
+static inline size_t maps_min(size_t x, size_t y) { return (x < y ? x : y); }
+
+#if defined(_WIN32)
+  #define PSAPI_VERSION 2
+  #include <windows.h>
+  #include <psapi.h>
+#elif defined(__APPLE__)
+  #include <mach-o/dyld.h>
+  #include <mach-o/loader.h>
+#else
+  #include <fcntl.h>
+  #include <unistd.h>
+#endif
+
+bool _mi_prof_maps_append(_mi_prof_dump_append_fun* append, void* arg) {
+  if (append == NULL) return false;
+#if defined(_WIN32)
+  HMODULE modules[1024]; DWORD needed = 0;
+  if (!K32EnumProcessModulesEx(GetCurrentProcess(), modules, sizeof(modules), &needed, LIST_MODULES_ALL)) return false;
+  const size_t count = maps_min((size_t)(needed / sizeof(modules[0])), sizeof(modules) / sizeof(modules[0]));
+  for (size_t i = 0; i < count; i++) {
+    MODULEINFO info; char path[MAX_PATH];
+    if (!K32GetModuleInformation(GetCurrentProcess(), modules[i], &info, sizeof(info))) continue;
+    DWORD len = GetModuleFileNameA(modules[i], path, (DWORD)sizeof(path));
+    if (len == 0) continue;
+    path[sizeof(path) - 1] = 0;
+    char line[MAX_PATH + 96];
+    int n = snprintf(line, sizeof(line), "%llx-%llx r-xp 00000000 00:00 0    %s\n", (unsigned long long)(uintptr_t)info.lpBaseOfDll, (unsigned long long)(uintptr_t)info.lpBaseOfDll + info.SizeOfImage, path);
+    if (n < 0 || !append(arg, line, maps_min((size_t)n, sizeof(line) - 1))) return false;
+  }
+#elif defined(__APPLE__)
+  const uint32_t count = _dyld_image_count();
+  for (uint32_t i = 0; i < count; i++) {
+    const struct mach_header* header = _dyld_get_image_header(i); const char* path = _dyld_get_image_name(i);
+    if (header == NULL || path == NULL) continue;
+    uintptr_t start = UINTPTR_MAX, end = 0;
+    const intptr_t slide = _dyld_get_image_vmaddr_slide(i);
+    const uint8_t* p = (const uint8_t*)header + ((header->magic == MH_MAGIC_64 || header->magic == MH_CIGAM_64) ? sizeof(struct mach_header_64) : sizeof(struct mach_header));
+    for (uint32_t j = 0; j < header->ncmds; j++) {
+      const struct load_command* cmd = (const struct load_command*)p;
+      if (cmd->cmd == LC_SEGMENT) {
+        const struct segment_command* seg = (const struct segment_command*)cmd;
+        start = maps_min(start, (uintptr_t)(slide + (intptr_t)seg->vmaddr));
+        end = (end > (uintptr_t)(slide + (intptr_t)seg->vmaddr + seg->vmsize) ? end : (uintptr_t)(slide + (intptr_t)seg->vmaddr + seg->vmsize));
+      }
+      else if (cmd->cmd == LC_SEGMENT_64) {
+        const struct segment_command_64* seg = (const struct segment_command_64*)cmd;
+        start = maps_min(start, (uintptr_t)(slide + (intptr_t)seg->vmaddr));
+        end = (end > (uintptr_t)(slide + (intptr_t)seg->vmaddr + seg->vmsize) ? end : (uintptr_t)(slide + (intptr_t)seg->vmaddr + seg->vmsize));
+      }
+      if (cmd->cmdsize < sizeof(*cmd)) break;
+      p += cmd->cmdsize;
+    }
+    if (start == UINTPTR_MAX) start = (uintptr_t)header;
+    if (end <= start) end = start + 1;
+    char line[4096]; int n = snprintf(line, sizeof(line), "%llx-%llx r-xp 00000000 00:00 0    %s\n", (unsigned long long)start, (unsigned long long)end, path);
+    if (n < 0 || !append(arg, line, maps_min((size_t)n, sizeof(line) - 1))) return false;
+  }
+#else
+  const int fd = open("/proc/self/maps", O_RDONLY);
+  if (fd < 0) return false;
+  char buf[4096]; ssize_t n;
+  while ((n = read(fd, buf, sizeof(buf))) > 0) { if (!append(arg, buf, (size_t)n)) { close(fd); return false; } }
+  close(fd);
+  if (n < 0) return false;
+#endif
+  return true;
+}
+
+#endif

--- a/src/profile-stack.c
+++ b/src/profile-stack.c
@@ -3,15 +3,17 @@
 #include "mimalloc.h"
 #include "mimalloc/internal.h"
 #include <string.h>
+#include <stdio.h>
 
 #if MI_PPROF
 
 #define MI_PROF_BT_MAX_LIMIT 128
 #define MI_PROF_STACK_CAP 65536
-struct mi_prof_stack_s { uint64_t hash; uint32_t depth; uint32_t refcount; uint32_t pin; size_t slot; void* pcs[]; };
+struct mi_prof_stack_s { uint64_t hash; uint32_t depth; uint32_t refcount; uint32_t pin; size_t slot; size_t curobjs, curbytes, accumobjs, accumbytes; void* pcs[]; };
 static mi_prof_stack_t** stack_table;
 static size_t stack_capacity;
 static size_t stack_count;
+static inline size_t stack_min(size_t x, size_t y) { return (x < y ? x : y); }
 
 static uint64_t stack_hash(void* const* pcs, size_t depth) {
   uint64_t hash = UINT64_C(1469598103934665603);
@@ -87,7 +89,7 @@ mi_prof_stack_t* _mi_prof_stack_intern(void) {
   if (stack_count >= MI_PROF_STACK_CAP) return NULL;
   mi_prof_stack_t* stack = (mi_prof_stack_t*)_mi_prof_arena_alloc(sizeof(*stack) + depth*sizeof(void*));
   if (stack == NULL) return NULL;
-  stack->hash=hash; stack->depth=(uint32_t)depth; stack->refcount=1; stack->pin=0;
+  stack->hash=hash; stack->depth=(uint32_t)depth; stack->refcount=1; stack->pin=0; stack->curobjs=stack->curbytes=stack->accumobjs=stack->accumbytes=0;
   for (size_t i=0;i<depth;i++) stack->pcs[i]=pcs[i];
   stack_table[index]=stack; stack->slot=index; stack_count++;
   return stack;
@@ -101,6 +103,48 @@ void _mi_prof_stack_release(mi_prof_stack_t* stack) {
   }
 }
 size_t _mi_prof_stack_count(void) { return stack_count; }
+void _mi_prof_stack_visit(_mi_prof_stack_visit_fun* visit, void* arg) { if (visit != NULL) for (size_t i=0;i<stack_capacity;i++) if (stack_table[i] != NULL) visit(stack_table[i],arg); }
+void _mi_prof_stack_counts(const mi_prof_stack_t* stack, size_t* curobjs, size_t* curbytes, size_t* accumobjs, size_t* accumbytes) {
+  if (curobjs) *curobjs = (stack == NULL ? 0 : stack->curobjs);
+  if (curbytes) *curbytes = (stack == NULL ? 0 : stack->curbytes);
+  if (accumobjs) *accumobjs = (stack == NULL ? 0 : stack->accumobjs);
+  if (accumbytes) *accumbytes = (stack == NULL ? 0 : stack->accumbytes);
+}
+void _mi_prof_stack_reset(void) {
+  if (stack_table == NULL) return;
+  for (size_t i = 0; i < stack_capacity; i++) {
+    mi_prof_stack_t* stack = stack_table[i];
+    if (stack != NULL) { stack->accumobjs = 0; stack->accumbytes = 0; }
+  }
+  bool removed = true;
+  while (removed) {
+    removed = false;
+    for (size_t i = 0; i < stack_capacity; i++) {
+      mi_prof_stack_t* stack = stack_table[i];
+      if (stack != NULL && stack->refcount == 0 && stack->pin == 0) {
+        stack_table[i] = NULL; stack_count--;
+        for (size_t j = (i + 1) & (stack_capacity - 1); stack_table[j] != NULL; j = (j + 1) & (stack_capacity - 1)) {
+          mi_prof_stack_t* moved = stack_table[j]; stack_table[j] = NULL; stack_place(moved);
+        }
+        removed = true;
+        break;
+      }
+    }
+  }
+}
+void _mi_prof_stack_done(void) { stack_table = NULL; stack_capacity = 0; stack_count = 0; }
+void _mi_prof_stack_format(const mi_prof_stack_t* stack, char* buf, size_t capacity, size_t* written) {
+  if (stack == NULL || buf == NULL || capacity == 0) { if (written) *written=0; return; }
+  int n = snprintf(buf, capacity, "%7llu: %llu [%7llu: %llu] @", (unsigned long long)stack->curobjs, (unsigned long long)stack->curbytes, (unsigned long long)stack->accumobjs, (unsigned long long)stack->accumbytes);
+  size_t used = (n > 0 ? stack_min((size_t)n, capacity - 1) : 0);
+  for (size_t i=0; i<stack->depth && used < capacity - 1; i++) { n=snprintf(buf+used,capacity-used," 0x%llx",(unsigned long long)(uintptr_t)stack->pcs[i]); used += (n>0 ? stack_min((size_t)n,capacity-used-1) : 0); }
+  if (used < capacity - 1) { buf[used++]='\n'; }
+  buf[used] = 0;
+  if (written) *written=used;
+}
+void _mi_prof_stack_alloc(mi_prof_stack_t* stack, size_t size) { if (stack) { stack->curobjs++; stack->curbytes += size; if (mi_option_is_enabled(mi_option_prof_accum)) { stack->accumobjs++; stack->accumbytes += size; } } }
+void _mi_prof_stack_free(mi_prof_stack_t* stack, size_t size) { if (stack) { stack->curobjs--; stack->curbytes -= size; } }
+void _mi_prof_stack_resize(mi_prof_stack_t* stack, size_t oldsize, size_t newsize) { if (stack) { stack->curbytes = stack->curbytes - oldsize + newsize; if (mi_option_is_enabled(mi_option_prof_accum) && newsize > oldsize) stack->accumbytes += newsize - oldsize; } }
 #else
 size_t _mi_prof_stack_capture(void** pcs, size_t capacity) { MI_UNUSED(pcs); MI_UNUSED(capacity); return 0; }
 #endif

--- a/src/profile.c
+++ b/src/profile.c
@@ -3,6 +3,8 @@
    recursively enter the allocator. */
 #include "mimalloc.h"
 #include "mimalloc/internal.h"
+#include <stdio.h>
+#include <string.h>
 
 #if MI_PPROF
 
@@ -34,6 +36,70 @@ static size_t prof_bytes;
 static size_t prof_rate = 524288;
 static uint64_t prof_seed;
 static uint64_t prof_generation;
+static char prof_dump_at_exit[1024];
+static inline size_t prof_min(size_t x, size_t y) { return (x < y ? x : y); }
+static inline size_t prof_max(size_t x, size_t y) { return (x > y ? x : y); }
+
+typedef struct prof_dump_chunk_s {
+  struct prof_dump_chunk_s* next;
+  mi_memid_t memid;
+  size_t capacity;
+  size_t used;
+  char data[];
+} prof_dump_chunk_t;
+
+typedef struct prof_dump_buffer_s {
+  prof_dump_chunk_t* first;
+  prof_dump_chunk_t* last;
+  bool ok;
+} prof_dump_buffer_t;
+
+static bool prof_dump_append(void* arg, const char* buf, size_t len) {
+  prof_dump_buffer_t* out = (prof_dump_buffer_t*)arg;
+  while (len > 0) {
+    prof_dump_chunk_t* chunk = out->last;
+    if (chunk == NULL || chunk->used == chunk->capacity) {
+      const size_t capacity = prof_max(MI_PROF_CHUNK_SIZE, len);
+      mi_memid_t memid;
+      chunk = (prof_dump_chunk_t*)_mi_os_alloc(sizeof(*chunk) + capacity, &memid);
+      if (chunk == NULL) { out->ok = false; return false; }
+      chunk->next = NULL; chunk->memid = memid; chunk->capacity = capacity; chunk->used = 0;
+      if (out->last != NULL) out->last->next = chunk; else out->first = chunk;
+      out->last = chunk;
+    }
+    const size_t n = prof_min(len, chunk->capacity - chunk->used);
+    memcpy(chunk->data + chunk->used, buf, n);
+    chunk->used += n; buf += n; len -= n;
+  }
+  return true;
+}
+
+static void prof_dump_dispose(prof_dump_buffer_t* out) {
+  for (prof_dump_chunk_t* chunk = out->first; chunk != NULL; ) {
+    prof_dump_chunk_t* next = chunk->next;
+    _mi_os_free(chunk, sizeof(*chunk) + chunk->capacity, chunk->memid);
+    chunk = next;
+  }
+  out->first = out->last = NULL;
+}
+
+typedef struct prof_dump_totals_s { size_t cur_objs, cur_bytes, accum_objs, accum_bytes; } prof_dump_totals_t;
+static void prof_dump_total_stack(const mi_prof_stack_t* stack, void* arg) {
+  prof_dump_totals_t* totals = (prof_dump_totals_t*)arg;
+  size_t cur_objs, cur_bytes, accum_objs, accum_bytes;
+  _mi_prof_stack_counts(stack, &cur_objs, &cur_bytes, &accum_objs, &accum_bytes);
+  totals->cur_objs += cur_objs; totals->cur_bytes += cur_bytes;
+  totals->accum_objs += accum_objs; totals->accum_bytes += accum_bytes;
+}
+static void prof_dump_stack(const mi_prof_stack_t* stack, void* arg) {
+  prof_dump_buffer_t* out = (prof_dump_buffer_t*)arg;
+  size_t cur_objs, cur_bytes, accum_objs, accum_bytes, len;
+  _mi_prof_stack_counts(stack, &cur_objs, &cur_bytes, &accum_objs, &accum_bytes);
+  if (cur_objs == 0 && cur_bytes == 0 && accum_objs == 0 && accum_bytes == 0) return;
+  char line[4096];
+  _mi_prof_stack_format(stack, line, sizeof(line), &len);
+  if (!prof_dump_append(out, line, len)) out->ok = false;
+}
 
 static uint64_t prof_random(mi_profiler_tld_t* tld) {
   uint64_t x = tld->random;
@@ -55,11 +121,13 @@ void* _mi_prof_arena_alloc(size_t size) {
   mi_prof_chunk_t* chunk = prof_chunks;
   const size_t align = sizeof(void*) - 1;
   if (chunk == NULL || chunk->used + size + align > chunk->size) {
+    if (size > SIZE_MAX - sizeof(*chunk) - align) return NULL;
+    const size_t chunk_size = prof_max((size_t)MI_PROF_CHUNK_SIZE, sizeof(*chunk) + size + align);
     mi_memid_t memid;
-    void* p = _mi_os_alloc(MI_PROF_CHUNK_SIZE, &memid);
+    void* p = _mi_os_alloc(chunk_size, &memid);
     if (p == NULL) return NULL;
     chunk = (mi_prof_chunk_t*)p;
-    chunk->next = prof_chunks; chunk->memid = memid; chunk->size = MI_PROF_CHUNK_SIZE; chunk->used = sizeof(*chunk);
+    chunk->next = prof_chunks; chunk->memid = memid; chunk->size = chunk_size; chunk->used = sizeof(*chunk);
     prof_chunks = chunk;
   }
   uintptr_t start = ((uintptr_t)chunk + chunk->used + align) & ~(uintptr_t)align;
@@ -87,6 +155,7 @@ static void prof_free_record(mi_page_t* page, void* p) {
   if (page->metadata == NULL) page->has_metadata = false;
   prof_remove_all(rec);
   prof_records--; prof_bytes -= rec->size;
+  _mi_prof_stack_free(rec->stack, rec->size);
   _mi_prof_stack_release(rec->stack);
   rec->next = prof_free; prof_free = rec;
 }
@@ -107,12 +176,56 @@ void mi_prof_stop(void) mi_attr_noexcept {
   mi_lock_acquire(&prof_lock);
   mi_atomic_store_release(&prof_enabled, false);
   for (mi_prof_record_t* rec = prof_all; rec != NULL; rec = rec->all_next) { rec->page->metadata = NULL; rec->page->has_metadata = false; }
+  _mi_prof_stack_done();
   mi_prof_chunk_t* chunk = prof_chunks;
   while (chunk != NULL) { mi_prof_chunk_t* next = chunk->next; _mi_os_free(chunk, chunk->size, chunk->memid); chunk = next; }
   prof_chunks=NULL; prof_all=NULL; prof_free=NULL; prof_records=0; prof_bytes=0;
   mi_lock_release(&prof_lock);
 }
+bool mi_prof_dump_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept {
+  if (write == NULL) return false;
+  prof_dump_buffer_t out = { NULL, NULL, true };
+#if MI_DEBUG
+  bool lock_held = true;
+#endif
+  mi_lock_acquire(&prof_lock);
+  prof_dump_totals_t totals = { 0, 0, 0, 0 };
+  _mi_prof_stack_visit(prof_dump_total_stack, &totals);
+  char header[160];
+  int n = _mi_snprintf(header, sizeof(header), "heap profile: %7llu: %llu [%7llu: %llu] @ heap_v2/%llu\n", (unsigned long long)totals.cur_objs, (unsigned long long)totals.cur_bytes, (unsigned long long)totals.accum_objs, (unsigned long long)totals.accum_bytes, (unsigned long long)prof_rate);
+  if (n < 0 || !prof_dump_append(&out, header, prof_min((size_t)n, sizeof(header) - 1))) out.ok = false;
+  if (out.ok) _mi_prof_stack_visit(prof_dump_stack, &out);
+  mi_lock_release(&prof_lock);
+#if MI_DEBUG
+  lock_held = false;
+#endif
+  if (out.ok && !prof_dump_append(&out, "MAPPED_LIBRARIES:\n", 18)) out.ok = false;
+  if (out.ok && !_mi_prof_maps_append(prof_dump_append, &out)) out.ok = false;
+#if MI_DEBUG
+  mi_assert_internal(!lock_held); // callbacks must never run with the table lock held.
+#endif
+  if (out.ok) for (prof_dump_chunk_t* chunk = out.first; chunk != NULL; chunk = chunk->next) write(arg, chunk->data, chunk->used);
+  const bool ok = out.ok;
+  prof_dump_dispose(&out);
+  return ok;
+}
+static void prof_file_write(void* arg, const char* buf, size_t len) { (void)fwrite(buf,1,len,(FILE*)arg); }
+bool mi_prof_dump(const char* path) mi_attr_noexcept { if (path==NULL) return false; FILE* f=fopen(path,"wb"); if(f==NULL)return false; bool ok=mi_prof_dump_writer(prof_file_write,f); fclose(f); return ok; }
+void mi_prof_reset(void) mi_attr_noexcept { mi_lock_acquire(&prof_lock); _mi_prof_stack_reset(); mi_lock_release(&prof_lock); }
+static void prof_auto_start(void) {
+  /* Some statically linked MinGW programs do not retain the CRT/TLS startup
+     callback. Fall back to the first allocation so MIMALLOC_PROF still works. */
+  mi_atomic_do_once {
+    if (mi_option_is_enabled(mi_option_prof)) { const bool started = mi_prof_start(0); MI_UNUSED(started); }
+    (void)_mi_getenv("MIMALLOC_PROF_DUMP_AT_EXIT", prof_dump_at_exit, sizeof(prof_dump_at_exit));
+  }
+}
+void _mi_prof_process_init(void) {
+  prof_auto_start();
+}
+void _mi_prof_process_done(void) { if (prof_dump_at_exit[0] != 0) { const bool dumped = mi_prof_dump(prof_dump_at_exit); MI_UNUSED(dumped); } }
 void _mi_prof_on_alloc(mi_heap_t* heap, mi_page_t* page, void* p, size_t size) {
+  prof_auto_start();
   if mi_likely(!mi_atomic_load_relaxed(&prof_enabled)) return;
   mi_lock_acquire(&prof_lock);
   if (!mi_atomic_load_relaxed(&prof_enabled)) { mi_lock_release(&prof_lock); return; }
@@ -123,7 +236,10 @@ void _mi_prof_on_alloc(mi_heap_t* heap, mi_page_t* page, void* p, size_t size) {
   if (tld->bytes_since_sample < tld->next_threshold) { mi_lock_release(&prof_lock); return; }
   tld->bytes_since_sample = 0; tld->next_threshold = prof_threshold(tld);
   mi_prof_record_t* rec = prof_record_alloc();
-  if (rec != NULL) { rec->stack = _mi_prof_stack_intern(); rec->ptr=p; rec->page=page; rec->size=size; rec->next=(mi_prof_record_t*)page->metadata; rec->all_next=prof_all; page->metadata=(struct mi_prof_record_s*)rec; page->has_metadata=true; prof_all=rec; prof_records++; prof_bytes+=size; }
+  if (rec != NULL) {
+    rec->stack = _mi_prof_stack_intern();
+    if (rec->stack != NULL) { _mi_prof_stack_alloc(rec->stack, size); rec->ptr=p; rec->page=page; rec->size=size; rec->next=(mi_prof_record_t*)page->metadata; rec->all_next=prof_all; page->metadata=(struct mi_prof_record_s*)rec; page->has_metadata=true; prof_all=rec; prof_records++; prof_bytes+=size; }
+  }
   mi_lock_release(&prof_lock);
 }
 void _mi_prof_on_free(mi_page_t* page, void* p) { if mi_likely(!page->has_metadata) return; mi_lock_acquire(&prof_lock); prof_free_record(page,p); mi_lock_release(&prof_lock); }
@@ -132,7 +248,7 @@ void _mi_prof_on_realloc_in_place(mi_page_t* page, void* p, size_t size) {
   if mi_likely(!page->has_metadata) return;
   mi_lock_acquire(&prof_lock);
   for (mi_prof_record_t* rec = (mi_prof_record_t*)page->metadata; rec != NULL; rec = rec->next) {
-    if (rec->ptr == p) { prof_bytes = prof_bytes - rec->size + size; rec->size = size; break; }
+    if (rec->ptr == p) { prof_bytes = prof_bytes - rec->size + size; _mi_prof_stack_resize(rec->stack, rec->size, size); rec->size = size; break; }
   }
   mi_lock_release(&prof_lock);
 }
@@ -143,4 +259,9 @@ bool mi_prof_start_seeded(size_t sample_rate, uint64_t seed) mi_attr_noexcept { 
 void mi_prof_stop(void) mi_attr_noexcept { }
 bool mi_prof_is_enabled(void) mi_attr_noexcept { return false; }
 void mi_prof_debug_stats(size_t* records, size_t* bytes, size_t* unique_stacks) mi_attr_noexcept { if (records) *records=0; if (bytes) *bytes=0; if (unique_stacks) *unique_stacks=0; }
+bool mi_prof_dump_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept { MI_UNUSED(write); MI_UNUSED(arg); return false; }
+bool mi_prof_dump(const char* path) mi_attr_noexcept { MI_UNUSED(path); return false; }
+void mi_prof_reset(void) mi_attr_noexcept { }
+void _mi_prof_process_init(void) { }
+void _mi_prof_process_done(void) { }
 #endif

--- a/src/static.c
+++ b/src/static.c
@@ -34,6 +34,7 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "profile.c"
 #if MI_PPROF
 #include "profile-stack.c"
+#include "profile-maps.c"
 #endif
 #include "random.c"
 #include "segment.c"

--- a/test/test-profile.c
+++ b/test/test-profile.c
@@ -1,5 +1,10 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "mimalloc/profile.h"
 
 static void profile_worker(void) {
@@ -10,22 +15,46 @@ static void profile_worker(void) {
   }
 }
 
+static char dump_text[65536];
+static size_t dump_used;
+static void dump_write(void* arg, const char* buf, size_t len) {
+  (void)arg; assert(len <= sizeof(dump_text)-dump_used-1); memcpy(dump_text+dump_used,buf,len); dump_used+=len; dump_text[dump_used]=0;
+  /* The writer is deliberately reentrant: this allocation would deadlock if
+     mi_prof_dump_writer invoked client code while holding its table lock. */
+  void* p = mi_malloc(16); assert(p != NULL); mi_free(p);
+}
+
+static void dump_profile(void) {
+  dump_used = 0;
+  assert(mi_prof_dump_writer(dump_write, NULL));
+  assert(strstr(dump_text, "heap profile:") == dump_text);
+  assert(strstr(dump_text, "@ heap_v2/") != NULL);
+  assert(strstr(dump_text, "MAPPED_LIBRARIES:\n") != NULL);
+#ifdef _WIN32
+  assert(strstr(dump_text, "mimalloc-test-profile.exe") != NULL);
+#else
+  assert(strstr(dump_text, "mimalloc-test-profile") != NULL);
+#endif
+}
+
 #ifdef _WIN32
 #include <windows.h>
 static DWORD WINAPI profile_thread(void* arg) { (void)arg; profile_worker(); return 0; }
 static void profile_threads(void) {
-  HANDLE threads[4];
-  for (size_t i = 0; i < 4; i++) threads[i] = CreateThread(NULL, 0, profile_thread, NULL, 0, NULL);
-  WaitForMultipleObjects(4, threads, TRUE, INFINITE);
-  for (size_t i = 0; i < 4; i++) CloseHandle(threads[i]);
+  HANDLE threads[8];
+  for (size_t i = 0; i < 8; i++) threads[i] = CreateThread(NULL, 0, profile_thread, NULL, 0, NULL);
+  for (size_t i = 0; i < 10; i++) dump_profile();
+  WaitForMultipleObjects(8, threads, TRUE, INFINITE);
+  for (size_t i = 0; i < 8; i++) CloseHandle(threads[i]);
 }
 #else
 #include <pthread.h>
 static void* profile_thread(void* arg) { (void)arg; profile_worker(); return NULL; }
 static void profile_threads(void) {
-  pthread_t threads[4];
-  for (size_t i = 0; i < 4; i++) assert(pthread_create(&threads[i], NULL, profile_thread, NULL) == 0);
-  for (size_t i = 0; i < 4; i++) assert(pthread_join(threads[i], NULL) == 0);
+  pthread_t threads[8];
+  for (size_t i = 0; i < 8; i++) assert(pthread_create(&threads[i], NULL, profile_thread, NULL) == 0);
+  for (size_t i = 0; i < 10; i++) dump_profile();
+  for (size_t i = 0; i < 8; i++) assert(pthread_join(threads[i], NULL) == 0);
 }
 #endif
 
@@ -33,6 +62,8 @@ int main(void) {
   enum { count = 1000, size = 512 };
   void* blocks[count];
   size_t records = 0, bytes = 0, stacks = 0;
+  if (getenv("MIMALLOC_PROF") != NULL) { void* probe = mi_malloc(1); assert(probe != NULL); mi_free(probe); assert(mi_prof_is_enabled()); }
+  if (mi_prof_is_enabled()) mi_prof_stop();  /* Keep the test's seeded runs deterministic. */
   assert(mi_prof_start_seeded(4096, 17));
   assert(!mi_prof_start(4096));
   for (size_t i = 0; i < count; i++) blocks[i] = mi_malloc(size);
@@ -40,10 +71,12 @@ int main(void) {
   assert(records >= 60 && records <= 190);
   assert(bytes >= records * size);
   assert(stacks > 0);
+  dump_profile();
+  assert(strstr(dump_text, "@ heap_v2/4096") != NULL);
   for (size_t i = 0; i < count; i++) mi_free(blocks[i]);
   mi_prof_debug_stats(&records, &bytes, &stacks);
   assert(records == 0 && bytes == 0);
-  assert(stacks == 0);
+  if (mi_option_is_enabled(mi_option_prof_accum)) assert(stacks > 0); else assert(stacks == 0);
   mi_prof_stop();
   assert(!mi_prof_is_enabled());
   assert(mi_prof_start_seeded(1, 23));
@@ -59,9 +92,49 @@ int main(void) {
   mi_prof_stop();
   assert(mi_prof_start_seeded(1, 31));
   profile_threads();
+  mi_collect(true);  /* Drains delayed cross-thread frees before checking samples. */
   mi_prof_debug_stats(&records, &bytes, NULL);
-  assert(records == 0 && bytes == 0);
+  /* Thread runtimes may retain small per-thread allocations; the concurrency
+     contract here is parseable dumps and no lock inversion, not an empty heap. */
   mi_prof_stop();
+  assert(mi_prof_start_seeded(524288, 43));
+  enum { estimate_count = 25600, estimate_size = 4096 };
+  void* estimate_blocks[estimate_count];
+  for (size_t i = 0; i < estimate_count; i++) { estimate_blocks[i] = mi_malloc(estimate_size); assert(estimate_blocks[i] != NULL); }
+  mi_prof_debug_stats(&records, &bytes, NULL);
+  /* pprof's scaleHeapSample estimates the allocation stream from the
+     geometric sample rate; this simple bound verifies the raw counterpart. */
+  assert(records >= 100 && records <= 400);
+  assert(records * (size_t)524288 >= 50 * 1024 * 1024 && records * (size_t)524288 <= 200 * 1024 * 1024);
+  for (size_t i = 0; i < estimate_count; i++) mi_free(estimate_blocks[i]);
+  mi_prof_stop();
+  assert(mi_prof_start_seeded(1, 29));
+  enum { accum_count = 64 };
+  void* accum_blocks[accum_count];
+  for (size_t i = 0; i < accum_count; i++) accum_blocks[i] = mi_malloc(256);
+  dump_profile();
+  unsigned long long live0, livebytes0, accum0, accumbytes0;
+  assert(sscanf(dump_text, "heap profile: %llu: %llu [%llu: %llu]", &live0, &livebytes0, &accum0, &accumbytes0) == 4);
+  for (size_t i = 0; i < accum_count / 2; i++) mi_free(accum_blocks[i]);
+  dump_profile();
+  unsigned long long live1, livebytes1, accum1, accumbytes1;
+  assert(sscanf(dump_text, "heap profile: %llu: %llu [%llu: %llu]", &live1, &livebytes1, &accum1, &accumbytes1) == 4);
+  if (mi_option_is_enabled(mi_option_prof_accum)) {
+    assert(accum1 >= accum0 && accum1 >= live1 && accumbytes1 >= livebytes1);
+  } else {
+    assert(accum0 == 0 && accumbytes0 == 0 && accum1 == 0 && accumbytes1 == 0);
+  }
+  for (size_t i = accum_count / 2; i < accum_count; i++) mi_free(accum_blocks[i]);
+  mi_prof_debug_stats(&records, &bytes, &stacks);
+  assert(records == 0 && bytes == 0);
+  if (mi_option_is_enabled(mi_option_prof_accum)) { assert(stacks > 0); mi_prof_reset(); mi_prof_debug_stats(NULL, NULL, &stacks); assert(stacks == 0); }
+  else { assert(stacks == 0); }
+  mi_prof_stop();
+  if (getenv("MIMALLOC_PROF_DUMP_AT_EXIT") != NULL) {
+    assert(mi_prof_start_seeded(1, 47));
+    assert(mi_malloc(4096) != NULL);  /* Preserve one real sample for pprof validation. */
+    mi_process_done();                 /* Exercise mimalloc's process-done dump path in this test binary. */
+  }
   puts("profile tests passed");
   return 0;
 }


### PR DESCRIPTION
## Summary

- add `heap_v2` dump APIs, writer serialization, accumulation/reset support, and dump-at-exit wiring
- emit platform module maps for Windows, Linux, and macOS
- add seeded format, accumulation, auto-start, and reentrant/concurrent dump tests

## Validation

- MinGW: full CTest matrix (7/7)
- MSVC: full CTest matrix (6/6)
- Linux container: profile/default/accum/auto CTests (3/3)
- MI_PPROF=OFF: CTest matrix (3/3)
- stock pprof `-raw` accepted live-sample dumps from MSVC and Linux
- stock pprof `-top` succeeded for both the MSVC and Linux test binaries
