### PR TITLE
feat: opt-in memory-change accounting + unwrapped allocator (closes #20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(mi_sources
     src/heap.c
     src/init.c
     src/libc.c
+    src/memory-events.c
     src/options.c
     src/os.c
     src/page.c
@@ -695,6 +696,7 @@ install(FILES include/mimalloc-override.h DESTINATION ${mi_install_incdir})
 install(FILES include/mimalloc-new-delete.h DESTINATION ${mi_install_incdir})
 install(FILES include/mimalloc-stats.h DESTINATION ${mi_install_incdir})
 install(FILES include/mimalloc/profile.h DESTINATION ${mi_install_incdir})
+install(FILES include/mimalloc/memory-events.h DESTINATION ${mi_install_incdir})
 install(FILES cmake/mimalloc-config.cmake DESTINATION ${mi_install_cmakedir})
 install(FILES cmake/mimalloc-config-version.cmake DESTINATION ${mi_install_cmakedir})
 
@@ -787,6 +789,16 @@ if (MI_BUILD_TESTS)
     add_test(NAME test-profile-auto COMMAND mimalloc-test-profile)
     set_tests_properties(test-profile-auto PROPERTIES ENVIRONMENT "MIMALLOC_PROF=1")
   endif()
+
+  # memory-events (issue #20): independent of MI_PPROF, always built/registered.
+  add_executable(mimalloc-test-memory-events test/test-memory-events.c)
+  target_compile_definitions(mimalloc-test-memory-events PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-test-memory-events PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-memory-events PRIVATE include)
+  target_link_libraries(mimalloc-test-memory-events PRIVATE mimalloc-static ${mi_libraries})
+  add_test(NAME test-memory-events COMMAND mimalloc-test-memory-events)
+  add_test(NAME test-memory-events-env-enabled COMMAND mimalloc-test-memory-events --env-enabled-check)
+  set_tests_properties(test-memory-events-env-enabled PROPERTIES ENVIRONMENT "MIMALLOC_MEMORY_EVENTS=1")
 
   # dynamic override test
   if(MI_BUILD_SHARED AND NOT (MI_TRACK_ASAN OR MI_DEBUG_TSAN OR MI_DEBUG_UBSAN) AND NOT (APPLE AND MI_USE_CXX))

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -437,6 +437,7 @@ typedef enum mi_option_e {
   mi_option_prof_accum,
   mi_option_prof_seed,
   mi_option_prof_max_bytes,             // budget (in bytes) for profiler-internal arena memory; 0 = unbudgeted (=0)
+  mi_option_memory_events,              // enable opt-in allocation-change accounting/callbacks (MIMALLOC_MEMORY_EVENTS) (=0)
   _mi_option_last,
   // legacy option names
   mi_option_large_os_pages = mi_option_allow_large_os_pages,
@@ -512,6 +513,7 @@ mi_decl_nodiscard mi_decl_export mi_decl_restrict void* mi_heap_alloc_new_n(mi_h
 #endif
 
 #include "mimalloc/profile.h"
+#include "mimalloc/memory-events.h"
 
 // ---------------------------------------------------------------------------------------------
 // Implement the C++ std::allocator interface for use in STL containers.

--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -320,6 +320,34 @@ void        _mi_prof_process_done(void);
 }
 #endif
 #endif
+
+// "memory-events.c" -- opt-in allocation-change accounting/callbacks. Independent of
+// MI_PPROF (always declared/defined). Hook sites: alloc.c (successful allocate and
+// in-place realloc), free.c (successful local free and remote/mt free), and the moving
+// realloc path in alloc.c's _mi_heap_realloc_zero (which suppresses the internal
+// allocate+free pair via _mi_memevt_suppress_begin/end and instead synthesizes exactly
+// one RESIZE via _mi_memevt_on_resize). Every hook itself performs the single
+// disabled-hot-path flag check (mi_memory_events.h's "Activation" contract); callers do
+// not need to guard the call site.
+#ifdef __cplusplus
+extern "C" {
+#endif
+void        _mi_memevt_on_alloc(mi_page_t* page, void* p, size_t request_size);
+void        _mi_memevt_on_free(mi_page_t* page, void* p);
+void        _mi_memevt_on_realloc_in_place(mi_page_t* page, void* p, size_t request_size);
+// Called after _mi_memevt_suppress_end, with suppression already lifted, to emit the
+// single synthesized RESIZE event for a moving realloc.
+void        _mi_memevt_on_resize(size_t usable_pre, size_t usable_post, size_t request_size);
+// Reentrancy/internal-op suppression (thread-local depth counter): while suppressed,
+// hooks above perform no accounting and no dispatch. Used around the internal
+// mi_heap_umalloc+mi_free pair inside a moving realloc so it does not leak an
+// ALLOCATE/FREE pair to consumers.
+void        _mi_memevt_suppress_begin(void);
+void        _mi_memevt_suppress_end(void);
+#ifdef __cplusplus
+}
+#endif
+
 void*       _mi_heap_malloc_zero(mi_heap_t* heap, size_t size, bool zero) mi_attr_noexcept;
 void*       _mi_heap_malloc_zero_ex(mi_heap_t* heap, size_t size, bool zero, size_t huge_alignment, size_t* usable) mi_attr_noexcept;     // called from `_mi_heap_malloc_aligned`
 void*       _mi_heap_realloc_zero(mi_heap_t* heap, void* p, size_t newsize, bool zero, size_t* usable_pre, size_t* usable_post) mi_attr_noexcept;

--- a/include/mimalloc/memory-events.h
+++ b/include/mimalloc/memory-events.h
@@ -1,0 +1,141 @@
+/* Public, allocation-change accounting/monitoring API. Independent of MI_PPROF: this
+   module (src/memory-events.c) is always compiled in, opt-in only via the
+   `MIMALLOC_MEMORY_EVENTS` environment variable or the `mi_memory_tracking_set_enabled`
+   API below.
+
+   ## Activation
+
+   - `MIMALLOC_MEMORY_EVENTS=1` is read lazily, exactly once, the first time any
+     allocation/free/realloc hook runs -- never during process startup. The result is
+     cached; later allocator operations never re-read the environment.
+   - `mi_memory_tracking_set_enabled` can also enable/disable tracking at any time,
+     including before the first allocation. An explicit API call is always authoritative:
+     if it runs before the first allocation, the later lazy environment read is skipped
+     entirely; if it runs after, it simply overrides the cached flag.
+   - Disabling tracking stops all accounting immediately. Re-enabling does NOT
+     reconstruct allocations made while tracking was disabled -- the running totals
+     silently omit that interval. Callers that need an exact total must enable tracking
+     before their first allocation and leave it enabled for the life of the process.
+   - When tracking is disabled (the default), every allocate/free/realloc pays for
+     exactly one relaxed flag check on the hot path -- no atomic accounting update, no
+     callback-table lock, no callback-table lookup.
+
+   ## Callback contract
+
+   - Callbacks are invoked with no mimalloc allocator locks held, and may themselves
+     call `mi_malloc`/`mi_free`/etc. without deadlocking (the callback-table lock is
+     acquired only to snapshot the handler pointer, then released before the handler
+     runs). Callbacks must still be short and non-blocking.
+   - A memory-change hook invoked while another hook's callback is already running on
+     the same thread (including as a side effect of that callback allocating/freeing)
+     is suppressed: no accounting update and no nested callback invocation. This bounds
+     stack depth and avoids double-counting/re-entrant surprises; it also means bytes
+     allocated or freed *from inside* a callback are not reflected in the running totals.
+   - `arg` pointers in `mi_memory_callbacks_t` are caller-owned: the caller must keep
+     them valid for as long as the callback might still be invoked (i.e. until a
+     subsequent `mi_memory_set_callbacks` call replaces/clears them, or tracking is
+     permanently torn down at process exit).
+*/
+#pragma once
+#ifndef MIMALLOC_MEMORY_EVENTS_H
+#define MIMALLOC_MEMORY_EVENTS_H
+
+#include "mimalloc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum mi_memory_change_kind_e {
+  MI_MEMORY_ALLOCATE,
+  MI_MEMORY_FREE,
+  MI_MEMORY_RESIZE,
+  MI_MEMORY_CHANGE_COUNT,
+} mi_memory_change_kind_t;
+
+typedef struct mi_memory_change_s {
+  // Successful allocation, free, or realloc.
+  mi_memory_change_kind_t kind;
+
+  // Tracked global live usable bytes after this operation.
+  uint64_t total_bytes;
+
+  // Signed change in tracked live usable bytes caused by this operation.
+  // Positive for allocation/growth; negative for free/shrink; zero for a
+  // same-size-class resize.
+  int64_t delta_bytes;
+
+  // Caller-requested size for allocation and resize; zero for free.
+  uint64_t request_size;
+} mi_memory_change_t;
+
+typedef void (mi_memory_change_fun)(
+  const mi_memory_change_t* change,
+  void* arg
+);
+
+typedef struct mi_memory_callbacks_s {
+  mi_memory_change_fun* handlers[MI_MEMORY_CHANGE_COUNT];
+  void*                 args[MI_MEMORY_CHANGE_COUNT];
+} mi_memory_callbacks_t;
+
+mi_decl_export bool mi_memory_tracking_set_enabled(bool enabled) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_memory_tracking_is_enabled(void) mi_attr_noexcept;
+
+// Installs, replaces, or (with callbacks == NULL) clears the callback table.
+// Safe to call at any time; synchronized against concurrent dispatch.
+mi_decl_export bool mi_memory_set_callbacks(const mi_memory_callbacks_t* callbacks) mi_attr_noexcept;
+
+// Versioned/sized struct, following this codebase's mi_prof_stats_t idiom, so future
+// fields can be added without breaking already-compiled callers (see
+// mi_memory_snapshot_t_decl below). All counters are maintained only while tracking is
+// enabled: they are not reconstructed for time spent disabled.
+#define MI_MEMORY_SNAPSHOT_VERSION 1
+typedef struct mi_memory_snapshot_s {
+  size_t   size; int version;
+  uint64_t live_bytes;         // tracked live usable bytes right now
+  uint64_t accum_bytes;        // cumulative usable bytes ever allocated (grows on ALLOCATE and on growing RESIZE)
+  uint64_t live_count;         // tracked live allocation count right now
+  uint64_t accum_count;        // cumulative count of successful ALLOCATE events
+} mi_memory_snapshot_t;
+#define mi_memory_snapshot_t_decl(name) mi_memory_snapshot_t name = { 0 }; name.size = sizeof(mi_memory_snapshot_t); name.version = MI_MEMORY_SNAPSHOT_VERSION
+
+mi_decl_nodiscard mi_decl_export bool mi_memory_snapshot(mi_memory_snapshot_t* out) mi_attr_noexcept;
+
+/* ---------------------------------------------------------------------------------------------
+   Best-effort live-allocation visitor (diagnostics only; not a consistent global snapshot).
+   Built on top of this codebase's existing per-heap block-visitation facility
+   (mi_heap_visit_blocks); see memory-events.c for the exact scope this walks. */
+
+// Return false to stop the visit early.
+typedef bool (mi_memory_allocation_visit_fun)(
+  void*  allocation,   // Address of a live allocation observed during the walk.
+  size_t usable_size,  // Its usable mimalloc size at the moment it was observed.
+  void*  arg           // Caller-owned visit context.
+);
+
+// Best effort, not a consistent global snapshot: another thread may free `allocation`
+// immediately after the callback begins. Do not dereference, retain, or free it. The
+// visitor must not allocate, free, or reenter mimalloc while the walk is active.
+mi_decl_export bool mi_memory_visit_live_allocations(
+  mi_memory_allocation_visit_fun* visitor,
+  void* arg
+) mi_attr_noexcept;
+
+/* ---------------------------------------------------------------------------------------------
+   Stable public "unwrapped" instrumentation allocation path: backed directly by the raw
+   OS layer (_mi_os_alloc / _mi_os_free), never by the hooked mi_malloc family. Page
+   granular. Pointers returned here are only valid for mi_unwrapped_free/realloc -- never
+   pass them to mi_free or vice versa. Excluded from normal mimalloc allocation stats and
+   from the memory-change accounting above. Intended for low-level instrumentation and
+   recursion avoidance (e.g. a memory-change callback that needs scratch storage without
+   recursively entering mimalloc). */
+
+mi_decl_export void* mi_unwrapped_malloc(size_t size, size_t alignment) mi_attr_noexcept;
+mi_decl_export void  mi_unwrapped_free(void* p) mi_attr_noexcept;
+mi_decl_export void* mi_unwrapped_realloc(void* p, size_t new_size, size_t alignment) mi_attr_noexcept;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/rust/libmimalloc-pprof-sys/src/lib.rs
+++ b/rust/libmimalloc-pprof-sys/src/lib.rs
@@ -132,4 +132,14 @@ unsafe extern "C" {
     /// the sampled-allocation table. `info` (and `info->path`) are valid only for
     /// the duration of the callback.
     pub fn mi_prof_modules_visit(visitor: mi_prof_module_visit_fun, arg: *mut c_void) -> bool;
+
+    /// Mirrors `mi_unwrapped_malloc` (include/mimalloc/memory-events.h): backed
+    /// directly by the raw OS layer, never by the hooked `mi_malloc` family.
+    /// See that header's "Stable public unwrapped instrumentation allocation
+    /// path" comment for the full contract.
+    pub fn mi_unwrapped_malloc(size: usize, alignment: usize) -> *mut c_void;
+    /// Mirrors `mi_unwrapped_free` (include/mimalloc/memory-events.h).
+    pub fn mi_unwrapped_free(p: *mut c_void);
+    /// Mirrors `mi_unwrapped_realloc` (include/mimalloc/memory-events.h).
+    pub fn mi_unwrapped_realloc(p: *mut c_void, new_size: usize, alignment: usize) -> *mut c_void;
 }

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -40,6 +40,85 @@ unsafe impl GlobalAlloc for MiMalloc {
     }
 }
 
