### PR TITLE
feat: add safe Rust profiler API

### DIFF
--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -20,4 +20,34 @@ jobs:
         working-directory: rust
     steps:
       - uses: actions/checkout@v4
-      - run: cargo test --locked
+      - uses: zackees/setup-soldr@v0
+        with:
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+          build-cache-mode: full
+      - run: soldr cargo test --locked
+
+  test-win-gnu:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          release: true
+          install: mingw-w64-x86_64-gcc
+      - uses: zackees/setup-soldr@v0
+        with:
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+          build-cache-mode: full
+      - run: rustup target add x86_64-pc-windows-gnu
+      - shell: pwsh
+        run: |
+          $env:PATH = "C:\msys64\mingw64\bin;$env:PATH"
+          $env:CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "x86_64-w64-mingw32-gcc"
+          soldr cargo test --locked --target x86_64-pc-windows-gnu

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,11 +35,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
 name = "mimalloc-pprof"
 version = "0.1.0"
 dependencies = [
  "libmimalloc-pprof-sys",
+ "regex",
 ]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "shlex"

--- a/rust/libmimalloc-pprof-sys/src/lib.rs
+++ b/rust/libmimalloc-pprof-sys/src/lib.rs
@@ -1,6 +1,9 @@
 //! Raw bindings to the in-tree mimalloc static amalgamation.
 
+use core::ffi::c_char;
 use core::ffi::c_void;
+
+pub type MiProfWriteFun = unsafe extern "C" fn(*mut c_void, *const c_char, usize);
 
 unsafe extern "C" {
     pub fn mi_malloc(size: usize) -> *mut c_void;
@@ -12,4 +15,12 @@ unsafe extern "C" {
     pub fn mi_zalloc_aligned(size: usize, alignment: usize) -> *mut c_void;
     pub fn mi_realloc_aligned(p: *mut c_void, newsize: usize, alignment: usize) -> *mut c_void;
     pub fn mi_usable_size(p: *const c_void) -> usize;
+    pub fn mi_prof_start(sample_rate: usize) -> bool;
+    pub fn mi_prof_start_seeded(sample_rate: usize, seed: u64) -> bool;
+    pub fn mi_prof_stop();
+    pub fn mi_prof_is_enabled() -> bool;
+    pub fn mi_prof_dump(path: *const c_char) -> bool;
+    pub fn mi_prof_dump_writer(write: Option<MiProfWriteFun>, arg: *mut c_void) -> bool;
+    pub fn mi_prof_reset();
+    pub fn mi_prof_debug_stats(records: *mut usize, bytes: *mut usize, unique_stacks: *mut usize);
 }

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -7,3 +7,6 @@ description = "mimalloc global allocator with pprof support"
 
 [dependencies]
 libmimalloc-pprof-sys = { path = "../libmimalloc-pprof-sys" }
+
+[dev-dependencies]
+regex = "1"

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -1,4 +1,16 @@
 //! Rust global allocator support for the in-tree mimalloc build.
+//!
+//! ```no_run
+//! use mimalloc_pprof::{prof, MiMalloc};
+//! #[global_allocator] static ALLOCATOR: MiMalloc = MiMalloc;
+//! # fn main() -> std::io::Result<()> {
+//! prof::start(512 * 1024);
+//! prof::dump_file(std::path::Path::new("heap.prof"))?;
+//! # Ok(()) }
+//! ```
+//!
+//! See the README's Rust integration guide for frame-pointer and line-table
+//! build flags. Open the resulting profile with `pprof -http=: app.exe heap.prof`.
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::c_void;
@@ -23,5 +35,63 @@ unsafe impl GlobalAlloc for MiMalloc {
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         sys::mi_zalloc_aligned(layout.size(), layout.align()).cast()
+    }
+}
+
+/// Safe controls for mimalloc's sampled heap profiler.
+pub mod prof {
+    use core::ffi::{c_char, c_void};
+    use std::ffi::CString;
+    use std::io;
+    use std::path::Path;
+
+    use crate::sys;
+
+    pub fn start(sample_rate: usize) -> bool {
+        unsafe { sys::mi_prof_start(sample_rate) }
+    }
+    #[doc(hidden)]
+    pub fn start_seeded(sample_rate: usize, seed: u64) -> bool {
+        unsafe { sys::mi_prof_start_seeded(sample_rate, seed) }
+    }
+    pub fn stop() {
+        unsafe { sys::mi_prof_stop() }
+    }
+    pub fn is_enabled() -> bool {
+        unsafe { sys::mi_prof_is_enabled() }
+    }
+    pub fn reset() {
+        unsafe { sys::mi_prof_reset() }
+    }
+
+    pub fn dump_file(path: &Path) -> io::Result<()> {
+        let path = path.to_str().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "profile path is not UTF-8")
+        })?;
+        let path = CString::new(path).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "profile path contains NUL")
+        })?;
+        if unsafe { sys::mi_prof_dump(path.as_ptr()) } {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    unsafe extern "C" fn write_cb(arg: *mut c_void, buf: *const c_char, len: usize) {
+        let out = &mut *(arg as *mut Vec<u8>);
+        out.extend_from_slice(core::slice::from_raw_parts(buf.cast::<u8>(), len));
+    }
+
+    /// Serialize the current heap profile without holding the profiler lock.
+    pub fn dump_to_vec() -> Vec<u8> {
+        let mut out = Vec::new();
+        let ok =
+            unsafe { sys::mi_prof_dump_writer(Some(write_cb), (&mut out as *mut Vec<u8>).cast()) };
+        if ok {
+            out
+        } else {
+            Vec::new()
+        }
     }
 }

