### PR TITLE
feat: profile.proto writer + module-map API (M3, closes #23)

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -220,3 +220,24 @@ jobs:
           & (Join-Path (go env GOPATH) 'bin/pprof.exe') -raw heap.prof | Tee-Object raw.txt
           if ($LASTEXITCODE -ne 0) { throw 'pprof could not parse heap.prof' }
           if (-not (Select-String -Path raw.txt -Pattern 'PeriodType: space|heap_v2|inuse_space')) { throw 'pprof output did not contain a heap profile' }
+      - name: Prove pprof parses a proto dump
+        if: matrix.pprof && runner.os != 'Windows'
+        shell: bash
+        run: |
+          generator=$(find dist/${{ matrix.target }} -maxdepth 1 -type f -name 't12_proto-*' | head -n 1)
+          test -n "$generator"
+          MIMALLOC_PROF_PROTO_PATH="$PWD/heap.pb" "$generator"
+          "$(go env GOPATH)/bin/pprof" -raw heap.pb > raw-pb.txt
+          grep -Eq 'inuse_space|alloc_space' raw-pb.txt
+      - name: Prove pprof parses a proto dump
+        if: matrix.pprof && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $generator = Get-ChildItem dist/${{ matrix.target }} -Filter 't12_proto-*' | Select-Object -First 1
+          if (-not $generator) { throw 't12_proto test binary was not staged' }
+          $env:MIMALLOC_PROF_PROTO_PATH = Join-Path $PWD 'heap.pb'
+          & $generator.FullName
+          if ($LASTEXITCODE -ne 0) { throw 'proto profile generator failed' }
+          & (Join-Path (go env GOPATH) 'bin/pprof.exe') -raw heap.pb | Tee-Object raw-pb.txt
+          if ($LASTEXITCODE -ne 0) { throw 'pprof could not parse heap.pb' }
+          if (-not (Select-String -Path raw-pb.txt -Pattern 'inuse_space|alloc_space')) { throw 'pprof output did not contain heap sample types' }

--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -311,6 +311,9 @@ void        _mi_prof_stack_unpin_all_and_sweep(void);
 bool        _mi_prof_stack_visit_info(mi_prof_visit_fun* fn, void* arg);
 typedef bool (_mi_prof_dump_append_fun)(void* arg, const char* buf, size_t len);
 bool        _mi_prof_maps_append(_mi_prof_dump_append_fun* append, void* arg);
+// structured module enumerator backing mi_prof_modules_visit and the profile.proto Mapping table;
+// unlike _mi_prof_maps_append (verbatim text) this yields one {path,base,size} per module.
+bool        _mi_prof_maps_visit(mi_prof_module_visit_fun* visitor, void* arg);
 void        _mi_prof_process_init(void);
 void        _mi_prof_process_done(void);
 #ifdef __cplusplus

--- a/include/mimalloc/profile.h
+++ b/include/mimalloc/profile.h
@@ -22,6 +22,11 @@ mi_decl_export void mi_prof_debug_stats(size_t* records, size_t* bytes, size_t* 
 typedef void (mi_prof_write_fun)(void* arg, const char* buf, size_t len);
 mi_decl_nodiscard mi_decl_export bool mi_prof_dump(const char* path) mi_attr_noexcept;
 mi_decl_nodiscard mi_decl_export bool mi_prof_dump_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept;
+/* profile.proto (google/pprof) writer: same sample/period/mapping semantics as
+   mi_prof_dump/mi_prof_dump_writer above but encoded as an uncompressed, binary
+   pprof Profile message instead of the legacy "heap profile:" text. */
+mi_decl_nodiscard mi_decl_export bool mi_prof_dump_proto(const char* path) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_prof_dump_proto_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept;
 mi_decl_export void mi_prof_reset(void) mi_attr_noexcept;
 
 #define MI_PROF_STAT_VERSION 1
@@ -51,6 +56,14 @@ typedef struct mi_prof_snapshot_s mi_prof_snapshot_t;
 mi_decl_nodiscard mi_decl_export mi_prof_snapshot_t* mi_prof_snapshot_new(void) mi_attr_noexcept;
 mi_decl_nodiscard mi_decl_export bool mi_prof_snapshot_visit(const mi_prof_snapshot_t* snap, mi_prof_visit_fun* visitor, void* arg) mi_attr_noexcept;
 mi_decl_export void mi_prof_snapshot_free(mi_prof_snapshot_t* snap) mi_attr_noexcept;
+
+/* Structured module (mapping) enumeration, e.g. to build pprof Mapping entries
+   yourself. No profiler lock is taken: module lists are OS-owned, not part of
+   the sampled-allocation table. `info` (and `info->path`) are valid only for
+   the duration of the callback. */
+typedef struct mi_prof_module_info_s { const char* path; uintptr_t base; size_t size; } mi_prof_module_info_t;
+typedef bool (mi_prof_module_visit_fun)(const mi_prof_module_info_t* info, void* arg);
+mi_decl_nodiscard mi_decl_export bool mi_prof_modules_visit(mi_prof_module_visit_fun* visitor, void* arg) mi_attr_noexcept;
 
 #ifdef __cplusplus
 }

--- a/rust/libmimalloc-pprof-sys/src/lib.rs
+++ b/rust/libmimalloc-pprof-sys/src/lib.rs
@@ -48,6 +48,19 @@ pub type mi_prof_visit_fun =
 #[allow(non_camel_case_types)]
 pub enum mi_prof_snapshot_t {}
 
+/// Mirrors `mi_prof_module_info_t` (include/mimalloc/profile.h) field-for-field.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct mi_prof_module_info_t {
+    pub path: *const c_char,
+    pub base: usize,
+    pub size: usize,
+}
+
+#[allow(non_camel_case_types)]
+pub type mi_prof_module_visit_fun =
+    unsafe extern "C" fn(info: *const mi_prof_module_info_t, arg: *mut c_void) -> bool;
+
 unsafe extern "C" {
     pub fn mi_malloc(size: usize) -> *mut c_void;
     pub fn mi_zalloc(size: usize) -> *mut c_void;
@@ -64,6 +77,11 @@ unsafe extern "C" {
     pub fn mi_prof_is_enabled() -> bool;
     pub fn mi_prof_dump(path: *const c_char) -> bool;
     pub fn mi_prof_dump_writer(write: Option<MiProfWriteFun>, arg: *mut c_void) -> bool;
+    /// profile.proto (google/pprof) writer: same sample/period/mapping semantics as
+    /// `mi_prof_dump`/`mi_prof_dump_writer` but encoded as an uncompressed, binary
+    /// pprof Profile message instead of the legacy "heap profile:" text.
+    pub fn mi_prof_dump_proto(path: *const c_char) -> bool;
+    pub fn mi_prof_dump_proto_writer(write: Option<MiProfWriteFun>, arg: *mut c_void) -> bool;
     pub fn mi_prof_reset();
     pub fn mi_prof_debug_stats(records: *mut usize, bytes: *mut usize, unique_stacks: *mut usize);
     pub fn mi_prof_stats_get(stats: *mut mi_prof_stats_t) -> bool;
@@ -75,4 +93,9 @@ unsafe extern "C" {
         arg: *mut c_void,
     ) -> bool;
     pub fn mi_prof_snapshot_free(snap: *mut mi_prof_snapshot_t);
+    /// Structured module (mapping) enumeration, e.g. to build pprof Mapping entries
+    /// yourself. No profiler lock is taken: module lists are OS-owned, not part of
+    /// the sampled-allocation table. `info` (and `info->path`) are valid only for
+    /// the duration of the callback.
+    pub fn mi_prof_modules_visit(visitor: mi_prof_module_visit_fun, arg: *mut c_void) -> bool;
 }

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -66,7 +66,7 @@ pub fn enable_heap_profiling() -> bool {
 /// Safe controls for mimalloc's sampled heap profiler.
 pub mod prof {
     use core::ffi::{c_char, c_void};
-    use std::ffi::CString;
+    use std::ffi::{CStr, CString};
     use std::io;
     use std::panic::{catch_unwind, AssertUnwindSafe};
     use std::path::Path;
@@ -118,6 +118,51 @@ pub mod prof {
             out
         } else {
             Vec::new()
+        }
+    }
+
+    /// Serialize the current heap profile as a binary pprof `profile.proto`
+    /// `Profile` message (see [google/pprof's `profile.proto`][proto]),
+    /// without holding the profiler lock.
+    ///
+    /// Sample values are pre-scaled the same way Go's `runtime/pprof` scales
+    /// legacy heap samples (the `protomem.go` convention: `alloc_objects`,
+    /// `alloc_space`, `inuse_objects`, `inuse_space`, each already corrected
+    /// for Poisson sampling bias rather than left for a downstream tool to
+    /// rescale). The `Mapping` table is included, so external symbolizers
+    /// need only the binary — no text parsing of a "heap profile:" header or
+    /// a `MAPPED_LIBRARIES:` section. This is the compact, machine-oriented
+    /// counterpart to [`dump_to_vec`]'s text format, intended for API and
+    /// transport use (issue #23) where a `pprof`-compatible tool consumes
+    /// the bytes directly.
+    ///
+    /// [proto]: https://github.com/google/pprof/blob/main/proto/profile.proto
+    pub fn dump_proto_to_vec() -> Vec<u8> {
+        let mut out = Vec::new();
+        let ok = unsafe {
+            sys::mi_prof_dump_proto_writer(Some(write_cb), (&mut out as *mut Vec<u8>).cast())
+        };
+        if ok {
+            out
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Write the current heap profile to `path` in `profile.proto` format.
+    ///
+    /// See [`dump_proto_to_vec`] for the format details.
+    pub fn dump_proto_file(path: &Path) -> io::Result<()> {
+        let path = path.to_str().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "profile path is not UTF-8")
+        })?;
+        let path = CString::new(path).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "profile path contains NUL")
+        })?;
+        if unsafe { sys::mi_prof_dump_proto(path.as_ptr()) } {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
         }
     }
 
