### PR TITLE
test+ci: memory and counter regression gate

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -118,6 +118,21 @@ jobs:
             exit 0
           fi
           exit $rc
+      # A gate that has never been observed to fire proves nothing -- it can be broken
+      # for months while every run stays green. Build a deliberately leaky copy and
+      # require the same comparison to catch it. This step failing means the gate above
+      # is decoration, so it is a hard failure, not a warning.
+      - name: Positive control -- the gate must catch an injected leak
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake -B build-leak -DMI_PPROF=ON -DMI_BENCH_INJECT_LEAK=200000
+          cmake --build build-leak --config Release --target mimalloc-test-memory-gate
+          exe=$(find build-leak -name 'mimalloc-test-memory-gate*' -type f -perm -u+x | head -1)
+          for i in 1 2 3 4; do
+            MI_BENCH_JSON="leak-$i.json" "$exe" > /dev/null || true
+          done
+          python3 ci/memory_gate.py control leak-*.json
       - uses: actions/upload-artifact@v4
         with:
           name: memory-gate-${{ matrix.os }}

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -99,11 +99,19 @@ jobs:
       - name: Emit JSON and compare against baseline
         shell: bash
         run: |
+          # NOTE: GitHub invokes `bash -e`, so a plain `set -uo pipefail` does NOT
+          # disable errexit -- the script would die on the gate's non-zero exit before
+          # the rc check could run. `set +e` is required, not decorative.
+          set +e
           set -uo pipefail
           exe=$(find build -name 'mimalloc-test-memory-gate*' -type f -perm -u+x | head -1)
-          MI_BENCH_JSON=result.json "$exe" > /dev/null
-          cat result.json
-          python3 ci/memory_gate.py check result.json
+          # Peak memory is noisy; the gate compares the minimum of several runs. Four
+          # is what the committed baselines are built from.
+          for i in 1 2 3 4; do
+            MI_BENCH_JSON="result-$i.json" "$exe" > /dev/null
+          done
+          cat result-1.json
+          python3 ci/memory_gate.py check result-*.json
           rc=$?
           if [ $rc -eq 2 ]; then
             echo "::warning::No committed baseline for this platform yet -- bootstrap it from this run's artifact."
@@ -113,7 +121,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: memory-gate-${{ matrix.os }}
-          path: result.json
+          path: result-*.json
           if-no-files-found: error
 
   ctest-win-gnu:

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -73,6 +73,49 @@ jobs:
       - run: cmake --build build
       - run: ctest --test-dir build --output-on-failure
 
+  # Memory + counter regression gate (issue #63). The test's own inline assertions are
+  # self-relative and gate on every runner unconditionally. The committed baselines add
+  # cross-COMMIT drift detection, which a per-run ratio cannot see: a leak introduced
+  # 3% at a time over ten PRs passes every self-relative check and still doubles memory.
+  #
+  # Baselines are per platform AND per MI_PPROF setting, never shared: lazy zeroing makes
+  # Linux RSS and Windows commit incomparable for identical behavior, and rule 4 puts the
+  # profiler's own arena in process memory so an ON build legitimately peaks higher.
+  memory-gate:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: cmake -B build -DMI_PPROF=ON
+      - run: cmake --build build --config Release
+      - name: Run the gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          ctest --test-dir build -C Release -R test-memory-gate --output-on-failure
+      - name: Emit JSON and compare against baseline
+        shell: bash
+        run: |
+          set -uo pipefail
+          exe=$(find build -name 'mimalloc-test-memory-gate*' -type f -perm -u+x | head -1)
+          MI_BENCH_JSON=result.json "$exe" > /dev/null
+          cat result.json
+          python3 ci/memory_gate.py check result.json
+          rc=$?
+          if [ $rc -eq 2 ]; then
+            echo "::warning::No committed baseline for this platform yet -- bootstrap it from this run's artifact."
+            exit 0
+          fi
+          exit $rc
+      - uses: actions/upload-artifact@v4
+        with:
+          name: memory-gate-${{ matrix.os }}
+          path: result.json
+          if-no-files-found: error
+
   ctest-win-gnu:
     runs-on: windows-latest
     defaults:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -903,6 +903,27 @@ if (MI_BUILD_TESTS)
     set_tests_properties(test-profile-race PROPERTIES TIMEOUT 300)
   endif()
 
+  # Memory + counter regression gate (issue #63). Emits JSON for CI baseline
+  # comparison; MI_BENCH_INJECT_LEAK is a build-time-only positive control.
+  add_executable(mimalloc-test-memory-gate test/test-memory-gate.c)
+  target_compile_definitions(mimalloc-test-memory-gate PRIVATE ${mi_defines})
+  if(MI_BENCH_INJECT_LEAK)
+    target_compile_definitions(mimalloc-test-memory-gate PRIVATE MI_BENCH_INJECT_LEAK=${MI_BENCH_INJECT_LEAK})
+  endif()
+  target_compile_options(mimalloc-test-memory-gate PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-memory-gate PRIVATE include)
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    target_link_libraries(mimalloc-test-memory-gate PRIVATE mimalloc-static ${mi_libraries})
+  else()
+    target_link_libraries(mimalloc-test-memory-gate PRIVATE mimalloc ${mi_libraries})
+  endif()
+  if(NOT WIN32)
+    find_package(Threads REQUIRED)
+    target_link_libraries(mimalloc-test-memory-gate PRIVATE Threads::Threads)
+  endif()
+  add_test(NAME test-memory-gate COMMAND mimalloc-test-memory-gate)
+  set_tests_properties(test-memory-gate PROPERTIES TIMEOUT 900)
+
   # Degenerate memory patterns and memory-bound regression guards (issue #47).
   # Independent of MI_PPROF: it guards allocator behavior, not the profiler.
   add_executable(mimalloc-test-degenerate test/test-degenerate.c)

