### PR TITLE
fix: silence -Wmaybe-uninitialized on fmt_buf in profile.c

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -302,7 +302,7 @@ bool mi_prof_start_ex(const mi_prof_config_t* config) mi_attr_noexcept {
       prof_dump_at_exit_format = config->dump_format;
     }
     else if (env_present) {
-      char fmt_buf[32];
+      char fmt_buf[32] = {0};  /* zeroed: GCC cannot see that _mi_getenv fills it on success */
       if (_mi_getenv("MIMALLOC_PROF_DUMP_FORMAT", fmt_buf, sizeof(fmt_buf)) == 0) prof_dump_at_exit_format = prof_parse_dump_format(fmt_buf);
     }
   }
@@ -796,7 +796,7 @@ static void prof_auto_start(void) {
     if (mi_option_is_enabled(mi_option_prof)) { const bool started = mi_prof_start(0); MI_UNUSED(started); }
     (void)_mi_getenv("MIMALLOC_PROF_DUMP_AT_EXIT", prof_dump_at_exit, sizeof(prof_dump_at_exit));
     /* So pure-env users (no mi_prof_start_ex call at all) still get profile.proto exit dumps. */
-    char fmt_buf[32];
+    char fmt_buf[32] = {0};  /* zeroed: GCC cannot see that _mi_getenv fills it on success */
     if (_mi_getenv("MIMALLOC_PROF_DUMP_FORMAT", fmt_buf, sizeof(fmt_buf)) == 0) prof_dump_at_exit_format = prof_parse_dump_format(fmt_buf);
   }
 }


### PR DESCRIPTION
Small hygiene fix, split out of #70 to keep that PR scoped.

Both `fmt_buf` uses in `src/profile.c` drew `-Wmaybe-uninitialized` on every Linux CI build:

```
src/profile.c:306:110: warning: 'fmt_buf' may be used uninitialized [-Wmaybe-uninitialized]
src/profile.c:800:108: warning: 'fmt_buf' may be used uninitialized [-Wmaybe-uninitialized]
```

It is a **false positive** — GCC can't see that `_mi_getenv` fills the buffer whenever it returns 0, and the buffer is only read on that success path. But it appeared in every build log, and a log full of benign warnings is where a real one goes unnoticed.

Zero-initializing a 32-byte stack buffer read once at startup costs nothing.

Verified: warning count for `fmt_buf` drops from 4 to 0, ctest 13/13 green.