### PR TITLE
ci: bring memory_gate.py under ruff + pyright strict (fixes red main)

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -33,4 +33,8 @@ jobs:
       # isa-baseline job runs, minus the compile: parser fixtures for both
       # architectures, which is what caught the arm64 breakage in the first place.
       - name: Gate scripts still work
-        run: python3 ci/check_isa_baseline.py --selftest
+        run: |
+          python3 ci/check_isa_baseline.py --selftest
+          # A gate script that imports cleanly but crashes on argv is still broken.
+          python3 ci/memory_gate.py 2>&1 | grep -q "Exit codes"
+          python3 ci/check_isa_baseline.py --help > /dev/null

--- a/ci/memory_gate.py
+++ b/ci/memory_gate.py
@@ -25,11 +25,49 @@ Usage:
 Exit codes: 0 pass, 1 regression, 2 usage/IO error.
 """
 
-import json
-import os
-import sys
+from __future__ import annotations
 
-BASELINE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "memory-baselines")
+import json
+import sys
+from pathlib import Path
+from typing import TypedDict, cast
+
+BASELINE_DIR = Path(__file__).resolve().parent / "memory-baselines"
+
+
+class Counters(TypedDict):
+    """Exact allocator counters emitted by test-memory-gate.c, not statistical."""
+
+    threads_start: int
+    threads_end: int
+    theaps_start: int
+    theaps_end: int
+    pages_start: int
+    pages_end: int
+
+
+class Result(TypedDict):
+    """One run of test-memory-gate. Mirrors the JSON that MI_BENCH_JSON writes.
+
+    Declared rather than left as dict[str, Any] because every field here is indexed by
+    string literal below. A typo in one of those keys would previously have been a
+    runtime KeyError inside a CI gate -- i.e. a gate that fails for the wrong reason,
+    or (worse, on a path that catches it) one that passes without checking anything.
+    """
+
+    schema: int
+    platform: str
+    gated_metric: str
+    mi_pprof: int
+    inject_leak: int
+    peak_mb: float
+    peak_rss_mb: float
+    peak_commit_mb: float
+    profiler_arena_mb: float
+    peak_minus_profiler_mb: float
+    purged_gb: float
+    counters: Counters
+
 
 # Peak memory tolerance, applied to the minimum of RUNS_EXPECTED runs.
 #
@@ -54,20 +92,20 @@ RUNS_EXPECTED = 4
 MAX_LIVE_THREADS = 32
 
 
-def baseline_path(result):
+def baseline_path(result: Result) -> Path:
     # MI_PPROF changes the legitimate peak (rule 4 puts the profiler arena in process
     # memory), so ON and OFF get separate baselines rather than one padded threshold.
-    return os.path.join(
-        BASELINE_DIR, "{}-pprof{}.json".format(result["platform"], result["mi_pprof"])
-    )
+    return BASELINE_DIR / "{}-pprof{}.json".format(result["platform"], result["mi_pprof"])
 
 
-def load(path):
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+def load(path: str | Path) -> Result:
+    with Path(path).open(encoding="utf-8") as f:
+        # json.load returns Any; this cast is the single point where untyped external
+        # data becomes typed, so the schema assumption is stated once and visibly.
+        return cast(Result, json.load(f))
 
 
-def load_runs(paths):
+def load_runs(paths: list[str]) -> tuple[Result, list[float], float]:
     """Load N runs of the same configuration and return (representative, peak_mb, spread%).
 
     The representative record is the run with the minimum gated peak; its counters are
@@ -76,30 +114,35 @@ def load_runs(paths):
     runs = [load(p) for p in paths]
     keys = {(r["platform"], r["mi_pprof"], r["gated_metric"]) for r in runs}
     if len(keys) != 1:
-        raise ValueError(
-            "runs are not from the same configuration: {}".format(sorted(keys)))
+        raise ValueError(f"runs are not from the same configuration: {sorted(keys)}")
     peaks = sorted(r["peak_mb"] for r in runs)
     best = min(runs, key=lambda r: r["peak_mb"])
     spread = (100.0 * (peaks[-1] - peaks[0]) / peaks[0]) if peaks[0] else 0.0
     return best, peaks, spread
 
 
-def report_runs(peaks, spread):
-    print("  {:<22} {}".format(
-        "runs (MB)", "  ".join("{:.1f}".format(p) for p in peaks)))
-    print("  {:<22} {:.1f}%  (min is used; noise on a shared runner only adds memory)"
-          .format("spread across runs", spread))
+def report_runs(peaks: list[float], spread: float) -> None:
+    print("  {:<22} {}".format("runs (MB)", "  ".join(f"{p:.1f}" for p in peaks)))
+    print(
+        "  {:<22} {:.1f}%  (min is used; noise on a shared runner only adds memory)".format(
+            "spread across runs", spread
+        )
+    )
     if len(peaks) < RUNS_EXPECTED:
-        print("  WARNING: only {} run(s); the committed baselines are min-of-{}. "
-              "A single run is not comparable.".format(len(peaks), RUNS_EXPECTED))
+        print(
+            f"  WARNING: only {len(peaks)} run(s); the committed baselines are min-of-{RUNS_EXPECTED}. "
+            "A single run is not comparable."
+        )
     if spread >= 100.0 * PEAK_TOLERANCE:
-        print("  WARNING: observed spread ({:.1f}%) is at or above the tolerance "
-              "({:.0f}%). The threshold cannot distinguish a regression from noise -- "
-              "raise RUNS_EXPECTED or the tolerance, with this measurement as the "
-              "justification.".format(spread, 100.0 * PEAK_TOLERANCE))
+        print(
+            f"  WARNING: observed spread ({spread:.1f}%) is at or above the tolerance "
+            f"({100.0 * PEAK_TOLERANCE:.0f}%). The threshold cannot distinguish a regression from noise -- "
+            "raise RUNS_EXPECTED or the tolerance, with this measurement as the "
+            "justification."
+        )
 
 
-def control(result_paths):
+def control(result_paths: list[str]) -> int:
     """Positive control: require the gate to FAIL on a deliberately leaky build.
 
     A gate that has never been observed to fire proves nothing -- it can be silently
@@ -112,9 +155,11 @@ def control(result_paths):
     """
     result, _, _ = load_runs(result_paths)
     if not result.get("inject_leak", 0):
-        print("REFUSING: positive control requires a build with MI_BENCH_INJECT_LEAK "
-              "set. This run has none, so a failure here would mean a real regression, "
-              "not a working control.")
+        print(
+            "REFUSING: positive control requires a build with MI_BENCH_INJECT_LEAK "
+            "set. This run has none, so a failure here would mean a real regression, "
+            "not a working control."
+        )
         return 2
 
     print("=== positive control: the gate is expected to FAIL below ===")
@@ -122,67 +167,87 @@ def control(result_paths):
     if rc == 1:
         print("\nPASS (control): the gate detected the injected leak.")
         return 0
-    print("\nFAIL (control): the gate did NOT detect an injected leak (rc={}).".format(rc))
+    print(f"\nFAIL (control): the gate did NOT detect an injected leak (rc={rc}).")
     print("The gate is not working. A green `check` on a real build means nothing")
     print("until this passes.")
     return 1
 
 
-def check(result_paths, _control=False):
+def check(result_paths: list[str], _control: bool = False) -> int:
     result, peaks, spread = load_runs(result_paths)
 
     if result.get("inject_leak", 0) and not _control:
         # An injected-leak run is a positive control; it is expected to fail and must
         # never be mistaken for a real result or used to re-baseline.
-        print("REFUSING: this run has MI_BENCH_INJECT_LEAK set and is a positive "
-              "control, not a measurement. Use `memory_gate.py control` for that.")
+        print(
+            "REFUSING: this run has MI_BENCH_INJECT_LEAK set and is a positive "
+            "control, not a measurement. Use `memory_gate.py control` for that."
+        )
         return 2
 
     bpath = baseline_path(result)
-    if not os.path.exists(bpath):
-        print("No baseline at {}.".format(bpath))
+    if not bpath.exists():
+        print(f"No baseline at {bpath}.")
         report_runs(peaks, spread)
         print("This platform/config has never been recorded. Create it with:")
         print("    python ci/memory_gate.py update {}".format(" ".join(result_paths)))
         return 2
     base = load(bpath)
 
-    failures = []
+    failures: list[str] = []
     metric = result["gated_metric"]
     peak, base_peak = peaks[0], base["peak_mb"]
     allowed = base_peak * (1.0 + PEAK_TOLERANCE)
 
-    print("platform={} metric={} mi_pprof={}".format(
-        result["platform"], metric, result["mi_pprof"]))
-    print("  {:<22} {:>9.1f} MB   baseline {:>9.1f} MB   allowed {:>9.1f} MB".format(
-        metric, peak, base_peak, allowed))
-    print("  {:<22} {:>9.1f} MB   (reported so the profiler's own arena is not "
-          "mistaken for allocator growth)".format(
-              "profiler arena", result.get("profiler_arena_mb", 0.0)))
+    print(
+        "platform={} metric={} mi_pprof={}".format(result["platform"], metric, result["mi_pprof"])
+    )
+    print(
+        f"  {metric:<22} {peak:>9.1f} MB   baseline {base_peak:>9.1f} MB   allowed {allowed:>9.1f} MB"
+    )
+    print(
+        "  {:<22} {:>9.1f} MB   (reported so the profiler's own arena is not "
+        "mistaken for allocator growth)".format(
+            "profiler arena", result.get("profiler_arena_mb", 0.0)
+        )
+    )
     report_runs(peaks, spread)
 
     if peak > allowed:
         failures.append(
             "{} regressed: {:.1f} MB vs baseline {:.1f} MB (+{:.1f}%, allowed +{:.0f}%)".format(
-                metric, peak, base_peak,
+                metric,
+                peak,
+                base_peak,
                 100.0 * (peak - base_peak) / base_peak if base_peak else float("inf"),
-                100.0 * PEAK_TOLERANCE))
+                100.0 * PEAK_TOLERANCE,
+            )
+        )
 
     c = result["counters"]