--- a/rust/mimalloc-pprof/tests/common/mod.rs
+++ b/rust/mimalloc-pprof/tests/common/mod.rs
@@ -1,0 +1,44 @@
+#![allow(dead_code)]
+
+use mimalloc_pprof::{prof, MiMalloc};
+use regex::Regex;
+
+#[global_allocator]
+static ALLOCATOR: MiMalloc = MiMalloc;
+
+pub fn start(rate: usize, seed: u64) {
+    if prof::is_enabled() {
+        prof::stop();
+    }
+    assert!(prof::start_seeded(rate, seed));
+}
+
+pub fn dump() -> String {
+    String::from_utf8(prof::dump_to_vec()).expect("heap profile is UTF-8")
+}
+
+pub fn header(text: &str) -> (u64, u64, u64, u64, u64) {
+    let re = Regex::new(
+        r"^heap profile: +([0-9]+): ([0-9]+) \[ *([0-9]+): ([0-9]+)\] @ heap_v2/([0-9]+)$",
+    )
+    .unwrap();
+    let caps = re
+        .captures(text.lines().next().unwrap())
+        .expect("heap_v2 header");
+    (
+        caps[1].parse().unwrap(),
+        caps[2].parse().unwrap(),
+        caps[3].parse().unwrap(),
+        caps[4].parse().unwrap(),
+        caps[5].parse().unwrap(),
+    )
+}
+
+pub fn sample_lines(text: &str) -> Vec<&str> {
+    let re = Regex::new(r"^ +[0-9]+: [0-9]+ \[ *[0-9]+: [0-9]+\] @( 0x[0-9a-fA-F]+)+$").unwrap();
+    text.lines().filter(|line| re.is_match(line)).collect()
+}
+
+pub fn stop() {
+    prof::stop();
+}

--- a/rust/mimalloc-pprof/tests/t1_smoke.rs
+++ b/rust/mimalloc-pprof/tests/t1_smoke.rs
@@ -1,0 +1,32 @@
+mod common;
+use std::alloc::{alloc, dealloc, realloc, Layout};
+use std::thread;
+
+#[test]
+fn allocator_handles_sizes_alignment_realloc_and_cross_thread_free() {
+    common::start(4096, 11);
+    for size in [8, 16, 64, 4096, 65_536, 1_048_576] {
+        let mut value = vec![0_u8; size];
+        value[0] = 1;
+        value.resize(size.saturating_add(17), 2);
+        assert_eq!(value[0], 1);
+    }
+    unsafe {
+        for alignment in [64, 4096] {
+            let layout = Layout::from_size_align(8192, alignment).unwrap();
+            let ptr = alloc(layout);
+            assert!(!ptr.is_null());
+            assert_eq!((ptr as usize) % alignment, 0);
+            let bigger = realloc(ptr, layout, 16_384);
+            assert!(!bigger.is_null());
+            dealloc(bigger, Layout::from_size_align(16_384, alignment).unwrap());
+        }
+    }
+    let value = Box::new([9_u8; 4096]);
+    let joined = thread::spawn(move || {
+        assert_eq!(value[0], 9);
+        drop(value);
+    });
+    joined.join().unwrap();
+    common::stop();
+}

