### PR TITLE
release: 0.8.1 -- ship the MinGW thread-cleanup fix to crates.io

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -53,7 +53,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Retried on purpose: this action has failed with a transient `write EPIPE`
+      # during cache restore (issue #55), which skipped the publish job and turned a
+      # tagged release into a silent no-op. A `uses:` step cannot be wrapped by a
+      # retry action, so attempt it twice explicitly.
       - uses: zackees/setup-soldr@v0
+        id: setup_soldr
+        continue-on-error: true
+        with:
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+          build-cache-mode: full
+
+      - name: Retry toolchain setup (first attempt failed)
+        if: steps.setup_soldr.outcome == 'failure'
+        uses: zackees/setup-soldr@v0
         with:
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
@@ -101,7 +116,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Retried on purpose: this action has failed with a transient `write EPIPE`
+      # during cache restore (issue #55), which skipped the publish job and turned a
+      # tagged release into a silent no-op. A `uses:` step cannot be wrapped by a
+      # retry action, so attempt it twice explicitly.
       - uses: zackees/setup-soldr@v0
+        id: setup_soldr
+        continue-on-error: true
+        with:
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+          build-cache-mode: full
+
+      - name: Retry toolchain setup (first attempt failed)
+        if: steps.setup_soldr.outcome == 'failure'
+        uses: zackees/setup-soldr@v0
         with:
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
@@ -155,6 +185,34 @@ jobs:
         working-directory: rust
         run: soldr cargo publish --dry-run -p mimalloc-pprof --locked
 
+      # Trust the registry, not the exit code. `cargo publish` returning 0 is not the
+      # same as the version being live and installable, and after issue #55 the whole
+      # point is that a green-looking pipeline had published nothing.
+      - name: Verify the version is live on crates.io
+        if: env.IS_DRY_RUN != 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+          version="$(grep -m1 '^version' rust/mimalloc-pprof/Cargo.toml | cut -d'"' -f2)"
+          url="https://crates.io/api/v1/crates/mimalloc-pprof/${version}"
+          echo "checking ${url}"
+          # The index can lag the publish by a few seconds; poll rather than fail fast.
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            code="$(curl -sS -o /tmp/crate.json -w '%{http_code}'                       -H 'User-Agent: mimalloc-pprof release verification' "$url" || echo 000)"
+            if [ "$code" = "200" ]; then
+              if grep -q '"yanked":true' /tmp/crate.json; then
+                echo "::error::mimalloc-pprof ${version} is on crates.io but YANKED."
+                exit 1
+              fi
+              echo "confirmed: mimalloc-pprof ${version} is live on crates.io"
+              exit 0
+            fi
+            echo "attempt ${attempt}: HTTP ${code}, retrying in 15s"
+            sleep 15
+          done
+          echo "::error::mimalloc-pprof ${version} is NOT on crates.io after publishing. The tag exists but the release did not land -- do not assume this release succeeded."
+          exit 1
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -162,3 +220,26 @@ jobs:
           name: mimalloc-pprof ${{ steps.tag.outputs.tag }}
           draft: ${{ env.IS_DRY_RUN == 'true' }}
           files: dist/mimalloc-pprof-c-${{ steps.tag.outputs.tag }}.zip
+
+  # Issue #55: the publish job is gated on all three OS builds, so a single transient
+  # runner failure silently turns a tagged release into a no-op. This job makes that
+  # outcome impossible to miss and says exactly how to recover.
+  release-outcome:
+    name: Release outcome check
+    needs: [build-and-package, release]
+    if: always() && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail loudly if the tag did not produce a release
+        shell: bash
+        run: |
+          build='${{ needs.build-and-package.result }}'
+          release='${{ needs.release.result }}'
+          echo "build-and-package: ${build}"
+          echo "release: ${release}"
+          if [ "$release" = "success" ]; then
+            echo "tag ${GITHUB_REF_NAME} released successfully"
+            exit 0
+          fi
+          echo "::error::Tag ${GITHUB_REF_NAME} was pushed but NOT released (build=${build}, release=${release}). Nothing was published to crates.io. If this was a transient runner failure, recover with: gh run rerun ${GITHUB_RUN_ID} --failed"
+          exit 1

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cc",
  "regex",

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "mimalloc-pprof"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "MIT"
-description = "mimalloc global allocator with pprof support"
+description = "mimalloc global allocator with pprof-compatible sampled heap profiling (mimalloc v2 engine)"
+repository = "https://github.com/zackees/mimalloc-pprof"
+homepage = "https://github.com/zackees/mimalloc-pprof"
+documentation = "https://docs.rs/mimalloc-pprof"
+readme = "README.md"
+keywords = ["mimalloc", "allocator", "pprof", "profiling", "heap"]
+categories = ["memory-management", "development-tools::profiling"]
 links = "mimalloc"
 build = "build.rs"
 