-    print("  counters: threads {}->{}  theaps {}->{}  pages {}->{}".format(
-        c["threads_start"], c["threads_end"], c["theaps_start"],
-        c["theaps_end"], c["pages_start"], c["pages_end"]))
+    print(
+        "  counters: threads {}->{}  theaps {}->{}  pages {}->{}".format(
+            c["threads_start"],
+            c["threads_end"],
+            c["theaps_start"],
+            c["theaps_end"],
+            c["pages_start"],
+            c["pages_end"],
+        )
+    )
 
     if c["threads_end"] >= MAX_LIVE_THREADS:
         failures.append(
             "{} threads still live after the run (limit {}). Thread-exit cleanup is "
             "not running -- this is the signature of #44 / #47.".format(
-                c["threads_end"], MAX_LIVE_THREADS))
+                c["threads_end"], MAX_LIVE_THREADS
+            )
+        )
 
     if failures:
         print("\nFAIL")
         for f in failures:
-            print("  - {}".format(f))
+            print(f"  - {f}")
         print("\nIf this growth is intentional, re-baseline deliberately:")
         print("    python ci/memory_gate.py update {}".format(" ".join(result_paths)))
         print("and say why in the PR. Do not re-baseline to make a red gate green.")
@@ -192,12 +257,12 @@ def check(result_paths, _control=False):
     return 0
 
 
-def update(result_paths):
+def update(result_paths: list[str]) -> int:
     result, peaks, spread = load_runs(result_paths)
     if result.get("inject_leak", 0):
         print("REFUSING to baseline a run with MI_BENCH_INJECT_LEAK set.")
         return 2
-    os.makedirs(BASELINE_DIR, exist_ok=True)
+    BASELINE_DIR.mkdir(parents=True, exist_ok=True)
     bpath = baseline_path(result)
     # Record how the number was obtained, so a later reader can tell whether a baseline
     # is comparable to the current methodology rather than having to guess.
@@ -205,15 +270,15 @@ def update(result_paths):
     record["peak_mb"] = peaks[0]
     record["baseline_runs"] = len(peaks)
     record["baseline_spread_pct"] = round(spread, 1)
-    with open(bpath, "w", encoding="utf-8") as f:
+    with bpath.open("w", encoding="utf-8") as f:
         json.dump(record, f, indent=2, sort_keys=True)
         f.write("\n")
-    print("wrote {} (min peak {:.1f} MB of {} runs)".format(bpath, peaks[0], len(peaks)))
+    print(f"wrote {bpath} (min peak {peaks[0]:.1f} MB of {len(peaks)} runs)")
     report_runs(peaks, spread)
     return 0
 
 
-def main(argv):
+def main(argv: list[str]) -> int:
     if len(argv) < 3 or argv[1] not in ("check", "update", "control"):
         print(__doc__)
         return 2
@@ -221,7 +286,7 @@ def main(argv):
         cmd = {"check": check, "update": update, "control": control}[argv[1]]
         return cmd(argv[2:])
     except (OSError, ValueError, KeyError) as e:
-        print("error: {}".format(e))
+        print(f"error: {e}")
         return 2
 
 


### PR DESCRIPTION
Closes #74. **Fixes a red `main`.**

#70 (memory gate) and #76 (Python linters) were both green and merged independently, but they landed in an order that left `main` with the `python-lint` job from one and an unchecked `ci/memory_gate.py` from the other: **19 ruff errors, 45 pyright errors**. Neither PR was wrong; this is the merge-order hazard between two PRs that don't share a file but do share a rule.

## The typing work

45 strict errors → 0. The bulk was untyped JSON. Every field of the result payload is indexed by string literal:

```python
result["peak_mb"], result["gated_metric"], c["threads_end"], ...
```

A typo in any of those was a runtime `KeyError` **inside a CI gate** — a gate failing for the wrong reason, or on a caught path, one that passes without checking anything. That is the specific failure mode this repo has already hit twice.

`Result` and `Counters` TypedDicts now declare the schema `test-memory-gate.c` actually writes, and the single `cast` in `load()` is the one visible point where untyped external data becomes typed.

Also: `os.path` → `pathlib` (PTH), the four command entry points annotated, `failures` accumulator typed.

## Behavior verified, not assumed

The refactor and `ruff format` both touched a live gate, so all four directions were re-run:

| Scenario | Result |
|---|---|
| clean CI run vs committed baseline → `check` | **PASS** (rc=0) |
| leaky build → `control` | **PASS** — gate fired (rc=0) |
| clean run → `control` | REFUSED (rc=2) |
| leaky run → `check` | REFUSED (rc=2) |

## Also

The lint job now smoke-runs both scripts' entry points. A gate script that imports cleanly but crashes on `argv` is still broken, and neither ruff nor pyright catches that.