### PR TITLE
fix: dropped-sample accounting, stats v2, self-describing proto dumps (closes #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ tooling (`pprof -http`, flamegraphs, `-base` diffs).
 - Byte-interval **allocation sampling** (tcmalloc-style, ~512 KiB default rate) with
   near-zero cost when disabled and bounded cost when enabled. Allocator-side design based on
   Datadog's draft [microsoft/mimalloc#1266](https://github.com/microsoft/mimalloc/pull/1266).
+  Profiler-internal memory (records, the stack intern table, dump buffers) is bounded and
+  never taken from the app's own allocations — see the Bounds table and failure policy in
+  `include/mimalloc/profile.h`'s top-of-file comment; under memory pressure samples are
+  dropped (counted in `mi_prof_stats_t.dropped_samples`), the app never fails an allocation
+  because of the profiler.
 - **Stack capture** per sample: `RtlCaptureStackBackTrace` on Windows, frame-pointer /
   libunwind on Linux and macOS.
 - **Heap profile dumps** in the gperftools `heap_v2` text format (accepted by pprof), with

--- a/include/mimalloc/profile.h
+++ b/include/mimalloc/profile.h
@@ -1,4 +1,23 @@
-/* Public, allocation-only sampling profiler API. */
+/* Public, allocation-only sampling profiler API.
+
+   ## Bounds (all profiler-internal memory; see rule 4 below)
+
+   | Vector | Bound | Worst case |
+   |---|---|---|
+   | Live sample records (~48-64 B, freelist-recycled) | live_heap / sample_interval | 10 GiB heap @ 512 KiB -> ~20k records ~= 1 MiB |
+   | Intern table entries (hdr + 8 B/frame, purge-at-zero) | hard cap MI_PROF_STACK_CAP = 65536 | ~20-25 MiB at cap with deep stacks; normally = live unique stacks |
+   | Accum mode | pins entries until mi_prof_reset | same cap; documented cost of accum |
+   | Arena chunks | high-water retention (never shrinks until mi_prof_stop) | by design; superseded rehash arrays <= 2x final table size |
+   | Snapshots / dump buffers / proto scratch | transient _mi_os_alloc, freed per call; failure -> NULL/false | graceful |
+
+   ## Failure policy: the app never pays
+
+   When the raw-OS-layer arena refuses memory in the sampling path, the sample is dropped
+   and the application's allocation succeeds normally. Profiling degrades; the app does not.
+   Same policy as Go/tcmalloc. Every drop cause (record-alloc failure, stack-intern failure,
+   including the MI_PROF_STACK_CAP cap) is counted in mi_prof_stats_t.dropped_samples (v2);
+   cap overflows are additionally broken out in stack_table_overflows, so
+   dropped_samples >= stack_table_overflows always. */
 #pragma once
 #ifndef MIMALLOC_PROFILE_H
 #define MIMALLOC_PROFILE_H
@@ -69,7 +88,7 @@ mi_decl_nodiscard mi_decl_export bool mi_prof_dump_proto(const char* path) mi_at
 mi_decl_nodiscard mi_decl_export bool mi_prof_dump_proto_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept;
 mi_decl_export void mi_prof_reset(void) mi_attr_noexcept;
 
-#define MI_PROF_STAT_VERSION 1
+#define MI_PROF_STAT_VERSION 2
 typedef struct mi_prof_stats_s {
   size_t size; int version;
   bool   enabled; bool accum;
@@ -79,6 +98,14 @@ typedef struct mi_prof_stats_s {
   size_t unique_stacks;
   size_t arena_committed;
   size_t stack_table_overflows;
+  /* v2. Count of ALL dropped samples: record-alloc failure, stack-intern failure
+     (capture failure, arena-alloc failure inside intern, or the intern table hitting
+     MI_PROF_STACK_CAP -- the latter is a subset also counted separately above in
+     stack_table_overflows, so dropped_samples >= stack_table_overflows always).
+     mi_prof_stats_get accepts a v1-sized struct (size == offsetof(mi_prof_stats_t,
+     dropped_samples), version == 1) for old callers; this field is left untouched
+     in that case. */
+  size_t dropped_samples;
 } mi_prof_stats_t;
 #define mi_prof_stats_t_decl(name) mi_prof_stats_t name = { 0 }; name.size = sizeof(mi_prof_stats_t); name.version = MI_PROF_STAT_VERSION
 mi_decl_nodiscard mi_decl_export bool mi_prof_stats_get(mi_prof_stats_t* stats) mi_attr_noexcept;

--- a/rust/libmimalloc-pprof-sys/src/lib.rs
+++ b/rust/libmimalloc-pprof-sys/src/lib.rs
@@ -7,7 +7,7 @@ use core::ffi::c_void;
 pub type MiProfWriteFun = unsafe extern "C" fn(*mut c_void, *const c_char, usize);
 
 /// Mirrors `MI_PROF_STAT_VERSION` in `include/mimalloc/profile.h`.
-pub const MI_PROF_STAT_VERSION: c_int = 1;
+pub const MI_PROF_STAT_VERSION: c_int = 2;
 
 /// Mirrors `mi_prof_stats_t` (include/mimalloc/profile.h) field-for-field.
 #[repr(C)]
@@ -25,6 +25,11 @@ pub struct mi_prof_stats_t {
     pub unique_stacks: usize,
     pub arena_committed: usize,
     pub stack_table_overflows: usize,
+    /// v2. Mirrors `mi_prof_stats_t.dropped_samples`: count of ALL dropped
+    /// samples (record-alloc failure, stack-intern failure, including the
+    /// `MI_PROF_STACK_CAP` cap); `stack_table_overflows` is a subset, so
+    /// `dropped_samples >= stack_table_overflows` always.
+    pub dropped_samples: usize,
 }
 
 /// Mirrors `MI_PROF_CONFIG_VERSION` in `include/mimalloc/profile.h`.

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -299,6 +299,11 @@ pub mod prof {
         pub unique_stacks: usize,
         pub arena_committed: usize,
         pub stack_table_overflows: usize,
+        /// Count of ALL dropped samples (record-alloc failure, stack-intern
+        /// failure, including the stack-table cap); a superset of
+        /// `stack_table_overflows`, so `dropped_samples >=
+        /// stack_table_overflows` always.
+        pub dropped_samples: usize,
     }
 
     /// Read the profiler's current counters via `mi_prof_stats_get`.
@@ -322,6 +327,7 @@ pub mod prof {
                 unique_stacks: raw.unique_stacks,
                 arena_committed: raw.arena_committed,
                 stack_table_overflows: raw.stack_table_overflows,
+                dropped_samples: raw.dropped_samples,
             }
         } else {
             ProfStats::default()

--- a/rust/mimalloc-pprof/tests/t9_stats.rs
+++ b/rust/mimalloc-pprof/tests/t9_stats.rs
@@ -7,6 +7,7 @@ fn stats_track_start_alloc_drop_stop_lifecycle() {
     // never fires and the profiler starts out disabled.
     let before = prof::stats();
     assert!(!before.enabled);
+    assert_eq!(before.dropped_samples, 0);
 
     common::start(4096, 101);
     let after_start = prof::stats();
@@ -16,6 +17,7 @@ fn stats_track_start_alloc_drop_stop_lifecycle() {
     let blocks: Vec<_> = (0..200).map(|_| vec![0_u8; 4096]).collect();
     let after_alloc = prof::stats();
     assert!(after_alloc.live_samples > 0);
+    assert!(after_alloc.dropped_samples >= after_alloc.stack_table_overflows);
 
     drop(blocks);
     let after_drop = prof::stats();

--- a/src/profile.c
+++ b/src/profile.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <stddef.h>
 
 #if MI_PPROF
 
@@ -43,6 +44,11 @@ static _Atomic(size_t) prof_bytes;
 static _Atomic(size_t) prof_accum_records;
 static _Atomic(size_t) prof_accum_bytes;
 static _Atomic(size_t) prof_arena_committed;
+/* All dropped-sample causes (record-alloc failure, stack-intern failure -- capture
+   failure, arena-alloc failure, or the MI_PROF_STACK_CAP cap already tracked
+   separately by _mi_prof_stack_overflows()). See profile.h's Bounds/failure-policy
+   comment and mi_prof_stats_t.dropped_samples. */
+static _Atomic(size_t) prof_dropped_samples;
 static size_t prof_rate = 524288;
 static uint64_t prof_seed;
 static uint64_t prof_generation;
@@ -330,7 +336,15 @@ bool mi_prof_start_ex(const mi_prof_config_t* config) mi_attr_noexcept {
 
 bool mi_prof_is_enabled(void) mi_attr_noexcept { return mi_atomic_load_relaxed(&prof_enabled); }
 bool mi_prof_stats_get(mi_prof_stats_t* stats) mi_attr_noexcept {
-  if (stats == NULL || stats->size != sizeof(mi_prof_stats_t) || stats->version != MI_PROF_STAT_VERSION) return false;
+  if (stats == NULL) return false;
+  /* v2 callers (current mi_prof_stats_t_decl) pass the full struct/version 2; v1 callers
+     (built against the pre-dropped_samples header) pass the struct truncated right before
+     dropped_samples and version 1 -- accept both, reject anything else. Writing into
+     dropped_samples for a v1-sized struct would be an out-of-bounds write, so that field
+     is only touched in the v2 branch. */
+  const bool is_v2 = (stats->size == sizeof(mi_prof_stats_t) && stats->version == 2);
+  const bool is_v1 = (stats->size == offsetof(mi_prof_stats_t, dropped_samples) && stats->version == 1);
+  if (!is_v2 && !is_v1) return false;
   stats->enabled = mi_atomic_load_relaxed(&prof_enabled);
   stats->accum = mi_option_is_enabled(mi_option_prof_accum);
   stats->sample_rate = prof_rate;
@@ -341,6 +355,7 @@ bool mi_prof_stats_get(mi_prof_stats_t* stats) mi_attr_noexcept {
   stats->unique_stacks = _mi_prof_stack_count();
   stats->arena_committed = _mi_prof_arena_committed();
   stats->stack_table_overflows = _mi_prof_stack_overflows();
+  if (is_v2) stats->dropped_samples = mi_atomic_load_relaxed(&prof_dropped_samples);
   return true;
 }
 void mi_prof_debug_stats(size_t* records, size_t* bytes, size_t* unique_stacks) mi_attr_noexcept { mi_prof_stats_t_decl(stats); const bool ok = mi_prof_stats_get(&stats); MI_UNUSED(ok); if (records) *records=stats.live_samples; if (bytes) *bytes=stats.live_bytes; if (unique_stacks) *unique_stacks=stats.unique_stacks; }
@@ -356,6 +371,7 @@ void mi_prof_stop(void) mi_attr_noexcept {
   mi_atomic_store_relaxed(&prof_records, (size_t)0); mi_atomic_store_relaxed(&prof_bytes, (size_t)0);
   mi_atomic_store_relaxed(&prof_accum_records, (size_t)0); mi_atomic_store_relaxed(&prof_accum_bytes, (size_t)0);
   mi_atomic_store_relaxed(&prof_arena_committed, (size_t)0);
+  mi_atomic_store_relaxed(&prof_dropped_samples, (size_t)0);
   mi_lock_release(&prof_lock);
 }
 bool mi_prof_dump_writer(mi_prof_write_fun* write, void* arg) mi_attr_noexcept {
@@ -680,6 +696,22 @@ bool mi_prof_dump_proto_writer(mi_prof_write_fun* write, void* arg) mi_attr_noex
   for (size_t i = 0; ok && i < PB_STR_FIXED_COUNT; i++) ok = pb_emit_bytes_field(&out, 6, prof_proto_fixed_strings[i], strlen(prof_proto_fixed_strings[i]));
   for (size_t i = 0; ok && i < module_count; i++) ok = pb_emit_bytes_field(&out, 6, modules[i].path, strlen(modules[i].path));
 
+  /* Self-describing validity signal (issue #33 finding #3): a shipped profile discloses its
+     own sampling bias without a separate mi_prof_stats_get call. Read the atomics directly
+     without prof_lock -- this function doesn't hold the lock across its body (see
+     mi_prof_snapshot_new above), same as the unguarded prof_rate read a few lines below. */
+  const size_t comment_str_idx = PB_STR_FIXED_COUNT + module_count;
+  if (ok) {
+    char comment_buf[128];
+    const unsigned long long dropped = (unsigned long long)mi_atomic_load_relaxed(&prof_dropped_samples);
+    const unsigned long long overflows = (unsigned long long)_mi_prof_stack_overflows();
+    int clen = _mi_snprintf(comment_buf, sizeof(comment_buf), "dropped_samples=%llu stack_table_overflows=%llu", dropped, overflows);
+    if (clen < 0) clen = 0;
+    if ((size_t)clen >= sizeof(comment_buf)) clen = (int)sizeof(comment_buf) - 1;
+    ok = pb_emit_bytes_field(&out, 6, comment_buf, (size_t)clen);
+  }
+  if (ok) { uint8_t packed[10]; size_t pn = pb_varint(packed, (uint64_t)comment_str_idx); ok = pb_emit_bytes_field(&out, 13, packed, pn); } // comment: packed repeated int64 of string_table indices (one entry).
+
   ok = ok && pb_emit_valuetype(&out, 11, PB_STR_SPACE, PB_STR_BYTES);              // period_type: space/bytes.
   ok = ok && pb_emit_varint_field(&out, 12, (uint64_t)prof_rate);                  // period: the configured sample rate.
   ok = ok && pb_emit_varint_field(&out, 14, (uint64_t)PB_STR_INUSE_SPACE);         // default_sample_type: inuse_space.
@@ -740,8 +772,9 @@ void _mi_prof_on_alloc(mi_heap_t* heap, mi_page_t* page, void* p, size_t size) {
       mi_atomic_increment_relaxed(&prof_records); mi_atomic_add_relaxed(&prof_bytes, size);
       if (mi_option_is_enabled(mi_option_prof_accum)) { mi_atomic_increment_relaxed(&prof_accum_records); mi_atomic_add_relaxed(&prof_accum_bytes, size); }
     }
-    else { rec->next = prof_free; prof_free = rec; }  /* dropped sample: recycle the record or every post-overflow sample leaks arena memory */
+    else { rec->next = prof_free; prof_free = rec; mi_atomic_increment_relaxed(&prof_dropped_samples); }  /* dropped sample: recycle the record or every post-overflow sample leaks arena memory */
   }
+  else { mi_atomic_increment_relaxed(&prof_dropped_samples); }  /* dropped sample: record-alloc itself failed (budget/arena exhausted). */
   mi_lock_release(&prof_lock);
 }
 static void prof_free_collect(mi_page_t* page, mi_block_t* head) { for (mi_block_t* b=head; b != NULL && page->has_metadata; b=mi_block_next(page,b)) prof_free_record(page,b); }

--- a/test/test-profile.c
+++ b/test/test-profile.c
@@ -197,8 +197,15 @@ static void test_proto_dump(void) {
   size_t mapping_filename_idx[max_mappings]; size_t mapping_count = 0;
   size_t sample_type_count = 0, sample_count = 0;
   unsigned long long inuse_sum = 0;
+  size_t comment_str_idx = SIZE_MAX; bool have_comment = false;
   size_t pos = 0; uint32_t field, wire; uint64_t val; const unsigned char* bytes; size_t blen;
   while (t12_pb_next(out.data, out.len, &pos, &field, &wire, &val, &bytes, &blen)) {
+    if (field == 13 && wire == 2) {
+      /* comment: packed repeated int64 of string_table indices (we only ever emit one). */
+      size_t p3 = 0; uint64_t v;
+      if (t12_pb_varint(bytes, blen, &p3, &v)) { comment_str_idx = (size_t)v; have_comment = true; }
+      continue;
+    }
     if (wire != 2) continue;  /* period/default_sample_type are top-level varints; not needed below. */
     if (field == 1) sample_type_count++;
     else if (field == 2) {
@@ -238,6 +245,17 @@ static void test_proto_dump(void) {
     if (idx < string_count && strstr(strtab[idx], "mimalloc-test-profile") != NULL) found_module = true;
   }
   assert(found_module);
+
+  /* field 13 (comment): self-describing validity signal, issue #33 finding #3. */
+  assert(have_comment);
+  assert(comment_str_idx < string_count);
+  const char* comment = strtab[comment_str_idx];
+  assert(strstr(comment, "dropped_samples=") != NULL);
+  assert(strstr(comment, "stack_table_overflows=") != NULL);
+  unsigned long long comment_dropped = 0, comment_overflows = 0;
+  assert(sscanf(comment, "dropped_samples=%llu stack_table_overflows=%llu", &comment_dropped, &comment_overflows) == 2);
+  assert(comment_dropped == (unsigned long long)stats.dropped_samples);
+  assert(comment_overflows == (unsigned long long)stats.stack_table_overflows);
 
   for (size_t i = 0; i < count; i++) mi_free(blocks[i]);
   mi_prof_stop();
@@ -377,6 +395,119 @@ static void test_start_ex_max_bytes(void) {
   mi_prof_stop();
 }
 
+/* ---- T16: dropped_samples / mi_prof_stats_t v2 --------------------------------------------
+   Issue #33: dropped_samples must count ALL drop causes (record-alloc failure AND
+   stack-intern failure), not just the MI_PROF_STACK_CAP overflow already tracked by
+   stack_table_overflows. MI_PROF_STACK_CAP (65536, src/profile-stack.c) has no test-only
+   override, and forcing the real 65536-entry cap in a unit test is impractical (that many
+   distinct call stacks would dominate test time/memory for no extra coverage). Instead this
+   drives drops via the already-implemented max_profiler_bytes budget (#32) with a tiny
+   budget and sample_interval=1: distinct allocation sites and sizes force both record-alloc
+   failures (budget exhausted) and intern-alloc failures (new stack, budget exhausted), which
+   is the same code path stack_table_overflows normally guards -- just reached through the
+   byte budget instead of the entry-count cap. This is a pragmatic substitution for the
+   literal cap test; it still exercises both NULL-return branches in _mi_prof_on_alloc. */
+static void* volatile t16_sink;  /* volatile: defeat any dead-store elimination of the recursive-site trick below. */
+#define T16_ALLOC_SITE(n) static void t16_alloc_site_##n(size_t sz) { t16_sink = mi_malloc(sz); }
+T16_ALLOC_SITE(0) T16_ALLOC_SITE(1) T16_ALLOC_SITE(2) T16_ALLOC_SITE(3) T16_ALLOC_SITE(4)
+T16_ALLOC_SITE(5) T16_ALLOC_SITE(6) T16_ALLOC_SITE(7) T16_ALLOC_SITE(8) T16_ALLOC_SITE(9)
+T16_ALLOC_SITE(10) T16_ALLOC_SITE(11) T16_ALLOC_SITE(12) T16_ALLOC_SITE(13) T16_ALLOC_SITE(14)
+T16_ALLOC_SITE(15)
+typedef void (*t16_site_fn)(size_t);
+static const t16_site_fn t16_sites[16] = {
+  t16_alloc_site_0, t16_alloc_site_1, t16_alloc_site_2, t16_alloc_site_3,
+  t16_alloc_site_4, t16_alloc_site_5, t16_alloc_site_6, t16_alloc_site_7,
+  t16_alloc_site_8, t16_alloc_site_9, t16_alloc_site_10, t16_alloc_site_11,
+  t16_alloc_site_12, t16_alloc_site_13, t16_alloc_site_14, t16_alloc_site_15,
+};
+
+static void test_dropped_samples_and_stats_v2(void) {
+  mi_prof_config_t_decl(cfg);
+  cfg.sample_interval = 1;                 /* sample (almost) every allocation. */
+  cfg.max_profiler_bytes = 64 * 1024;      /* one chunk: exhausts fast under varied stacks. */
+  assert(mi_prof_start_ex(&cfg));
+
+  enum { rounds = 4000 };
+  for (size_t i = 0; i < rounds; i++) {
+    t16_sites[i % 16]((i % 8 + 1) * 16);  /* vary call site AND size to force many distinct stacks. */
+  }
+
+  mi_prof_stats_t_decl(stats);
+  assert(mi_prof_stats_get(&stats));
+  assert(stats.dropped_samples > 0);                          /* budget forced drops. */
+  assert(stats.dropped_samples >= stats.stack_table_overflows);/* cap overflows are a subset of all drops. */
+  assert(stats.arena_committed <= cfg.max_profiler_bytes);     /* budget honored. */
+
+  /* Re-run the same workload: arena_committed must stay bounded/stable, proving the PR #34
+     record-recycle fix holds under repeated post-budget drops (no unbounded leak growth). */
+  const size_t committed_before = stats.arena_committed;
+  for (size_t i = 0; i < rounds; i++) {
+    t16_sites[i % 16]((i % 8 + 1) * 16);
+  }
+  mi_prof_stats_t_decl(stats2);
+  assert(mi_prof_stats_get(&stats2));
+  assert(stats2.dropped_samples > stats.dropped_samples);      /* more drops accumulated. */
+  assert(stats2.arena_committed <= cfg.max_profiler_bytes);
+  assert(stats2.arena_committed <= committed_before + 64 * 1024);  /* at most a little headroom, not unbounded growth. */
+
+  mi_prof_stop();
+}
+
+/* T16b: a v1-sized mi_prof_stats_t (size == offsetof(dropped_samples), version == 1) must
+   still succeed and populate every pre-v2 field; dropped_samples itself must be left
+   untouched (still 0 from the enum-brace zero-init) rather than written past the "v1 bound". */
+static void test_stats_v1_compat(void) {
+  typedef struct { size_t size; int version; bool enabled; bool accum; size_t sample_rate;
+    size_t live_samples; size_t live_bytes; size_t accum_samples; size_t accum_bytes;
+    size_t unique_stacks; size_t arena_committed; size_t stack_table_overflows; } t16_stats_v1_t;
+  /* Layout must mirror mi_prof_stats_t's pre-v2 prefix exactly (same field order/types). */
+  assert(offsetof(t16_stats_v1_t, stack_table_overflows) + sizeof(size_t) == offsetof(mi_prof_stats_t, dropped_samples));
+
+  assert(mi_prof_start_seeded(4096, 89));
+  enum { count = 64, size = 4096 };
+  void* blocks[count];
+  for (size_t i = 0; i < count; i++) blocks[i] = mi_malloc(size);
+
+  mi_prof_stats_t full;
+  memset(&full, 0xAB, sizeof(full));  /* poison, so an accidental v2 write into dropped_samples would be visible. */
+  full.size = offsetof(mi_prof_stats_t, dropped_samples);
+  full.version = 1;
+  assert(mi_prof_stats_get(&full));
+  assert(full.enabled);
+  assert(full.sample_rate == 4096);
+  assert(full.live_samples > 0);
+  assert(full.live_bytes >= full.live_samples * size);
+  assert(full.unique_stacks > 0);
+  /* dropped_samples lives past the v1 struct's declared size; the implementation must not
+     have written there. It stays poisoned. */
+  unsigned char* poison_bytes = (unsigned char*)&full.dropped_samples;
+  bool still_poisoned = true;
+  for (size_t i = 0; i < sizeof(full.dropped_samples); i++) if (poison_bytes[i] != 0xAB) still_poisoned = false;
+  assert(still_poisoned);
+
+  for (size_t i = 0; i < count; i++) mi_free(blocks[i]);
+  mi_prof_stop();
+}
+
+/* T16c: the full v2 struct correctly reports dropped_samples for a fresh, non-budgeted
+   session (no drops expected -- proves v2 doesn't spuriously report drops). */
+static void test_stats_v2_full(void) {
+  assert(mi_prof_start_seeded(4096, 97));
+  enum { count = 64, size = 4096 };
+  void* blocks[count];
+  for (size_t i = 0; i < count; i++) blocks[i] = mi_malloc(size);
+
+  mi_prof_stats_t_decl(stats);
+  assert(stats.version == 2);
+  assert(stats.size == sizeof(mi_prof_stats_t));
+  assert(mi_prof_stats_get(&stats));
+  assert(stats.dropped_samples == 0);  /* unbudgeted session: nothing should have been dropped. */
+  assert(stats.dropped_samples >= stats.stack_table_overflows);
+
+  for (size_t i = 0; i < count; i++) mi_free(blocks[i]);
+  mi_prof_stop();
+}
+
 int main(void) {
   enum { count = 1000, size = 512 };
   void* blocks[count];
@@ -459,6 +590,9 @@ int main(void) {
   test_start_ex_fallback();
   test_start_ex_bad_version();
   test_start_ex_max_bytes();
+  test_dropped_samples_and_stats_v2();
+  test_stats_v1_compat();
+  test_stats_v2_full();
   if (getenv("MIMALLOC_PROF_DUMP_AT_EXIT") != NULL) {
     assert(mi_prof_start_seeded(1, 47));
     assert(mi_malloc(4096) != NULL);  /* Preserve one real sample for pprof validation. */


### PR DESCRIPTION
## Summary
- `mi_prof_stats_t` v2: adds `dropped_samples`, counting ALL sample-drop causes (record-alloc failure, stack-intern failure -- including but not limited to the stack-cap overflow already tracked separately by `stack_table_overflows`, so `dropped_samples >= stack_table_overflows` always). Appended ABI-additively (no reordering); `mi_prof_stats_get` accepts a size/version-tagged v1 struct for old callers and leaves the new field untouched in that case.
- Proto dumps (`mi_prof_dump_proto`/`_writer`) now write both counters into the pprof `Profile.comment` field (13), so a shipped profile discloses its own sampling bias without a separate stats call.
- Documents the profiler's memory bounds and "the app never pays" failure policy (audit results from #33) in `profile.h`'s header comment and the README.
- Rust: `ProfStats`/`mi_prof_stats_t` sys mirror gets the same `dropped_samples` field (no v1-compat concern on the Rust side -- the sys crate always builds against the in-tree C header it links).

## Test plan
- [x] T16: forces drops via the `max_profiler_bytes` budget (#32) across varied call sites/sizes -- `MI_PROF_STACK_CAP` (65536) has no test-only override, so the literal cap is impractical to hit in a unit test; the budget path exercises the same two `_mi_prof_on_alloc` NULL-return branches. Confirms `dropped_samples > 0`, `dropped_samples >= stack_table_overflows`, and `arena_committed` stays bounded across repeated post-budget rounds (proving PR #34's record-recycle fix holds under sustained drops).
- [x] T16b/T16c: v1-sized/versioned struct leaves `dropped_samples` untouched (poison-byte check); full v2 struct reports `dropped_samples == 0` on an unbudgeted session.
- [x] T12 extended to decode proto field 13 and cross-check the comment string against `mi_prof_stats_get`.
- [x] `MI_PPROF=ON` local build + ctest: all green (MinGW-w64 GCC and MSVC across two passes).
- [x] `MI_PPROF=OFF` local build: clean.
- [x] Rust build/test/clippy (`-D warnings`)/fmt (touched files only): all green.
- [x] Proxy validation of the new proto `comment` field: dumped a real proto profile and decoded it against the actual upstream `google/pprof` `profile.proto` schema (protoc) -- parsed cleanly, `comment` decoded as `"dropped_samples=N stack_table_overflows=M"`. The Go `pprof` binary itself wasn't installable in this sandbox; CI's pprof-validation gate is the authoritative final check.
- [ ] CI: full matrix, especially the pprof proto-validation gate exercising the new comment field for real.

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