@@ -246,6 +291,53 @@ pub mod prof {
                 guard.0,
                 collect_visitor,
                 (&mut out as *mut Vec<Sample>).cast(),
+            );
+        }
+        out
+    }
+
+    /// One loaded module (shared library or the main executable), copied out
+    /// of the OS module list by [`modules`].
+    #[derive(Debug, Clone)]
+    pub struct ModuleInfo {
+        pub path: String,
+        pub base: usize,
+        pub size: usize,
+    }
+
+    unsafe extern "C" fn modules_visitor(
+        info: *const sys::mi_prof_module_info_t,
+        arg: *mut c_void,
+    ) -> bool {
+        let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+            let out = &mut *(arg as *mut Vec<ModuleInfo>);
+            let info = &*info;
+            // `info.path` is only valid for the duration of this callback (it
+            // points into OS-owned module-list storage), so it must be copied
+            // into an owned `String` right here rather than stashed for later.
+            let path = CStr::from_ptr(info.path).to_string_lossy().into_owned();
+            out.push(ModuleInfo {
+                path,
+                base: info.base,
+                size: info.size,
+            });
+        }));
+        result.is_ok()
+    }
+
+    /// Enumerate the process's loaded modules (shared libraries and the main
+    /// executable), e.g. to build pprof `Mapping` entries yourself.
+    ///
+    /// Unlike [`samples`]'s `collect_visitor`, this callback is free to
+    /// allocate: `mi_prof_modules_visit` never takes the profiler lock (the
+    /// module list is OS-owned, not part of the sampled-allocation table), so
+    /// there is no reentrant-allocation-under-the-lock hazard here.
+    pub fn modules() -> Vec<ModuleInfo> {
+        let mut out: Vec<ModuleInfo> = Vec::new();
+        unsafe {
+            sys::mi_prof_modules_visit(
+                modules_visitor,
+                (&mut out as *mut Vec<ModuleInfo>).cast(),
             );
         }
         out

--- a/rust/mimalloc-pprof/tests/t12_proto.rs
+++ b/rust/mimalloc-pprof/tests/t12_proto.rs
@@ -1,0 +1,42 @@
+mod common;
+use mimalloc_pprof::prof;
+
+#[test]
+fn proto_dump_is_compact_binary_pprof_and_supports_ci_export() {
+    common::start(4096, 13);
+    let blocks: Vec<_> = (0..200).map(|_| vec![0_u8; 4096]).collect();
+
+    // Both dumps are captured while `blocks` is still alive, so they
+    // describe the same profiler state and are directly comparable.
+    let proto = prof::dump_proto_to_vec();
+    let text = prof::dump_to_vec();
+
+    assert!(!proto.is_empty());
+
+    // First byte is the tag for field 1 (sample_type), wire type 2
+    // (length-delimited submessage): (1 << 3) | 2 = 0x0a. `sample_type` is
+    // always the first field mi_prof_dump_proto_writer emits (src/profile.c),
+    // so this pins the encoding to a real pprof Profile message rather than
+    // an accidental passthrough of the text format.
+    assert_eq!(proto[0], 0x0a, "first byte should be the sample_type tag");
+
+    // The binary pprof encoding is materially smaller than the legacy text
+    // dump for the same live set: no repeated ASCII-decimal formatting, no
+    // "heap profile:"/"MAPPED_LIBRARIES:" boilerplate, and varints instead
+    // of hex text for stack addresses.
+    assert!(
+        proto.len() < text.len(),
+        "proto ({} bytes) should be smaller than text ({} bytes)",
+        proto.len(),
+        text.len()
+    );
+
+    // Hook for CI's pprof gate: when set, persist the proto bytes so an
+    // external pprof-compatible validator can inspect them directly.
+    if let Some(path) = std::env::var_os("MIMALLOC_PROF_PROTO_PATH") {
+        std::fs::write(&path, &proto).expect("write MIMALLOC_PROF_PROTO_PATH");
+    }
+
+    drop(blocks);
+    common::stop();
+}

--- a/rust/mimalloc-pprof/tests/t14_modules.rs
+++ b/rust/mimalloc-pprof/tests/t14_modules.rs
@@ -1,0 +1,35 @@
+mod common;
+use mimalloc_pprof::prof;
+
+#[test]
+fn modules_lists_loaded_modules_including_this_test_binary() {
+    let modules = prof::modules();
+    assert!(!modules.is_empty());
+
+    for module in &modules {
+        assert!(module.size > 0, "module has zero size: {module:?}");
+        assert!(!module.path.is_empty(), "module has an empty path");
+    }
+
+    // Cargo names integration-test binaries `<stem>-<hash>[.exe]`, so we
+    // cannot match on the crate name ("t14_modules") alone. Instead, take
+    // the *running* executable's own file stem (file name minus one
+    // extension) via `current_exe` and check that it is a substring of some
+    // enumerated module's path. On MSVC and MinGW alike the main executable
+    // is reported with a `.exe` extension, so stripping exactly one
+    // extension leaves `t14_modules-<hash>`, which is exactly the fragment
+    // that appears inside that module's full path; on Unix-like targets
+    // there is no extension to strip and the same containment check still
+    // holds.
+    let exe = std::env::current_exe().expect("current_exe");
+    let exe_stem = exe
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .expect("exe file stem is valid UTF-8");
+
+    assert!(
+        modules.iter().any(|m| m.path.contains(exe_stem)),
+        "no module path contains {exe_stem:?}; paths: {:?}",
+        modules.iter().map(|m| &m.path).collect::<Vec<_>>()
+    );
+}

--- a/src/profile-maps.c
+++ b/src/profile-maps.c
@@ -4,6 +4,7 @@
 #include "mimalloc.h"
 #include "mimalloc/internal.h"
 #include <stdio.h>
+#include <string.h>
 
 #if MI_PPROF
 
@@ -72,6 +73,98 @@ bool _mi_prof_maps_append(_mi_prof_dump_append_fun* append, void* arg) {
   while ((n = read(fd, buf, sizeof(buf))) > 0) { if (!append(arg, buf, (size_t)n)) { close(fd); return false; } }
   close(fd);
   if (n < 0) return false;
+#endif
+  return true;
+}
+
+/* Structured module enumeration for mi_prof_modules_visit and the profile.proto Mapping table.
+   Deliberately independent of _mi_prof_maps_append above (which stays a byte-for-byte copy of
+   /proc/self/maps / an equivalent legacy-format line per platform): the TEXT emitter must not
+   change behavior since test/test-profile.c's T2 parses it, so on Linux this is a *second*,
+   from-scratch structured parser rather than a refactor of the verbatim-copy path. */
+bool _mi_prof_maps_visit(mi_prof_module_visit_fun* visitor, void* arg) {
+  if (visitor == NULL) return false;
+#if defined(_WIN32)
+  HMODULE modules[1024]; DWORD needed = 0;
+  if (!K32EnumProcessModulesEx(GetCurrentProcess(), modules, sizeof(modules), &needed, LIST_MODULES_ALL)) return false;
+  const size_t count = maps_min((size_t)(needed / sizeof(modules[0])), sizeof(modules) / sizeof(modules[0]));
+  for (size_t i = 0; i < count; i++) {
+    MODULEINFO info; char path[MAX_PATH];
+    if (!K32GetModuleInformation(GetCurrentProcess(), modules[i], &info, sizeof(info))) continue;
+    DWORD len = GetModuleFileNameA(modules[i], path, (DWORD)sizeof(path));
+    if (len == 0) continue;
+    path[sizeof(path) - 1] = 0;
+    mi_prof_module_info_t m; m.path = path; m.base = (uintptr_t)info.lpBaseOfDll; m.size = (size_t)info.SizeOfImage;
+    if (!visitor(&m, arg)) break;
+  }
+#elif defined(__APPLE__)
+  const uint32_t count = _dyld_image_count();
+  for (uint32_t i = 0; i < count; i++) {
+    const struct mach_header* header = _dyld_get_image_header(i); const char* path = _dyld_get_image_name(i);
+    if (header == NULL || path == NULL) continue;
+    uintptr_t start = UINTPTR_MAX, end = 0;
+    const intptr_t slide = _dyld_get_image_vmaddr_slide(i);
+    const uint8_t* p = (const uint8_t*)header + ((header->magic == MH_MAGIC_64 || header->magic == MH_CIGAM_64) ? sizeof(struct mach_header_64) : sizeof(struct mach_header));
+    for (uint32_t j = 0; j < header->ncmds; j++) {
+      const struct load_command* cmd = (const struct load_command*)p;
+      if (cmd->cmd == LC_SEGMENT) {
+        const struct segment_command* seg = (const struct segment_command*)cmd;
+        start = maps_min(start, (uintptr_t)(slide + (intptr_t)seg->vmaddr));
+        end = (end > (uintptr_t)(slide + (intptr_t)seg->vmaddr + seg->vmsize) ? end : (uintptr_t)(slide + (intptr_t)seg->vmaddr + seg->vmsize));
+      }
+      else if (cmd->cmd == LC_SEGMENT_64) {
+        const struct segment_command_64* seg = (const struct segment_command_64*)cmd;
+        start = maps_min(start, (uintptr_t)(slide + (intptr_t)seg->vmaddr));
+        end = (end > (uintptr_t)(slide + (intptr_t)seg->vmaddr + seg->vmsize) ? end : (uintptr_t)(slide + (intptr_t)seg->vmaddr + seg->vmsize));
+      }
+      if (cmd->cmdsize < sizeof(*cmd)) break;
+      p += cmd->cmdsize;
+    }
+    if (start == UINTPTR_MAX) start = (uintptr_t)header;
+    if (end <= start) end = start + 1;
+    mi_prof_module_info_t m; m.path = path; m.base = start; m.size = end - start;
+    if (!visitor(&m, arg)) break;
+  }
+#else
+  /* Parse /proc/self/maps ourselves and merge contiguous same-file regions into one module each
+     (a shared object is typically mapped as several adjacent r--p/r-xp/rw-p VMAs for its ELF
+     LOAD segments); a module is reported once at least one of its contiguous regions is
+     executable. Streamed line-by-line with fixed stack buffers, no heap allocation. */
+  const int fd = open("/proc/self/maps", O_RDONLY);
+  if (fd < 0) return false;
+  enum { MAPS_LINE_MAX = 1024 };
+  char line[MAPS_LINE_MAX]; size_t line_len = 0; bool line_overflow = false;
+  char run_path[MAPS_LINE_MAX]; uintptr_t run_start = 0, run_end = 0; bool run_has_exec = false, run_active = false;
+  bool stop = false, failed = false;
+  char rbuf[4096]; ssize_t n;
+  while (!stop && (n = read(fd, rbuf, sizeof(rbuf))) > 0) {
+    for (ssize_t i = 0; i < n && !stop; i++) {
+      const char c = rbuf[i];
+      if (c != '\n') { if (line_len < sizeof(line) - 1) line[line_len++] = c; else line_overflow = true; continue; }
+      line[line_len] = 0;
+      if (line_overflow || line_len == 0) { line_len = 0; line_overflow = false; continue; }
+      unsigned long long start = 0, end = 0; char perms[8] = { 0 }; char path[MAPS_LINE_MAX] = { 0 };
+      const int fields = sscanf(line, "%llx-%llx %7s %*x %*x:%*x %*u %1023s", &start, &end, perms, path);  // offset/dev/inode intentionally unassigned (%*..).
+      const bool has_path = (fields >= 4 && path[0] == '/');
+      if (has_path && run_active && strcmp(run_path, path) == 0 && (uintptr_t)start == run_end) {
+        run_end = (uintptr_t)end;
+        if (perms[2] == 'x') run_has_exec = true;
+      } else {
+        if (run_active && run_has_exec) { mi_prof_module_info_t m; m.path = run_path; m.base = run_start; m.size = run_end - run_start; if (!visitor(&m, arg)) stop = true; }
+        run_active = false;
+        if (has_path && !stop) {
+          const size_t plen = maps_min(strlen(path), sizeof(run_path) - 1);
+          memcpy(run_path, path, plen); run_path[plen] = 0;
+          run_start = (uintptr_t)start; run_end = (uintptr_t)end; run_has_exec = (perms[2] == 'x'); run_active = true;
+        }
+      }
+      line_len = 0; line_overflow = false;
+    }
+  }
+  if (n < 0) failed = true;
+  close(fd);
+  if (!stop && !failed && run_active && run_has_exec) { mi_prof_module_info_t m; m.path = run_path; m.base = run_start; m.size = run_end - run_start; (void)visitor(&m, arg); /* last entry: nothing left to stop for */ }
+  if (failed) return false;
 #endif
   return true;
 }

--- a/src/profile.c
+++ b/src/profile.c
@@ -329,6 +329,239 @@ bool mi_prof_snapshot_visit(const mi_prof_snapshot_t* snap, mi_prof_visit_fun* v
   return true;
 }
 void mi_prof_snapshot_free(mi_prof_snapshot_t* snap) mi_attr_noexcept { if (snap != NULL) _mi_os_free(snap, snap->total_size, snap->memid); }
+
+bool mi_prof_modules_visit(mi_prof_module_visit_fun* visitor, void* arg) mi_attr_noexcept {
+  if (visitor == NULL) return false;
+  if (prof_callback_depth > 0) return false;
+  return _mi_prof_maps_visit(visitor, arg);  // OS-owned module list: no profiler lock needed.
+}
+
+/* ---------------------------------------------------------------------------------------------
+   profile.proto (google/pprof) writer.
+
+   Minimal hand-written protobuf encoder: varint(), a tag+varint field writer, and a tag+length
+   "bytes" field writer (used for both length-delimited strings/submessages and, with a
+   pre-concatenated-varint payload, PACKED repeated scalar fields -- proto3 packs repeated
+   numeric fields by default, and this is exactly how Go's own hand-rolled encoder for pprof
+   builds Sample.location_id/Sample.value too, via `b.pb.uint64s`/`b.pb.int64s`
+   (go/src/runtime/pprof/proto.go)). Submessages (ValueType/Mapping/Location/Sample) are built
+   into small stack scratch buffers first (their max size is bounded: <=128 stack frames per
+   sample, module paths capped below) so no first pass is needed to size them; the buffer holding
+   them is then written to the top-level Profile message as one length-delimited field. All
+   scratch memory here is transient stack space or _mi_os_alloc (never mi_malloc), consistent
+   with the rest of the profiler.
+
+   Field numbers verified against https://github.com/google/pprof/blob/main/proto/profile.proto:
+     Profile:   sample_type=1 sample=2 mapping=3 location=4 string_table=6
+                period_type=11 period=12 default_sample_type=14
+     ValueType: type=1 unit=2                      (both string_table indices)
+     Sample:    location_id=1 (packed uint64)  value=2 (packed int64)
+     Mapping:   id=1 memory_start=2 memory_limit=3  filename=5 (string_table index)
+     Location:  id=1 mapping_id=2 address=3
+   No Function/Line tables are written (id-less: consumers resolve symbols via the Mapping's
+   filename, same as any pprof profile with has_functions=false on its mappings). */
+
+static size_t pb_varint(uint8_t* buf, uint64_t v) {
+  size_t n = 0;
+  do { uint8_t b = (uint8_t)(v & 0x7F); v >>= 7; if (v != 0) b |= 0x80; buf[n++] = b; } while (v != 0);
+  return n;
+}
+static size_t pb_field_varint(uint8_t* buf, size_t pos, uint32_t field, uint64_t value) {
+  pos += pb_varint(buf + pos, ((uint64_t)field << 3) | 0);
+  pos += pb_varint(buf + pos, value);
+  return pos;
+}
+static size_t pb_field_bytes(uint8_t* buf, size_t pos, uint32_t field, const void* data, size_t len) {
+  pos += pb_varint(buf + pos, ((uint64_t)field << 3) | 2);
+  pos += pb_varint(buf + pos, (uint64_t)len);
+  if (len > 0) memcpy(buf + pos, data, len);
+  return pos + len;
+}
+static bool pb_emit_bytes_field(prof_dump_buffer_t* out, uint32_t field, const void* data, size_t len) {
+  uint8_t hdr[16]; size_t n = pb_varint(hdr, ((uint64_t)field << 3) | 2); n += pb_varint(hdr + n, (uint64_t)len);
+  if (!prof_dump_append(out, (const char*)hdr, n)) return false;
+  return (len == 0) || prof_dump_append(out, (const char*)data, len);
+}
+static bool pb_emit_varint_field(prof_dump_buffer_t* out, uint32_t field, uint64_t value) {
+  uint8_t buf[20]; size_t n = pb_varint(buf, ((uint64_t)field << 3) | 0); n += pb_varint(buf + n, value);
+  return prof_dump_append(out, (const char*)buf, n);
+}
+static bool pb_emit_valuetype(prof_dump_buffer_t* out, uint32_t field, int64_t type_idx, int64_t unit_idx) {
+  uint8_t vt[24]; size_t n = 0;
+  n = pb_field_varint(vt, n, 1, (uint64_t)type_idx);
+  n = pb_field_varint(vt, n, 2, (uint64_t)unit_idx);
+  return pb_emit_bytes_field(out, field, vt, n);
+}
+
+/* Mirrors go/src/runtime/pprof/protomem.go's scaleHeapSample, which this comment quotes from
+   memory (verified against the live file on github.com/golang/go):
+     // scaleHeapSample adjusts the data from a heap Sample to account for its probability of
+     // appearing in the collected data. heap profiles are a sampling of the memory allocation
+     // requests... we estimate the unsampled value by dividing the sampled value by the
+     // probability of a sample.
+     func scaleHeapSample(count, size, rate int64) (int64, int64) {
+       if count == 0 || size == 0 { return 0, 0 }
+       if rate <= 1 { return count, size }              // rate<=1: everything was sampled.
+       avgSize := float64(size) / float64(count)
+       scale := 1 / (1 - math.Exp(-avgSize/float64(rate)))
+       return int64(float64(count) * scale), int64(float64(size) * scale)
+     }
+   Go calls this twice per record -- once for the Alloc* totals, once for the InUse* totals --
+   each with that record's own (count,bytes,rate). We do the same per unique stack below: once
+   for (accum_objects,accum_bytes) -> alloc_*, once for (live_objects,live_bytes) -> inuse_*.
+   When MIMALLOC_PROF_ACCUM is off, accum_objects/accum_bytes are always 0 (profile-stack.c's
+   _mi_prof_stack_alloc only updates them when mi_option_prof_accum is enabled), so alloc_* comes
+   out (0,0) via the count==0||size==0 shortcut above -- this is the "accum-off => alloc_* zero"
+   behavior called for in the work order. */
+/* Self-contained exp(), avoiding a new libm link dependency for this one call site: this
+   profiler has no other transcendental-math usage today, CMakeLists.txt (out of scope for this
+   change) does not link `m` on Unix, and "no new required dependencies" is a hard rule for this
+   fork's C build. Textbook range reduction + Taylor series: exp(x) = 2^k * exp(r) with
+   k = round(x/ln2) so |r| <= ln2/2 ~= 0.3466, which a 17-term Taylor series resolves to full
+   double precision (error ~ r^18/18!, negligible). Only ever called below with x <= 0. */
+static double prof_exp(double x) {
+  if (x > 700.0) return 1e308;   // saturate; unreachable from prof_scale_heap_sample (x = -avg_size/rate <= 0)
+  if (x < -700.0) return 0.0;    // underflows to 0 well before double's actual limit
+  const double ln2 = 0.69314718055994530942;
+  const long k = (long)(x / ln2 + (x >= 0.0 ? 0.5 : -0.5));  // round(x/ln2) to nearest, ties away from zero
+  const double r = x - (double)k * ln2;
+  double term = 1.0, sum = 1.0;
+  for (int i = 1; i <= 17; i++) { term *= r / (double)i; sum += term; }
+  double result = sum;
+  if (k >= 0) { for (long i = 0; i < k; i++) result *= 2.0; }
+  else        { for (long i = 0; i < -k; i++) result *= 0.5; }
+  return result;
+}
+static void prof_scale_heap_sample(size_t count, size_t bytes, size_t rate, size_t* out_count, size_t* out_bytes) {
+  if (count == 0 || bytes == 0) { *out_count = 0; *out_bytes = 0; return; }
+  if (rate <= 1) { *out_count = count; *out_bytes = bytes; return; }
+  const double avg_size = (double)bytes / (double)count;
+  const double scale = 1.0 / (1.0 - prof_exp(-avg_size / (double)rate));
+  *out_count = (size_t)((double)count * scale);
+  *out_bytes = (size_t)((double)bytes * scale);
+}
+
+enum { PROF_PROTO_MAX_MODULES = 512 };   // dense fixed cap, mirrors the HMODULE[1024] cap in profile-maps.c
+enum { PROF_PROTO_MAX_DEPTH = 128 };     // mirrors MI_PROF_BT_MAX_LIMIT in profile-stack.c
+typedef struct proto_module_s { uintptr_t base; size_t size; char path[512]; } proto_module_t;
+typedef struct proto_module_ctx_s { proto_module_t* modules; size_t count; } proto_module_ctx_t;
+static bool proto_collect_module(const mi_prof_module_info_t* info, void* arg) {
+  proto_module_ctx_t* ctx = (proto_module_ctx_t*)arg;
+  if (ctx->count >= PROF_PROTO_MAX_MODULES) return true;  // table full: keep visiting, just stop recording.
+  proto_module_t* m = &ctx->modules[ctx->count++];
+  m->base = info->base; m->size = info->size;
+  const size_t plen = prof_min(strlen(info->path), sizeof(m->path) - 1);
+  memcpy(m->path, info->path, plen); m->path[plen] = 0;
+  return true;
+}
+static uint32_t proto_module_for_pc(const proto_module_t* modules, size_t count, const void* pc) {
+  const uintptr_t addr = (uintptr_t)pc;
+  for (size_t i = 0; i < count; i++) if (addr >= modules[i].base && addr < modules[i].base + modules[i].size) return (uint32_t)(i + 1);
+  return 0;
+}
+
+typedef struct proto_pc_slot_s { const void* pc; uint32_t id; } proto_pc_slot_t;
+static uint32_t proto_pc_intern(proto_pc_slot_t* table, size_t capacity, const void* pc, uint32_t* next_id) {
+  size_t index = (size_t)(((uintptr_t)pc >> 4) * (uintptr_t)2654435761u) & (capacity - 1);
+  while (table[index].pc != NULL) { if (table[index].pc == pc) return table[index].id; index = (index + 1) & (capacity - 1); }
+  table[index].pc = pc; table[index].id = (*next_id)++;
+  return table[index].id;
+}
+
+enum { PB_STR_EMPTY = 0, PB_STR_ALLOC_OBJECTS, PB_STR_COUNT, PB_STR_ALLOC_SPACE, PB_STR_BYTES, PB_STR_INUSE_OBJECTS, PB_STR_INUSE_SPACE, PB_STR_SPACE, PB_STR_FIXED_COUNT };
+static const char* const prof_proto_fixed_strings[PB_STR_FIXED_COUNT] = { "", "alloc_objects", "count", "alloc_space", "bytes", "inuse_objects", "inuse_space", "space" };
+
+bool mi_prof_dump_proto_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept {
+  if (write == NULL) return false;
+  if (prof_callback_depth > 0) return false;
+  mi_prof_snapshot_t* snap = mi_prof_snapshot_new();  // deep-copies stacks+counts under prof_lock, then releases it.
+  if (snap == NULL) return false;
+
+  mi_memid_t mods_memid;
+  proto_module_t* modules = (proto_module_t*)_mi_os_alloc(PROF_PROTO_MAX_MODULES * sizeof(proto_module_t), &mods_memid);
+  if (modules == NULL) { mi_prof_snapshot_free(snap); return false; }
+  proto_module_ctx_t mod_ctx = { modules, 0 };
+  const bool maps_ok = _mi_prof_maps_visit(proto_collect_module, &mod_ctx);
+  const size_t module_count = mod_ctx.count;
+
+  // Unique-PC table (Location ids start at 1), sized once from the total PC count so no growth
+  // logic is needed (upper bound is unique_stacks * max depth, the same bound the snapshot's
+  // pcpool above is already sized to).
+  size_t total_pcs = 0;
+  for (size_t i = 0; i < snap->count; i++) total_pcs += snap->entries[i].depth;
+  size_t pc_capacity = 16;
+  while (pc_capacity < total_pcs * 2 + 1) pc_capacity *= 2;
+  mi_memid_t pc_memid;
+  proto_pc_slot_t* pc_table = (proto_pc_slot_t*)_mi_os_alloc(pc_capacity * sizeof(proto_pc_slot_t), &pc_memid);
+  if (pc_table == NULL) { _mi_os_free(modules, PROF_PROTO_MAX_MODULES * sizeof(proto_module_t), mods_memid); mi_prof_snapshot_free(snap); return false; }
+  memset(pc_table, 0, pc_capacity * sizeof(proto_pc_slot_t));
+  uint32_t next_location_id = 1;
+
+  prof_dump_buffer_t out = { NULL, NULL, true };
+  bool ok = maps_ok;  // parity with mi_prof_dump_writer, which also fails the whole dump if maps enumeration fails.
+
+  ok = ok && pb_emit_valuetype(&out, 1, PB_STR_ALLOC_OBJECTS, PB_STR_COUNT);
+  ok = ok && pb_emit_valuetype(&out, 1, PB_STR_ALLOC_SPACE, PB_STR_BYTES);
+  ok = ok && pb_emit_valuetype(&out, 1, PB_STR_INUSE_OBJECTS, PB_STR_COUNT);
+  ok = ok && pb_emit_valuetype(&out, 1, PB_STR_INUSE_SPACE, PB_STR_BYTES);
+
+  for (size_t i = 0; ok && i < snap->count; i++) {
+    const mi_prof_snapshot_entry_t* e = &snap->entries[i];
+    if (e->live_objects == 0 && e->live_bytes == 0 && e->accum_objects == 0 && e->accum_bytes == 0) continue;  // parity with the TEXT emitter's zero-filter.
+    uint32_t location_ids[PROF_PROTO_MAX_DEPTH];
+    const size_t depth = prof_min(e->depth, (size_t)PROF_PROTO_MAX_DEPTH);
+    for (size_t f = 0; f < depth; f++) location_ids[f] = proto_pc_intern(pc_table, pc_capacity, e->pcs[f], &next_location_id);  // pcs[] is already callee-first (innermost frame first).
+    size_t alloc_objs, alloc_bytes, live_objs, live_bytes;
+    prof_scale_heap_sample(e->accum_objects, e->accum_bytes, prof_rate, &alloc_objs, &alloc_bytes);
+    prof_scale_heap_sample(e->live_objects, e->live_bytes, prof_rate, &live_objs, &live_bytes);
+    uint8_t sm[1536]; size_t sn = 0;
+    { uint8_t packed[PROF_PROTO_MAX_DEPTH * 10]; size_t pn = 0; for (size_t f = 0; f < depth; f++) pn += pb_varint(packed + pn, (uint64_t)location_ids[f]); sn = pb_field_bytes(sm, sn, 1, packed, pn); }
+    { uint8_t packed[64]; size_t pn = 0; const uint64_t vals[4] = { (uint64_t)alloc_objs, (uint64_t)alloc_bytes, (uint64_t)live_objs, (uint64_t)live_bytes }; for (int k = 0; k < 4; k++) pn += pb_varint(packed + pn, vals[k]); sn = pb_field_bytes(sm, sn, 2, packed, pn); }
+    ok = pb_emit_bytes_field(&out, 2, sm, sn);
+  }
+
+  for (size_t i = 0; ok && i < module_count; i++) {
+    uint8_t mp[64]; size_t mn = 0;
+    mn = pb_field_varint(mp, mn, 1, (uint64_t)(i + 1));
+    mn = pb_field_varint(mp, mn, 2, (uint64_t)modules[i].base);
+    mn = pb_field_varint(mp, mn, 3, (uint64_t)(modules[i].base + modules[i].size));
+    mn = pb_field_varint(mp, mn, 5, (uint64_t)(PB_STR_FIXED_COUNT + i));
+    ok = pb_emit_bytes_field(&out, 3, mp, mn);
+  }
+
+  for (size_t i = 0; ok && i < pc_capacity; i++) {
+    if (pc_table[i].pc == NULL) continue;
+    const uint32_t mapping_id = proto_module_for_pc(modules, module_count, pc_table[i].pc);
+    uint8_t lc[48]; size_t ln = 0;
+    ln = pb_field_varint(lc, ln, 1, (uint64_t)pc_table[i].id);
+    if (mapping_id != 0) ln = pb_field_varint(lc, ln, 2, (uint64_t)mapping_id);
+    ln = pb_field_varint(lc, ln, 3, (uint64_t)(uintptr_t)pc_table[i].pc);
+    ok = pb_emit_bytes_field(&out, 4, lc, ln);
+  }
+
+  for (size_t i = 0; ok && i < PB_STR_FIXED_COUNT; i++) ok = pb_emit_bytes_field(&out, 6, prof_proto_fixed_strings[i], strlen(prof_proto_fixed_strings[i]));
+  for (size_t i = 0; ok && i < module_count; i++) ok = pb_emit_bytes_field(&out, 6, modules[i].path, strlen(modules[i].path));
+
+  ok = ok && pb_emit_valuetype(&out, 11, PB_STR_SPACE, PB_STR_BYTES);              // period_type: space/bytes.
+  ok = ok && pb_emit_varint_field(&out, 12, (uint64_t)prof_rate);                  // period: the configured sample rate.
+  ok = ok && pb_emit_varint_field(&out, 14, (uint64_t)PB_STR_INUSE_SPACE);         // default_sample_type: inuse_space.
+
+  if (ok) for (prof_dump_chunk_t* chunk = out.first; chunk != NULL; chunk = chunk->next) write(arg, chunk->data, chunk->used);
+  prof_dump_dispose(&out);
+  _mi_os_free(pc_table, pc_capacity * sizeof(proto_pc_slot_t), pc_memid);
+  _mi_os_free(modules, PROF_PROTO_MAX_MODULES * sizeof(proto_module_t), mods_memid);
+  mi_prof_snapshot_free(snap);
+  return ok;
+}
+bool mi_prof_dump_proto(const char* path) mi_attr_noexcept {
+  if (prof_callback_depth > 0) return false;
+  if (path == NULL) return false;
+  FILE* f = fopen(path, "wb"); if (f == NULL) return false;
+  const bool ok = mi_prof_dump_proto_writer(prof_file_write, f);
+  fclose(f);
+  return ok;
+}
+
 static void prof_auto_start(void) {
   /* Some statically linked MinGW programs do not retain the CRT/TLS startup
      callback. Fall back to the first allocation so MIMALLOC_PROF still works. */
@@ -361,6 +594,7 @@ void _mi_prof_on_alloc(mi_heap_t* heap, mi_page_t* page, void* p, size_t size) {
       mi_atomic_increment_relaxed(&prof_records); mi_atomic_add_relaxed(&prof_bytes, size);
       if (mi_option_is_enabled(mi_option_prof_accum)) { mi_atomic_increment_relaxed(&prof_accum_records); mi_atomic_add_relaxed(&prof_accum_bytes, size); }
     }
+    else { rec->next = prof_free; prof_free = rec; }  /* dropped sample: recycle the record or every post-overflow sample leaks arena memory */
   }
   mi_lock_release(&prof_lock);
 }