+/// Allocate `size` bytes from mimalloc's raw-OS-layer "unwrapped" path.
+///
+/// Thin wrapper around `mi_unwrapped_malloc` (include/mimalloc/memory-events.h):
+/// backed directly by `_mi_os_alloc_aligned`, never by the hooked `mi_malloc`
+/// family. Page granular, so this is not meant for hot-path/small allocations
+/// — it exists for low-level instrumentation and recursion avoidance (e.g.
+/// scratch storage for a memory-change callback that must not recursively
+/// enter mimalloc). Excluded from normal mimalloc allocation stats and from
+/// the memory-change accounting.
+///
+/// Returns a null pointer on failure (including invalid `alignment`; see
+/// `# Safety` below).
+///
+/// # Safety
+///
+/// - `alignment` must be `0` (treated as `align_of::<*const ()>()`, i.e.
+///   pointer size) or a power of two. A non-power-of-two, non-zero alignment
+///   is a validated input on the C side: `mi_unwrapped_malloc` returns a null
+///   pointer rather than invoking undefined behavior, but callers should not
+///   rely on that as anything other than a defined-failure contract — treat
+///   the alignment argument as a precondition to get right, not a value to
+///   probe.
+/// - The returned pointer, if non-null, must be passed only to
+///   [`unwrapped_free`] or [`unwrapped_realloc`] — never to `mi_free`, this
+///   crate's [`MiMalloc`] allocator, or Rust's global allocator, and vice
+///   versa (a pointer from `mi_malloc`/the Rust global allocator must never
+///   be passed to [`unwrapped_free`]/[`unwrapped_realloc`]). Mixing these
+///   families corrupts allocator-internal bookkeeping.
+/// - The memory is uninitialized; reading it before writing is undefined
+///   behavior, as with any raw allocation.
+pub unsafe fn unwrapped_malloc(size: usize, alignment: usize) -> *mut u8 {
+    unsafe { sys::mi_unwrapped_malloc(size, alignment).cast() }
+}
+
+/// Free a pointer returned by [`unwrapped_malloc`] or [`unwrapped_realloc`].
+///
+/// Thin wrapper around `mi_unwrapped_free` (include/mimalloc/memory-events.h).
+///
+/// # Safety
+///
+/// - `p` must be either a null pointer (a documented, safe no-op on the C
+///   side) or a pointer previously returned by [`unwrapped_malloc`] or
+///   [`unwrapped_realloc`] that has not already been freed.
+/// - `p` must never have come from `mi_malloc`, this crate's [`MiMalloc`]
+///   allocator, or Rust's global allocator — passing such a pointer here is
+///   undefined behavior (the "unwrapped" and normal allocation families use
+///   incompatible header layouts and are validated by a magic-number check
+///   that a foreign pointer will not satisfy).
+pub unsafe fn unwrapped_free(p: *mut u8) {
+    unsafe { sys::mi_unwrapped_free(p.cast()) }
+}
+
+/// Resize a pointer returned by [`unwrapped_malloc`] or [`unwrapped_realloc`].
+///
+/// Thin wrapper around `mi_unwrapped_realloc` (include/mimalloc/memory-events.h).
+/// If `p` is null, this behaves like [`unwrapped_malloc`]. If `new_size` is
+/// `0`, this frees `p` (like [`unwrapped_free`]) and returns a null pointer.
+/// Otherwise the existing contents are copied into a freshly allocated
+/// unwrapped block (up to `min(old payload size, new_size)` bytes) and `p` is
+/// freed; `p` must not be used again after this call, whether or not it
+/// returns null.
+///
+/// Returns a null pointer on failure (including invalid `alignment`; see
+/// [`unwrapped_malloc`]'s `# Safety` section), in which case `p` is left
+/// valid and unfreed.
+///
+/// # Safety
+///
+/// - `p` must be either a null pointer or a pointer previously returned by
+///   [`unwrapped_malloc`] or [`unwrapped_realloc`] that has not already been
+///   freed, per the same family-isolation rule as [`unwrapped_free`].
+/// - `alignment` has the same power-of-two-or-zero contract as
+///   [`unwrapped_malloc`].
+/// - After this call, `p` must not be read, written, or freed again — treat
+///   it as consumed regardless of whether the return value is null.
+pub unsafe fn unwrapped_realloc(p: *mut u8, new_size: usize, alignment: usize) -> *mut u8 {
+    unsafe { sys::mi_unwrapped_realloc(p.cast(), new_size, alignment).cast() }
+}
+
 /// Turn on sampled heap profiling at the default sample rate.
 ///
 /// Convenience entry point for wiring profiling to a command-line flag:
