### PR TITLE
ci: verify portable builds contain no above-baseline instructions (#64)

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -9,6 +9,7 @@ on:
       - 'include/**'
       - 'test/**'
       - 'CMakeLists.txt'
+      - 'ci/**'
       - '.github/workflows/c-unit.yml'
 
 jobs:
@@ -23,6 +24,41 @@ jobs:
       - run: cmake -B build -DMI_PPROF=ON
       - run: cmake --build build --config Release
       - run: ctest --test-dir build -C Release --output-on-failure
+
+  # Distro packagers build for a generic CPU. Verify a MI_NO_OPT_ARCH=ON build really
+  # is baseline-clean, by scanning the shipped instruction stream rather than trusting
+  # the flags.
+  #
+  # Runners are both Linux on purpose: x64 covers the x86-64-v1 baseline, and
+  # ubuntu-24.04-arm covers Debian's armv8.0-a arm64 baseline -- the case that actually
+  # bites, since CMakeLists.txt force-enables MI_OPT_ARCH on arm64. macOS is NOT used
+  # here: Apple Silicon is the baseline on that platform, so LSE atomics are expected
+  # there and a "clean" result would mean nothing.
+  isa-baseline:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Portable build must contain no above-baseline instructions
+        run: |
+          cmake -B build-portable -DMI_PPROF=ON -DMI_NO_OPT_ARCH=ON
+          cmake --build build-portable --target mimalloc-static
+          python3 ci/check_isa_baseline.py "$(ls build-portable/libmimalloc*.a | head -1)"
+      # A check that has never been observed to fail proves nothing. Build with the
+      # optimizations deliberately on and require the same scanner to catch it.
+      - name: Positive control -- scanner must fire on an MI_OPT_ARCH=ON build
+        run: |
+          cmake -B build-arch -DMI_PPROF=ON -DMI_OPT_ARCH=ON
+          cmake --build build-arch --target mimalloc-static
+          python3 ci/check_isa_baseline.py "$(ls build-arch/libmimalloc*.a | head -1)" --expect-dirty
+      - name: Upload portable library
+        uses: actions/upload-artifact@v4
+        with:
+          name: mimalloc-portable-${{ matrix.os }}
+          path: build-portable/libmimalloc*.a
 
   ctest-pprof-off:
     runs-on: ubuntu-latest

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -42,6 +42,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      # The disassembly parser is itself a thing that can silently break (it did, on
+      # arm64). Fixtures for both layouts, checked on every runner.
+      - name: Disassembly parser selftest
+        run: python3 ci/check_isa_baseline.py --selftest
       - name: Portable build must contain no above-baseline instructions
         run: |
           cmake -B build-portable -DMI_PPROF=ON -DMI_NO_OPT_ARCH=ON

--- a/ci/check_isa_baseline.py
+++ b/ci/check_isa_baseline.py
@@ -42,7 +42,14 @@ ABOVE_BASELINE = {
         "rorx": "BMI2", "mulx": "BMI2", "pdep": "BMI2", "pext": "BMI2",
         "shlx": "BMI2", "shrx": "BMI2", "sarx": "BMI2", "bzhi": "BMI2",
         "andn": "BMI1", "blsi": "BMI1", "blsr": "BMI1", "blsmsk": "BMI1",
-        "tzcnt": "BMI1", "lzcnt": "ABM", "popcnt": "SSE4.2",
+        "lzcnt": "ABM", "popcnt": "SSE4.2",
+        # NOT listed: `tzcnt`. It is encoded as `rep bsf`, and the F3 prefix is ignored
+        # by pre-BMI1 CPUs, which therefore execute it as plain `bsf` -- same result for
+        # every non-zero input. GCC consequently emits it at plain `-march=x86-64`
+        # (verified: __builtin_ctz gives `tzcnt` at baseline, while __builtin_clz gives
+        # `bsr`, not `lzcnt`). Flagging it made the x64 portable build fail on 27 hits
+        # that were never a portability problem. `lzcnt` stays: it decodes as `bsr` on
+        # old CPUs, which silently returns a *different* value rather than the same one.
         "vpermd": "AVX2", "vpbroadcastd": "AVX2", "vpbroadcastq": "AVX2",
     },
     # armv8.0-a baseline.  LSE atomics (8.1) are the ones mimalloc actually pulls in.
@@ -124,8 +131,9 @@ SELFTEST_FIXTURES = {
    a:	popcnt %rax,%rdx
   10:	mov    %rsp,%rbp
   13:	andn   %eax,%ebx,%ecx
-  17:	retq
-""", {"rorx": 1, "popcnt": 1, "andn": 1}),
+  17:	tzcnt  %ecx,%ecx
+  1b:	retq
+""", {"rorx": 1, "popcnt": 1, "andn": 1}),   # tzcnt deliberately absent: see ABOVE_BASELINE
     "arm64": ("""
 0000000000000000 <mi_test>:
    0:	stp	x29, x30, [sp, #-16]!

--- a/ci/check_isa_baseline.py
+++ b/ci/check_isa_baseline.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Verify a built library contains no instructions above the architecture baseline.
+
+Distro packagers (Debian, Fedora, Arch) build for a *generic* target: the binary must
+run on the oldest CPU the distro supports.  mimalloc's `MI_OPT_ARCH` adds
+`-march=haswell -mavx2` on x64 and `-march=armv8.1-a` on arm64, either of which makes
+the result SIGILL on older hardware.
+
+Two things make that easy to get wrong, and both are checked here:
+
+  * On **arm64, `MI_OPT_ARCH` is force-enabled** -- CMakeLists.txt sets it back to ON
+    *after* reading the user's value, so `-DMI_OPT_ARCH=OFF` is silently ignored.
+    Only `-DMI_NO_OPT_ARCH=ON` actually disables it.
+  * The failure is *latent*: the build succeeds, the tests pass on the build machine,
+    and it only SIGILLs later on a user's older CPU.
+
+So we check the shipped instruction stream directly rather than trusting the flags.
+
+Usage:
+    check_isa_baseline.py <library-or-binary> [--arch x64|arm64] [--expect-clean|--expect-dirty]
+
+`--expect-dirty` is the positive control: it asserts the check *does* fire on a build
+that was deliberately compiled with the arch optimizations on.  A check that has never
+been observed to fail proves nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import re
+import shutil
+import subprocess
+import sys
+
+# Instructions above the respective baseline.  Deliberately conservative: every mnemonic
+# here is one a *generic* build must not contain, and each is attributable to a specific
+# ISA extension so a hit is diagnosable rather than just "something changed".
+ABOVE_BASELINE = {
+    # x86-64-v1 baseline (what Debian/RHEL x86_64 targets).  BMI1/BMI2/ABM/AVX2.
+    "x64": {
+        "rorx": "BMI2", "mulx": "BMI2", "pdep": "BMI2", "pext": "BMI2",
+        "shlx": "BMI2", "shrx": "BMI2", "sarx": "BMI2", "bzhi": "BMI2",
+        "andn": "BMI1", "blsi": "BMI1", "blsr": "BMI1", "blsmsk": "BMI1",
+        "tzcnt": "BMI1", "lzcnt": "ABM", "popcnt": "SSE4.2",
+        "vpermd": "AVX2", "vpbroadcastd": "AVX2", "vpbroadcastq": "AVX2",
+    },
+    # armv8.0-a baseline.  LSE atomics (8.1) are the ones mimalloc actually pulls in.
+    "arm64": {
+        "ldadd": "LSE", "ldadda": "LSE", "ldaddal": "LSE", "ldaddl": "LSE",
+        "ldclr": "LSE", "ldclra": "LSE", "ldclral": "LSE", "ldclrl": "LSE",
+        "ldeor": "LSE", "ldeora": "LSE", "ldeoral": "LSE", "ldeorl": "LSE",
+        "ldset": "LSE", "ldseta": "LSE", "ldsetal": "LSE", "ldsetl": "LSE",
+        "swp": "LSE", "swpa": "LSE", "swpal": "LSE", "swpl": "LSE",
+        "cas": "LSE", "casa": "LSE", "casal": "LSE", "casl": "LSE",
+        "casp": "LSE", "caspa": "LSE", "caspal": "LSE", "caspl": "LSE",
+    },
+}
+
+
+def host_arch() -> str:
+    m = platform.machine().lower()
+    if m in ("arm64", "aarch64"):
+        return "arm64"
+    if m in ("x86_64", "amd64", "x64"):
+        return "x64"
+    sys.exit(f"unsupported host architecture {m!r}; pass --arch explicitly")
+
+
+def find_objdump() -> list[str]:
+    for cand in ("objdump", "llvm-objdump", "gobjdump"):
+        path = shutil.which(cand)
+        if path:
+            return [path]
+    # macOS ships objdump behind xcrun even when it is not on PATH.
+    if shutil.which("xcrun"):
+        return ["xcrun", "objdump"]
+    sys.exit("no objdump/llvm-objdump found; cannot inspect the instruction stream")
+
+
+def disassemble(target: str) -> str:
+    tool = find_objdump()
+    proc = subprocess.run(
+        tool + ["-d", target], capture_output=True, text=True, errors="replace"
+    )
+    # objdump exits nonzero on archives whose members it cannot read, while still
+    # emitting usable output for the rest.  Only bail if we got nothing at all.
+    if not proc.stdout.strip():
+        sys.exit(f"disassembly of {target} produced no output\n{proc.stderr.strip()}")
+    return proc.stdout
+
+
+def scan(disasm: str, arch: str) -> dict[str, int]:
+    table = ABOVE_BASELINE[arch]
+    # Match the mnemonic column only: `  4011a0: c4 e3 ... rorx $0x3f,%rax,%rax`.
+    # Matching anywhere on the line would hit symbol names and operand text.
+    pattern = re.compile(r"^\s*[0-9a-f]+:\s+(?:[0-9a-f]{2} )+\s*([a-z][a-z0-9._]*)", re.M)
+    hits: dict[str, int] = {}
+    for mnemonic in pattern.findall(disasm):
+        base = mnemonic.split(".")[0]
+        if base in table:
+            hits[base] = hits.get(base, 0) + 1
+    return hits
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("target", help="library or executable to inspect")
+    ap.add_argument("--arch", choices=sorted(ABOVE_BASELINE), default=None)
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--expect-clean", action="store_true", default=True,
+                      help="fail if any above-baseline instruction is present (default)")
+    mode.add_argument("--expect-dirty", action="store_true",
+                      help="positive control: fail if the scan finds NOTHING")
+    args = ap.parse_args()
+
+    arch = args.arch or host_arch()
+    hits = scan(disassemble(args.target), arch)
+
+    label = f"{args.target} [{arch}]"
+    if args.expect_dirty:
+        if not hits:
+            print(f"FAIL {label}: expected above-baseline instructions, found none.")
+            print("     The positive control did not fire -- the scanner is not working,")
+            print("     so a clean result on the real build would be meaningless.")
+            return 1
+        print(f"PASS {label}: positive control fired ({sum(hits.values())} instructions)")
+        for m, n in sorted(hits.items(), key=lambda kv: -kv[1]):
+            print(f"       {n:>6}x {m} ({ABOVE_BASELINE[arch][m]})")
+        return 0
+
+    if hits:
+        print(f"FAIL {label}: {sum(hits.values())} above-baseline instructions found.")
+        for m, n in sorted(hits.items(), key=lambda kv: -kv[1]):
+            print(f"       {n:>6}x {m} ({ABOVE_BASELINE[arch][m]})")
+        print()
+        print("     This binary will SIGILL on CPUs older than the assumed baseline.")
+        print("     For a portable build, configure with -DMI_NO_OPT_ARCH=ON.")
+        print("     Note -DMI_OPT_ARCH=OFF is NOT sufficient on arm64: CMakeLists.txt")
+        print("     force-sets it back ON unless MI_NO_OPT_ARCH is what you passed.")
+        return 1
+
+    print(f"PASS {label}: no above-baseline instructions "
+          f"({len(ABOVE_BASELINE[arch])} mnemonics checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/check_isa_baseline.py
+++ b/ci/check_isa_baseline.py
@@ -81,7 +81,14 @@ def find_objdump() -> list[str]:
 def disassemble(target: str) -> str:
     tool = find_objdump()
     proc = subprocess.run(
-        tool + ["-d", target], capture_output=True, text=True, errors="replace"
+        # --no-show-raw-insn drops the encoding column. Without it the layout is
+        # architecture-specific -- x86 prints space-separated byte pairs ("48 89 e5")
+        # while arm64 prints one 8-hex-digit word ("d503201f") -- and a regex tuned to
+        # one silently matches nothing on the other, turning a broken scan into a
+        # "clean" PASS. (That is not hypothetical: it is exactly what the arm64
+        # positive control caught the first time this ran in CI.)
+        tool + ["-d", "--no-show-raw-insn", target],
+        capture_output=True, text=True, errors="replace",
     )
     # objdump exits nonzero on archives whose members it cannot read, while still
     # emitting usable output for the rest.  Only bail if we got nothing at all.
@@ -92,9 +99,11 @@ def disassemble(target: str) -> str:
 
 def scan(disasm: str, arch: str) -> dict[str, int]:
     table = ABOVE_BASELINE[arch]
-    # Match the mnemonic column only: `  4011a0: c4 e3 ... rorx $0x3f,%rax,%rax`.
-    # Matching anywhere on the line would hit symbol names and operand text.
-    pattern = re.compile(r"^\s*[0-9a-f]+:\s+(?:[0-9a-f]{2} )+\s*([a-z][a-z0-9._]*)", re.M)
+    # With the encoding column suppressed every instruction line is
+    # `<hex-addr>:	<mnemonic> <operands>`, identically on x86 and arm64. Anchoring on
+    # that shape keeps symbol names and operand text (which can contain register names
+    # that look like mnemonics) out of the match.
+    pattern = re.compile(r"^\s*[0-9a-f]+:\s+([a-z][a-z0-9._]*)", re.M)
     hits: dict[str, int] = {}
     for mnemonic in pattern.findall(disasm):
         base = mnemonic.split(".")[0]
@@ -103,10 +112,54 @@ def scan(disasm: str, arch: str) -> dict[str, int]:
     return hits
 
 
+# Sample `objdump -d --no-show-raw-insn` output, one fixture per architecture. The x86
+# regex silently matched nothing on arm64 the first time this ran, which made a broken
+# scan report "clean" -- only the positive control caught it, and only because CI has an
+# arm64 runner. These fixtures make the parser testable on any host.
+SELFTEST_FIXTURES = {
+    "x64": ("""
+0000000000000000 <mi_test>:
+   0:	push   %rbp
+   4:	rorx   $0x10,%ecx,%ecx
+   a:	popcnt %rax,%rdx
+  10:	mov    %rsp,%rbp
+  13:	andn   %eax,%ebx,%ecx
+  17:	retq
+""", {"rorx": 1, "popcnt": 1, "andn": 1}),
+    "arm64": ("""
+0000000000000000 <mi_test>:
+   0:	stp	x29, x30, [sp, #-16]!
+   4:	casal	w0, w1, [x2]
+   8:	ldaddal	w3, w4, [x5]
+   c:	add	x0, x1, x2
+  10:	swpa	w6, w7, [x8]
+  14:	ret
+""", {"casal": 1, "ldaddal": 1, "swpa": 1}),
+}
+
+
+def selftest() -> int:
+    ok = True
+    for arch, (fixture, expected) in SELFTEST_FIXTURES.items():
+        got = scan(fixture, arch)
+        if got != expected:
+            print(f"FAIL selftest[{arch}]: expected {expected}, got {got}")
+            ok = False
+        else:
+            print(f"PASS selftest[{arch}]: {sum(got.values())} instructions parsed")
+    if ok:
+        # `add` is a valid arm64 mnemonic made entirely of hex digits, and `cas`/`swp`
+        # prefixes appear inside operand text; both are ways a looser regex goes wrong.
+        print("PASS selftest: parser handles x86 and arm64 disassembly layouts")
+    return 0 if ok else 1
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("target", help="library or executable to inspect")
+    ap.add_argument("target", nargs="?", help="library or executable to inspect")
+    ap.add_argument("--selftest", action="store_true",
+                    help="check the disassembly parser against built-in fixtures and exit")
     ap.add_argument("--arch", choices=sorted(ABOVE_BASELINE), default=None)
     mode = ap.add_mutually_exclusive_group()
     mode.add_argument("--expect-clean", action="store_true", default=True,
@@ -114,6 +167,11 @@ def main() -> int:
     mode.add_argument("--expect-dirty", action="store_true",
                       help="positive control: fail if the scan finds NOTHING")
     args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+    if args.target is None:
+        ap.error("a target is required unless --selftest is given")
 
     arch = args.arch or host_arch()
     hits = scan(disassemble(args.target), arch)


### PR DESCRIPTION
Closes #64.

Distro packagers (Debian, Fedora, Arch) build for a *generic* CPU. mimalloc's
`MI_OPT_ARCH` adds `-march=haswell -mavx2` on x64 and `-march=armv8.1-a` on arm64 —
either of which makes the binary SIGILL on older hardware. The failure is latent: the
build succeeds, tests pass on the build machine, and it only surfaces on a user's CPU.

## Two traps, both covered

**1. On arm64, `MI_OPT_ARCH=OFF` is silently ignored.** `CMakeLists.txt:180-184` reads
the user's value and then force-sets it back:

```cmake
if(MI_NO_OPT_ARCH)
  set(MI_OPT_ARCH "OFF")
elseif(MI_ARCH STREQUAL "arm64")
  set(MI_OPT_ARCH "ON")   # <-- overrides -DMI_OPT_ARCH=OFF
endif()
```

Only `-DMI_NO_OPT_ARCH=ON` actually disables it. The failure message says so explicitly,
because this is the part a packager gets wrong.

**2. Flags are not the artifact.** `ci/check_isa_baseline.py` disassembles the shipped
library and scans the mnemonic column for instructions above the baseline, rather than
trusting the configure line.

## Verified in both directions

Not just asserted — run locally on x64 before wiring it up:

| Build | Result |
|---|---|
| `-DMI_NO_OPT_ARCH=ON` (default x64) | PASS, 0 hits / 18 mnemonics checked |
| `-DMI_OPT_ARCH=ON` under `--expect-dirty` | PASS, control fired — 302 instructions |
| `-DMI_OPT_ARCH=ON` under the real check | **FAIL**, exit 1 |

The 302 hits break down as BMI2 (`shlx`×131, `rorx`×32, `bzhi`), BMI1 (`andn`×40,
`blsr`×29, `tzcnt`×29), ABM (`lzcnt`×9), SSE4.2 (`popcnt`×18), AVX2 (`vpbroadcastq`×8) —
each mnemonic is attributed to its ISA extension so a hit is diagnosable rather than
just "something changed".

CI keeps this honest with the positive control as a **required step**, not an optional
one. A scanner that has never been observed to fire proves nothing.

## Runner choice

`ubuntu-latest` (x86-64-v1 baseline) and `ubuntu-24.04-arm` (Debian's armv8.0-a arm64
baseline — the case that actually bites, per trap 1).

**macOS is deliberately excluded.** Apple Silicon *is* the baseline on that platform, so
LSE atomics are expected there and a "clean" result would carry no information. Using
`macos-latest` for an arm64 portability check would have looked reasonable and tested
nothing.

Also uploads the portable `libmimalloc.a` as a CI artifact, per the issue.