--- a/ci/memory-baselines/linux-pprof1.json
+++ b/ci/memory-baselines/linux-pprof1.json
@@ -1,0 +1,23 @@
+{
+  "baseline_runs": 4,
+  "baseline_spread_pct": 5.8,
+  "counters": {
+    "pages_end": 1,
+    "pages_start": 1,
+    "theaps_end": 1,
+    "theaps_start": 0,
+    "threads_end": 1,
+    "threads_start": 1
+  },
+  "gated_metric": "peak_rss",
+  "inject_leak": 0,
+  "mi_pprof": 1,
+  "peak_commit_mb": 49.7,
+  "peak_mb": 22.3,
+  "peak_minus_profiler_mb": 22.3,
+  "peak_rss_mb": 22.3,
+  "platform": "linux",
+  "profiler_arena_mb": 0.0,
+  "purged_gb": 0.06,
+  "schema": 1
+}

--- a/ci/memory-baselines/macos-pprof1.json
+++ b/ci/memory-baselines/macos-pprof1.json
@@ -1,0 +1,23 @@
+{
+  "baseline_runs": 4,
+  "baseline_spread_pct": 0.7,
+  "counters": {
+    "pages_end": 1,
+    "pages_start": 0,
+    "theaps_end": 1,
+    "theaps_start": 0,
+    "threads_end": 1,
+    "threads_start": 1
+  },
+  "gated_metric": "peak_rss",
+  "inject_leak": 0,
+  "mi_pprof": 1,
+  "peak_commit_mb": 58.7,
+  "peak_mb": 13.4,
+  "peak_minus_profiler_mb": 13.4,
+  "peak_rss_mb": 13.4,
+  "platform": "macos",
+  "profiler_arena_mb": 0.0,
+  "purged_gb": 0.07,
+  "schema": 1
+}

--- a/ci/memory-baselines/windows-pprof1.json
+++ b/ci/memory-baselines/windows-pprof1.json
@@ -1,0 +1,23 @@
+{
+  "baseline_runs": 4,
+  "baseline_spread_pct": 9.9,
+  "counters": {
+    "pages_end": 1,
+    "pages_start": 0,
+    "theaps_end": 1,
+    "theaps_start": 0,
+    "threads_end": 1,
+    "threads_start": 1
+  },
+  "gated_metric": "peak_commit",
+  "inject_leak": 0,
+  "mi_pprof": 1,
+  "peak_commit_mb": 52.5,
+  "peak_mb": 52.5,
+  "peak_minus_profiler_mb": 52.5,
+  "peak_rss_mb": 16.2,
+  "platform": "windows",
+  "profiler_arena_mb": 0.0,
+  "purged_gb": 0.06,
+  "schema": 1
+}

--- a/ci/memory_gate.py
+++ b/ci/memory_gate.py
@@ -10,9 +10,16 @@ Windows commit report different numbers for identical allocator behavior, and ma
 compresses memory so its resident figure falls under pressure while a leak grows. Only
 same-OS deltas are meaningful.
 
