### PR TITLE
ci: add ruff + pyright (strict) over the Python gate scripts

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,36 @@
+name: python-lint
+
+# The Python here is small but load-bearing: it is the CI gating layer. A bug in
+# ci/memory_gate.py or ci/check_isa_baseline.py silently disables a gate rather than
+# failing loudly, which has already happened twice (the arm64 scanner matched nothing
+# and reported "clean"; the memory gate returned before printing its diagnostics).
+# Neither was a C bug. Both were Python. Hence: hard failure, not advisory.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'ci/**'
+      - 'pyproject.toml'
+      - '.github/workflows/python-lint.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      # Pinned so a tool release cannot turn a green PR red (or a red one green)
+      # without a commit that says so.
+      - run: pip install ruff==0.12.10 pyright==1.1.411
+      - run: ruff check ci/
+      - run: ruff format --check ci/
+      - run: pyright
+      # The linters must not have changed behavior. These are the same checks the
+      # isa-baseline job runs, minus the compile: parser fixtures for both
+      # architectures, which is what caught the arm64 breakage in the first place.
+      - name: Gate scripts still work
+        run: python3 ci/check_isa_baseline.py --selftest

--- a/ci/check_isa_baseline.py
+++ b/ci/check_isa_baseline.py
@@ -39,10 +39,20 @@ import sys
 ABOVE_BASELINE = {
     # x86-64-v1 baseline (what Debian/RHEL x86_64 targets).  BMI1/BMI2/ABM/AVX2.
     "x64": {
-        "rorx": "BMI2", "mulx": "BMI2", "pdep": "BMI2", "pext": "BMI2",
-        "shlx": "BMI2", "shrx": "BMI2", "sarx": "BMI2", "bzhi": "BMI2",
-        "andn": "BMI1", "blsi": "BMI1", "blsr": "BMI1", "blsmsk": "BMI1",
-        "lzcnt": "ABM", "popcnt": "SSE4.2",
+        "rorx": "BMI2",
+        "mulx": "BMI2",
+        "pdep": "BMI2",
+        "pext": "BMI2",
+        "shlx": "BMI2",
+        "shrx": "BMI2",
+        "sarx": "BMI2",
+        "bzhi": "BMI2",
+        "andn": "BMI1",
+        "blsi": "BMI1",
+        "blsr": "BMI1",
+        "blsmsk": "BMI1",
+        "lzcnt": "ABM",
+        "popcnt": "SSE4.2",
         # NOT listed: `tzcnt`. It is encoded as `rep bsf`, and the F3 prefix is ignored
         # by pre-BMI1 CPUs, which therefore execute it as plain `bsf` -- same result for
         # every non-zero input. GCC consequently emits it at plain `-march=x86-64`
@@ -50,17 +60,40 @@ ABOVE_BASELINE = {
         # `bsr`, not `lzcnt`). Flagging it made the x64 portable build fail on 27 hits
         # that were never a portability problem. `lzcnt` stays: it decodes as `bsr` on
         # old CPUs, which silently returns a *different* value rather than the same one.
-        "vpermd": "AVX2", "vpbroadcastd": "AVX2", "vpbroadcastq": "AVX2",
+        "vpermd": "AVX2",
+        "vpbroadcastd": "AVX2",
+        "vpbroadcastq": "AVX2",
     },
     # armv8.0-a baseline.  LSE atomics (8.1) are the ones mimalloc actually pulls in.
     "arm64": {
-        "ldadd": "LSE", "ldadda": "LSE", "ldaddal": "LSE", "ldaddl": "LSE",
-        "ldclr": "LSE", "ldclra": "LSE", "ldclral": "LSE", "ldclrl": "LSE",
-        "ldeor": "LSE", "ldeora": "LSE", "ldeoral": "LSE", "ldeorl": "LSE",
-        "ldset": "LSE", "ldseta": "LSE", "ldsetal": "LSE", "ldsetl": "LSE",
-        "swp": "LSE", "swpa": "LSE", "swpal": "LSE", "swpl": "LSE",
-        "cas": "LSE", "casa": "LSE", "casal": "LSE", "casl": "LSE",
-        "casp": "LSE", "caspa": "LSE", "caspal": "LSE", "caspl": "LSE",
+        "ldadd": "LSE",
+        "ldadda": "LSE",
+        "ldaddal": "LSE",
+        "ldaddl": "LSE",
+        "ldclr": "LSE",
+        "ldclra": "LSE",
+        "ldclral": "LSE",
+        "ldclrl": "LSE",
+        "ldeor": "LSE",
+        "ldeora": "LSE",
+        "ldeoral": "LSE",
+        "ldeorl": "LSE",
+        "ldset": "LSE",
+        "ldseta": "LSE",
+        "ldsetal": "LSE",
+        "ldsetl": "LSE",
+        "swp": "LSE",
+        "swpa": "LSE",
+        "swpal": "LSE",
+        "swpl": "LSE",
+        "cas": "LSE",
+        "casa": "LSE",
+        "casal": "LSE",
+        "casl": "LSE",
+        "casp": "LSE",
+        "caspa": "LSE",
+        "caspal": "LSE",
+        "caspl": "LSE",
     },
 }
 
@@ -94,8 +127,10 @@ def disassemble(target: str) -> str:
         # one silently matches nothing on the other, turning a broken scan into a
         # "clean" PASS. (That is not hypothetical: it is exactly what the arm64
         # positive control caught the first time this ran in CI.)
-        tool + ["-d", "--no-show-raw-insn", target],
-        capture_output=True, text=True, errors="replace",
+        [*tool, "-d", "--no-show-raw-insn", target],
+        capture_output=True,
+        text=True,
+        errors="replace",
     )
     # objdump exits nonzero on archives whose members it cannot read, while still
     # emitting usable output for the rest.  Only bail if we got nothing at all.
