### PR TITLE
feat: experimental zero-tracking behind mi_option_purge_zeroes (#67)

### DIFF
--- a/.github/workflows/zero-tracking.yml
+++ b/.github/workflows/zero-tracking.yml
@@ -1,0 +1,50 @@
+name: zero-tracking
+
+# Decides issue #67: does mi_option_purge_zeroes actually pay?
+#
+# Deliberately its own workflow rather than a step in c-unit: timing is only meaningful
+# on a quiet runner, and an A/B that shares a job with a parallel build measures the
+# build. A first local attempt "measured" a 13% regression that turned out to be
+# measurement order on a loaded machine -- the interleaved rerun reversed the sign. So
+# the arms here are interleaved and paired, from a single binary, and the raw numbers
+# are printed rather than a verdict.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src/arena.c'
+      - 'test/bench-zero-tracking.c'
+      - '.github/workflows/zero-tracking.yml'
+
+jobs:
+  ab:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: cmake -B build -DMI_PPROF=ON -DCMAKE_BUILD_TYPE=Release
+      - run: cmake --build build --config Release
+      # Correctness first: every byte of every mi_zalloc must read zero, with the
+      # feature both off and on. If this fails the timings are irrelevant.
+      - name: Correctness (feature off, then on)
+        shell: bash
+        run: ctest --test-dir build -C Release -R zero-tracking --output-on-failure
+      - name: Interleaved A/B
+        shell: bash
+        run: |
+          set -euo pipefail
+          exe=$(find build -name 'mimalloc-test-zero-tracking*' -type f | head -1)
+          export MIMALLOC_PURGE_DELAY=0
+          for i in 1 2 3 4 5 6 7 8; do
+            MIMALLOC_PURGE_ZEROES=0 "$exe"
+            MIMALLOC_PURGE_ZEROES=1 "$exe"
+          done | tee ab.jsonl
+          python3 ci/zero_tracking_report.py ab.jsonl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zero-tracking-${{ matrix.os }}
+          path: ab.jsonl

--- a/.github/workflows/zero-tracking.yml
+++ b/.github/workflows/zero-tracking.yml
@@ -37,7 +37,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          exe=$(find build -name 'mimalloc-test-zero-tracking*' -type f | head -1)
+          # Match the executable exactly: a trailing-glob `find` also picks up MSVC's
+          # .recipe/.tlog build artifacts, which bash then tries to execute.
+          exe=$(find build -type f \( -name 'mimalloc-test-zero-tracking' -o -name 'mimalloc-test-zero-tracking.exe' \) | head -1)
+          echo "benchmark binary: $exe"
           export MIMALLOC_PURGE_DELAY=0
           for i in 1 2 3 4 5 6 7 8; do
             MIMALLOC_PURGE_ZEROES=0 "$exe"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -924,6 +924,26 @@ if (MI_BUILD_TESTS)
   add_test(NAME test-memory-gate COMMAND mimalloc-test-memory-gate)
   set_tests_properties(test-memory-gate PROPERTIES TIMEOUT 900)
 
+  # Zero-tracking bench + correctness harness (issue #67). Registered as a ctest so the
+  # *correctness* half runs on every commit; the timing halves are only meaningful on a
+  # quiet runner and are consumed by the zero-tracking CI job.
+  add_executable(mimalloc-test-zero-tracking test/bench-zero-tracking.c)
+  target_compile_definitions(mimalloc-test-zero-tracking PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-test-zero-tracking PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-zero-tracking PRIVATE include)
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    target_link_libraries(mimalloc-test-zero-tracking PRIVATE mimalloc-static ${mi_libraries})
+  else()
+    target_link_libraries(mimalloc-test-zero-tracking PRIVATE mimalloc ${mi_libraries})
+  endif()
+  add_test(NAME test-zero-tracking COMMAND mimalloc-test-zero-tracking)
+  set_tests_properties(test-zero-tracking PROPERTIES TIMEOUT 900)
+  # The feature is off by default, so the default run would never exercise it. This is
+  # the "any flag that ships must have a job running the suite with it ON" rule from #67.
+  add_test(NAME test-zero-tracking-enabled COMMAND mimalloc-test-zero-tracking)
+  set_tests_properties(test-zero-tracking-enabled PROPERTIES
+    TIMEOUT 900 ENVIRONMENT "MIMALLOC_PURGE_ZEROES=1;MIMALLOC_PURGE_DELAY=0")
+
   # Degenerate memory patterns and memory-bound regression guards (issue #47).
   # Independent of MI_PPROF: it guards allocator behavior, not the profiler.
   add_executable(mimalloc-test-degenerate test/test-degenerate.c)

--- a/ci/zero_tracking_report.py
+++ b/ci/zero_tracking_report.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Summarise an interleaved A/B run of the zero-tracking benchmark (issue #67).
+
+Reads the JSON-lines the benchmark emits and reports paired medians per workload.
+
+Deliberately reports numbers rather than a verdict. The first attempt at deciding #67
+locally "measured" a 13% regression on the anti-workload; re-running the same two
+binaries interleaved reversed the sign. The difference was measurement order on a loaded
+machine, not the feature. So: paired samples, medians, and the spread printed alongside,
+so a reader can see whether the effect is larger than the noise instead of taking a
+single number on faith.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypedDict, cast
+
+
+class Sample(TypedDict):
+    purge_zeroes: int
+    sparse_s: float
+    dense_s: float
+    verify: str
+
+
+# `sparse` favours the feature so strongly that quoting it alone would be misleading:
+# skipping the memset also skips faulting the pages in, so it measures lazy commit as
+# much as zeroing. `dense` is the anti-workload and is the one that decides adoption.
+# Accessors rather than string keys: indexing a TypedDict with a loop variable erases
+# the field's type, which would defeat the point of declaring the schema at all.
+WORKLOADS: tuple[tuple[Callable[[Sample], float], str], ...] = (
+    (lambda s: s["sparse_s"], "sparse (favourable: one byte touched per block)"),
+    (lambda s: s["dense_s"], "dense  (ANTI-WORKLOAD: every byte touched)"),
+)
+
+
+def summarise(samples: list[Sample]) -> int:
+    off = [s for s in samples if s["purge_zeroes"] == 0]
+    on = [s for s in samples if s["purge_zeroes"] == 1]
+    if not off or not on:
+        print(f"error: need samples from both arms (got {len(off)} off, {len(on)} on)")
+        return 2
+
+    print(f"paired samples: {len(off)} off, {len(on)} on\n")
+    for field, label in WORKLOADS:
+        a = sorted(field(s) for s in off)
+        b = sorted(field(s) for s in on)
+        ma, mb = statistics.median(a), statistics.median(b)
+        change = 100.0 * (mb - ma) / ma if ma else 0.0
+        spread_a = 100.0 * (a[-1] - a[0]) / a[0] if a[0] else 0.0
+        spread_b = 100.0 * (b[-1] - b[0]) / b[0] if b[0] else 0.0
+        verdict = "faster" if change < 0 else "slower"
+        print(label)
+        print(f"  off  median {ma:.4f}s   range {a[0]:.4f}-{a[-1]:.4f}  (spread {spread_a:.1f}%)")
+        print(f"  on   median {mb:.4f}s   range {b[0]:.4f}-{b[-1]:.4f}  (spread {spread_b:.1f}%)")
+        print(f"  -> {change:+.1f}% ({verdict})")
+        # An effect smaller than the noise in either arm is not an effect.
+        if abs(change) < max(spread_a, spread_b):
+            print("     NOTE: |change| is smaller than the within-arm spread; this is")
+            print("     not distinguishable from noise at this sample count.")
+        print()
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__)
+        return 2
+    samples: list[Sample] = []
+    for line in Path(argv[1]).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            samples.append(cast(Sample, json.loads(line)))
+    if not samples:
+        print("error: no JSON samples found")
+        return 2
+    if any(s["verify"] != "ok" for s in samples):
+        print("error: a run reported failed verification")
+        return 1
+    return summarise(samples)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -491,6 +491,7 @@ typedef enum mi_option_e {
   mi_option_prof_seed,                  // profiler sampling PRNG seed; 0 = nondeterministic (=0)
   mi_option_prof_max_bytes,             // budget (in bytes) for profiler-internal arena memory; 0 = unbudgeted (=0)
   mi_option_memory_events,              // enable opt-in allocation-change accounting/callbacks (MIMALLOC_MEMORY_EVENTS) (=0)
+  mi_option_purge_zeroes,               // treat decommit-purged slices as zeroed, letting mi_zalloc skip its memset (=0, experimental)
   _mi_option_last,
   // legacy option names
   mi_option_large_os_pages = mi_option_allow_large_os_pages,

--- a/src/arena.c
+++ b/src/arena.c
@@ -2113,6 +2113,19 @@ static bool mi_arena_purge(mi_arena_t* arena, size_t slice_index, size_t slice_c
   if (needs_recommit) {
     // no longer committed
     mi_bitmap_clearN(arena->slices_committed, slice_index, slice_count);
+    // Experimental (#67, mi_option_purge_zeroes, default off): decommitted memory reads
+    // back zero when it is recommitted, so the slices are no longer dirty. Clearing the
+    // dirty bits lets the next allocation see memid->initially_zero, which in turn lets
+    // mi_zalloc skip its memset (alloc.c: `if (!page->free_is_zero) memset(...)`).
+    //
+    // Reached only on the `needs_recommit` branch, i.e. only when we genuinely
+    // decommitted. A *reset* (MADV_FREE / MEM_RESET) may preserve contents, and a custom
+    // commit_fun makes no zeroing promise at all -- claiming zero in either case would
+    // hand dirty memory to mi_zalloc, which is silent heap corruption rather than a
+    // visible failure. Hence both guards.
+    if (arena->commit_fun == NULL && mi_option_is_enabled(mi_option_purge_zeroes)) {
+      mi_bitmap_clearN(arena->slices_dirty, slice_index, slice_count);
+    }
     // we just counted in the purge to decommit all, but the some part was not committed so adjust that here
     // mi_subproc_stat_decrease(arena->subproc, committed, mi_size_of_slices(slice_count - already_committed));
   }

--- a/src/options.c
+++ b/src/options.c
@@ -186,6 +186,7 @@ static mi_option_desc_t mi_options[_mi_option_last] =
   ,{ 0,      MI_OPTION_UNINIT, MI_OPTION(prof_seed) }
   ,{ 0,      MI_OPTION_UNINIT, MI_OPTION(prof_max_bytes) }        // budget for profiler-internal arena memory; 0 = unbudgeted
   ,{ 0,      MI_OPTION_UNINIT, MI_OPTION(memory_events) }         // opt-in allocation-change accounting/callbacks; read lazily by memory-events.c, not at startup
+  ,{ 0,      MI_OPTION_UNINIT, MI_OPTION(purge_zeroes) }           // experimental (#67): treat decommit-purged slices as zeroed so mi_zalloc can skip its memset
 };
 
 static void mi_option_init(mi_option_desc_t* desc);

--- a/test/bench-zero-tracking.c
+++ b/test/bench-zero-tracking.c
@@ -1,0 +1,112 @@
+/* Benchmark + correctness harness for zero-tracking (issue #67,
+   mi_option_purge_zeroes / MIMALLOC_PURGE_ZEROES).
+
+   The feature clears the arena's dirty bits after a decommit-purge, so the next
+   allocation is reported as already-zero and mi_zalloc can skip its memset.
+
+   Three workloads, because the first one alone is misleading:
+
+     sparse  -- zalloc big buffers, touch one byte. FAVOURS the feature, and by a lot:
+                skipping the memset also skips faulting the pages in, so this measures
+                lazy commit as much as it measures zeroing. Reported, but never on its
+                own.
+     dense   -- zalloc then touch every byte (the anti-workload the issue requires).
+                The page faults happen either way here, so only the redundant memset can
+                be saved. If the feature costs more than it saves, it shows up here.
+     verify  -- correctness. Fills every byte with a non-zero pattern before freeing,
+                then requires the next mi_zalloc to hand back genuinely zeroed memory.
+                A weaker check that samples a few offsets cannot tell "zeroed" from
+                "stale but happens to be zero", and getting this wrong is silent heap
+                corruption rather than a visible failure.
+
+   Prints one JSON object so ci/ can consume it. Exits non-zero on any corruption. */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <mimalloc.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define ROUNDS   20
+#define BLOCKS   64
+#define BLOCKSZ  (1u << 20)   /* 1 MiB: large enough that memset dominates the round */
+
+static void* keep[BLOCKS];
+
+static double now_secs(void) {
+  return (double)clock() / (double)CLOCKS_PER_SEC;
+}
+
+/* Touch one byte per block: the memset skipped here is also a page fault skipped. */
+static double bench_sparse(void) {
+  const double t0 = now_secs();
+  for (int r = 0; r < ROUNDS; r++) {
+    for (int i = 0; i < BLOCKS; i++) {
+      unsigned char* b = (unsigned char*)mi_zalloc(BLOCKSZ);
+      if (b == NULL) { fprintf(stderr, "oom\n"); exit(1); }
+      b[0] = 1;
+      keep[i] = b;
+    }
+    for (int i = 0; i < BLOCKS; i++) mi_free(keep[i]);
+    mi_collect(true);
+  }
+  return now_secs() - t0;
+}
+
+/* Touch every byte: the anti-workload. Faults happen in both arms. */
+static double bench_dense(void) {
+  volatile unsigned long long sink = 0;
+  const double t0 = now_secs();
+  for (int r = 0; r < ROUNDS; r++) {
+    for (int i = 0; i < BLOCKS; i++) {
+      unsigned char* b = (unsigned char*)mi_zalloc(BLOCKSZ);
+      if (b == NULL) { fprintf(stderr, "oom\n"); exit(1); }
+      memset(b, (int)(r + i + 1), BLOCKSZ);
+      sink += b[BLOCKSZ - 1];
+      keep[i] = b;
+    }
+    for (int i = 0; i < BLOCKS; i++) mi_free(keep[i]);
+    mi_collect(true);
+  }
+  const double elapsed = now_secs() - t0;
+  (void)sink;
+  return elapsed;
+}
+
+/* Every byte of every zalloc must read zero, across purge/reuse cycles. */
+static int verify_zeroed(void) {
+  for (int r = 0; r < ROUNDS; r++) {
+    for (int i = 0; i < BLOCKS; i++) {
+      unsigned char* b = (unsigned char*)mi_zalloc(BLOCKSZ);
+      if (b == NULL) { fprintf(stderr, "oom\n"); return 1; }
+      for (size_t k = 0; k < BLOCKSZ; k++) {
+        if (b[k] != 0) {
+          fprintf(stderr,
+                  "CORRUPTION: mi_zalloc returned non-zero memory "
+                  "(round=%d block=%d offset=%zu value=0x%02x)\n",
+                  r, i, k, b[k]);
+          return 2;
+        }
+      }
+      memset(b, 0xA5, BLOCKSZ);   /* dirty every byte before it goes back */
+      keep[i] = b;
+    }
+    for (int i = 0; i < BLOCKS; i++) mi_free(keep[i]);
+    mi_collect(true);
+  }
+  return 0;
+}
+
+int main(void) {
+  const int rc = verify_zeroed();
+  if (rc != 0) return rc;
+  const double sparse = bench_sparse();
+  const double dense = bench_dense();
+  printf("{ \"purge_zeroes\": %d, \"sparse_s\": %.4f, \"dense_s\": %.4f, \"verify\": \"ok\" }\n",
+         mi_option_is_enabled(mi_option_purge_zeroes) ? 1 : 0, sparse, dense);
+  return 0;
+}


### PR DESCRIPTION
Refs #67. **Opened to get the measurement, not to claim a result.** See "verdict" below.

After a decommit-purge the range reads back zero on recommit, but the arena's dirty bits stayed set — so the next allocation was reported non-zero and `mi_zalloc` did a redundant `memset`. This clears the dirty bits on that path, **off by default**.

## Two guards, both load-bearing

Claiming zero wrongly hands dirty memory to `mi_zalloc` — silent heap corruption, not a visible failure. So:

- only on the `needs_recommit` branch (a genuine decommit). A **reset** (`MADV_FREE`/`MEM_RESET`) may preserve contents.
- only when the arena has no custom `commit_fun`, which makes no zeroing promise at all.

Both verified by running the correctness test with `MIMALLOC_PURGE_DECOMMITS=0` as well as the default.

The option is appended at the **end** of the `mi_option` enum rather than beside the other purge options, so the numeric values published in 0.9.0 don't shift.

## Correctness

Fills **every byte** of every block with `0xA5` before freeing, then requires the next `mi_zalloc` to return genuinely zeroed memory across purge/reuse cycles.

This matters: my first benchmark checked 3 bytes per block and never dirtied the middle, so it could not distinguish "zeroed" from "stale but happens to be zero" — it would have passed a corrupting implementation. Registered twice in ctest, off and on, per #67's rule that *any flag that ships must have a job running the suite with it ON*.

## No verdict yet — deliberately

Local numbers do not support one, and I nearly published a wrong one:

| attempt | anti-workload result |
|---|---|
| sequential A then B | **+13% slower** — looked decisive |
| same binaries, interleaved | **6 of 8 faster** — sign reversed |

The difference was measurement order on a machine running concurrent builds. So this PR ships the harness rather than a conclusion: the `zero-tracking` workflow runs the arms **interleaved and paired from a single binary** on all three runners, and `ci/zero_tracking_report.py` prints medians with the within-arm spread, explicitly flagging any effect smaller than the noise.

One thing already clear: **the favourable workload is not evidence on its own.** It shows ~−97%, but touching only one byte per block means skipping the memset also skips faulting the pages in. That is lazy commit, not zeroing. The anti-workload decides adoption.

## Merge criteria

Per #67, this merges only on a measured win with the anti-workload number published, and is **dropped if it regresses anything**. If CI shows neutral, the right outcome is to close this unmerged — a neutral feature that ships lives forever untested.