+Peak memory is *not* a low-variance signal, so both commands take several runs of the
+same binary and use the **minimum** observed peak. Noise on a shared CI runner only ever
+adds memory (another tenant's page cache, a straggler thread still winding down), so the
+minimum is the estimator closest to the allocator's true high-water mark, and it is far
+more stable than any single run. The spread across runs is printed every time -- if it
+ever approaches the tolerance, the tolerance is wrong and the printout says so.
+
 Usage:
-    memory_gate.py check   <result.json>   # compare against the committed baseline
-    memory_gate.py update  <result.json>   # re-baseline (deliberate, reviewed act)
+    memory_gate.py check   <result.json> [more.json ...]
+    memory_gate.py update  <result.json> [more.json ...]   # deliberate, reviewed act
 
 Exit codes: 0 pass, 1 regression, 2 usage/IO error.
 """
@@ -23,10 +30,22 @@ import sys
 
 BASELINE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "memory-baselines")
 
-# Peak memory tolerance. Deliberately tighter than a throughput threshold would be:
-# memory is the low-variance signal here (the gated numbers are kernel high-water marks,
-# not sampled), and this repository has shipped two memory bugs and zero throughput bugs.
-PEAK_TOLERANCE = 0.10
+# Peak memory tolerance, applied to the minimum of RUNS_EXPECTED runs.
+#
+# An earlier version of this file asserted that memory was "the low-variance signal here
+# (the gated numbers are kernel high-water marks, not sampled)" and set this to 0.10.
+# That was an assumption, and measuring disproved it: repeated runs of the same binary
+# span roughly 20% peak-to-peak. Taking the minimum of several runs cuts that to a few
+# percent, which is what makes a tight threshold defensible rather than flaky.
+#
+# This number is set from the observed spread reported by the runs below, not guessed.
+# Raise it only with the measurement that justifies it; a gate that flakes gets ignored,
+# and an ignored gate is worse than none.
+PEAK_TOLERANCE = 0.15
+
+# Number of runs the CI job is expected to supply. Fewer is allowed (with a warning) so
+# the script stays usable locally, but the committed baselines are min-of-N.
+RUNS_EXPECTED = 4
 
 # Counters are exact, not statistical. A thread that was created and joined must not
 # still be live; anything above this is cleanup that did not run. Matches the inline
@@ -47,8 +66,40 @@ def load(path):
         return json.load(f)
 
 
-def check(result_path):
-    result = load(result_path)
+def load_runs(paths):
+    """Load N runs of the same configuration and return (representative, peak_mb, spread%).
+
+    The representative record is the run with the minimum gated peak; its counters are
+    the ones checked, so the counter assertions and the peak refer to the same run.
+    """
+    runs = [load(p) for p in paths]
+    keys = {(r["platform"], r["mi_pprof"], r["gated_metric"]) for r in runs}
+    if len(keys) != 1:
+        raise ValueError(
+            "runs are not from the same configuration: {}".format(sorted(keys)))
+    peaks = sorted(r["peak_mb"] for r in runs)
+    best = min(runs, key=lambda r: r["peak_mb"])
+    spread = (100.0 * (peaks[-1] - peaks[0]) / peaks[0]) if peaks[0] else 0.0
+    return best, peaks, spread
+
+
+def report_runs(peaks, spread):
+    print("  {:<22} {}".format(
+        "runs (MB)", "  ".join("{:.1f}".format(p) for p in peaks)))
+    print("  {:<22} {:.1f}%  (min is used; noise on a shared runner only adds memory)"
+          .format("spread across runs", spread))
+    if len(peaks) < RUNS_EXPECTED:
+        print("  WARNING: only {} run(s); the committed baselines are min-of-{}. "
+              "A single run is not comparable.".format(len(peaks), RUNS_EXPECTED))
+    if spread >= 100.0 * PEAK_TOLERANCE:
+        print("  WARNING: observed spread ({:.1f}%) is at or above the tolerance "
+              "({:.0f}%). The threshold cannot distinguish a regression from noise -- "
+              "raise RUNS_EXPECTED or the tolerance, with this measurement as the "
+              "justification.".format(spread, 100.0 * PEAK_TOLERANCE))
+
+
+def check(result_paths):
+    result, peaks, spread = load_runs(result_paths)
 
     if result.get("inject_leak", 0):
         # An injected-leak run is a positive control; it is expected to fail and must
@@ -61,13 +112,13 @@ def check(result_path):
     if not os.path.exists(bpath):
         print("No baseline at {}.".format(bpath))
         print("This platform/config has never been recorded. Create it with:")
-        print("    python ci/memory_gate.py update {}".format(result_path))
+        print("    python ci/memory_gate.py update {}".format(" ".join(result_paths)))
         return 2
     base = load(bpath)
 
     failures = []
     metric = result["gated_metric"]
-    peak, base_peak = result["peak_mb"], base["peak_mb"]
+    peak, base_peak = peaks[0], base["peak_mb"]
     allowed = base_peak * (1.0 + PEAK_TOLERANCE)
 
     print("platform={} metric={} mi_pprof={}".format(
@@ -77,6 +128,7 @@ def check(result_path):
     print("  {:<22} {:>9.1f} MB   (reported so the profiler's own arena is not "
           "mistaken for allocator growth)".format(
               "profiler arena", result.get("profiler_arena_mb", 0.0)))
+    report_runs(peaks, spread)
 
     if peak > allowed:
         failures.append(
@@ -101,7 +153,7 @@ def check(result_path):
         for f in failures:
             print("  - {}".format(f))
         print("\nIf this growth is intentional, re-baseline deliberately:")
-        print("    python ci/memory_gate.py update {}".format(result_path))
+        print("    python ci/memory_gate.py update {}".format(" ".join(result_paths)))
         print("and say why in the PR. Do not re-baseline to make a red gate green.")
         return 1
 
@@ -109,26 +161,33 @@ def check(result_path):
     return 0
 
 
-def update(result_path):
-    result = load(result_path)
+def update(result_paths):
+    result, peaks, spread = load_runs(result_paths)
     if result.get("inject_leak", 0):
         print("REFUSING to baseline a run with MI_BENCH_INJECT_LEAK set.")
         return 2
     os.makedirs(BASELINE_DIR, exist_ok=True)
     bpath = baseline_path(result)
+    # Record how the number was obtained, so a later reader can tell whether a baseline
+    # is comparable to the current methodology rather than having to guess.
+    record = dict(result)
+    record["peak_mb"] = peaks[0]
+    record["baseline_runs"] = len(peaks)
+    record["baseline_spread_pct"] = round(spread, 1)
     with open(bpath, "w", encoding="utf-8") as f:
-        json.dump(result, f, indent=2, sort_keys=True)
+        json.dump(record, f, indent=2, sort_keys=True)
         f.write("\n")
-    print("wrote {} (peak {:.1f} MB)".format(bpath, result["peak_mb"]))
+    print("wrote {} (min peak {:.1f} MB of {} runs)".format(bpath, peaks[0], len(peaks)))
+    report_runs(peaks, spread)
     return 0
 
 
 def main(argv):
-    if len(argv) != 3 or argv[1] not in ("check", "update"):
+    if len(argv) < 3 or argv[1] not in ("check", "update"):
         print(__doc__)
         return 2
     try:
-        return check(argv[2]) if argv[1] == "check" else update(argv[2])
+        return check(argv[2:]) if argv[1] == "check" else update(argv[2:])
     except (OSError, ValueError, KeyError) as e:
         print("error: {}".format(e))
         return 2

--- a/ci/memory_gate.py
+++ b/ci/memory_gate.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Compare a test-memory-gate JSON run against the committed per-platform baseline.
+
+This is the piece that turns test-memory-gate from a self-relative assertion into an
+actual regression gate: it compares against numbers recorded on a previous commit, so a
+leak introduced gradually over several PRs cannot hide inside a per-run ratio.
+
+Why per-platform baselines and never a shared one: lazy zeroing means Linux RSS and
+Windows commit report different numbers for identical allocator behavior, and macOS
+compresses memory so its resident figure falls under pressure while a leak grows. Only
+same-OS deltas are meaningful.
+
+Usage:
+    memory_gate.py check   <result.json>   # compare against the committed baseline
+    memory_gate.py update  <result.json>   # re-baseline (deliberate, reviewed act)
+
+Exit codes: 0 pass, 1 regression, 2 usage/IO error.
+"""
+
+import json
+import os
+import sys
+
+BASELINE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "memory-baselines")
+
+# Peak memory tolerance. Deliberately tighter than a throughput threshold would be:
+# memory is the low-variance signal here (the gated numbers are kernel high-water marks,
+# not sampled), and this repository has shipped two memory bugs and zero throughput bugs.
+PEAK_TOLERANCE = 0.10
+
+# Counters are exact, not statistical. A thread that was created and joined must not
+# still be live; anything above this is cleanup that did not run. Matches the inline
+# assertion in test-memory-gate.c.
+MAX_LIVE_THREADS = 32
+
+
+def baseline_path(result):
+    # MI_PPROF changes the legitimate peak (rule 4 puts the profiler arena in process
+    # memory), so ON and OFF get separate baselines rather than one padded threshold.
+    return os.path.join(
+        BASELINE_DIR, "{}-pprof{}.json".format(result["platform"], result["mi_pprof"])
+    )
+
+
+def load(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def check(result_path):
+    result = load(result_path)
+
+    if result.get("inject_leak", 0):
+        # An injected-leak run is a positive control; it is expected to fail and must
+        # never be mistaken for a real result or used to re-baseline.
+        print("REFUSING: this run has MI_BENCH_INJECT_LEAK set and is a positive "
+              "control, not a measurement.")
+        return 2
+
+    bpath = baseline_path(result)
+    if not os.path.exists(bpath):
+        print("No baseline at {}.".format(bpath))
+        print("This platform/config has never been recorded. Create it with:")
+        print("    python ci/memory_gate.py update {}".format(result_path))
+        return 2
+    base = load(bpath)
+
+    failures = []
+    metric = result["gated_metric"]
+    peak, base_peak = result["peak_mb"], base["peak_mb"]
+    allowed = base_peak * (1.0 + PEAK_TOLERANCE)
+
+    print("platform={} metric={} mi_pprof={}".format(
+        result["platform"], metric, result["mi_pprof"]))
+    print("  {:<22} {:>9.1f} MB   baseline {:>9.1f} MB   allowed {:>9.1f} MB".format(
+        metric, peak, base_peak, allowed))
+    print("  {:<22} {:>9.1f} MB   (reported so the profiler's own arena is not "
+          "mistaken for allocator growth)".format(
+              "profiler arena", result.get("profiler_arena_mb", 0.0)))
+
+    if peak > allowed:
+        failures.append(
+            "{} regressed: {:.1f} MB vs baseline {:.1f} MB (+{:.1f}%, allowed +{:.0f}%)".format(
+                metric, peak, base_peak,
+                100.0 * (peak - base_peak) / base_peak if base_peak else float("inf"),
+                100.0 * PEAK_TOLERANCE))
+
+    c = result["counters"]
+    print("  counters: threads {}->{}  theaps {}->{}  pages {}->{}".format(
+        c["threads_start"], c["threads_end"], c["theaps_start"],
+        c["theaps_end"], c["pages_start"], c["pages_end"]))
+
+    if c["threads_end"] >= MAX_LIVE_THREADS:
+        failures.append(
+            "{} threads still live after the run (limit {}). Thread-exit cleanup is "
+            "not running -- this is the signature of #44 / #47.".format(
+                c["threads_end"], MAX_LIVE_THREADS))
+
+    if failures:
+        print("\nFAIL")
+        for f in failures:
+            print("  - {}".format(f))
+        print("\nIf this growth is intentional, re-baseline deliberately:")
+        print("    python ci/memory_gate.py update {}".format(result_path))
+        print("and say why in the PR. Do not re-baseline to make a red gate green.")
+        return 1
+
+    print("\nPASS")
+    return 0
+
+
+def update(result_path):
+    result = load(result_path)
+    if result.get("inject_leak", 0):
+        print("REFUSING to baseline a run with MI_BENCH_INJECT_LEAK set.")
+        return 2
+    os.makedirs(BASELINE_DIR, exist_ok=True)
+    bpath = baseline_path(result)
+    with open(bpath, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print("wrote {} (peak {:.1f} MB)".format(bpath, result["peak_mb"]))
+    return 0
+
+
+def main(argv):
+    if len(argv) != 3 or argv[1] not in ("check", "update"):
+        print(__doc__)
+        return 2
+    try:
+        return check(argv[2]) if argv[1] == "check" else update(argv[2])
+    except (OSError, ValueError, KeyError) as e:
+        print("error: {}".format(e))
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/ci/memory_gate.py
+++ b/ci/memory_gate.py
@@ -20,6 +20,7 @@ ever approaches the tolerance, the tolerance is wrong and the printout says so.
 Usage:
     memory_gate.py check   <result.json> [more.json ...]
     memory_gate.py update  <result.json> [more.json ...]   # deliberate, reviewed act
+    memory_gate.py control <result.json> [more.json ...]   # positive control: must FAIL
 
 Exit codes: 0 pass, 1 regression, 2 usage/IO error.
 """
@@ -98,19 +99,49 @@ def report_runs(peaks, spread):
               "justification.".format(spread, 100.0 * PEAK_TOLERANCE))
 
 
-def check(result_paths):
+def control(result_paths):
+    """Positive control: require the gate to FAIL on a deliberately leaky build.
+
+    A gate that has never been observed to fire proves nothing -- it can be silently
+    broken for months and every run still looks green. So CI builds a copy with
+    MI_BENCH_INJECT_LEAK, runs it through the very same comparison, and this command
+    inverts the verdict: exit 0 only if `check` would have failed.
+
+    Requiring inject_leak to be *set* is what keeps this from being usable as an escape
+    hatch -- it cannot be pointed at a real regression to turn it green.
+    """
+    result, _, _ = load_runs(result_paths)
+    if not result.get("inject_leak", 0):
+        print("REFUSING: positive control requires a build with MI_BENCH_INJECT_LEAK "
+              "set. This run has none, so a failure here would mean a real regression, "
+              "not a working control.")
+        return 2
+
+    print("=== positive control: the gate is expected to FAIL below ===")
+    rc = check(result_paths, _control=True)
+    if rc == 1:
+        print("\nPASS (control): the gate detected the injected leak.")
+        return 0
+    print("\nFAIL (control): the gate did NOT detect an injected leak (rc={}).".format(rc))
+    print("The gate is not working. A green `check` on a real build means nothing")
+    print("until this passes.")
+    return 1
+
+
+def check(result_paths, _control=False):
     result, peaks, spread = load_runs(result_paths)
 
-    if result.get("inject_leak", 0):
+    if result.get("inject_leak", 0) and not _control:
         # An injected-leak run is a positive control; it is expected to fail and must
         # never be mistaken for a real result or used to re-baseline.
         print("REFUSING: this run has MI_BENCH_INJECT_LEAK set and is a positive "
-              "control, not a measurement.")
+              "control, not a measurement. Use `memory_gate.py control` for that.")
         return 2
 
     bpath = baseline_path(result)
     if not os.path.exists(bpath):
         print("No baseline at {}.".format(bpath))
+        report_runs(peaks, spread)
         print("This platform/config has never been recorded. Create it with:")
         print("    python ci/memory_gate.py update {}".format(" ".join(result_paths)))
         return 2
@@ -183,11 +214,12 @@ def update(result_paths):
 
 
 def main(argv):
-    if len(argv) < 3 or argv[1] not in ("check", "update"):
+    if len(argv) < 3 or argv[1] not in ("check", "update", "control"):
         print(__doc__)
         return 2
     try:
-        return check(argv[2:]) if argv[1] == "check" else update(argv[2:])
+        cmd = {"check": check, "update": update, "control": control}[argv[1]]
+        return cmd(argv[2:])
     except (OSError, ValueError, KeyError) as e:
         print("error: {}".format(e))
         return 2

--- a/test/test-memory-gate.c
+++ b/test/test-memory-gate.c
@@ -1,0 +1,371 @@
+/* Memory and counter regression gate.
+
+   This repository shipped two unbounded memory leaks (#44 v3, #47 v2) -- 23.5 GB at 100
+   iterations of test-stress -- through a completely green CI pipeline. Every test asked
+   "did it crash?" and none asked "did memory stay bounded?". An audit of the workflows
+   confirmed it: no baseline, no threshold, no memory assertion anywhere.
+
+   This binary is the answer. It runs a battery of allocation stress scenarios, records
+   peak memory and the engine's own liveness counters, and emits a JSON blob that CI
+   compares against a committed baseline. It also asserts bounds inline, so it fails
+   usefully when run by hand with no CI around it.
+
+   Design notes that matter:
+
+   - Peak memory is not one number across platforms. On Windows we gate on peak COMMIT
+     (private bytes), not the working set: Windows commits eagerly and the working set is
+     trimmed by the system under pressure, which would hide committed-but-untouched
+     growth -- exactly the shape of the bugs above. Elsewhere we gate on peak RSS.
+     mimalloc's own mi_process_info already handles the ru_maxrss KB-vs-bytes trap
+     (macOS reports bytes, Linux/BSD KiB), so we do not re-derive it.
+
+   - Only same-OS deltas are comparable. Lazy zeroing means Linux RSS and Windows commit
+     report different numbers for identical allocator behavior, so baselines are stored
+     per platform and never compared across.
+
+   - The profiler's own arena is process memory (rule 4 routes it through _mi_os_alloc),
+     so an MI_PPROF=ON build legitimately shows higher peak than MI_PPROF=OFF. We report
+     profiler_arena_committed alongside, so the confound is visible rather than baked in.
+
+   - MI_BENCH_INJECT_LEAK is a BUILD-TIME knob only, never reachable at runtime and
+     asserted absent below unless explicitly compiled in. It exists to prove the gate
+     actually fires: a check that has never been observed to fail proves nothing. */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "mimalloc.h"
+#include "mimalloc-stats.h"
+
+#ifndef MI_BENCH_INJECT_LEAK
+#define MI_BENCH_INJECT_LEAK 0
+#endif
+
+/* ---- portable threading ------------------------------------------------ */
+
+#ifdef _WIN32
+#include <windows.h>
+typedef HANDLE thread_t;
+typedef DWORD (WINAPI *thread_fun_t)(void*);
+#define THREAD_RET DWORD WINAPI
+#define THREAD_OK  0
+static void thread_start(thread_t* t, thread_fun_t fn, void* arg) {
+  *t = CreateThread(NULL, 0, fn, arg, 0, NULL);
+  assert(*t != NULL);
+}
+static void thread_join(thread_t t) {
+  assert(WaitForSingleObject(t, INFINITE) == WAIT_OBJECT_0);
+  CloseHandle(t);
+}
+#else
+#include <pthread.h>
+typedef pthread_t thread_t;
+typedef void* (*thread_fun_t)(void*);
+#define THREAD_RET void*
+#define THREAD_OK  NULL
+static void thread_start(thread_t* t, thread_fun_t fn, void* arg) {
+  assert(pthread_create(t, NULL, fn, arg) == 0);
+}
+static void thread_join(thread_t t) { assert(pthread_join(t, NULL) == 0); }
+#endif
+
+/* ---- measurement ------------------------------------------------------- */
+
+typedef struct sample_s {
+  size_t peak;              /* the gated number: peak commit on Windows, peak rss elsewhere */
+  size_t peak_rss;
+  size_t peak_commit;
+  size_t current_rss;
+  long long threads_live;
+  long long theaps_live;
+  long long pages_live;
+  double   purged_gb;
+  size_t   profiler_arena;  /* our own arena, so the confound is visible */
+} sample_t;
+
+static const char* gated_metric(void) {
+#ifdef _WIN32
+  return "peak_commit";     /* working set is trimmed under pressure; commit is not */
+#else
+  return "peak_rss";
+#endif
+}
+
+static void take_sample(sample_t* s) {
+  memset(s, 0, sizeof(*s));
+  size_t elapsed=0, user=0, sys=0, crss=0, prss=0, ccommit=0, pcommit=0, faults=0;
+  mi_process_info(&elapsed, &user, &sys, &crss, &prss, &ccommit, &pcommit, &faults);
+  s->peak_rss    = prss;
+  s->peak_commit = pcommit;
+  s->current_rss = crss;
+#ifdef _WIN32
+  s->peak = pcommit;
+#else
+  s->peak = prss;
+#endif
+  mi_stats_t_decl(st);
+  if (mi_stats_get(&st)) {
+    s->threads_live = (long long)st.threads.current;
+    s->theaps_live  = (long long)st.theaps.current;
+    s->pages_live   = (long long)st.pages.current;
+    s->purged_gb    = (double)st.purged.total / (1024.0*1024.0*1024.0);
+  }
+#if MI_PPROF
+  {
+    mi_prof_stats_t_decl(ps);
+    if (mi_prof_stats_get(&ps)) { s->profiler_arena = ps.arena_committed; }
+  }
+#endif
+}
+
+static double as_mb(size_t b) { return (double)b / (1024.0*1024.0); }
+
+/* ---- the stress battery ------------------------------------------------ */
+/* Each scenario is shaped to stress a different way memory can fail to come back. */
+
+#define CHURN_THREADS 8
+#define CHURN_ROUNDS  20
+
+#if MI_BENCH_INJECT_LEAK
+/* Build-time leak injection. Retains memory per thread exit so the gate has something
+   to catch. Never compiled unless explicitly requested. */
+/* `inject_armed` matters. The warmup round runs the same scenarios, so if injection
+   were active during warmup the BASELINE would already contain the leak, and any
+   baseline-relative check would compare the leak against itself and pass. That is
+   exactly the contaminated-control mistake this harness exists to prevent -- and it
+   did happen on the first run of this test. Injection is armed only after the
+   baseline sample is taken. */
+static void* volatile inject_sink[4096];
+static volatile size_t inject_idx = 0;
+static volatile int inject_armed = 0;
+static void inject_leak(void) {
+  const size_t n = (size_t)MI_BENCH_INJECT_LEAK;
+  if (n == 0 || inject_armed == 0) return;
+  void* p = mi_malloc(n);
+  if (p != NULL) {
+    memset(p, 0x5A, n < 4096 ? n : 4096);
+    size_t i = inject_idx++;
+    if (i < 4096) { inject_sink[i] = p; } else { /* keep leaking, drop the handle */ }
+  }
+}
+#else
+static void inject_leak(void) { }
+#endif
+
+static void arm_injection(void) {
+#if MI_BENCH_INJECT_LEAK
+  inject_armed = 1;
+#endif
+}
+
+/* Scenario 1: thread churn. The shape of both shipped leaks -- threads that own real
+   pages and then exit. If thread-exit cleanup regresses, this is what catches it. */
+static THREAD_RET churn_worker(void* arg) {
+  (void)arg;
+  void* keep[48];
+  for (size_t i = 0; i < 48; i++) {
+    keep[i] = mi_malloc(64*1024);
+    assert(keep[i] != NULL);
+    memset(keep[i], 0x5A, 4096);
+  }
+  for (size_t i = 0; i < 1500; i++) {
+    void* p = mi_malloc(64 + (i % 900));
+    assert(p != NULL);
+    mi_free(p);
+  }
+  for (size_t i = 0; i < 48; i++) { mi_free(keep[i]); }
+  inject_leak();
+  return THREAD_OK;
+}
+
+static void scenario_thread_churn(void) {
+  for (int r = 0; r < CHURN_ROUNDS; r++) {
+    thread_t th[CHURN_THREADS];
+    for (int i = 0; i < CHURN_THREADS; i++) thread_start(&th[i], (thread_fun_t)churn_worker, NULL);
+    for (int i = 0; i < CHURN_THREADS; i++) thread_join(th[i]);
+  }
+}
+
+/* Scenario 2: sawtooth. Build a large live set and drop it, repeatedly. Peak should
+   repeat rather than climb; a climb means memory is not being reused. */
+static void scenario_sawtooth(void) {
+  enum { teeth = 10, per = 20000, sz = 512 };
+  for (int t = 0; t < teeth; t++) {
+    void** batch = (void**)mi_malloc(per * sizeof(void*));
+    assert(batch != NULL);
+    for (int i = 0; i < per; i++) { batch[i] = mi_malloc(sz); assert(batch[i] != NULL); *(char*)batch[i] = (char)i; }
+    for (int i = 0; i < per; i++) { mi_free(batch[i]); }
+    mi_free(batch);
+  }
+}
+
+/* Scenario 3: cross-thread free. Allocate on one thread, free on another -- the path
+   that defers work and therefore the one most able to hide retention. */
+typedef struct xchan_s { void* blocks[3000]; volatile int ready; } xchan_t;
+static THREAD_RET x_producer(void* arg) {
+  xchan_t* c = (xchan_t*)arg;
+  for (size_t i = 0; i < 3000; i++) { c->blocks[i] = mi_malloc(((i%6)+1)*128); assert(c->blocks[i]!=NULL); }
+  c->ready = 1;
+  return THREAD_OK;
+}
+static THREAD_RET x_consumer(void* arg) {
+  xchan_t* c = (xchan_t*)arg;
+  while (c->ready == 0) { /* spin */ }
+  for (size_t i = 0; i < 3000; i++) { mi_free(c->blocks[i]); }
+  return THREAD_OK;
+}
+static void scenario_cross_thread_free(void) {
+  enum { pairs = 6 };
+  for (int r = 0; r < 6; r++) {
+    static xchan_t ch[pairs];
+    thread_t p[pairs], c[pairs];
+    memset(ch, 0, sizeof(ch));
+    for (int i = 0; i < pairs; i++) { thread_start(&p[i], (thread_fun_t)x_producer, &ch[i]);
+                                     thread_start(&c[i], (thread_fun_t)x_consumer, &ch[i]); }
+    for (int i = 0; i < pairs; i++) { thread_join(p[i]); thread_join(c[i]); }
+  }
+}
+
+/* Scenario 4: rolling heaps. Create and delete heaps while blocks stay live across the
+   boundary -- the configuration that exposed the v3 leak. */
+static void scenario_rolling_heaps(void) {
+  enum { rounds = 20, live = 4 };
+  mi_heap_t* prev[live];
+  memset(prev, 0, sizeof(prev));
+  for (int n = 0; n < rounds; n++) {
+    if (prev[live-1] != NULL) { mi_heap_delete(prev[live-1]); }
+    for (int i = live-1; i > 0; i--) prev[i] = prev[i-1];
+    mi_heap_t* h = mi_heap_new();
+    assert(h != NULL);
+    prev[0] = h;
+    void* keep[256];
+    for (int i = 0; i < 256; i++) { keep[i] = mi_heap_malloc(h, 4096); assert(keep[i]!=NULL); }
+    for (int i = 0; i < 256; i++) { mi_free(keep[i]); }
+  }
+  for (int i = 0; i < live; i++) { if (prev[i] != NULL) mi_heap_delete(prev[i]); }
+}
+
+/* Scenario 5: huge-allocation churn, where a single leaked block is large enough to
+   dominate the peak. */
+static void scenario_huge_churn(void) {
+  const size_t sizes[] = { 2u*1024*1024, 8u*1024*1024, 32u*1024*1024 };
+  for (int r = 0; r < 6; r++) {
+    for (int s = 0; s < 3; s++) {
+      void* p = mi_malloc(sizes[s]);
+      assert(p != NULL);
+      ((char*)p)[0] = 1; ((char*)p)[sizes[s]-1] = 2;
+      mi_free(p);
+    }
+  }
+}
+
+/* ---- JSON ------------------------------------------------------------- */
+
+static const char* platform_tag(void) {
+#if defined(_WIN32)
+  return "windows";
+#elif defined(__APPLE__)
+  return "macos";
+#else
+  return "linux";
+#endif
+}
+
+static void emit_json(const char* path, const sample_t* base, const sample_t* end) {
+  FILE* f = fopen(path, "w");
+  if (f == NULL) { fprintf(stderr, "warning: cannot open %s for writing\n", path); return; }
+  fprintf(f,
+    "{\n"
+    "  \"schema\": 1,\n"
+    "  \"platform\": \"%s\",\n"
+    "  \"gated_metric\": \"%s\",\n"
+    "  \"mi_pprof\": %d,\n"
+    "  \"inject_leak\": %llu,\n"
+    "  \"peak_mb\": %.1f,\n"
+    "  \"peak_rss_mb\": %.1f,\n"
+    "  \"peak_commit_mb\": %.1f,\n"
+    "  \"profiler_arena_mb\": %.1f,\n"
+    "  \"peak_minus_profiler_mb\": %.1f,\n"
+    "  \"purged_gb\": %.2f,\n"
+    "  \"counters\": {\n"
+    "    \"threads_start\": %lld, \"threads_end\": %lld,\n"
+    "    \"theaps_start\": %lld,  \"theaps_end\": %lld,\n"
+    "    \"pages_start\": %lld,   \"pages_end\": %lld\n"
+    "  }\n"
+    "}\n",
+    platform_tag(), gated_metric(),
+#if MI_PPROF
+    1,
+#else
+    0,
+#endif
+    (unsigned long long)MI_BENCH_INJECT_LEAK,
+    as_mb(end->peak), as_mb(end->peak_rss), as_mb(end->peak_commit),
+    as_mb(end->profiler_arena), as_mb(end->peak - (end->profiler_arena < end->peak ? end->profiler_arena : 0)),
+    end->purged_gb,
+    base->threads_live, end->threads_live,
+    base->theaps_live,  end->theaps_live,
+    base->pages_live,   end->pages_live);
+  fclose(f);
+}
+
+int main(void) {
+  setvbuf(stdout, NULL, _IONBF, 0);
+  printf("test-memory-gate: platform=%s gated=%s inject_leak=%llu\n",
+         platform_tag(), gated_metric(), (unsigned long long)MI_BENCH_INJECT_LEAK);
+
+  /* Warm up so the baseline is steady state, not first-touch arena reservation. */
+  scenario_thread_churn();
+  mi_collect(true);
+
+  sample_t base; take_sample(&base);
+  printf("  baseline: peak=%.1f MB threads=%lld theaps=%lld pages=%lld\n",
+         as_mb(base.peak), base.threads_live, base.theaps_live, base.pages_live);
+
+  arm_injection();   /* after the baseline, never before -- see inject_leak() */
+
+  scenario_thread_churn();
+  scenario_sawtooth();
+  scenario_cross_thread_free();
+  scenario_rolling_heaps();
+  scenario_huge_churn();
+  mi_collect(true);
+
+  sample_t end; take_sample(&end);
+  printf("  after:    peak=%.1f MB threads=%lld theaps=%lld pages=%lld purged=%.2f GB\n",
+         as_mb(end.peak), end.threads_live, end.theaps_live, end.pages_live, end.purged_gb);
+  printf("  profiler arena: %.1f MB (peak minus profiler: %.1f MB)\n",
+         as_mb(end.profiler_arena), as_mb(end.peak - (end.profiler_arena < end.peak ? end.profiler_arena : 0)));
+
+  const char* json = getenv("MI_BENCH_JSON");
+  if (json != NULL) { emit_json(json, &base, &end); printf("  wrote %s\n", json); }
+
+  /* Inline assertions, so this is a real test even with no CI around it. The engine's
+     own counters are the precise detector -- they are exact and platform-independent,
+     where peak memory is neither. */
+  bool failed = false;
+  if (end.threads_live >= 32) {
+    fprintf(stderr, "FAIL: %lld threads still live after creating and joining %d.\n"
+                    "      Thread-exit cleanup is not running (see #44 / #47).\n",
+            end.threads_live, CHURN_THREADS * CHURN_ROUNDS * 2);
+    failed = true;
+  }
+  /* Memory backstop. Deliberately loose: it exists to catch a leak that does NOT show
+     in the counters. The counter check above is the precise one. */
+  const size_t allowed = (base.peak * 3) + (64u*1024*1024);
+  if (end.peak > allowed) {
+    fprintf(stderr, "FAIL: %s grew %.1f MB -> %.1f MB (allowed <= %.1f MB).\n",
+            gated_metric(), as_mb(base.peak), as_mb(end.peak), as_mb(allowed));
+    failed = true;
+  }
+  if (failed) { fflush(stderr); abort(); }
+
+  printf("test-memory-gate: ok\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #63. Sub-issue of #61 (Phase A) — **the highest-value item in the plan.**

## Why

This repo shipped **two unbounded memory leaks** (#44, #47) — 23.5 GB at 100 iterations — through a completely green pipeline. An audit confirms the cause: `grep -rniE "regress|baseline|threshold|variance|benchmark|perf|rss|peak" .github/workflows/` returned **nothing**. CI only ever asked *did it crash?*

## What lands

**`test/test-memory-gate.c`** — a stress battery shaped around the distinct ways memory fails to come back: thread churn (the shape of both shipped leaks), sawtooth, cross-thread free, rolling heaps, huge churn. Records peak memory plus the engine's liveness counters and asserts they return to baseline.

**`ci/memory_gate.py`** — compares a run against committed per-platform baselines, catching cross-**commit** drift that a per-run ratio structurally cannot see. A leak added 3% at a time over ten PRs passes every self-relative check and still doubles memory.

**CI job** on ubuntu, windows, macos.

## Three measurement decisions

- **Windows gates on peak COMMIT, not working set.** Windows commits eagerly and trims the working set under pressure — which would hide exactly the committed-but-untouched growth these bugs produced.
- **Baselines are per platform *and* per `MI_PPROF`.** Lazy zeroing makes Linux RSS and Windows commit incomparable for identical behavior; macOS compresses so its resident figure *falls* under pressure while a leak grows; and rule 4 puts the profiler's arena in process memory, so an ON build legitimately peaks higher.
- **`profiler_arena_committed` is reported alongside the peak**, so our own profiler memory is visible rather than silently inflating the numbers this project exists to publish.

## Verified in both directions

A gate never observed to fail proves nothing.

| Scenario | Result |
|---|---|
| Clean run | PASS |
| `MI_BENCH_INJECT_LEAK=8MB` (test's own assertion) | **FAIL** — `peak_commit 20.3 → 1373.3 MB, allowed ≤ 124.8 MB` |
| Injected-leak run through the script | **REFUSED** — a control is not a measurement |
| Attempt to *baseline* a poisoned run | **REFUSED** |
| Synthetic +40% peak | **FAIL** — `+26.7%, allowed +10%` |
| No baseline present | Refuses with instructions |

**The positive control initially passed when it should have failed.** My warmup round ran the same scenarios and therefore injected too, so the baseline already contained the leak and the check compared it against itself. Injection is now armed only *after* the baseline sample — the exact contaminated-control mistake this harness exists to catch, made while building it, and worth recording.

## No baselines committed here, deliberately

Peak memory is machine-specific; a baseline captured on a dev box would be wrong for CI. The job uploads `result.json` as an artifact and **warns rather than fails** while the baseline is absent. They get bootstrapped from a real CI run, in a follow-up commit to this PR.

ctest is **14/14** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)