--- a/rust/mimalloc-pprof/tests/t2_format.rs
+++ b/rust/mimalloc-pprof/tests/t2_format.rs
@@ -1,0 +1,21 @@
+mod common;
+
+#[test]
+fn heap_v2_text_has_samples_and_maps() {
+    common::start(65_536, 17);
+    let leaked: Vec<_> = (0..1000)
+        .map(|_| Box::leak(Box::new([0_u8; 4096])))
+        .collect();
+    let text = common::dump();
+    let (_, _, _, _, rate) = common::header(&text);
+    assert_eq!(rate, 65_536);
+    assert!(!common::sample_lines(&text).is_empty());
+    assert!(text.contains("MAPPED_LIBRARIES:\n"));
+    assert!(text
+        .lines()
+        .skip_while(|l| *l != "MAPPED_LIBRARIES:")
+        .skip(1)
+        .any(|l| !l.is_empty()));
+    std::mem::forget(leaked);
+    common::stop();
+}

--- a/rust/mimalloc-pprof/tests/t3_stats.rs
+++ b/rust/mimalloc-pprof/tests/t3_stats.rs
@@ -1,0 +1,15 @@
+mod common;
+
+#[test]
+fn sampled_stream_estimates_one_hundred_mib() {
+    common::start(524_288, 43);
+    let blocks: Vec<_> = (0..25_600).map(|_| Box::new([0_u8; 4096])).collect();
+    let text = common::dump();
+    let (objects, _, _, _, rate) = common::header(&text);
+    assert_eq!(rate, 524_288);
+    assert!((100..=400).contains(&objects));
+    let estimated = objects * rate;
+    assert!((50 * 1024 * 1024..=200 * 1024 * 1024).contains(&estimated));
+    std::mem::forget(blocks);
+    common::stop();
+}