@@ -124,7 +159,8 @@ def scan(disasm: str, arch: str) -> dict[str, int]:
 # scan report "clean" -- only the positive control caught it, and only because CI has an
 # arm64 runner. These fixtures make the parser testable on any host.
 SELFTEST_FIXTURES = {
-    "x64": ("""
+    "x64": (
+        """
 0000000000000000 <mi_test>:
    0:	push   %rbp
    4:	rorx   $0x10,%ecx,%ecx
@@ -133,8 +169,11 @@ SELFTEST_FIXTURES = {
   13:	andn   %eax,%ebx,%ecx
   17:	tzcnt  %ecx,%ecx
   1b:	retq
-""", {"rorx": 1, "popcnt": 1, "andn": 1}),   # tzcnt deliberately absent: see ABOVE_BASELINE
-    "arm64": ("""
+""",
+        {"rorx": 1, "popcnt": 1, "andn": 1},
+    ),  # tzcnt deliberately absent: see ABOVE_BASELINE
+    "arm64": (
+        """
 0000000000000000 <mi_test>:
    0:	stp	x29, x30, [sp, #-16]!
    4:	casal	w0, w1, [x2]
@@ -142,7 +181,9 @@ SELFTEST_FIXTURES = {
    c:	add	x0, x1, x2
   10:	swpa	w6, w7, [x8]
   14:	ret
-""", {"casal": 1, "ldaddal": 1, "swpa": 1}),
+""",
+        {"casal": 1, "ldaddal": 1, "swpa": 1},
+    ),
 }
 
 
@@ -163,17 +204,28 @@ def selftest() -> int:
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("target", nargs="?", help="library or executable to inspect")
-    ap.add_argument("--selftest", action="store_true",
-                    help="check the disassembly parser against built-in fixtures and exit")
+    ap.add_argument(
+        "--selftest",
+        action="store_true",
+        help="check the disassembly parser against built-in fixtures and exit",
+    )
     ap.add_argument("--arch", choices=sorted(ABOVE_BASELINE), default=None)
     mode = ap.add_mutually_exclusive_group()
-    mode.add_argument("--expect-clean", action="store_true", default=True,
-                      help="fail if any above-baseline instruction is present (default)")
-    mode.add_argument("--expect-dirty", action="store_true",
-                      help="positive control: fail if the scan finds NOTHING")
+    mode.add_argument(
+        "--expect-clean",
+        action="store_true",
+        default=True,
+        help="fail if any above-baseline instruction is present (default)",
+    )
+    mode.add_argument(
+        "--expect-dirty",
+        action="store_true",
+        help="positive control: fail if the scan finds NOTHING",
+    )
     args = ap.parse_args()
 
     if args.selftest:
@@ -207,8 +259,10 @@ def main() -> int:
         print("     force-sets it back ON unless MI_NO_OPT_ARCH is what you passed.")
         return 1
 
-    print(f"PASS {label}: no above-baseline instructions "
-          f"({len(ABOVE_BASELINE[arch])} mnemonics checked)")
+    print(
+        f"PASS {label}: no above-baseline instructions "
+        f"({len(ABOVE_BASELINE[arch])} mnemonics checked)"
+    )
     return 0
 
 

--- a/ci/dev_linux.py
+++ b/ci/dev_linux.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 """Fast, volume-backed Linux build/test loop for Docker Desktop developers."""
+
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import statistics
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 if os.name != "nt":
     import signal
@@ -19,9 +23,9 @@ C_TEST = (
     "cmake -S /src -B /target/c-build -G Ninja -DMI_PPROF=ON "
     "-DCMAKE_C_COMPILER_LAUNCHER=zccache && cmake --build /target/c-build && "
     "ctest --test-dir /target/c-build --output-on-failure -E 'test-stress.*' && "
-    "threads=$(nproc); [ \"$threads\" -le 4 ] || threads=4; "
-    "/target/c-build/mimalloc-test-stress \"$threads\" 50 50 && "
-    "/target/c-build/mimalloc-test-stress-dynamic \"$threads\" 50 50"
+    'threads=$(nproc); [ "$threads" -le 4 ] || threads=4; '
+    '/target/c-build/mimalloc-test-stress "$threads" 50 50 && '
+    '/target/c-build/mimalloc-test-stress-dynamic "$threads" 50 50'
 )
 
 
@@ -29,7 +33,14 @@ def soldr_timeout_diagnostics() -> None:
     """Print enough state to investigate a fail-fast development-loop timeout."""
     print("soldr command exceeded 60 seconds; collecting Docker diagnostics:", file=sys.stderr)
     for command in (
-        ["docker", "ps", "--filter", "name=clud-docker-build-soldr", "--format", "table {{.Names}}\\t{{.Status}}"],
+        [
+            "docker",
+            "ps",
+            "--filter",
+            "name=clud-docker-build-soldr",
+            "--format",
+            "table {{.Names}}\\t{{.Status}}",
+        ],
         ["docker", "stats", "--no-stream"],
         ["docker", "ps", "-a", "--filter", "name=clud-docker-build-soldr"],
     ):
@@ -39,21 +50,34 @@ def soldr_timeout_diagnostics() -> None:
             print(f"diagnostic also timed out: {' '.join(command)}", file=sys.stderr)
 
 
-def run_tool(args: list[str], *, capture: bool = False,
-             timeout_seconds: int | None = None) -> str:
+def run_tool(args: list[str], *, capture: bool = False, timeout_seconds: int | None = None) -> str:
     env = os.environ.copy()
     env["MSYS_NO_PATHCONV"] = "1"
-    popen_args: dict[str, object] = {}
+    stdout = subprocess.PIPE if capture else None
+    stderr = subprocess.STDOUT if capture else None
+    # Spelled out per platform rather than splatting a `dict[str, object]` of kwargs:
+    # the dict form erases every argument's type, so a typo in a keyword or a wrong
+    # value type reaches Popen unchecked. These two calls are the whole difference.
     if os.name == "nt":
-        popen_args["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        process = subprocess.Popen(
+            [*DOCKER_BUILD, *args],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=stdout,
+            stderr=stderr,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
     else:
-        popen_args["start_new_session"] = True
-    process = subprocess.Popen(
-        DOCKER_BUILD + args, cwd=ROOT, env=env, text=True,
-        stdout=subprocess.PIPE if capture else None,
-        stderr=subprocess.STDOUT if capture else None,
-        **popen_args,
-    )
+        process = subprocess.Popen(
+            [*DOCKER_BUILD, *args],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=stdout,
+            stderr=stderr,
+            start_new_session=True,
+        )
     try:
         output, _ = process.communicate(timeout=timeout_seconds)
     except subprocess.TimeoutExpired as error:
@@ -61,8 +85,9 @@ def run_tool(args: list[str], *, capture: bool = False,
         # Windows.  `clud tool run` has a Python and Docker child tree; leave
         # none of it behind or its delayed container start races the next run.
         if os.name == "nt":
-            subprocess.run(["taskkill", "/PID", str(process.pid), "/T", "/F"],
-                           check=False, capture_output=True)
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"], check=False, capture_output=True
+            )
         else:
             os.killpg(process.pid, signal.SIGKILL)
         output, _ = process.communicate()
@@ -83,8 +108,7 @@ def c_test(extra: list[str], *, capture: bool = False) -> str:
         command += " " + " ".join(extra)
     # `clud tool run` consumes a standalone `--`; docker-build's `run`
     # parser accepts the command directly as its remainder instead.
-    return run_tool(["run", "bash", "-lc", command], capture=capture,
-                    timeout_seconds=60)
+    return run_tool(["run", "bash", "-lc", command], capture=capture, timeout_seconds=60)
 
 
 def rust_test(extra: list[str]) -> None:
@@ -97,7 +121,7 @@ def rust_test(extra: list[str]) -> None:
     run_tool(["run", "bash", "-lc", command], timeout_seconds=60)
 
 
-def timed(label: str, action):
+def timed(label: str, action: Callable[[], str]) -> tuple[str, float, str]:
     start = time.monotonic()
     output = action()
     return label, time.monotonic() - start, output
@@ -106,15 +130,18 @@ def timed(label: str, action):
 def container_id() -> str:
     return subprocess.check_output(
         ["docker", "ps", "-q", "-f", "name=^clud-docker-build-soldr-" + project_key() + "$"],
-        cwd=ROOT, text=True).strip()
+        cwd=ROOT,
+        text=True,
+    ).strip()
 
 
 def marker_toggle() -> None:
     alloc = ROOT / "src" / "alloc.c"
     marker = "// dev-loop-bench-marker\n"
     text = alloc.read_text(encoding="utf-8")
-    alloc.write_text(text[:-len(marker)] if text.endswith(marker) else text + marker,
-                     encoding="utf-8")
+    alloc.write_text(
+        text[: -len(marker)] if text.endswith(marker) else text + marker, encoding="utf-8"
+    )
 
 
 def bench(reuse: bool = False) -> None:
@@ -131,24 +158,51 @@ def bench(reuse: bool = False) -> None:
     results.append(timed("single edit", lambda: c_test([], capture=True)))
     if (ROOT / "rust" / "Cargo.toml").is_file():
         rust_test([])
-        results.append(timed("rust warm no-op", lambda: run_tool(
-            ["run", "bash", "-lc", "cd /src/rust && soldr cargo test"], capture=True,
-            timeout_seconds=60)))
+        results.append(
+            timed(
+                "rust warm no-op",
+                lambda: run_tool(
+                    ["run", "bash", "-lc", "cd /src/rust && soldr cargo test"],
+                    capture=True,
+                    timeout_seconds=60,
+                ),
+            )
+        )
 
     warm = [seconds for name, seconds, _ in results if name.startswith("warm no-op")]
     checks = {
         "warm median <= 60 s": statistics.median(warm) <= 60,
-        "single edit <= 60 s": next(seconds for name, seconds, _ in results if name == "single edit") <= 60,
-        "ninja reported no work": all("no work to do" in output.lower() for name, _, output in results if name.startswith("warm no-op")),
-        "container reused across warm runs": bool(initial_container) and container_id() == initial_container,
+        "single edit <= 60 s": next(
+            seconds for name, seconds, _ in results if name == "single edit"
+        )
+        <= 60,
+        "ninja reported no work": all(
+            "no work to do" in output.lower()
+            for name, _, output in results
+            if name.startswith("warm no-op")
+        ),
+        "container reused across warm runs": bool(initial_container)
+        and container_id() == initial_container,
         "warm runs did not rebuild the image": all(
             "step 1/" not in output.lower() and "writing image" not in output.lower()
-            for name, _, output in results if name.startswith("warm no-op")),
-        "compiler launcher is zccache": "zccache" in run_tool(["run", "bash", "-lc", "grep CMAKE_C_COMPILER_LAUNCHER /target/c-build/CMakeCache.txt"], capture=True),
-        "source bind is read-only": subprocess.run(["docker", "exec", "clud-docker-build-soldr-" + project_key(), "touch", "/src/.probe"], cwd=ROOT).returncode != 0,
+            for name, _, output in results
+            if name.startswith("warm no-op")
+        ),
+        "compiler launcher is zccache": "zccache"
+        in run_tool(
+            ["run", "bash", "-lc", "grep CMAKE_C_COMPILER_LAUNCHER /target/c-build/CMakeCache.txt"],
+            capture=True,
+        ),
+        "source bind is read-only": subprocess.run(
+            ["docker", "exec", "clud-docker-build-soldr-" + project_key(), "touch", "/src/.probe"],
+            cwd=ROOT,
+        ).returncode
+        != 0,
     }
     fs = run_tool(["run", "bash", "-lc", "df -T /target | tail -1"], capture=True).lower()
-    checks["target is not a host filesystem"] = not any(kind in fs for kind in ("9p", "fuse", "virtiofs"))
+    checks["target is not a host filesystem"] = not any(
+        kind in fs for kind in ("9p", "fuse", "virtiofs")
+    )
     print("| phase | seconds |\n| --- | ---: |")
     for name, seconds, _ in results:
         print(f"| {name} | {seconds:.2f} |")
@@ -160,7 +214,6 @@ def bench(reuse: bool = False) -> None:
 
 
 def project_key() -> str:
-    import hashlib
     return hashlib.blake2b(str(ROOT.resolve()).encode(), digest_size=6).hexdigest()
 
 
@@ -171,15 +224,24 @@ def main() -> None:
         p = sub.add_parser(name)
         p.add_argument("args", nargs=argparse.REMAINDER)
     bench_parser = sub.add_parser("bench")
-    bench_parser.add_argument("--reuse", action="store_true",
-                              help="keep the current named volumes (restart validation)")
+    bench_parser.add_argument(
+        "--reuse", action="store_true", help="keep the current named volumes (restart validation)"
+    )
     for name in ("shell", "doctor", "clean"):
         sub.add_parser(name)
     args = parser.parse_args()
-    if args.command == "c-test": c_test(args.args)
-    elif args.command == "rust-test": rust_test(args.args)
-    elif args.command == "bench": bench(args.reuse)
-    else: run_tool([args.command])
+    # argparse hands back Any; pin each field to what the parser above guarantees so a
+    # renamed subcommand or flag is a type error here rather than an AttributeError at
+    # the moment someone runs it.
+    command: str = args.command
+    if command == "c-test":
+        c_test(cast("list[str]", args.args))
+    elif command == "rust-test":
+        rust_test(cast("list[str]", args.args))
+    elif command == "bench":
+        bench(cast(bool, args.reuse))
+    else:
+        run_tool([command])
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+# This project is C (mimalloc) plus a Rust workspace in rust/. There is no Python
+# package here -- this file exists purely to configure the linters for the CI scripts
+# in ci/, which are small but load-bearing: they decide whether a PR is a memory
+# regression (ci/memory_gate.py) or whether a build is CPU-portable
+# (ci/check_isa_baseline.py). A bug in one of those silently disables a gate, which
+# has already happened twice -- so they get checked like the gating code they are.
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"          # oldest Python the CI runners are guaranteed to have
+src = ["ci"]
+
+[tool.ruff.lint]
+select = [
+    "E", "W",    # pycodestyle
+    "F",         # pyflakes
+    "I",         # import sorting
+    "B",         # bugbear -- mutable defaults, unused loop vars, except-blind
+    "UP",        # pyupgrade
+    "SIM",       # simplify
+    "RUF",       # ruff-specific
+    "PTH",       # prefer pathlib over os.path
+    "RET",       # return-path consistency
+    "C4",        # comprehensions
+]
+ignore = [
+    # The scripts print user-facing diagnostics; long single-line f-strings in those
+    # messages are clearer unwrapped than split across continuations.
+    "E501",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.pyright]
+include = ["ci"]
+pythonVersion = "3.9"
+typeCheckingMode = "strict"
+# These scripts run standalone from the repo root, not as an installed package.
+reportMissingModuleSource = false


### PR DESCRIPTION
Closes #74.

The Python here is the **CI gating layer**, and it was entirely unchecked. Two bugs this week landed in it, not in the C:

- the arm64 ISA scanner matched nothing and reported `PASS ... no above-baseline instructions`
- the memory gate returned before printing the diagnostics that would have shown the problem

Both silently *weakened a gate* rather than failing. That is the argument for strict checking on 630 lines of Python.

## What's added

- **`pyproject.toml`** (there was none) — ruff config (`E,W,F,I,B,UP,SIM,RUF,PTH,RET,C4`) and pyright `strict`
- **`.github/workflows/python-lint.yml`** — `ruff check`, `ruff format --check`, `pyright`, hard failure, tool versions pinned so a tool release can't flip a PR's result without a commit saying so

## The substantive fix

`ci/dev_linux.py` built Popen's platform-specific arguments as a `dict[str, object]` and splatted them:

```python
popen_args: dict[str, object] = {}
if os.name == "nt":
    popen_args["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
else:
    popen_args["start_new_session"] = True
process = subprocess.Popen(..., **popen_args)
```

That erases every argument's type — a misspelled keyword or a wrong value type reaches `Popen` unchecked, and it produced 6 of the 24 strict errors on its own. Now spelled out per platform: two calls, each fully checked, and the difference between them is visible.

Also: argparse results are `cast` to what the parser actually guarantees (a renamed subcommand becomes a type error, not a runtime `AttributeError`), and `timed()` is generic over its callable instead of returning a partially-unknown tuple.

**24 pyright strict errors → 0. 5 ruff errors → 0.** No blanket `# type: ignore`.

## Behavior verified, not assumed

`ruff format` rewrote both gate scripts, so I re-ran every direction of the ISA gate afterward rather than trusting that formatting is safe:

| Check | Result |
|---|---|
| `--selftest` (x86 + arm64 fixtures) | PASS |
| clean build → `check` | PASS, rc=0 |
| dirty build → `--expect-dirty` | PASS, control fired (274 hits) |
| dirty build → real `check` | **FAIL, rc=1** ✓ |

A formatter that quietly broke a gate is the specific risk this PR would otherwise introduce.

## Note

`ci/memory_gate.py` is not covered here because it is still in #70. Once that merges, a follow-up commit brings it under the same checks — the issue is left open until then.