### PR TITLE
docs: keep MIMALLOC_PROF*, document the namespace hazard and its escape hatch (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,38 @@ MIMALLOC_PROF_SAMPLE_INTERVAL=524288 \
 `MIMALLOC_PROF_SAMPLE_RATE` remains a compatibility alias for
 `MIMALLOC_PROF_SAMPLE_INTERVAL`; when both are set, `..._INTERVAL` wins.
 
+#### A caution about the shared `MIMALLOC_*` namespace
+
+Environment variables are process-global, and **mimalloc is often embedded in
+libraries you did not choose to load** — NVIDIA's display driver ships mimalloc 3.1.6,
+for instance. Every `MIMALLOC_*` variable is therefore seen by every mimalloc instance
+in the process.
+
+That is inherent to mimalloc's option mechanism rather than something this fork
+introduced: `mi_option_init` hardcodes the `mimalloc_` prefix, and the profiler's
+options are registered in mimalloc's own option table, so their env names follow from
+that. It applies equally to upstream's `MIMALLOC_SHOW_STATS`, `MIMALLOC_VERBOSE`, and
+friends. Renaming ours to a private prefix would not fix the shared-namespace problem;
+it would only move our share of it, at the cost of the published 0.9.0 API.
+
+**If you are embedding this library and need to be immune to the ambient environment,
+do not rely on the variable names — use `MI_PROF_CONFIG_OVERRIDE`:**
+
+```c
+mi_prof_config_t_decl(cfg);           /* zeroed, with size + version filled in */
+cfg.mode = MI_PROF_CONFIG_OVERRIDE;   /* struct wins over env, field by field */
+cfg.sample_interval = 2048;
+if (!mi_prof_start_ex(&cfg)) return 1;
+```
+
+The default mode, `MI_PROF_CONFIG_FALLBACK`, is the opposite: env wins and the struct
+only fills gaps, so ops can tune a shipped binary without a rebuild. Both directions are
+covered by the test suite for every env-backed field, not just some of them.
+
+One asymmetry to know about: because `0`/`NULL` doubles as "field not set", `OVERRIDE`
+cannot force `accum` *off* or `max_profiler_bytes` back to unbudgeted — those fall
+through to env-then-default. It can force them on.
+
 ### Allocator statistics in the profile (v3 only)
 
 v3 exposes per-heap and per-subprocess counters (`mi_heap_stats_get`,

--- a/test/test-profile.c
+++ b/test/test-profile.c
@@ -398,6 +398,41 @@ static void test_start_ex_override(void) {
   test_unsetenv("MIMALLOC_PROF_SAMPLE_INTERVAL");
 }
 
+/* T15b2: OVERRIDE must hold for *every* env-backed field, not just sample_interval.
+   This is the documented escape hatch for the shared-namespace hazard (issue #65):
+   MIMALLOC_* is process-global and other libraries embed mimalloc (NVIDIA's display
+   driver ships 3.1.6), so an embedder needs a way to be immune to whatever
+   MIMALLOC_PROF* the ambient environment happens to hold. If OVERRIDE only covered
+   some fields, that guarantee would be quietly false for the rest -- so set every var
+   to a hostile value at once and require the struct to win across the board. */
+static void test_start_ex_override_all_fields(void) {
+  test_setenv("MIMALLOC_PROF_SAMPLE_INTERVAL", "1000");
+  test_setenv("MIMALLOC_PROF_BT_MAX", "7");
+  test_setenv("MIMALLOC_PROF_MAX_BYTES", "65536");
+  test_setenv("MIMALLOC_PROF_ACCUM", "0");
+
+  mi_prof_config_t_decl(cfg);
+  cfg.mode = MI_PROF_CONFIG_OVERRIDE;
+  cfg.sample_interval = 2048;
+  cfg.max_stack_depth = 21;
+  cfg.max_profiler_bytes = 1u << 20;
+  cfg.accum = true;
+  assert(mi_prof_start_ex(&cfg));
+
+  mi_prof_stats_t_decl(stats);
+  assert(mi_prof_stats_get(&stats));
+  assert(stats.sample_rate == 2048);
+  assert(stats.accum);                                          /* env said 0, struct said true */
+  assert(mi_option_get(mi_option_prof_bt_max) == 21);           /* env said 7 */
+  assert(mi_option_get(mi_option_prof_max_bytes) == (1 << 20)); /* env said 65536 */
+
+  mi_prof_stop();
+  test_unsetenv("MIMALLOC_PROF_SAMPLE_INTERVAL");
+  test_unsetenv("MIMALLOC_PROF_BT_MAX");
+  test_unsetenv("MIMALLOC_PROF_MAX_BYTES");
+  test_unsetenv("MIMALLOC_PROF_ACCUM");
+}
+
 /* T15c: MI_PROF_CONFIG_FALLBACK (the default, mode == 0) -- the env var wins over the
    struct field; the struct only fills gaps where env is silent (ops can tune a shipped
    binary without a rebuild). */
@@ -794,6 +829,7 @@ int main(void) {
 #endif
   test_start_ex_default();
   test_start_ex_override();
+  test_start_ex_override_all_fields();
   test_start_ex_fallback();
   test_start_ex_bad_version();
   test_start_ex_max_bytes();


### PR DESCRIPTION
Closes #65.

**Decision: keep `MIMALLOC_PROF*`.** Renaming was the alternative on the table, and
investigating it showed it does not solve the stated problem.

## Why not rename

The hazard is real: `MIMALLOC_*` is process-global, and NVIDIA's display driver embeds
mimalloc 3.1.6, so any mimalloc instance in the process sees our variables and we see
theirs.

But it is a property of **mimalloc's option mechanism**, not of our naming:

- `mi_option_init` (`src/options.c:641`) hardcodes the `mimalloc_` prefix.
- The profiler's options are registered in mimalloc's own option table
  (`src/options.c:182-187`) and exposed as documented `mi_option_prof*` enum values in
  `mimalloc.h`.

So the names *follow from* being a drop-in mimalloc. Upstream's own
`MIMALLOC_SHOW_STATS` / `MIMALLOC_VERBOSE` share the namespace on identical terms.
A private prefix would move our share of the collision, not remove it — and would cost
the API published in 0.9.0, plus either a second hardcoded prefix path for a subset of
options or giving up `mi_option_get/set` for them entirely.

## What actually protects an embedder

It already exists: `MI_PROF_CONFIG_OVERRIDE` makes programmatic config beat the
environment, field by field. That is the real answer for anyone who needs immunity from
the ambient environment, so the README now documents it rather than implying the
variable names are the whole story.

Also documented: the asymmetry that `OVERRIDE` can force `accum` **on** but not **off**,
because `0`/`NULL` doubles as "field not set".

## Testing

The decision leans on that escape hatch, so it is now tested properly. `T15b` covered
only `sample_interval` — a guarantee that holds for one field and quietly fails for the
rest is worse than none. **`T15b2`** sets every env-backed variable to a hostile value
at once (`SAMPLE_INTERVAL`, `BT_MAX`, `MAX_BYTES`, `ACCUM`) and requires the struct to
win across the board.

`mimalloc-test-profile` green. The README C snippet was compiled and run with
`-Wall -Wextra`, not eyeballed.

**No code change** — this is a decision plus its documentation and test.