--- a/rust/mimalloc-pprof/README.md
+++ b/rust/mimalloc-pprof/README.md
@@ -1,0 +1,84 @@
+# mimalloc-pprof (v2 engine)
+
+[mimalloc](https://github.com/microsoft/mimalloc) as a Rust global allocator, with
+**pprof-compatible sampled heap profiling** built in. Windows is a first-class
+target alongside Linux and macOS.
+
+Dumps open directly in [google/pprof](https://github.com/google/pprof) for flame
+graphs, call graphs, top reports, and profile diffs.
+
+> **This is the 0.8.x line, built on the mimalloc v2 engine.**
+> The current line is [**0.9.x**](https://crates.io/crates/mimalloc-pprof), built on
+> mimalloc v3, and is what most users should take. The profiler API, environment
+> variables, and output formats are identical, so moving between them is a version
+> bump rather than a code change. 0.8.x remains available for anyone who prefers the
+> longer-established v2 allocator.
+
+## Upgrade note for 0.8.0 users
+
+**0.8.0 leaks memory on Windows/MinGW and should not be used.** Every exiting thread
+leaked its thread-local heap and pages — about 0.24 GB per stress iteration, reaching
+23.5 GB at 100 iterations, growing without bound. The process still exited
+successfully, so it was invisible on a large-memory machine and only surfaced as an
+out-of-memory failure on a smaller one.
+
+0.8.1 fixes it: flat at 0.28 GB across the same run. MSVC builds were never affected.
+Details in [issue #47](https://github.com/zackees/mimalloc-pprof/issues/47).
+
+## Usage
+
+```toml
+[dependencies]
+mimalloc-pprof = "0.8"
+
+[profile.release]
+debug = "line-tables-only"
+strip = false
+```
+
+```rust
+use mimalloc_pprof::{prof, MiMalloc};
+use std::path::Path;
+
+#[global_allocator]
+static ALLOCATOR: MiMalloc = MiMalloc;
+
+fn main() -> std::io::Result<()> {
+    assert!(prof::start(0), "profiler already running"); // 0 = default, ~512 KiB
+
+    let retained = vec![0_u8; 1024 * 1024];
+    prof::dump_file(Path::new("heap.prof"))?;            // dump while still live
+    std::hint::black_box(&retained);
+
+    prof::stop();
+    Ok(())
+}
+```
+
+Then:
+
+```sh
+pprof -http=:0 ./target/release/my_app heap.prof
+```
+
+Or profile without touching the code at all:
+
+```sh
+MIMALLOC_PROF=1 MIMALLOC_PROF_DUMP_AT_EXIT=heap.prof ./my_app
+```
+
+## Notes
+
+- On Linux and macOS, keep frame pointers for reliable stack walking:
+  `rustflags = ["-Cforce-frame-pointers=yes"]` in `.cargo/config.toml`.
+  Windows x64 uses unwind information instead — keep the PDB.
+- Do not link a second mimalloc into the same process; this crate vendors its own.
+- The per-heap allocator statistics (`ProfStats::heap`) are a v3 feature and are not
+  available on this line.
+
+Full documentation is in the
+[repository README](https://github.com/zackees/mimalloc-pprof).
+
+## License
+
+MIT, the same as upstream mimalloc.


### PR DESCRIPTION
Fixes #54.

**0.8.0 on crates.io still leaks memory on Windows/MinGW.** The fix landed on this branch in #48 but was never published, so everyone pinned to the 0.8.x line is running the broken version.

| iterations | 0.8.0 | 0.8.1 |
|---|---|---|
| 12 | 2.35 GB | 0.24 GB |
| 25 | 5.75 GB | 0.25 GB |
| 50 | 11.98 GB | 0.28 GB |
| 100 | **23.50 GB** | **0.28 GB** |

Linear and unbounded before; flat after. The process still exits 0, which is why it went unnoticed — invisible on a large-memory machine, fatal on a small one. MSVC was never affected.

## What is in this PR

- **Version bump to 0.8.1.**
- **Crate metadata** (repository/homepage/documentation/keywords/categories) and a sharper description, ported from #53, so the crates.io page is not bare.
- **A crate-level README** — what crates.io actually renders. It deliberately *leads with the upgrade warning*: anyone landing on 0.8.x from a search should immediately see that 0.8.0 leaks and that 0.9.x is the current line. It also notes that the per-heap statistics are v3-only, so nobody expects them here.
- **The hardened auto-release workflow from #55**, so this release cannot silently publish nothing the way v0.9.0's first attempt did. I verified the two branches' workflows were byte-identical beforehand, so this is a clean copy rather than a merge.

## Validation

- `xtask check` — vendored amalgamation matches `src/`/`include/`
- Rust workspace suite green (`--locked`)
- Memory scaling table above, measured on this branch

## After merge

Tag `v0.8.1` — pushing the single ref explicitly (`git push origin refs/tags/v0.8.1`), never `--tags`, since this repo carries upstream mimalloc's ~100 `v1/v2/v3` tags locally and `auto-release` fires on any `v*` tag.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)