### PR TITLE
fix: v2/0.8.x unbounded memory leak on Windows/MinGW (use FLS for thread cleanup)

### DIFF
--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2c82d8b2 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 492cdba1 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -19326,7 +19326,25 @@ static void NTAPI mi_win_main(PVOID module, DWORD reason, LPVOID reserved) {
    both static and dynamic linkage (`MI_WIN_INIT_USE_CRT_TLS`).
 ------------------------------------------------------------------------- */
 #if !defined(MI_WIN_INIT_USE_CRT_TLS) && !defined(MI_WIN_INIT_USE_RAW_DLLMAIN) && !defined(MI_WIN_INIT_USE_TLS_DLLMAIN) && !defined(MI_WIN_INIT_USE_FLS)
-  #if !defined(__INTEL_LLVM_COMPILER) && !defined(__INTEL_COMPILER)
+  #if defined(__GNUC__) && !defined(_MSC_VER)
+    /* MinGW/GCC: CRT_TLS does not work here and silently leaks every exiting thread.
+       Two independent reasons:
+         1. Its loader TLS callbacks are registered with MSVC-only pragmas
+            (`#pragma comment(linker, "/INCLUDE:...")`, `const_seg`/`data_seg`) which GCC
+            ignores, so the `.CRT$XL*` entries are never emitted at all.
+         2. Even when they ARE emitted (via GCC section attributes), the thread's default
+            heap lives in a `mi_decl_thread` variable which GCC implements with emutls on
+            MinGW. emutls is torn down before any PE TLS callback runs, so at
+            DLL_THREAD_DETACH `mi_prim_get_default_heap()` already returns the *empty* heap
+            and `_mi_thread_done` early-returns on `!mi_heap_is_initialized(heap)` --
+            the thread's heap is never abandoned.
+       FLS does not have this problem: the Fls callback receives the stored value as an
+       argument, so it never has to read a thread-local that may already be gone.
+       Measured on test-stress (32 threads x N iterations): CRT_TLS grows ~0.24 GB per
+       iteration unbounded (23.5 GB at 100 iterations) with `threads` never decrementing;
+       FLS is flat at ~0.1 GB with `threads` returning to 0. */
+    #define MI_WIN_INIT_USE_FLS          1
+  #elif !defined(__INTEL_LLVM_COMPILER) && !defined(__INTEL_COMPILER)
     #define MI_WIN_INIT_USE_CRT_TLS      1
   #else
     #define MI_WIN_INIT_USE_TLS_DLLMAIN  1  /* default for Intel ICX, see issue #1268 */

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit f96cc337 of the three public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 492cdba1 of the three public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/src/prim/windows/prim.c
+++ b/src/prim/windows/prim.c
@@ -721,7 +721,25 @@ static void NTAPI mi_win_main(PVOID module, DWORD reason, LPVOID reserved) {
    both static and dynamic linkage (`MI_WIN_INIT_USE_CRT_TLS`).
 ------------------------------------------------------------------------- */
 #if !defined(MI_WIN_INIT_USE_CRT_TLS) && !defined(MI_WIN_INIT_USE_RAW_DLLMAIN) && !defined(MI_WIN_INIT_USE_TLS_DLLMAIN) && !defined(MI_WIN_INIT_USE_FLS)
-  #if !defined(__INTEL_LLVM_COMPILER) && !defined(__INTEL_COMPILER)
+  #if defined(__GNUC__) && !defined(_MSC_VER)
+    /* MinGW/GCC: CRT_TLS does not work here and silently leaks every exiting thread.
+       Two independent reasons:
+         1. Its loader TLS callbacks are registered with MSVC-only pragmas
+            (`#pragma comment(linker, "/INCLUDE:...")`, `const_seg`/`data_seg`) which GCC
+            ignores, so the `.CRT$XL*` entries are never emitted at all.
+         2. Even when they ARE emitted (via GCC section attributes), the thread's default
+            heap lives in a `mi_decl_thread` variable which GCC implements with emutls on
+            MinGW. emutls is torn down before any PE TLS callback runs, so at
+            DLL_THREAD_DETACH `mi_prim_get_default_heap()` already returns the *empty* heap
+            and `_mi_thread_done` early-returns on `!mi_heap_is_initialized(heap)` --
+            the thread's heap is never abandoned.
+       FLS does not have this problem: the Fls callback receives the stored value as an
+       argument, so it never has to read a thread-local that may already be gone.
+       Measured on test-stress (32 threads x N iterations): CRT_TLS grows ~0.24 GB per
+       iteration unbounded (23.5 GB at 100 iterations) with `threads` never decrementing;
+       FLS is flat at ~0.1 GB with `threads` returning to 0. */
+    #define MI_WIN_INIT_USE_FLS          1
+  #elif !defined(__INTEL_LLVM_COMPILER) && !defined(__INTEL_COMPILER)
     #define MI_WIN_INIT_USE_CRT_TLS      1
   #else
     #define MI_WIN_INIT_USE_TLS_DLLMAIN  1  /* default for Intel ICX, see issue #1268 */


### PR DESCRIPTION
Fixes #47 — the unbounded memory leak in the v2 line (published 0.8.x) on Windows/MinGW.

## Result

Peak working set, `mimalloc-test-stress.exe 32 50 N`:

| iterations | before | after |
|---|---|---|
| 12 | 2.35 GB | **0.24 GB** |
| 25 | 5.75 GB | **0.25 GB** |
| 50 | 11.98 GB | **0.28 GB** |
| 100 | **23.50 GB** | **0.28 GB** |

Linear and unbounded before; flat after. 84x reduction at 100 iterations.

## Root cause

On Windows the default init mode is `MI_WIN_INIT_USE_CRT_TLS`. It does not work under MinGW, for **two independent reasons** — which is why the obvious fix alone is not enough:

1. **The callbacks are never registered.** They are declared with MSVC-only pragmas — `#pragma comment(linker, "/INCLUDE:...")` plus `#pragma const_seg`/`data_seg` — all silently ignored by GCC, so the `.CRT$XL*` entries are never emitted. Verified with a debug print inside `mi_tls_detach`: a stock MinGW build never reaches it.

2. **Even once registered, the handler is too late.** Registering them with GCC section attributes *does* make `DLL_THREAD_DETACH` fire — but the thread's default heap lives in a `mi_decl_thread` variable, which GCC implements with **emutls** on MinGW. emutls is torn down before any PE TLS callback runs, so `mi_prim_get_default_heap()` already returns the *empty* heap and `_mi_thread_done` early-returns on `!mi_heap_is_initialized(heap)`.

   Verified directly — the callback fires with `default_heap != NULL` but `initialized == 0`. Moving it to the earlier `.CRT$XLB` slot does not help; emutls is gone before *any* callback.

**FLS avoids both problems**: the Fls callback receives the stored value as an argument, so it never reads a thread-local that may already be torn down. mimalloc's FLS path already exists — it simply is no longer the default.

## This is upstream, not fork-introduced

Stock `microsoft/mimalloc` v2 (`a3ca0e5e`), zero fork changes, same toolchain, leaks identically: **2.58 / 5.29 / 11.47 GB** at 12/25/50 iterations, with `threads` never decrementing (`thr=960` after 30 iterations x 32 threads). With FLS that counter returns to **0** and purging works (7.5 GB purged). Worth reporting upstream.

## Scope guard

**The v3 line must NOT take this change.** v3 uses its own TLS slot machinery rather than emutls; its own fix (registering the callbacks for GCC, #44) works there, and an FLS build of v3 fails at startup. `main` is v3 and is unaffected.

## Validation

- `ctest` 9/9 on the v2 branch
- Rust workspace suite green (`--locked`)
- `xtask check` — vendored amalgamation matches `src/`/`include/`
- Memory scaling table above

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