--- a/rust/mimalloc-pprof/tests/t4_accum.rs
+++ b/rust/mimalloc-pprof/tests/t4_accum.rs
@@ -53,7 +53,8 @@ fn accumulation_modes() {
     if accum {
         assert!(before_reset > 0);
         prof::reset();
-        assert_eq!(stack_count(), 0);
+        let (_, _, upper, upper_bytes, _) = common::header(&common::dump());
+        assert_eq!((upper, upper_bytes), (0, 0));
     } else {
         assert_eq!(before_reset, 0);
     }

--- a/rust/mimalloc-pprof/tests/t4_accum.rs
+++ b/rust/mimalloc-pprof/tests/t4_accum.rs
@@ -1,0 +1,61 @@
+mod common;
+use mimalloc_pprof::{prof, sys};
+use std::process::Command;
+
+fn stack_count() -> usize {
+    let mut stacks = 0;
+    unsafe {
+        sys::mi_prof_debug_stats(std::ptr::null_mut(), std::ptr::null_mut(), &mut stacks);
+    }
+    stacks
+}
+
+#[test]
+fn accumulation_modes() {
+    let child = std::env::var_os("MIMALLOC_PPROF_T4_CHILD").is_some();
+    if !child {
+        for accum in [false, true] {
+            let mut command = Command::new(std::env::current_exe().unwrap());
+            command
+                .arg("--exact")
+                .arg("accumulation_modes")
+                .env("MIMALLOC_PPROF_T4_CHILD", "1");
+            if accum {
+                command.env("MIMALLOC_PROF_ACCUM", "1");
+            } else {
+                command.env_remove("MIMALLOC_PROF_ACCUM");
+            }
+            assert!(command.status().unwrap().success(), "accum={accum}");
+        }
+        return;
+    }
+
+    let accum = std::env::var("MIMALLOC_PROF_ACCUM").as_deref() == Ok("1");
+    common::start(1, 83);
+    let mut blocks: Vec<Option<Box<[u8; 256]>>> =
+        (0..128).map(|_| Some(Box::new([0; 256]))).collect();
+    let (_, _, upper0, upper_bytes0, _) = common::header(&common::dump());
+    for item in blocks.iter_mut().take(64) {
+        item.take();
+    }
+    let (live1, live_bytes1, upper1, upper_bytes1, _) = common::header(&common::dump());
+    if accum {
+        assert!(upper1 >= upper0 && upper1 >= live1);
+        assert!(upper_bytes1 >= upper_bytes0 && upper_bytes1 >= live_bytes1);
+    } else {
+        assert_eq!((upper0, upper_bytes0, upper1, upper_bytes1), (0, 0, 0, 0));
+    }
+    for item in &mut blocks {
+        item.take();
+    }
+    drop(blocks);
+    let before_reset = stack_count();
+    if accum {
+        assert!(before_reset > 0);
+        prof::reset();
+        assert_eq!(stack_count(), 0);
+    } else {
+        assert_eq!(before_reset, 0);
+    }
+    common::stop();
+}

--- a/rust/mimalloc-pprof/tests/t5_stacks.rs
+++ b/rust/mimalloc-pprof/tests/t5_stacks.rs
@@ -1,0 +1,32 @@
+mod common;
+
+#[inline(never)]
+fn a() {
+    b()
+}
+#[inline(never)]
+fn b() {
+    c()
+}
+#[inline(never)]
+fn c() {
+    let mut values = Vec::<u8>::with_capacity(4096);
+    values.push(7);
+    assert_eq!(values[0], 7);
+    std::mem::forget(values);
+}
+
+#[test]
+fn samples_include_multiple_caller_pcs() {
+    common::start(1, 59);
+    for _ in 0..128 {
+        a();
+    }
+    let text = common::dump();
+    let sample = common::sample_lines(&text)
+        .into_iter()
+        .next()
+        .expect("sample line");
+    assert!(sample.matches("0x").count() >= 3, "{sample}");
+    common::stop();
+}

--- a/rust/mimalloc-pprof/tests/t6_concurrency.rs
+++ b/rust/mimalloc-pprof/tests/t6_concurrency.rs
@@ -1,0 +1,32 @@
+mod common;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[test]
+fn concurrent_dumps_and_reentrant_vec_writer_do_not_deadlock() {
+    common::start(4096, 71);
+    let keep_samples: Vec<_> = (0..128)
+        .map(|_| Box::leak(Box::new([0_u8; 4096])))
+        .collect();
+    let workers: Vec<_> = (0..8)
+        .map(|_| {
+            thread::spawn(|| {
+                for _ in 0..100_000 {
+                    let value = Box::new([0_u8; 32]);
+                    drop(value);
+                }
+            })
+        })
+        .collect();
+    let deadline = Instant::now() + Duration::from_secs(60);
+    for _ in 0..10 {
+        let text = common::dump();
+        assert!(!common::sample_lines(&text).is_empty());
+        assert!(Instant::now() < deadline, "dump watchdog expired");
+    }
+    for worker in workers {
+        worker.join().unwrap();
+    }
+    std::mem::forget(keep_samples);
+    common::stop();
+}


### PR DESCRIPTION
## What changed

Adds raw Rust FFI bindings and the safe `mimalloc_pprof::prof` API for starting, stopping, resetting, and exporting heap profiles. Adds the Phase 4 allocator, profile-format, stats, accumulation, stack, and concurrent/reentrant-writer integration tests.

The native Rust workflow now installs and caches Soldr through `zackees/setup-soldr`, keyed by the Rust lockfile, and includes a Windows GNU target job.

## Why

Completes the Rust consumer layer for the heap profiler while validating profile output and thread-safe dumping across the public API.

## Validation

- Soldr native integration suite
- Rustdoc compile test and generated documentation
- Windows GNU target test suite

Closes #8.