@@ -513,5 +592,62 @@ mod tests {
         assert_eq!(prof::stats().sample_rate, 4096);
 
         prof::stop();
+    }
+
+    #[test]
+    fn unwrapped_malloc_write_realloc_grow_verify_free() {
+        unsafe {
+            let size = 64usize;
+            let p = unwrapped_malloc(size, 0);
+            assert!(!p.is_null());
+
+            for i in 0..size {
+                *p.add(i) = (i % 256) as u8;
+            }
+
+            let new_size = 256usize;
+            let p2 = unwrapped_realloc(p, new_size, 0);
+            assert!(!p2.is_null());
+
+            for i in 0..size {
+                assert_eq!(*p2.add(i), (i % 256) as u8);
+            }
+
+            unwrapped_free(p2);
+        }
+    }
+
+    #[test]
+    fn unwrapped_free_null_is_noop() {
+        unsafe {
+            unwrapped_free(core::ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn unwrapped_malloc_rejects_non_power_of_two_alignment() {
+        unsafe {
+            let p = unwrapped_malloc(16, 3);
+            assert!(p.is_null());
+        }
+    }
+
+    #[test]
+    fn unwrapped_realloc_with_null_ptr_behaves_like_malloc() {
+        unsafe {
+            let p = unwrapped_realloc(core::ptr::null_mut(), 32, 0);
+            assert!(!p.is_null());
+            unwrapped_free(p);
+        }
+    }
+
+    #[test]
+    fn unwrapped_realloc_with_zero_size_frees_and_returns_null() {
+        unsafe {
+            let p = unwrapped_malloc(32, 0);
+            assert!(!p.is_null());
+            let p2 = unwrapped_realloc(p, 0, 0);
+            assert!(p2.is_null());
+        }
     }
 }

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -114,6 +114,7 @@ extern inline void* _mi_page_malloc_zero(mi_heap_t* heap, mi_page_t* page, size_
   #if MI_PPROF
   _mi_prof_on_alloc(heap, page, block, size - MI_PADDING_SIZE);
   #endif
+  _mi_memevt_on_alloc(page, block, size - MI_PADDING_SIZE);
   return block;
 }
 
@@ -283,6 +284,7 @@ void* mi_expand(void* p, size_t newsize) mi_attr_noexcept {
   #if MI_PPROF
   _mi_prof_on_realloc_in_place((mi_page_t*)page, p, newsize);
   #endif
+  _mi_memevt_on_realloc_in_place((mi_page_t*)page, p, newsize);
   return p; // it fits
   #endif
 }
@@ -312,9 +314,25 @@ void* _mi_heap_realloc_zero(mi_heap_t* heap, void* p, size_t newsize, bool zero,
     #if MI_PPROF
     _mi_prof_on_realloc_in_place((mi_page_t*)page, p, newsize);
     #endif
+    _mi_memevt_on_realloc_in_place((mi_page_t*)page, p, newsize);
     return p;  // reallocation still fits and not more than 50% waste
   }
-  void* newp = mi_heap_umalloc(heap,newsize,usable_post);
+  // memory-events (issue #20): a moving realloc below is internally an unrelated
+  // mi_heap_umalloc (new block) + mi_free (old block); those two calls funnel through
+  // the normal ALLOCATE/FREE hooks and would otherwise leak an internal allocate/free
+  // pair to consumers instead of one RESIZE. When p != NULL this really is a resize, so
+  // suppress those two internal hook calls and synthesize exactly one RESIZE afterwards
+  // (delta computed from mi_page_usable_block_size on both sides, the same usable-size
+  // notion the ALLOCATE/FREE hooks use, so accounting stays exact and symmetric).
+  // When p == NULL this call behaves as a plain malloc (documented above), not a
+  // resize: leave it unsuppressed so it naturally emits ALLOCATE like any other malloc.
+  const bool memevt_is_resize = (p != NULL);
+  const size_t memevt_usable_pre = (memevt_is_resize ? mi_page_usable_block_size(page) : 0);
+  size_t memevt_local_usable_post = 0;
+  size_t* const memevt_up = (memevt_is_resize && usable_post == NULL ? &memevt_local_usable_post : usable_post);
+  if (memevt_is_resize) _mi_memevt_suppress_begin();
+  void* newp = mi_heap_umalloc(heap,newsize,memevt_up);
+  const size_t memevt_usable_post = (memevt_up != NULL ? *memevt_up : 0);
   if mi_likely(newp != NULL) {
     if (zero && newsize > size) {
       // also set last word in the previous allocation to zero to ensure any padding is zero-initialized
@@ -330,6 +348,13 @@ void* _mi_heap_realloc_zero(mi_heap_t* heap, void* p, size_t newsize, bool zero,
       _mi_memcpy(newp, p, copysize);
       mi_free(p); // only free the original pointer if successful
     }
+  }
+  if (memevt_is_resize) {
+    _mi_memevt_suppress_end();
+    // Suppression is lifted: this call is not suppressed and dispatches normally.
+    // On failure (newp == NULL) usable_post stays 0 == usable_pre, delta 0 -- but per
+    // spec a failed realloc must emit no event at all, so only call this on success.
+    if (newp != NULL) { _mi_memevt_on_resize(memevt_usable_pre, memevt_usable_post, newsize); }
   }
   return newp;
 }

--- a/src/free.c
+++ b/src/free.c
@@ -36,6 +36,7 @@ static inline void mi_free_block_local(mi_page_t* page, mi_block_t* block, bool 
   #if MI_PPROF
   _mi_prof_on_free(page, block);
   #endif
+  _mi_memevt_on_free(page, block);
   if (!was_guarded) { mi_check_padding(page, block); }
   if (track_stats) { mi_stat_free(page, block); }
   #if (MI_DEBUG>0) && !MI_TRACK_ENABLED  && !MI_TSAN
@@ -297,10 +298,17 @@ static void mi_decl_noinline mi_free_block_mt(mi_page_t* page, mi_segment_t* seg
     if (_mi_segment_attempt_reclaim(mi_heap_get_default(), segment)) {
       mi_assert_internal(_mi_thread_id() == mi_atomic_load_relaxed(&segment->thread_id));
       mi_assert_internal(mi_heap_get_default()->tld->segments.subproc == segment->subproc);
-      mi_free(p);  // recursively free as now it will be a local free in our heap
+      mi_free(p);  // recursively free as now it will be a local free in our heap (hooked there; do not double-hook here)
       return;
     }
   }
+
+  // memory-events (issue #20): from here on this is a genuine remote (cross-thread)
+  // free that will actually complete below -- the profiler currently has no equivalent
+  // hook on this path (a documented gap), but the acceptance criteria for this feature
+  // explicitly require remote frees to be tracked, so hook here, mirroring
+  // mi_free_block_local's placement (definitely-freeing, page/block still valid).
+  _mi_memevt_on_free(page, block);
 
   // The padding check may access the non-thread-owned page for the key values.
   // that is safe as these are constant and the page won't be freed (as the block is not freed yet).

--- a/src/memory-events.c
+++ b/src/memory-events.c
@@ -303,21 +303,32 @@ static size_t memevt_align_up(size_t sz, size_t alignment) {
 }
 
 void* mi_unwrapped_malloc(size_t size, size_t alignment) mi_attr_noexcept {
-  // Ensure the OS layer is initialized before touching it directly. Every other path into
-  // _mi_os_alloc_aligned (mi_malloc's slow path, the profiler's arena, etc.) goes through
-  // mi_thread_init/mi_process_init first, which populates the process-global
-  // mi_os_mem_config_t (page size, allocation granularity, has_partial_free, ...) exactly
-  // once under mi_atomic_do_once -- and that guard makes every other caller *block* until
-  // the write is complete, not just skip it (see _mi_atomic_once_enter's contract). This
-  // unwrapped path is the only public entry point that calls _mi_os_alloc_aligned without
-  // first going through that guard, so if it is a process's very first allocation call --
-  // plausible for a caller reaching it on a freshly spawned thread before any mi_malloc --
-  // it could otherwise read mi_os_mem_config while another thread is concurrently mid-write
-  // via its own first mi_malloc/mi_prof_start call, i.e. a torn read of a not-yet-initialized
-  // (or partially initialized) struct. mi_process_init() is cheap and idempotent once the
-  // once-guard has resolved, so this is a no-op on the (overwhelmingly common) already-
-  // initialized path.
-  mi_process_init();
+  // Ensure THIS thread is initialized before touching the OS layer directly -- not just the
+  // process. A prior fix here called mi_process_init(), reasoning that every other path into
+  // _mi_os_alloc_aligned goes through process init first so the process-global
+  // mi_os_mem_config_t is never read torn. That part is true but incomplete: mi_process_init()
+  // only runs mi_thread_init() for the *one* thread that wins its internal mi_atomic_do_once
+  // race (see mi_process_init_once in init.c); every other thread that calls mi_process_init()
+  // concurrently just blocks on the once-guard and returns *without* mi_thread_init() ever
+  // running for itself. That matters because _mi_os_alloc_aligned's callees read per-thread
+  // heap state, not just the process-global config: mi_os_prim_alloc_at -> _mi_os_get_aligned_hint
+  // calls _mi_heap_random_next(mi_prim_get_default_heap()) in release builds (the address-hint
+  // randomization is compiled out under MI_DEBUG>0, which is exactly why this never reproduced
+  // in a debug build). A thread that never ran mi_thread_init() still has its TLS default-heap
+  // pointer at its process-start value, `&_mi_heap_empty` -- a `const`, read-only-mapped sentinel
+  // (see _mi_heap_empty/_mi_heap_default in init.c). _mi_heap_random_next mutates the chacha
+  // state it is given (chacha_next32/chacha_block regenerate the block in place), so calling it
+  // on `_mi_heap_empty.random` is a write into read-only memory: an immediate, near-deterministic
+  // SIGSEGV inside chacha_block, reproduced (~100% of runs) via gdb backtrace:
+  //   mi_unwrapped_malloc -> _mi_os_alloc_aligned -> mi_os_prim_alloc_at -> _mi_prim_alloc ->
+  //   _mi_os_get_aligned_hint -> _mi_random_next -> chacha_block (SIGSEGV, all GP regs zeroed)
+  // mi_thread_init() is the right call here, not mi_process_init(): it calls mi_process_init()
+  // itself first (unconditionally, cheap once the once-guard has resolved), and then -- for
+  // *every* calling thread, not just the process-init winner -- calls _mi_thread_heap_init(),
+  // which is itself a cheap already-initialized check-and-return once this thread has a real
+  // heap. This guarantees mi_prim_get_default_heap() never points at the const empty sentinel
+  // by the time anything below reads or mutates per-thread heap state.
+  mi_thread_init();
   if (alignment == 0) alignment = sizeof(void*);
   if ((alignment & (alignment - 1)) != 0) return NULL; // must be a power of two
   const size_t hdr_reserved = memevt_align_up(sizeof(mi_unwrapped_header_t), alignment);

--- a/src/memory-events.c
+++ b/src/memory-events.c
@@ -1,0 +1,351 @@
+/* Opt-in global-heap allocation-change accounting and callbacks (issue #20).
+
+   Independent of MI_PPROF: always compiled in (see src/static.c), gated only by the
+   runtime `memevt_state` flag below (env var MIMALLOC_MEMORY_EVENTS, or the
+   mi_memory_tracking_set_enabled API). Structurally this module mirrors src/profile.c's
+   patterns (mi_atomic_do_once-style lazy env read, snapshot-then-release callback
+   dispatch, a thread-local reentrancy depth counter) but is a separate, independent
+   feature: see include/mimalloc/memory-events.h for the full API contract.
+
+   Like the profiler, this module's own bookkeeping never uses mi_malloc: the callback
+   table and counters below are static storage (no dynamic allocation at all), so there
+   is nothing here that could recursively enter the hooked allocation paths. The public
+   mi_unwrapped_* family (backed directly by _mi_os_alloc/_mi_os_free) is provided as a
+   stable API for *callers* (e.g. a memory-change callback) that need non-recursive
+   scratch storage; this module does not need to consume its own API for that purpose. */
+#include "mimalloc.h"
+#include "mimalloc/internal.h"
+#include "mimalloc/prim.h"   // mi_prim_get_default_heap
+#include <string.h>
+#include <stdint.h>
+
+// ---------------------------------------------------------------------------------------
+// Activation state.
+//
+// State machine (single _Atomic(size_t), not a bool -- see profile.c's prof_enabled
+// comment on MSVC's plain-C atomic wrapper only implementing uintptr_t/int64_t widths):
+//   MEMEVT_UNINIT   (0): never resolved; the disabled-hot-path check below treats this
+//                        the same as "maybe active" and falls into the slow path once.
+//   MEMEVT_DISABLED (1): resolved off, by env or by explicit API call. Steady-state
+//                        common case: the hot-path check below is exactly one relaxed
+//                        atomic load + compare, no lock, no callback-table touch.
+//   MEMEVT_ENABLED  (2): resolved on, by env or by explicit API call.
+//
+// A shared mi_atomic_once_t (memevt_once) synchronizes the two ways this can first
+// resolve -- the lazy env read at the first allocation hook, and an explicit
+// mi_memory_tracking_set_enabled call, which may happen before any allocation at all.
+// Whichever runs first "wins" the once (so the other is a no-op for the *env read*);
+// but mi_memory_tracking_set_enabled always writes memevt_state directly afterwards too,
+// so an explicit call remains authoritative even if it runs after the once already
+// resolved via the lazy env path -- matching "tracking may also be enabled/disabled by
+// API" as an override, not just a fallback.
+// ---------------------------------------------------------------------------------------
+#define MEMEVT_UNINIT    0
+#define MEMEVT_DISABLED  1
+#define MEMEVT_ENABLED   2
+
+static _Atomic(size_t) memevt_state;
+static mi_atomic_once_t memevt_once = { MI_ATOMIC_VAR_INIT(0), MI_LOCK_INITIALIZER };
+
+// Counters (see mi_memory_snapshot_t). Maintained only while MEMEVT_ENABLED; never
+// reset on disable/re-enable (the running totals just stop advancing while disabled --
+// this is the documented "partial accounting" caveat in memory-events.h).
+static _Atomic(size_t) memevt_live_bytes;
+static _Atomic(size_t) memevt_accum_bytes;
+static _Atomic(size_t) memevt_live_count;
+static _Atomic(size_t) memevt_accum_count;
+
+// Callback table + its lock. The lock only ever guards a snapshot-copy of the table
+// (mi_memory_set_callbacks writing it, or memevt_dispatch reading one entry out of it);
+// it is never held while a user handler runs.
+static mi_lock_t memevt_cb_lock = MI_LOCK_INITIALIZER;
+static mi_memory_change_fun* memevt_handlers[MI_MEMORY_CHANGE_COUNT];
+static void*                 memevt_args[MI_MEMORY_CHANGE_COUNT];
+
+// Reentrancy / internal-op suppression (mirrors profile.c's prof_callback_depth).
+// >0 means: skip accounting and skip dispatch entirely. Two callers increment this:
+//   (a) memevt_dispatch, around invoking the user's handler -- so if the handler itself
+//       calls mi_malloc/mi_free, that nested allocation is not itself accounted for or
+//       dispatched (bounds recursion depth; see memory-events.h's callback contract).
+//   (b) _mi_heap_realloc_zero's moving-realloc path, around its internal
+//       mi_heap_umalloc+mi_free pair, so those two calls don't leak an ALLOCATE/FREE
+//       pair to consumers; the caller then explicitly calls _mi_memevt_on_resize once,
+//       after suppression is lifted, to emit the single synthesized RESIZE.
+static mi_decl_thread int memevt_suppress_depth;
+
+void _mi_memevt_suppress_begin(void) { memevt_suppress_depth++; }
+void _mi_memevt_suppress_end(void)   { memevt_suppress_depth--; }
+
+// ---------------------------------------------------------------------------------------
+// Lazy activation.
+// ---------------------------------------------------------------------------------------
+
+static void memevt_resolve_env(void) {
+  if (_mi_atomic_once_enter(&memevt_once)) {
+    const bool enabled = mi_option_is_enabled(mi_option_memory_events);
+    mi_atomic_store_release(&memevt_state, (size_t)(enabled ? MEMEVT_ENABLED : MEMEVT_DISABLED));
+    _mi_atomic_once_release(&memevt_once);
+  }
+  // else: either a concurrent thread is mid-resolution (we blocked until it finished, in
+  // which case memevt_state now holds its result) or an explicit API call already won
+  // the once before any allocation occurred (memevt_state already holds that value).
+}
+
+bool mi_memory_tracking_set_enabled(bool enabled) mi_attr_noexcept {
+  const size_t new_state = (size_t)(enabled ? MEMEVT_ENABLED : MEMEVT_DISABLED);
+  if (_mi_atomic_once_enter(&memevt_once)) {
+    // First-ever activation path, and it is this explicit call: resolve the once
+    // without ever reading the environment, so a later first-allocation lazy read is
+    // permanently skipped (memevt_resolve_env's `else` branch above).
+    mi_atomic_store_release(&memevt_state, new_state);
+    _mi_atomic_once_release(&memevt_once);
+  }
+  else {
+    // Once already resolved (by a prior lazy env read or a prior API call): an explicit
+    // call always overrides the cached flag, matching "tracking may also be enabled or
+    // disabled by API" as an authoritative override, not merely a fallback default.
+    mi_atomic_store_release(&memevt_state, new_state);
+  }
+  return true;
+}
+
+bool mi_memory_tracking_is_enabled(void) mi_attr_noexcept {
+  return (mi_atomic_load_relaxed(&memevt_state) == MEMEVT_ENABLED);
+}
+
+// ---------------------------------------------------------------------------------------
+// Callback table.
+// ---------------------------------------------------------------------------------------
+
+bool mi_memory_set_callbacks(const mi_memory_callbacks_t* callbacks) mi_attr_noexcept {
+  mi_lock_acquire(&memevt_cb_lock);
+  for (int i = 0; i < MI_MEMORY_CHANGE_COUNT; i++) {
+    memevt_handlers[i] = (callbacks != NULL ? callbacks->handlers[i] : NULL);
+    memevt_args[i]     = (callbacks != NULL ? callbacks->args[i]     : NULL);
+  }
+  mi_lock_release(&memevt_cb_lock);
+  return true;
+}
+
+bool mi_memory_snapshot(mi_memory_snapshot_t* out) mi_attr_noexcept {
+  if (out == NULL) return false;
+  if (out->size != sizeof(mi_memory_snapshot_t) || out->version != MI_MEMORY_SNAPSHOT_VERSION) return false;
+  out->live_bytes  = (uint64_t)mi_atomic_load_relaxed(&memevt_live_bytes);
+  out->accum_bytes = (uint64_t)mi_atomic_load_relaxed(&memevt_accum_bytes);
+  out->live_count  = (uint64_t)mi_atomic_load_relaxed(&memevt_live_count);
+  out->accum_count = (uint64_t)mi_atomic_load_relaxed(&memevt_accum_count);
+  return true;
+}
+
+// ---------------------------------------------------------------------------------------
+// Dispatch. Called only once tracking is confirmed MEMEVT_ENABLED. Updates counters
+// (total_bytes-affecting update happens before the callback, per spec), then snapshots
+// the relevant handler/arg pair under memevt_cb_lock, releases the lock, and only then
+// invokes the handler -- so the handler runs with neither memevt_cb_lock nor any
+// mimalloc allocator lock held (the latter is already guaranteed by hook placement: see
+// the call sites in alloc.c/free.c, all positioned after the corresponding page-local
+// work / list push is already complete).
+// ---------------------------------------------------------------------------------------
+
+static void memevt_dispatch(mi_memory_change_kind_t kind, int64_t delta_bytes, uint64_t request_size) {
+  if (memevt_suppress_depth > 0) return;
+
+  size_t live_bytes_after;
+  if (delta_bytes >= 0) {
+    live_bytes_after = mi_atomic_add_relaxed(&memevt_live_bytes, (size_t)delta_bytes) + (size_t)delta_bytes;
+  }
+  else {
+    const size_t magnitude = (size_t)(-delta_bytes);
+    live_bytes_after = mi_atomic_sub_relaxed(&memevt_live_bytes, magnitude) - magnitude;
+  }
+
+  switch (kind) {
+    case MI_MEMORY_ALLOCATE:
+      mi_atomic_increment_relaxed(&memevt_live_count);
+      mi_atomic_increment_relaxed(&memevt_accum_count);
+      if (delta_bytes > 0) mi_atomic_add_relaxed(&memevt_accum_bytes, (size_t)delta_bytes);
+      break;
+    case MI_MEMORY_FREE:
+      mi_atomic_decrement_relaxed(&memevt_live_count);
+      break;
+    case MI_MEMORY_RESIZE:
+      if (delta_bytes > 0) mi_atomic_add_relaxed(&memevt_accum_bytes, (size_t)delta_bytes);
+      break;
+    default:
+      break;
+  }
+
+  mi_lock_acquire(&memevt_cb_lock);
+  mi_memory_change_fun* handler = memevt_handlers[kind];
+  void* handler_arg = memevt_args[kind];
+  mi_lock_release(&memevt_cb_lock);
+  if (handler == NULL) return;
+
+  mi_memory_change_t change;
+  change.kind = kind;
+  change.total_bytes = (uint64_t)live_bytes_after;
+  change.delta_bytes = delta_bytes;
+  change.request_size = request_size;
+
+  memevt_suppress_depth++;
+  handler(&change, handler_arg);
+  memevt_suppress_depth--;
+}
+
+// ---------------------------------------------------------------------------------------
+// Hook entry points. Each begins with the single disabled-hot-path flag check: a plain
+// relaxed load compared against MEMEVT_DISABLED. Only when that check is *not* true
+// (either MEMEVT_UNINIT -- resolved once, here -- or MEMEVT_ENABLED) does any further
+// work happen; no accounting atomic and no callback-table lock/lookup occur on the
+// disabled path.
+// ---------------------------------------------------------------------------------------
+
+void _mi_memevt_on_alloc(mi_page_t* page, void* p, size_t request_size) {
+  MI_UNUSED(p);
+  size_t state = mi_atomic_load_relaxed(&memevt_state);
+  if mi_likely(state == MEMEVT_DISABLED) return;
+  if (state == MEMEVT_UNINIT) { memevt_resolve_env(); state = mi_atomic_load_relaxed(&memevt_state); }
+  if (state != MEMEVT_ENABLED) return;
+  const size_t usable = mi_page_usable_block_size(page);
+  memevt_dispatch(MI_MEMORY_ALLOCATE, (int64_t)usable, (uint64_t)request_size);
+}
+
+void _mi_memevt_on_free(mi_page_t* page, void* p) {
+  MI_UNUSED(p);
+  const size_t state = mi_atomic_load_relaxed(&memevt_state);
+  if mi_likely(state == MEMEVT_DISABLED) return;
+  if (state != MEMEVT_ENABLED) return; // MEMEVT_UNINIT: nothing can have been counted yet, nothing to free-account.
+  const size_t usable = mi_page_usable_block_size(page);
+  memevt_dispatch(MI_MEMORY_FREE, -(int64_t)usable, 0);
+}
+
+void _mi_memevt_on_realloc_in_place(mi_page_t* page, void* p, size_t request_size) {
+  MI_UNUSED(p);
+  const size_t state = mi_atomic_load_relaxed(&memevt_state);
+  if mi_likely(state == MEMEVT_DISABLED) return;
+  if (state != MEMEVT_ENABLED) return;
+  // Same page => same block-size class => usable size is identical before and after;
+  // delta is always exactly 0 (still a real, dispatched RESIZE event, per spec).
+  MI_UNUSED(page);
+  memevt_dispatch(MI_MEMORY_RESIZE, 0, (uint64_t)request_size);
+}
+
+void _mi_memevt_on_resize(size_t usable_pre, size_t usable_post, size_t request_size) {
+  const size_t state = mi_atomic_load_relaxed(&memevt_state);
+  if mi_likely(state == MEMEVT_DISABLED) return;
+  if (state != MEMEVT_ENABLED) return;
+  const int64_t delta = (int64_t)usable_post - (int64_t)usable_pre;
+  memevt_dispatch(MI_MEMORY_RESIZE, delta, (uint64_t)request_size);
+}
+
+// ---------------------------------------------------------------------------------------
+// Best-effort live-allocation visitor. Built on the existing per-heap block-visitation
+// facility (mi_heap_visit_blocks / mi_block_visit_fun), per the issue's explicit
+// instruction to use that as the basis rather than new page-walking logic.
+//
+// Scope note (deviation from a literal "global" reading -- see final report): this
+// walks every heap on the *calling thread* (mi_tld_t::heaps, the same list the runtime
+// itself uses to abandon all of a thread's heaps on thread exit). mimalloc keeps no
+// process-wide registry of every thread's heaps (unlike the segment/arena layer, heaps
+// are pure thread-local structures with no cross-thread linkage), and building one would
+// mean new cross-thread bookkeeping infrastructure -- out of scope for "the existing
+// per-heap visitation facilities are the basis". The API is already documented as
+// best-effort/non-consistent, and single-threaded or per-thread-tracked callers (the
+// common case for this kind of diagnostic) get full coverage; multi-threaded callers get
+// their own thread's live allocations only.
+// ---------------------------------------------------------------------------------------
+
+typedef struct memevt_visit_ctx_s {
+  mi_memory_allocation_visit_fun* visitor;
+  void* arg;
+} memevt_visit_ctx_t;
+
+static bool mi_cdecl memevt_visit_adapter(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, void* arg) {
+  MI_UNUSED(heap); MI_UNUSED(area);
+  if (block == NULL) return true; // area-only callback; visit_blocks=true below still yields one of these per area too.
+  memevt_visit_ctx_t* ctx = (memevt_visit_ctx_t*)arg;
+  return ctx->visitor(block, block_size, ctx->arg);
+}
+
+bool mi_memory_visit_live_allocations(mi_memory_allocation_visit_fun* visitor, void* arg) mi_attr_noexcept {
+  if (visitor == NULL) return false;
+  if (memevt_suppress_depth > 0) return false; // do not reenter while a callback/internal-op is in flight on this thread.
+  mi_heap_t* heap = mi_prim_get_default_heap();
+  if (heap == NULL || !mi_heap_is_initialized(heap)) return true; // nothing to visit yet on this thread.
+  memevt_visit_ctx_t ctx = { visitor, arg };
+  for (mi_heap_t* h = heap->tld->heaps; h != NULL; h = h->next) {
+    if (!mi_heap_visit_blocks(h, true /* visit_blocks */, &memevt_visit_adapter, &ctx)) break;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------------------
+// Stable public "unwrapped" instrumentation allocation path: backed directly by
+// _mi_os_alloc/_mi_os_free (never mi_malloc), page granular, with a small prepended
+// header carrying the mi_memid_t provenance token _mi_os_free requires. This mirrors
+// _mi_prof_arena_alloc's chunk-header shape in profile.c, but each allocation here owns
+// its own OS mapping (paired release, not an arena) since these are meant to be
+// individually freed/resized by instrumentation callers, not bump-allocated bookkeeping.
+// ---------------------------------------------------------------------------------------
+
+#define MI_UNWRAPPED_MAGIC ((uint32_t)0x6D697577) /* "miuw" */
+
+typedef struct mi_unwrapped_header_s {
+  void*      base;          // OS allocation base, for _mi_os_free
+  size_t     total_size;    // OS allocation total size, for _mi_os_free
+  size_t     payload_size;  // current payload size, for realloc's memcpy
+  mi_memid_t memid;         // provenance token, for _mi_os_free
+  uint32_t   magic;
+} mi_unwrapped_header_t;
+
+static size_t memevt_align_up(size_t sz, size_t alignment) {
+  return (sz + (alignment - 1)) & ~(alignment - 1);
+}
+
+void* mi_unwrapped_malloc(size_t size, size_t alignment) mi_attr_noexcept {
+  if (alignment == 0) alignment = sizeof(void*);
+  if ((alignment & (alignment - 1)) != 0) return NULL; // must be a power of two
+  const size_t hdr_reserved = memevt_align_up(sizeof(mi_unwrapped_header_t), alignment);
+  if (size > SIZE_MAX - hdr_reserved) return NULL; // overflow guard
+  const size_t total = hdr_reserved + size;
+  mi_memid_t memid;
+  uint8_t* base = (uint8_t*)_mi_os_alloc_aligned(total, alignment, true /* commit */, false /* allow_large */, &memid);
+  if (base == NULL) return NULL;
+  uint8_t* user = base + hdr_reserved;
+  mi_unwrapped_header_t* hdr = (mi_unwrapped_header_t*)(user - sizeof(mi_unwrapped_header_t));
+  hdr->base = base;
+  hdr->total_size = total;
+  hdr->payload_size = size;
+  hdr->memid = memid;
+  hdr->magic = MI_UNWRAPPED_MAGIC;
+  return user;
+}
+
+static mi_unwrapped_header_t* mi_unwrapped_header_of(void* p, const char* msg) {
+  mi_unwrapped_header_t* hdr = (mi_unwrapped_header_t*)((uint8_t*)p - sizeof(mi_unwrapped_header_t));
+  if (hdr->magic != MI_UNWRAPPED_MAGIC) {
+    _mi_error_message(EINVAL, "%s: pointer %p was not returned by mi_unwrapped_malloc/realloc\n", msg, p);
+    return NULL;
+  }
+  return hdr;
+}
+
+void mi_unwrapped_free(void* p) mi_attr_noexcept {
+  if (p == NULL) return;
+  mi_unwrapped_header_t* hdr = mi_unwrapped_header_of(p, "mi_unwrapped_free");
+  if (hdr == NULL) return;
+  _mi_os_free(hdr->base, hdr->total_size, hdr->memid);
+}
+
+void* mi_unwrapped_realloc(void* p, size_t new_size, size_t alignment) mi_attr_noexcept {
+  if (p == NULL) return mi_unwrapped_malloc(new_size, alignment);
+  if (new_size == 0) { mi_unwrapped_free(p); return NULL; }
+  mi_unwrapped_header_t* hdr = mi_unwrapped_header_of(p, "mi_unwrapped_realloc");
+  if (hdr == NULL) return NULL;
+  void* newp = mi_unwrapped_malloc(new_size, alignment);
+  if (newp == NULL) return NULL;
+  const size_t copy = (hdr->payload_size < new_size ? hdr->payload_size : new_size);
+  _mi_memcpy(newp, p, copy);
+  mi_unwrapped_free(p);
+  return newp;
+}

--- a/src/memory-events.c
+++ b/src/memory-events.c
@@ -303,6 +303,21 @@ static size_t memevt_align_up(size_t sz, size_t alignment) {
 }
 
 void* mi_unwrapped_malloc(size_t size, size_t alignment) mi_attr_noexcept {
+  // Ensure the OS layer is initialized before touching it directly. Every other path into
+  // _mi_os_alloc_aligned (mi_malloc's slow path, the profiler's arena, etc.) goes through
+  // mi_thread_init/mi_process_init first, which populates the process-global
+  // mi_os_mem_config_t (page size, allocation granularity, has_partial_free, ...) exactly
+  // once under mi_atomic_do_once -- and that guard makes every other caller *block* until
+  // the write is complete, not just skip it (see _mi_atomic_once_enter's contract). This
+  // unwrapped path is the only public entry point that calls _mi_os_alloc_aligned without
+  // first going through that guard, so if it is a process's very first allocation call --
+  // plausible for a caller reaching it on a freshly spawned thread before any mi_malloc --
+  // it could otherwise read mi_os_mem_config while another thread is concurrently mid-write
+  // via its own first mi_malloc/mi_prof_start call, i.e. a torn read of a not-yet-initialized
+  // (or partially initialized) struct. mi_process_init() is cheap and idempotent once the
+  // once-guard has resolved, so this is a no-op on the (overwhelmingly common) already-
+  // initialized path.
+  mi_process_init();
   if (alignment == 0) alignment = sizeof(void*);
   if ((alignment & (alignment - 1)) != 0) return NULL; // must be a power of two
   const size_t hdr_reserved = memevt_align_up(sizeof(mi_unwrapped_header_t), alignment);

--- a/src/options.c
+++ b/src/options.c
@@ -176,6 +176,7 @@ static mi_option_desc_t options[_mi_option_last] =
   ,{ 0, UNINIT, MI_OPTION(prof_accum) }
   ,{ 0, UNINIT, MI_OPTION(prof_seed) }
   ,{ 0, UNINIT, MI_OPTION(prof_max_bytes) }   // budget for profiler-internal arena memory; 0 = unbudgeted
+  ,{ 0, UNINIT, MI_OPTION(memory_events) }    // opt-in allocation-change accounting/callbacks; read lazily by memory-events.c, not at startup
 };
 
 static void mi_option_init(mi_option_desc_t* desc);

--- a/src/page.c
+++ b/src/page.c
@@ -217,6 +217,16 @@ static void _mi_page_thread_free_collect(mi_page_t* page)
   #if MI_PPROF
   _mi_prof_on_free_collect(page, head);
   #endif
+  // memory-events (issue #20): deliberately NOT hooked here. page->xthread_free (the
+  // `head` list collected below) is populated exclusively by mi_free_block_delayed_mt,
+  // which is only ever called from mi_free_block_mt in free.c -- i.e. every block
+  // reaching this function was already counted by the _mi_memevt_on_free hook added to
+  // mi_free_block_mt. Hooking again here would double-count every remote free (this
+  // collect is deferred *reclamation* of an already-freed block onto the local free
+  // list, not a new free event). This intentionally differs from the profiler, which
+  // hooks here instead of in mi_free_block_mt (its only counting point for remote
+  // frees, since it does not hook mi_free_block_mt at all) -- see the profiler's own
+  // documented gap in that function.
 
   // find the tail -- also to get a proper count (without data races)
   size_t max_count = page->capacity; // cannot collect more than capacity

--- a/src/static.c
+++ b/src/static.c
@@ -28,6 +28,7 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "heap.c"
 #include "init.c"
 #include "libc.c"
+#include "memory-events.c"
 #include "options.c"
 #include "os.c"
 #include "page.c"           // includes page-queue.c

--- a/test/test-memory-events.c
+++ b/test/test-memory-events.c
@@ -1,0 +1,688 @@
+/* Tests for the opt-in global-heap allocation-change accounting/callback API (issue #20).
+   See include/mimalloc/memory-events.h for the full contract this exercises. Follows this
+   codebase's test-profile.c style: numbered T-series functions, assert()-based, a single
+   main() driver calling each in sequence. */
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "mimalloc.h"
+#include "mimalloc/memory-events.h"
+
+/* ---------------------------------------------------------------------------------------------
+   Shared callback-counting harness: one handler function for all three kinds, dispatching on
+   change->kind, writing into a caller-owned evt_ctx_t. */
+
+typedef struct evt_ctx_s {
+  int                    counts[MI_MEMORY_CHANGE_COUNT];
+  mi_memory_change_t     last[MI_MEMORY_CHANGE_COUNT];
+} evt_ctx_t;
+
+static void evt_ctx_reset(evt_ctx_t* ctx) { memset(ctx, 0, sizeof(*ctx)); }
+
+static void on_change(const mi_memory_change_t* change, void* arg) {
+  evt_ctx_t* ctx = (evt_ctx_t*)arg;
+  ctx->counts[change->kind]++;
+  ctx->last[change->kind] = *change;
+}
+
+static void evt_install(evt_ctx_t* ctx) {
+  mi_memory_callbacks_t cbs;
+  for (int i = 0; i < MI_MEMORY_CHANGE_COUNT; i++) { cbs.handlers[i] = on_change; cbs.args[i] = ctx; }
+  assert(mi_memory_set_callbacks(&cbs));
+}
+
+/* ---- T1: disabled by default -------------------------------------------------------------
+   Must run first, before any explicit mi_memory_tracking_set_enabled call, so the module's
+   activation state is still MEMEVT_UNINIT / resolves lazily via the (unset) env var. */
+static void test_disabled_by_default(void) {
+  assert(!mi_memory_tracking_is_enabled());
+  evt_ctx_t ctx; evt_ctx_reset(&ctx);
+  evt_install(&ctx);
+  enum { count = 500 };
+  void* blocks[count];
+  for (size_t i = 0; i < count; i++) { blocks[i] = mi_malloc(32 + (i % 64)); assert(blocks[i] != NULL); }
+  for (size_t i = 0; i < count; i++) mi_free(blocks[i]);
+  /* Also exercise a realloc while disabled. */
+  void* p = mi_malloc(16); assert(p != NULL);
+  void* p2 = mi_realloc(p, 4096); assert(p2 != NULL);
+  mi_free(p2);
+  assert(!mi_memory_tracking_is_enabled());
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 0);
+  assert(ctx.counts[MI_MEMORY_FREE] == 0);
+  assert(ctx.counts[MI_MEMORY_RESIZE] == 0);
+  assert(mi_memory_set_callbacks(NULL));
+}
+
+/* ---- T3: explicit API enable/disable, both before and after allocation; API is
+   authoritative even though the lazy env-read already resolved the once (in T1). */
+static void test_explicit_enable_disable(void) {
+  assert(!mi_memory_tracking_is_enabled());
+  assert(mi_memory_tracking_set_enabled(true));
+  assert(mi_memory_tracking_is_enabled());
+
+  evt_ctx_t ctx; evt_ctx_reset(&ctx);
+  evt_install(&ctx);
+
+  void* p = mi_malloc(48); assert(p != NULL);
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 1);
+
+  assert(mi_memory_tracking_set_enabled(false));
+  assert(!mi_memory_tracking_is_enabled());
+  evt_ctx_reset(&ctx);
+  void* q = mi_malloc(48); assert(q != NULL);
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 0);  /* disabled: no accounting, no dispatch */
+
+  mi_free(p);
+  mi_free(q);
+
+  /* Re-enable and leave enabled for the rest of the test suite. */
+  assert(mi_memory_tracking_set_enabled(true));
+  assert(mi_memory_tracking_is_enabled());
+  assert(mi_memory_set_callbacks(NULL));
+}
+
+/* ---- T4: callback registration/replacement/clearing after tracking is already enabled. */
+static void test_callback_registration_timing(void) {
+  assert(mi_memory_tracking_is_enabled());
+
+  evt_ctx_t ctx1; evt_ctx_reset(&ctx1);
+  evt_install(&ctx1);
+  void* p = mi_malloc(32); assert(p != NULL);
+  assert(ctx1.counts[MI_MEMORY_ALLOCATE] == 1);
+  mi_free(p);
+  assert(ctx1.counts[MI_MEMORY_FREE] == 1);
+
+  /* Replace with a different table -- old ctx1 must stop receiving events. */
+  evt_ctx_t ctx2; evt_ctx_reset(&ctx2);
+  evt_install(&ctx2);
+  evt_ctx_reset(&ctx1);
+  void* q = mi_malloc(32); assert(q != NULL);
+  mi_free(q);
+  assert(ctx1.counts[MI_MEMORY_ALLOCATE] == 0 && ctx1.counts[MI_MEMORY_FREE] == 0);
+  assert(ctx2.counts[MI_MEMORY_ALLOCATE] == 1 && ctx2.counts[MI_MEMORY_FREE] == 1);
+
+  /* Clear -- delivery stops entirely. */
+  assert(mi_memory_set_callbacks(NULL));
+  evt_ctx_reset(&ctx2);
+  void* r = mi_malloc(32); assert(r != NULL);
+  mi_free(r);
+  assert(ctx2.counts[MI_MEMORY_ALLOCATE] == 0 && ctx2.counts[MI_MEMORY_FREE] == 0);
+}
+
+/* ---- T5/T6: event correctness (ALLOCATE/FREE/RESIZE shapes) and failed-op/double-free
+   no-event guarantees. */
+static void test_event_correctness(void) {
+  assert(mi_memory_tracking_is_enabled());
+  evt_ctx_t ctx; evt_ctx_reset(&ctx);
+  evt_install(&ctx);
+
+  /* T5a: ALLOCATE -- correct kind/delta/total/request_size.
+     Note: delta_bytes is deliberately NOT compared against the public mi_usable_size(p)
+     here. The accounting hooks use mi_page_usable_block_size (the internal "size class"
+     usable size, excluding the fixed padding header) while mi_usable_size(p) -- when
+     MI_PADDING/MI_PADDING_CHECK are compiled in (default for MI_DEBUG>=1 debug builds) --
+     decodes the padding canary and returns something closer to the originally *requested*
+     size instead. The two are only guaranteed equal in a non-padded (release-style,
+     MI_DEBUG==0) build. So this test treats the event's own reported delta as ground
+     truth and cross-checks it against itself (T5b below) and against mi_memory_snapshot,
+     rather than against mi_usable_size(). */
+  evt_ctx_reset(&ctx);
+  void* p = mi_malloc(100); assert(p != NULL);
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 1);
+  assert(ctx.counts[MI_MEMORY_FREE] == 0 && ctx.counts[MI_MEMORY_RESIZE] == 0);
+  int64_t p_delta = 0;
+  {
+    const mi_memory_change_t* c = &ctx.last[MI_MEMORY_ALLOCATE];
+    assert(c->kind == MI_MEMORY_ALLOCATE);
+    assert(c->request_size == 100);
+    assert(c->delta_bytes >= 100);  /* usable size is always >= the requested size */
+    p_delta = c->delta_bytes;
+    mi_memory_snapshot_t_decl(snap);
+    assert(mi_memory_snapshot(&snap));
+    assert(c->total_bytes == snap.live_bytes);
+  }
+
+  /* T5b: FREE -- correct kind/negative delta/total; the freed delta must exactly negate
+     the allocate delta for the same block (same page, no resize in between). */
+  evt_ctx_reset(&ctx);
+  mi_free(p);
+  assert(ctx.counts[MI_MEMORY_FREE] == 1);
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 0 && ctx.counts[MI_MEMORY_RESIZE] == 0);
+  {
+    const mi_memory_change_t* c = &ctx.last[MI_MEMORY_FREE];
+    assert(c->kind == MI_MEMORY_FREE);
+    assert(c->request_size == 0);
+    assert(c->delta_bytes == -p_delta);
+    mi_memory_snapshot_t_decl(snap);
+    assert(mi_memory_snapshot(&snap));
+    assert(c->total_bytes == snap.live_bytes);
+  }
+
+  /* T5c: grow-realloc forced to move (far past the current size class) -- exactly one
+     RESIZE, zero net ALLOCATE/FREE from this call. */
+  {
+    void* a = mi_malloc(8); assert(a != NULL);
+    evt_ctx_reset(&ctx);
+    void* a2 = mi_realloc(a, 1024 * 1024); assert(a2 != NULL);
+    assert(ctx.counts[MI_MEMORY_RESIZE] == 1);
+    assert(ctx.counts[MI_MEMORY_ALLOCATE] == 0 && ctx.counts[MI_MEMORY_FREE] == 0);
+    const mi_memory_change_t* c = &ctx.last[MI_MEMORY_RESIZE];
+    assert(c->kind == MI_MEMORY_RESIZE);
+    assert(c->request_size == 1024 * 1024);
+    assert(c->delta_bytes > 0);
+    mi_free(a2);
+  }
+
+  /* T5d: shrink-realloc forced to move (shrink past the in-place half-waste threshold) --
+     exactly one RESIZE with a negative delta, zero net ALLOCATE/FREE. */
+  {
+    void* a = mi_malloc(1024 * 1024); assert(a != NULL);
+    evt_ctx_reset(&ctx);
+    void* a2 = mi_realloc(a, 8); assert(a2 != NULL);
+    assert(ctx.counts[MI_MEMORY_RESIZE] == 1);
+    assert(ctx.counts[MI_MEMORY_ALLOCATE] == 0 && ctx.counts[MI_MEMORY_FREE] == 0);
+    const mi_memory_change_t* c = &ctx.last[MI_MEMORY_RESIZE];
+    assert(c->kind == MI_MEMORY_RESIZE);
+    assert(c->request_size == 8);
+    assert(c->delta_bytes < 0);
+    mi_free(a2);
+  }
+
+  /* T5e: same-size-class realloc (in-place path) -- delta must be exactly 0, but a RESIZE
+     event still fires. */
+  {
+    void* a = mi_malloc(100); assert(a != NULL);
+    const size_t u = mi_usable_size(a);
+    evt_ctx_reset(&ctx);
+    void* a2 = mi_realloc(a, u);  /* newsize == usable size: satisfies the in-place condition */
+    assert(a2 == a);              /* in-place realloc must return the same pointer */
+    assert(ctx.counts[MI_MEMORY_RESIZE] == 1);
+    assert(ctx.counts[MI_MEMORY_ALLOCATE] == 0 && ctx.counts[MI_MEMORY_FREE] == 0);
+    const mi_memory_change_t* c = &ctx.last[MI_MEMORY_RESIZE];
+    assert(c->kind == MI_MEMORY_RESIZE);
+    assert(c->request_size == u);
+    assert(c->delta_bytes == 0);
+    mi_free(a2);
+  }
+
+  /* T6: failed allocation emits no event. */
+  {
+    evt_ctx_reset(&ctx);
+    void* huge = mi_malloc(SIZE_MAX / 2);
+    assert(huge == NULL);
+    assert(ctx.counts[MI_MEMORY_ALLOCATE] == 0);
+  }
+
+  /* T6: failed realloc emits no event (and the original pointer remains valid/untouched). */
+  {
+    void* a = mi_malloc(16); assert(a != NULL);
+    evt_ctx_reset(&ctx);
+    void* a2 = mi_realloc(a, SIZE_MAX / 2);
+    assert(a2 == NULL);
+    assert(ctx.counts[MI_MEMORY_RESIZE] == 0 && ctx.counts[MI_MEMORY_ALLOCATE] == 0 && ctx.counts[MI_MEMORY_FREE] == 0);
+    mi_free(a);  /* a must still be valid per the realloc(3) failure contract */
+  }
+
+  /* T6: double free emits no event. Only reachable when the double-free check is actually
+     compiled in (MI_DEBUG!=0 or MI_SECURE>=4 -- see src/free.c's mi_check_is_double_free);
+     in a Release-style build (this file's MI_DEBUG is undefined/0 and MI_SECURE<4 by
+     default) the check is entirely compiled out and a real double free is undefined
+     behavior, so this sub-case is skipped in that configuration rather than risking a
+     crash/corruption. Build with -DCMAKE_BUILD_TYPE=Debug (or -DMI_DEBUG=ON) to exercise it. */
+#if defined(MI_DEBUG) && (MI_DEBUG > 0)
+  {
+    void* a = mi_malloc(64); assert(a != NULL);
+    mi_free(a);
+    evt_ctx_reset(&ctx);
+    mi_free(a);  /* double free: mi_check_is_double_free must detect and no-op before the
+                    _mi_memevt_on_free hook is ever reached. _mi_error_message(EAGAIN, ...)
+                    does not abort (mi_error_default only aborts on EFAULT/ENOMEM/EOVERFLOW
+                    depending on build mode; EAGAIN is a silent-by-default diagnostic here). */
+    assert(ctx.counts[MI_MEMORY_FREE] == 0);
+  }
+#else
+  fprintf(stderr, "test-memory-events: skipping double-free sub-case (MI_DEBUG not enabled in this build)\n");
+#endif
+
+  assert(mi_memory_set_callbacks(NULL));
+}
+
+/* ---- T7: concurrency -- self-consistent live/accum counters, no underflow, no crash.
+   Follows test-profile.c's portable CreateThread/pthread_create pattern.
+
+   Correctness is checked via a callback that tallies events into per-thread counters
+   (each worker thread only ever touches its own slot -- no atomics needed), rather than
+   via a before/after mi_memory_snapshot() diff. This matters specifically on Linux: this
+   test binary links mimalloc-static, which statically overrides the process's malloc/free
+   (see CMakeLists' MI_MALLOC_OVERRIDE), so glibc/pthread's own internal bookkeeping
+   allocations (e.g. per-thread stack/TCB housekeeping done by pthread_create/pthread_join,
+   observed empirically as ~320-byte blocks allocated and only partially freed -- within
+   the measurement window -- on the *calling* thread, consistent with glibc's dead-stack
+   cache deferring some frees) are also captured by these hooks. A raw global snapshot
+   diff conflates that unrelated libc-internal traffic with the test's own allocations and
+   is not a reliable equality check once malloc is globally overridden; scoping the count
+   to only events whose delta magnitude matches this test's own known block-size class
+   (t7_usable) sidesteps that entirely and keeps the check to its actual intent: verifying
+   the accounting hooks never lose or duplicate an event under concurrent hot-path access. */
+enum { T7_THREADS = 8, T7_PER_THREAD = 2000 };
+static size_t t7_block_size = 96;
+static size_t t7_usable;
+
+#if defined(_MSC_VER)
+#define T7_THREAD_LOCAL __declspec(thread)
+#else
+#define T7_THREAD_LOCAL __thread
+#endif
+
+static T7_THREAD_LOCAL uint64_t t7_local_alloc_count;
+static T7_THREAD_LOCAL uint64_t t7_local_alloc_bytes;
+static T7_THREAD_LOCAL uint64_t t7_local_free_count;
+static T7_THREAD_LOCAL uint64_t t7_local_free_bytes;
+
+typedef struct t7_result_s { uint64_t alloc_count, alloc_bytes, free_count, free_bytes; } t7_result_t;
+static t7_result_t t7_results[T7_THREADS];
+
+static void t7_change_handler(const mi_memory_change_t* change, void* arg) {
+  (void)arg;
+  if (change->kind == MI_MEMORY_ALLOCATE && (uint64_t)change->delta_bytes == (uint64_t)t7_usable) {
+    t7_local_alloc_count++;
+    t7_local_alloc_bytes += (uint64_t)change->delta_bytes;
+  }
+  else if (change->kind == MI_MEMORY_FREE && (uint64_t)(-change->delta_bytes) == (uint64_t)t7_usable) {
+    t7_local_free_count++;
+    t7_local_free_bytes += (uint64_t)(-change->delta_bytes);
+  }
+}
+
+static void t7_worker(int idx) {
+  t7_local_alloc_count = t7_local_alloc_bytes = t7_local_free_count = t7_local_free_bytes = 0;
+  for (int i = 0; i < T7_PER_THREAD; i++) {
+    void* p = mi_malloc(t7_block_size);
+    assert(p != NULL);
+    mi_free(p);
+  }
+  t7_results[idx].alloc_count = t7_local_alloc_count;
+  t7_results[idx].alloc_bytes = t7_local_alloc_bytes;
+  t7_results[idx].free_count  = t7_local_free_count;
+  t7_results[idx].free_bytes  = t7_local_free_bytes;
+}
+
+#ifdef _WIN32
+#include <windows.h>
+static DWORD WINAPI t7_thread(void* arg) { t7_worker((int)(intptr_t)arg); return 0; }
+static void t7_run_threads(void) {
+  HANDLE threads[T7_THREADS];
+  for (int i = 0; i < T7_THREADS; i++) threads[i] = CreateThread(NULL, 0, t7_thread, (void*)(intptr_t)i, 0, NULL);
+  WaitForMultipleObjects(T7_THREADS, threads, TRUE, INFINITE);
+  for (int i = 0; i < T7_THREADS; i++) CloseHandle(threads[i]);
+}
+#else
+#include <pthread.h>
+static void* t7_thread(void* arg) { t7_worker((int)(intptr_t)arg); return NULL; }
+static void t7_run_threads(void) {
+  pthread_t threads[T7_THREADS];
+  for (int i = 0; i < T7_THREADS; i++) assert(pthread_create(&threads[i], NULL, t7_thread, (void*)(intptr_t)i) == 0);
+  for (int i = 0; i < T7_THREADS; i++) assert(pthread_join(threads[i], NULL) == 0);
+}
+#endif
+
+static void test_concurrency(void) {
+  assert(mi_memory_tracking_is_enabled());
+  /* Probe the per-block accounting delta for the fixed block size every worker thread
+     uses. Captured from the ALLOCATE event's own delta_bytes (not mi_usable_size(p) --
+     see the T5a comment above on why those two can differ in a padded/debug build) so
+     the expectation below matches exactly what the accounting hooks themselves compute. */
+  evt_ctx_t probe_ctx; evt_ctx_reset(&probe_ctx);
+  evt_install(&probe_ctx);
+  void* probe = mi_malloc(t7_block_size); assert(probe != NULL);
+  assert(probe_ctx.counts[MI_MEMORY_ALLOCATE] == 1);
+  t7_usable = (size_t)probe_ctx.last[MI_MEMORY_ALLOCATE].delta_bytes;
+  mi_free(probe);
+
+  memset(t7_results, 0, sizeof(t7_results));
+  mi_memory_callbacks_t cbs;
+  memset(&cbs, 0, sizeof(cbs));
+  cbs.handlers[MI_MEMORY_ALLOCATE] = t7_change_handler;
+  cbs.handlers[MI_MEMORY_FREE] = t7_change_handler;
+  assert(mi_memory_set_callbacks(&cbs));
+
+  mi_memory_snapshot_t_decl(before);
+  assert(mi_memory_snapshot(&before));
+
+  t7_run_threads();
+  mi_collect(true);  /* drain delayed cross-thread frees before checking counters */
+
+  mi_memory_snapshot_t_decl(after);
+  assert(mi_memory_snapshot(&after));
+  assert(mi_memory_set_callbacks(NULL));
+
+  /* No underflow: unsigned/atomic subtraction gone wrong would wrap to a huge value. */
+  assert(after.live_bytes < ((uint64_t)1 << 48));
+  assert(after.live_count < ((uint64_t)1 << 48));
+
+  /* Every thread's allocations were paired locally (alloc then free): sum the per-thread
+     tallies (scoped to this test's own block-size class, see the comment above) and check
+     against the exact serially-computed expectation -- no lost or duplicated events. */
+  uint64_t total_alloc_count = 0, total_alloc_bytes = 0, total_free_count = 0, total_free_bytes = 0;
+  for (int i = 0; i < T7_THREADS; i++) {
+    total_alloc_count += t7_results[i].alloc_count;
+    total_alloc_bytes += t7_results[i].alloc_bytes;
+    total_free_count  += t7_results[i].free_count;
+    total_free_bytes  += t7_results[i].free_bytes;
+  }
+  assert(total_alloc_count == (uint64_t)T7_THREADS * T7_PER_THREAD);
+  assert(total_free_count == (uint64_t)T7_THREADS * T7_PER_THREAD);
+  assert(total_alloc_bytes == (uint64_t)T7_THREADS * T7_PER_THREAD * t7_usable);
+  assert(total_free_bytes == (uint64_t)T7_THREADS * T7_PER_THREAD * t7_usable);
+}
+
+/* ---- T8: a callback may call mi_malloc/mi_free without deadlocking (no allocator locks
+   held while the handler runs). The reentrant inner alloc/free must itself be suppressed
+   (not double-dispatched) per the documented reentrancy-guard semantics. */
+typedef struct t8_ctx_s { int outer_calls; bool completed; } t8_ctx_t;
+static void t8_reentrant_handler(const mi_memory_change_t* change, void* arg) {
+  (void)change;
+  t8_ctx_t* ctx = (t8_ctx_t*)arg;
+  ctx->outer_calls++;
+  void* tmp = mi_malloc(16);
+  assert(tmp != NULL);
+  mi_free(tmp);
+  ctx->completed = true;
+}
+
+static void test_reentrant_callback(void) {
+  assert(mi_memory_tracking_is_enabled());
+  t8_ctx_t ctx = { 0, false };
+  mi_memory_callbacks_t cbs;
+  memset(&cbs, 0, sizeof(cbs));
+  cbs.handlers[MI_MEMORY_ALLOCATE] = t8_reentrant_handler;
+  cbs.args[MI_MEMORY_ALLOCATE] = &ctx;
+  assert(mi_memory_set_callbacks(&cbs));
+
+  void* p = mi_malloc(64); assert(p != NULL);
+  assert(ctx.completed);
+  assert(ctx.outer_calls == 1);  /* the inner mi_malloc/mi_free must not have re-dispatched */
+  mi_free(p);
+
+  assert(mi_memory_set_callbacks(NULL));
+}
+
+/* ---- T9: snapshot accuracy across an uninterrupted enabled session -- allocate/free a
+   known pattern and check the four counters against hand-computed deltas exactly. */
+static void test_snapshot_accuracy(void) {
+  assert(mi_memory_tracking_is_enabled());
+
+  evt_ctx_t ctx; evt_ctx_reset(&ctx);
+  evt_install(&ctx);
+
+  mi_memory_snapshot_t_decl(before);
+  assert(mi_memory_snapshot(&before));
+
+  /* Hand-computed expectation is derived from the ALLOCATE events' own delta_bytes (not
+     mi_usable_size(p) -- see the T5a comment for why those can differ in a padded/debug
+     build), so this test is checking snapshot self-consistency against the accounting
+     hooks' own reported deltas, exactly. */
+  enum { N = 50 };
+  void* blocks[N];
+  size_t usable = 0;
+  for (int i = 0; i < N; i++) {
+    evt_ctx_reset(&ctx);
+    blocks[i] = mi_malloc(200);
+    assert(blocks[i] != NULL);
+    assert(ctx.counts[MI_MEMORY_ALLOCATE] == 1);
+    const size_t u = (size_t)ctx.last[MI_MEMORY_ALLOCATE].delta_bytes;
+    if (i == 0) usable = u; else assert(u == usable);  /* same request => same size class */
+  }
+
+  mi_memory_snapshot_t_decl(mid);
+  assert(mi_memory_snapshot(&mid));
+  assert(mid.live_count == before.live_count + N);
+  assert(mid.live_bytes == before.live_bytes + (uint64_t)N * usable);
+  assert(mid.accum_count == before.accum_count + N);
+  assert(mid.accum_bytes == before.accum_bytes + (uint64_t)N * usable);
+
+  for (int i = 0; i < N / 2; i++) mi_free(blocks[i]);
+
+  mi_memory_snapshot_t_decl(after);
+  assert(mi_memory_snapshot(&after));
+  assert(after.live_count == mid.live_count - N / 2);
+  assert(after.live_bytes == mid.live_bytes - (uint64_t)(N / 2) * usable);
+  assert(after.accum_count == mid.accum_count);   /* frees never advance accum_* */
+  assert(after.accum_bytes == mid.accum_bytes);
+
+  for (int i = N / 2; i < N; i++) mi_free(blocks[i]);
+
+  assert(mi_memory_set_callbacks(NULL));  /* ctx is about to go out of scope */
+}
+
+/* ---- T10: runtime disable/re-enable -- allocations made while disabled are never counted,
+   even after re-enabling (no reconstruction of the disabled interval). Free the untracked
+   allocation while still disabled too, so the disabled interval nets to zero and later
+   delta-based assertions elsewhere in this file stay valid. */
+static void test_disable_reenable_partial(void) {
+  assert(mi_memory_tracking_set_enabled(true));
+
+  evt_ctx_t ctx; evt_ctx_reset(&ctx);
+  evt_install(&ctx);
+
+  mi_memory_snapshot_t_decl(s0);
+  assert(mi_memory_snapshot(&s0));
+
+  evt_ctx_reset(&ctx);
+  void* p1 = mi_malloc(64); assert(p1 != NULL);
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 1);
+  const size_t u1 = (size_t)ctx.last[MI_MEMORY_ALLOCATE].delta_bytes;
+
+  mi_memory_snapshot_t_decl(s1);
+  assert(mi_memory_snapshot(&s1));
+  assert(s1.live_count == s0.live_count + 1);
+  assert(s1.live_bytes == s0.live_bytes + u1);
+  assert(s1.accum_count == s0.accum_count + 1);
+  assert(s1.accum_bytes == s0.accum_bytes + u1);
+
+  assert(mi_memory_tracking_set_enabled(false));
+  void* p2 = mi_malloc(64); assert(p2 != NULL);  /* allocated while disabled: NOT counted */
+  mi_free(p2);                                    /* freed while still disabled: NOT counted either */
+
+  mi_memory_snapshot_t_decl(s2);
+  assert(mi_memory_snapshot(&s2));
+  assert(s2.live_count == s1.live_count);
+  assert(s2.live_bytes == s1.live_bytes);
+  assert(s2.accum_count == s1.accum_count);
+  assert(s2.accum_bytes == s1.accum_bytes);
+
+  assert(mi_memory_tracking_set_enabled(true));
+  evt_ctx_reset(&ctx);
+  void* p3 = mi_malloc(64); assert(p3 != NULL);  /* resumes counting fresh, from where it left off */
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 1);
+  const size_t u3 = (size_t)ctx.last[MI_MEMORY_ALLOCATE].delta_bytes;
+
+  mi_memory_snapshot_t_decl(s3);
+  assert(mi_memory_snapshot(&s3));
+  assert(s3.live_count == s2.live_count + 1);
+  assert(s3.live_bytes == s2.live_bytes + u3);
+  assert(s3.accum_count == s2.accum_count + 1);
+  assert(s3.accum_bytes == s2.accum_bytes + u3);
+
+  mi_free(p1);
+  mi_free(p3);
+  assert(mi_memory_set_callbacks(NULL));
+}
+
+/* ---- T11: mi_memory_visit_live_allocations -- known blocks observed with correct
+   usable_size, early-stop via returning false, freed blocks never reported. */
+enum { T11_N = 20 };
+typedef struct t11_track_s { void* addr; size_t want_size; bool seen; } t11_track_t;
+static t11_track_t t11_tracked[T11_N];
+
+static bool t11_full_visitor(void* allocation, size_t usable_size, void* arg) {
+  (void)arg;
+  for (int i = 0; i < T11_N; i++) {
+    if (t11_tracked[i].addr == allocation) {
+      assert(usable_size == t11_tracked[i].want_size);
+      t11_tracked[i].seen = true;
+      break;
+    }
+  }
+  return true;
+}
+
+static int t11_stop_calls;
+static bool t11_stop_visitor(void* allocation, size_t usable_size, void* arg) {
+  (void)allocation; (void)usable_size; (void)arg;
+  t11_stop_calls++;
+  return false;
+}
+
+static bool t11_freed_visitor(void* allocation, size_t usable_size, void* arg) {
+  (void)usable_size;
+  bool* found_freed = (bool*)arg;
+  for (int i = 0; i < T11_N / 2; i++) {
+    if (t11_tracked[i].addr == allocation) *found_freed = true;
+  }
+  return true;
+}
+
+static void test_visit_live_allocations(void) {
+  /* mi_heap_visit_blocks (which the visitor is built on) reports mi_page_usable_block_size,
+     the same internal usable-size notion the memory-change hooks use -- not the public,
+     possibly-padding-adjusted mi_usable_size(p) (see the T5a comment). Capture the expected
+     size the same way, from an ALLOCATE event's own delta_bytes, so this comparison is
+     apples-to-apples regardless of build configuration. */
+  assert(mi_memory_tracking_is_enabled());
+  evt_ctx_t ctx; evt_ctx_reset(&ctx);
+  evt_install(&ctx);
+  for (int i = 0; i < T11_N; i++) {
+    evt_ctx_reset(&ctx);
+    void* p = mi_malloc(64 + (size_t)i * 8);
+    assert(p != NULL);
+    assert(ctx.counts[MI_MEMORY_ALLOCATE] == 1);
+    t11_tracked[i].addr = p;
+    t11_tracked[i].want_size = (size_t)ctx.last[MI_MEMORY_ALLOCATE].delta_bytes;
+    t11_tracked[i].seen = false;
+  }
+  assert(mi_memory_set_callbacks(NULL));
+
+  assert(mi_memory_visit_live_allocations(t11_full_visitor, NULL));
+  for (int i = 0; i < T11_N; i++) assert(t11_tracked[i].seen);
+
+  /* Early stop: the visitor returns false after its first invocation. */
+  t11_stop_calls = 0;
+  assert(mi_memory_visit_live_allocations(t11_stop_visitor, NULL));
+  assert(t11_stop_calls == 1);
+
+  /* Free the first half, then confirm the visitor never reports them again. */
+  for (int i = 0; i < T11_N / 2; i++) { mi_free(t11_tracked[i].addr); }
+  bool found_freed = false;
+  assert(mi_memory_visit_live_allocations(t11_freed_visitor, &found_freed));
+  assert(!found_freed);
+
+  for (int i = T11_N / 2; i < T11_N; i++) mi_free(t11_tracked[i].addr);
+}
+
+/* ---- T12: mi_unwrapped_malloc/_free/_realloc -- round trip, data preservation, and
+   confirmation that these do NOT trigger memory-change events even while tracking is
+   enabled. Also exercises the magic-mismatch error path (mi_unwrapped_free on a regular
+   mi_malloc pointer) -- confirmed safe because _mi_error_message(EINVAL, ...) is a
+   non-fatal diagnostic in this build (mi_error_default only aborts for EFAULT under
+   MI_DEBUG/MI_SECURE, or ENOMEM/EOVERFLOW under MI_XMALLOC -- none of which apply to
+   EINVAL). Not done: mixing the families the other direction (mi_free on an unwrapped
+   pointer) -- header explicitly documents that as forbidden/UB-adjacent territory beyond
+   the one safe, diagnostic-only direction exercised here. */
+static void test_unwrapped_family(void) {
+  assert(mi_memory_tracking_is_enabled());
+  evt_ctx_t ctx; evt_ctx_reset(&ctx);
+  evt_install(&ctx);
+
+  void* p = mi_unwrapped_malloc(64, 16);
+  assert(p != NULL);
+  assert(((uintptr_t)p % 16) == 0);
+  memset(p, 0xAB, 64);
+
+  void* p2 = mi_unwrapped_realloc(p, 256, 16);
+  assert(p2 != NULL);
+  for (int i = 0; i < 64; i++) assert(((unsigned char*)p2)[i] == 0xAB);
+  memset((unsigned char*)p2 + 64, 0xCD, 256 - 64);
+
+  void* p3 = mi_unwrapped_realloc(p2, 32, 16);
+  assert(p3 != NULL);
+  for (int i = 0; i < 32; i++) assert(((unsigned char*)p3)[i] == 0xAB);
+
+  mi_unwrapped_free(p3);
+
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 0);
+  assert(ctx.counts[MI_MEMORY_FREE] == 0);
+  assert(ctx.counts[MI_MEMORY_RESIZE] == 0);
+
+  /* Safe error-path check: magic-number mismatch, not a crash. Note q itself is a regular
+     mi_malloc allocation, so it IS tracked normally -- only the failed mi_unwrapped_free
+     call on it must emit nothing. */
+  evt_ctx_reset(&ctx);
+  void* q = mi_malloc(16); assert(q != NULL);
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 1);
+
+  evt_ctx_reset(&ctx);
+  mi_unwrapped_free(q);  /* expected to fail its magic check and print a diagnostic; must not abort */
+  assert(ctx.counts[MI_MEMORY_ALLOCATE] == 0);
+  assert(ctx.counts[MI_MEMORY_FREE] == 0);
+  assert(ctx.counts[MI_MEMORY_RESIZE] == 0);
+
+  mi_free(q);  /* q was never touched by the failed call above; free it properly */
+  assert(ctx.counts[MI_MEMORY_FREE] == 1);
+
+  assert(mi_memory_set_callbacks(NULL));
+}
+
+/* ---- Env-var lazy activation (acceptance criterion #2) ------------------------------------
+   MIMALLOC_MEMORY_EVENTS=1 is read lazily, exactly once, on the first allocation hook. This
+   cannot be exercised by toggling the env var mid-process (the once-guard only ever resolves
+   once), so this is driven as a *separate process*: this same test binary re-invoked with
+   argv[1] == "--env-enabled-check" and MIMALLOC_MEMORY_EVENTS=1 set, registered as its own
+   CTest case (mirrors this repo's existing test-profile-auto pattern of re-running the same
+   binary with a CTest-level ENVIRONMENT property). */
+static int run_env_enabled_check(void) {
+  if (getenv("MIMALLOC_MEMORY_EVENTS") == NULL) {
+    fprintf(stderr, "test-memory-events --env-enabled-check: MIMALLOC_MEMORY_EVENTS not set in environment\n");
+    return 1;
+  }
+  /* Nothing must have touched the allocator yet in this fresh process; the very first
+     allocation hook below is what triggers the lazy env resolution. */
+  void* p = mi_malloc(64);
+  if (p == NULL) { fprintf(stderr, "alloc failed\n"); return 2; }
+  if (!mi_memory_tracking_is_enabled()) { fprintf(stderr, "tracking not enabled after lazy env read\n"); mi_free(p); return 3; }
+
+  evt_ctx_t ctx; evt_ctx_reset(&ctx);
+  evt_install(&ctx);
+  void* q = mi_malloc(32);
+  if (q == NULL) { fprintf(stderr, "second alloc failed\n"); mi_free(p); return 4; }
+  if (ctx.counts[MI_MEMORY_ALLOCATE] != 1) { fprintf(stderr, "callback did not fire after lazy env activation\n"); mi_free(p); mi_free(q); return 5; }
+
+  mi_free(p);
+  mi_free(q);
+  return 0;
+}
+
+int main(int argc, char** argv) {
+  if (argc > 1 && strcmp(argv[1], "--env-enabled-check") == 0) {
+    return run_env_enabled_check();
+  }
+
+  test_disabled_by_default();
+  test_explicit_enable_disable();
+  test_callback_registration_timing();
+  test_event_correctness();
+  test_concurrency();
+  test_reentrant_callback();
+  test_snapshot_accuracy();
+  test_disable_reenable_partial();
+  test_visit_live_allocations();
+  test_unwrapped_family();
+
+  puts("memory-events tests passed");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- `mi_memory_tracking_set_enabled`/`is_enabled`, `mi_memory_set_callbacks`, `mi_memory_snapshot`: opt-in global-heap allocation-change accounting. Consumers implement their own threshold/rearm/leak/allocation-rate/resize policies from `ALLOCATE`/`FREE`/`RESIZE` events, replacing a dedicated high-watermark API. Independent of `MI_PPROF`.
- Disabled (default) hot path is exactly one relaxed flag check -- no accounting atomic, no callback-table lookup. `MIMALLOC_MEMORY_EVENTS` is read lazily on the first allocation via a shared `mi_atomic_once_t`; an explicit `mi_memory_tracking_set_enabled` call is always authoritative over the env read, whichever runs first.
- Callbacks run with no allocator locks held (snapshot-then-release dispatch) and may themselves call `mi_malloc`/`mi_free`; a thread-local suppression depth stops that from re-dispatching recursively.
- A moving realloc internally does an unrelated malloc+free of the new/old blocks; those two calls are suppressed and a single synthesized `RESIZE` is emitted afterward instead, so consumers never see a spurious allocate/free pair for what is semantically one resize.
- `mi_memory_visit_live_allocations`: a best-effort, non-consistent visitor over the calling thread's live blocks, built on the existing `mi_heap_visit_blocks` facility (mimalloc keeps no cross-thread heap registry, so this is scoped to the calling thread, not process-wide -- documented explicitly).
- `mi_unwrapped_malloc`/`_free`/`_realloc`: a stable, page-granular allocation path backed directly by the raw OS layer, for instrumentation callers (e.g. a memory-change callback) needing scratch storage without recursively entering mimalloc. Never mixable with `mi_malloc`/`mi_free`.
- Rust: `unsafe` bindings for the unwrapped-allocator family only, per the issue's explicit scoping -- a safe wrapper for the callback API itself is a non-goal for this issue.

## Test plan
- [x] T1-T7 + unwrapped-allocator round trip in new `test/test-memory-events.c`, covering every acceptance criterion in #20: disabled-by-default, explicit-enable precedence over the lazy env read, callback registration/replace/clear timing, event correctness (allocate/free/grow/shrink/same-class-resize, exactly one RESIZE for a moving realloc), no event on failed alloc or double-free, 8-thread concurrency self-consistency, a callback that itself allocates without deadlock/re-dispatch, snapshot accuracy, disable/re-enable partial accounting, the live-allocation visitor, and unwrapped-allocator isolation from the event stream.
- [x] `MI_PPROF=ON` Debug + Release, full `ctest`: all green (Windows MinGW + a fresh Linux/Docker rebuild), no regressions to the existing suite despite touching the shared hot alloc/free path.
- [x] `MI_PPROF=OFF`: memory-events builds and tests pass independently, confirming it's not gated behind the profiler feature.
- [x] Rust build/test/clippy (`-D warnings`)/fmt (touched files only): all green.
- [x] TSan spot-check: `test-stress` clean (no races). `test-memory-events` under TSan+`MI_OVERRIDE` hit a segfault, root-caused to a pre-existing, unrelated `MI_OVERRIDE`+TSan bootstrap-ordering hazard (TSan's own `dlsym` interceptor init allocates before its trace machinery is ready, and mimalloc's static override redirects that into `mi_malloc` too early) -- confirmed unrelated to this feature by rebuilding with `-DMI_OVERRIDE=OFF`, which ran clean with zero races.
- [x] One real test-flakiness bug found and fixed during validation (not an implementation bug): T7's concurrency check diffed a global snapshot, which on Linux also captured glibc/pthread's own internal bookkeeping allocations during `pthread_create`/`join` (via `MI_OVERRIDE`) that don't all free within the test's window. The accounting logic itself was traced and confirmed correct; fixed by scoping T7 to per-thread-local, size-class-scoped counters instead.

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
