### PR TITLE
ci: make a tagged release fail loudly instead of silently publishing nothing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -53,7 +53,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Retried on purpose: this action has failed with a transient `write EPIPE`
+      # during cache restore (issue #55), which skipped the publish job and turned a
+      # tagged release into a silent no-op. A `uses:` step cannot be wrapped by a
+      # retry action, so attempt it twice explicitly.
       - uses: zackees/setup-soldr@v0
+        id: setup_soldr
+        continue-on-error: true
+        with:
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+          build-cache-mode: full
+
+      - name: Retry toolchain setup (first attempt failed)
+        if: steps.setup_soldr.outcome == 'failure'
+        uses: zackees/setup-soldr@v0
         with:
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
@@ -101,7 +116,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Retried on purpose: this action has failed with a transient `write EPIPE`
+      # during cache restore (issue #55), which skipped the publish job and turned a
+      # tagged release into a silent no-op. A `uses:` step cannot be wrapped by a
+      # retry action, so attempt it twice explicitly.
       - uses: zackees/setup-soldr@v0
+        id: setup_soldr
+        continue-on-error: true
+        with:
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+          build-cache-mode: full
+
+      - name: Retry toolchain setup (first attempt failed)
+        if: steps.setup_soldr.outcome == 'failure'
+        uses: zackees/setup-soldr@v0
         with:
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
@@ -155,6 +185,34 @@ jobs:
         working-directory: rust
         run: soldr cargo publish --dry-run -p mimalloc-pprof --locked
 
+      # Trust the registry, not the exit code. `cargo publish` returning 0 is not the
+      # same as the version being live and installable, and after issue #55 the whole
+      # point is that a green-looking pipeline had published nothing.
+      - name: Verify the version is live on crates.io
+        if: env.IS_DRY_RUN != 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          version="$(grep -m1 '^version' rust/mimalloc-pprof/Cargo.toml | cut -d'"' -f2)"
+          url="https://crates.io/api/v1/crates/mimalloc-pprof/${version}"
+          echo "checking ${url}"
+          # The index can lag the publish by a few seconds; poll rather than fail fast.
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            code="$(curl -sS -o /tmp/crate.json -w '%{http_code}'                       -H 'User-Agent: mimalloc-pprof release verification' "$url" || echo 000)"
+            if [ "$code" = "200" ]; then
+              if grep -q '"yanked":true' /tmp/crate.json; then
+                echo "::error::mimalloc-pprof ${version} is on crates.io but YANKED."
+                exit 1
+              fi
+              echo "confirmed: mimalloc-pprof ${version} is live on crates.io"
+              exit 0
+            fi
+            echo "attempt ${attempt}: HTTP ${code}, retrying in 15s"
+            sleep 15
+          done
+          echo "::error::mimalloc-pprof ${version} is NOT on crates.io after publishing. The tag exists but the release did not land -- do not assume this release succeeded."
+          exit 1
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -162,3 +220,26 @@ jobs:
           name: mimalloc-pprof ${{ steps.tag.outputs.tag }}
           draft: ${{ env.IS_DRY_RUN == 'true' }}
           files: dist/mimalloc-pprof-c-${{ steps.tag.outputs.tag }}.zip
+
+  # Issue #55: the publish job is gated on all three OS builds, so a single transient
+  # runner failure silently turns a tagged release into a no-op. This job makes that
+  # outcome impossible to miss and says exactly how to recover.
+  release-outcome:
+    name: Release outcome check
+    needs: [build-and-package, release]
+    if: always() && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail loudly if the tag did not produce a release
+        shell: bash
+        run: |
+          build='${{ needs.build-and-package.result }}'
+          release='${{ needs.release.result }}'
+          echo "build-and-package: ${build}"
+          echo "release: ${release}"
+          if [ "$release" = "success" ]; then
+            echo "tag ${GITHUB_REF_NAME} released successfully"
+            exit 0
+          fi
+          echo "::error::Tag ${GITHUB_REF_NAME} was pushed but NOT released (build=${build}, release=${release}). Nothing was published to crates.io. If this was a transient runner failure, recover with: gh run rerun ${GITHUB_RUN_ID} --failed"
+          exit 1


### PR DESCRIPTION
Fixes #55.

## What happened

The real `v0.9.0` release run failed on `macos-latest` inside `zackees/setup-soldr` with a transient `write EPIPE` during cache restore. The publish job is gated on all three OS builds, so it was **skipped** — the tag existed but produced no crates.io version. It was only recovered because someone noticed the red run and re-ran it by hand.

The gating itself is correct; a partially-validated release would be worse. The problem is that a transient runner hiccup quietly converts a tagged release into a no-op.

## Three changes

**1. Retry the toolchain setup.** A `uses:` step can't be wrapped by a retry action, so the first attempt is `continue-on-error` and a second runs only if the first failed. Applied to both jobs.

**2. Verify the version is actually live on crates.io after publishing.** Polls up to 10 times (the index can lag the publish) and fails if the version is missing *or yanked*.

This is the substantive one: `cargo publish` exiting 0 is **not** the same as the version being installable, and the entire lesson of this incident is that a green-looking pipeline had published nothing. It mirrors the manual registry check I did for 0.9.0.

**3. Add a `release-outcome` job** that runs on any tag push with `if: always()` and fails with an explicit message — including the `gh run rerun <id> --failed` recovery command — when the tag did not produce a release. A skipped publish is now impossible to mistake for a successful one.

Also replaced the version-extraction `sed` with `cut -d'"' -f2`; the backslash backreference was fragile to escape and offered nothing over `cut` here.

## Validation

Dry-run dispatched against this branch — **green on all three OSes**, publish job included. The `release-outcome` job correctly showed as *skipped*, since it is gated on `github.event_name == 'push'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)