@@ -394,9 +628,12 @@ bool mi_prof_is_enabled(void) mi_attr_noexcept { return false; }
 void mi_prof_debug_stats(size_t* records, size_t* bytes, size_t* unique_stacks) mi_attr_noexcept { if (records) *records=0; if (bytes) *bytes=0; if (unique_stacks) *unique_stacks=0; }
 bool mi_prof_dump_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept { MI_UNUSED(write); MI_UNUSED(arg); return false; }
 bool mi_prof_dump(const char* path) mi_attr_noexcept { MI_UNUSED(path); return false; }
+bool mi_prof_dump_proto_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept { MI_UNUSED(write); MI_UNUSED(arg); return false; }
+bool mi_prof_dump_proto(const char* path) mi_attr_noexcept { MI_UNUSED(path); return false; }
 void mi_prof_reset(void) mi_attr_noexcept { }
 bool mi_prof_stats_get(mi_prof_stats_t* stats) mi_attr_noexcept { MI_UNUSED(stats); return false; }
 bool mi_prof_visit(mi_prof_visit_fun* visitor, void* arg) mi_attr_noexcept { MI_UNUSED(visitor); MI_UNUSED(arg); return false; }
+bool mi_prof_modules_visit(mi_prof_module_visit_fun* visitor, void* arg) mi_attr_noexcept { MI_UNUSED(visitor); MI_UNUSED(arg); return false; }
 mi_prof_snapshot_t* mi_prof_snapshot_new(void) mi_attr_noexcept { return NULL; }
 bool mi_prof_snapshot_visit(const mi_prof_snapshot_t* snap, mi_prof_visit_fun* visitor, void* arg) mi_attr_noexcept { MI_UNUSED(snap); MI_UNUSED(visitor); MI_UNUSED(arg); return false; }
 void mi_prof_snapshot_free(mi_prof_snapshot_t* snap) mi_attr_noexcept { MI_UNUSED(snap); }

