### PR TITLE
feat(rust): enable_heap_profiling() for CLI-flag opt-in

### DIFF
--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -38,6 +38,31 @@ unsafe impl GlobalAlloc for MiMalloc {
     }
 }
 
+/// Turn on sampled heap profiling at the default sample rate.
+///
+/// Convenience entry point for wiring profiling to a command-line flag:
+///
+/// ```no_run
+/// # let args_profile_heap = true;
+/// if args_profile_heap {
+///     mimalloc_pprof::enable_heap_profiling();
+/// }
+/// ```
+///
+/// Uses the built-in default rate (one sample per ~512 KiB allocated;
+/// `MIMALLOC_PROF_SAMPLE_RATE` still overrides it). Call [`prof::start`]
+/// instead to pick a rate programmatically. Allocations made before this
+/// call — including process-startup and static initialization — are not
+/// tracked; profiles reflect steady-state behavior from this point on,
+/// which is the usual intent for an opt-in CLI switch. To capture startup
+/// as well, set `MIMALLOC_PROF=1` in the environment instead.
+///
+/// Returns `false` if profiling was already enabled (the earlier session,
+/// and its sample rate, stay active).
+pub fn enable_heap_profiling() -> bool {
+    prof::start(0)
+}
+
 /// Safe controls for mimalloc's sampled heap profiler.
 pub mod prof {
     use core::ffi::{c_char, c_void};

--- a/rust/mimalloc-pprof/tests/t11_enable.rs
+++ b/rust/mimalloc-pprof/tests/t11_enable.rs
@@ -1,0 +1,21 @@
+mod common;
+use mimalloc_pprof::{enable_heap_profiling, prof};
+
+#[test]
+fn enable_heap_profiling_uses_default_rate() {
+    // No MIMALLOC_PROF* env vars in the cargo-test environment, so the
+    // profiler starts out disabled and the default rate applies.
+    assert!(!prof::is_enabled());
+    assert!(enable_heap_profiling());
+    assert!(prof::is_enabled());
+    assert_eq!(prof::stats().sample_rate, 512 * 1024);
+
+    // A second call reports the already-running session untouched.
+    assert!(!enable_heap_profiling());
+    assert!(prof::is_enabled());
+
+    let blocks: Vec<_> = (0..64).map(|_| vec![0_u8; 64 * 1024]).collect();
+    assert!(prof::stats().live_samples > 0);
+    drop(blocks);
+    prof::stop();
+}


### PR DESCRIPTION
Adds `mimalloc_pprof::enable_heap_profiling() -> bool` — a root-level convenience for wiring heap profiling to a command-line switch:

```rust
if args.profile_heap {
    mimalloc_pprof::enable_heap_profiling();
}
```

- Wraps `prof::start(0)`, so the C side resolves the rate: `MIMALLOC_PROF_SAMPLE_RATE` if set, else the built-in 512 KiB default.
- Doc-comments the deliberate trade-off: enabling mid-process misses startup/static allocations — profiles reflect steady-state from the call onward, which is the intent of an opt-in flag. `MIMALLOC_PROF=1` remains the way to capture startup.
- Returns `false` if a profiling session is already active (that session and its rate stay untouched).
- Named "heap profiling" rather than "memory profiling" since it samples heap allocations specifically (not RSS/pages).

New test `t11_enable.rs` covers: disabled at start, enable succeeds with the 512 KiB default rate visible via `prof::stats()`, second call reports already-enabled, samples accumulate. Local run green (test + doc-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