--- a/test/test-profile.c
+++ b/test/test-profile.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include "mimalloc/profile.h"
 
 static void profile_worker(void) {
@@ -152,6 +153,122 @@ static void test_visit_reentrancy(void) {
   mi_prof_snapshot_free(snap);
 }
 
+/* ---- T12: mi_prof_dump_proto_writer -------------------------------------------------------
+   A ~40-line mini protobuf decoder that walks only the top-level Profile fields (and, for
+   Sample/Mapping, one level into their known submessage shape) -- not a general pprof reader. */
+static bool t12_pb_varint(const unsigned char* buf, size_t len, size_t* pos, uint64_t* out) {
+  uint64_t result = 0; int shift = 0;
+  while (*pos < len) {
+    unsigned char b = buf[(*pos)++];
+    result |= ((uint64_t)(b & 0x7F)) << shift;
+    if (!(b & 0x80)) { *out = result; return true; }
+    shift += 7; if (shift >= 64) return false;
+  }
+  return false;
+}
+static bool t12_pb_next(const unsigned char* buf, size_t len, size_t* pos, uint32_t* field, uint32_t* wire, uint64_t* val, const unsigned char** bytes, size_t* blen) {
+  if (*pos >= len) return false;
+  uint64_t tag; if (!t12_pb_varint(buf, len, pos, &tag)) return false;
+  *field = (uint32_t)(tag >> 3); *wire = (uint32_t)(tag & 7);
+  if (*wire == 0) return t12_pb_varint(buf, len, pos, val);
+  if (*wire == 2) { uint64_t l; if (!t12_pb_varint(buf, len, pos, &l)) return false; *bytes = buf + *pos; *blen = (size_t)l; *pos += (size_t)l; return true; }
+  return false;
+}
+typedef struct t12_buf_s { unsigned char* data; size_t len, cap; } t12_buf_t;
+static unsigned char t12_proto_buf[262144];
+static void t12_write(void* arg, const char* buf, size_t len) {
+  t12_buf_t* b = (t12_buf_t*)arg;
+  assert(b->len + len <= b->cap);
+  memcpy(b->data + b->len, buf, len); b->len += len;
+}
+static void test_proto_dump(void) {
+  enum { count = 200, size = 4096, max_strings = 64, max_mappings = 16 };
+  void* blocks[count];
+  assert(mi_prof_start_seeded(4096, 71));
+  for (size_t i = 0; i < count; i++) blocks[i] = mi_malloc(size);
+  mi_prof_stats_t_decl(stats);
+  assert(mi_prof_stats_get(&stats));
+
+  t12_buf_t out = { t12_proto_buf, 0, sizeof(t12_proto_buf) };
+  assert(mi_prof_dump_proto_writer(t12_write, &out));
+  assert(out.len > 0);
+
+  char strtab[max_strings][300]; size_t string_count = 0;
+  size_t mapping_filename_idx[max_mappings]; size_t mapping_count = 0;
+  size_t sample_type_count = 0, sample_count = 0;
+  unsigned long long inuse_sum = 0;
+  size_t pos = 0; uint32_t field, wire; uint64_t val; const unsigned char* bytes; size_t blen;
+  while (t12_pb_next(out.data, out.len, &pos, &field, &wire, &val, &bytes, &blen)) {
+    if (wire != 2) continue;  /* period/default_sample_type are top-level varints; not needed below. */
+    if (field == 1) sample_type_count++;
+    else if (field == 2) {
+      sample_count++;
+      size_t p2 = 0; uint32_t f2, w2; uint64_t v2; const unsigned char* b2; size_t bl2;
+      while (t12_pb_next(bytes, blen, &p2, &f2, &w2, &v2, &b2, &bl2)) {
+        if (f2 == 2 && w2 == 2) {  /* Sample.value: packed varints, no per-element tag. */
+          size_t p3 = 0; int idx = 0;
+          while (p3 < bl2) { uint64_t v; if (!t12_pb_varint(b2, bl2, &p3, &v)) break; if (idx == 2) inuse_sum += v; idx++; }
+        }
+      }
+    }
+    else if (field == 3 && mapping_count < max_mappings) {
+      size_t p2 = 0; uint32_t f2, w2; uint64_t v2; const unsigned char* b2; size_t bl2; size_t fname_idx = SIZE_MAX;
+      while (t12_pb_next(bytes, blen, &p2, &f2, &w2, &v2, &b2, &bl2)) if (f2 == 5 && w2 == 0) fname_idx = (size_t)v2;
+      mapping_filename_idx[mapping_count++] = fname_idx;
+    }
+    else if (field == 6 && string_count < max_strings) {
+      size_t n = (blen < sizeof(strtab[0]) - 1) ? blen : sizeof(strtab[0]) - 1;
+      memcpy(strtab[string_count], bytes, n); strtab[string_count][n] = 0; string_count++;
+    }
+  }
+
+  assert(sample_type_count >= 1);
+  assert(sample_count > 0);
+  /* mi_prof_dump_proto_writer pre-scales values with Go's protomem.go scaleHeapSample convention
+     (see the comment above that function in src/profile.c), it does not emit raw sampled counts.
+     With size==rate==4096 here the scale factor is 1/(1-exp(-1)) ~= 1.582, so the summed
+     inuse_objects across samples should land strictly between 1x and 2x the raw live_samples
+     count -- not exact, hence the 2x tolerance rather than an equality check. */
+  assert(inuse_sum >= (unsigned long long)stats.live_samples);
+  assert(inuse_sum <= (unsigned long long)stats.live_samples * 2);
+
+  bool found_module = false;
+  for (size_t i = 0; i < mapping_count; i++) {
+    size_t idx = mapping_filename_idx[i];
+    if (idx < string_count && strstr(strtab[idx], "mimalloc-test-profile") != NULL) found_module = true;
+  }
+  assert(found_module);
+
+  for (size_t i = 0; i < count; i++) mi_free(blocks[i]);
+  mi_prof_stop();
+}
+
+/* ---- T14-C: mi_prof_modules_visit ---------------------------------------------------------- */
+typedef struct t14_ctx_s { bool found; } t14_ctx_t;
+static bool t14_module_visitor(const mi_prof_module_info_t* info, void* arg) {
+  t14_ctx_t* ctx = (t14_ctx_t*)arg;
+  if (strstr(info->path, "mimalloc-test-profile") != NULL) ctx->found = true;
+  return true;
+}
+static bool t14_guard_visitor(const mi_prof_sample_info_t* info, void* arg) {
+  (void)info; (void)arg;
+  t14_ctx_t modctx = { false };
+  const bool inner_ok = mi_prof_modules_visit(t14_module_visitor, &modctx);
+  assert(!inner_ok);  /* guard: mi_prof_modules_visit must fail fast from inside a mi_prof_visit callback. */
+  return true;
+}
+static void test_modules_visit(void) {
+  t14_ctx_t ctx = { false };
+  assert(mi_prof_modules_visit(t14_module_visitor, &ctx));
+  assert(ctx.found);
+
+  assert(mi_prof_start_seeded(4096, 79));
+  void* p = mi_malloc(65536); assert(p != NULL);  /* 64KiB at rate 4096 is always sampled (see test_visit_reentrancy). */
+  assert(mi_prof_visit(t14_guard_visitor, NULL));
+  mi_free(p);
+  mi_prof_stop();
+}
+
 int main(void) {
   enum { count = 1000, size = 512 };
   void* blocks[count];
@@ -227,6 +344,8 @@ int main(void) {
   test_visit_and_snapshot();
   test_stats_get();
   test_visit_reentrancy();
+  test_proto_dump();
+  test_modules_visit();
   if (getenv("MIMALLOC_PROF_DUMP_AT_EXIT") != NULL) {
     assert(mi_prof_start_seeded(1, 47));
     assert(mi_malloc(4096) != NULL);  /* Preserve one real sample for pprof validation. */


### PR DESCRIPTION
Implements #23 (M3): compact, externally-symbolizable profiles via the pprof `profile.proto` format, plus programmatic module-map access. Design settled in the issue; signatures were frozen there.

## What's in here

**C core (commits 1–2):**
- `mi_prof_dump_proto` / `mi_prof_dump_proto_writer` — hand-rolled minimal protobuf encoder (varint + length-delimited, no protobuf/zlib deps, uncompressed — pprof auto-detects). Collect happens via the M2 snapshot under the lock; encoding and the user write callback run after release, per the passive-core/writer-callback rules in #31.
- Value scaling matches Go's `runtime/pprof/protomem.go` exactly (verified from source, quoted in a comment): heap samples are pre-scaled with `scaleHeapSample` (1/(1−exp(−avg/rate))); `period_type=(space,bytes)`, `period=sample interval`, sample types `alloc_objects/alloc_space/inuse_objects/inuse_space`, `default_sample_type=inuse_space`. accum-off ⇒ alloc_* zero, same caveat as text.
- Locations are per-unique-PC with `Mapping` references (module path + base + limit) — address-only, no Function/Line tables: symbolization stays external by design.
- `mi_prof_modules_visit` — structured module enumeration (Windows: EnumProcessModulesEx; macOS: dyld; Linux: /proc/self/maps parser merging contiguous same-file VMAs). The legacy `MAPPED_LIBRARIES` text emitter is byte-for-byte untouched.
- Self-contained `exp()` (range reduction + Taylor, ~1e-24 relative error in range) to avoid the first libm link dependency in `src/`.
- **Drive-by fix from the #33 OOM audit:** `_mi_prof_on_alloc` leaked the sample record when stack interning failed — after the 64k stack-table cap that was every sample, forever. Records now recycle to the freelist.
- Tests: T12 (mini protobuf decoder validates sample types, scaled totals vs `mi_prof_stats_get` bounds, and the test binary's Mapping entry), T14-C (modules visit + fail-fast from inside a visitor callback).

**Rust (commit 3):**
- `prof::dump_proto_to_vec()` / `dump_proto_file()`, `prof::modules() -> Vec<ModuleInfo>` (catch_unwind trampoline, paths copied during the callback). Tests t12_proto.rs (tag/wire sanity, proto < text size, `MIMALLOC_PROF_PROTO_PATH` CI hook) and t14_modules.rs (current_exe stem containment, MSVC+MinGW-robust).

**CI (commit 4):**
- cross.yml pprof gate extended: on the pprof-enabled targets, produce `heap.pb` via the t12 hook and require `pprof -raw` to parse it with heap sample types present (T13).

## Local validation
- ctest 7/7 green with `MI_PPROF=ON` (MinGW GCC + Ninja); `MI_PPROF=OFF` build + its 4/4 tests green (upstream equivalence).
- Rust suite fully green including the two new tests (soldr toolchain, MSVC via cc).
- **End-to-end pprof check:** produced a real `heap.pb` via the t12 hook; stock `pprof -raw` parsed it — sample types `alloc_objects/alloc_space/inuse_objects/inuse_space[dflt]`, sample rows, Locations, and Mappings including the test binary.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)
