### PR TITLE
rust: regenerate the vendored amalgamation after the profile.c fmt_buf fix

### DIFF
--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit e6f47a41 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit be5e067f of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -20019,7 +20019,7 @@ bool mi_prof_start_ex(const mi_prof_config_t* config) mi_attr_noexcept {
       prof_dump_at_exit_format = config->dump_format;
     }
     else if (env_present) {
-      char fmt_buf[32];
+      char fmt_buf[32] = {0};  /* zeroed: GCC cannot see that _mi_getenv fills it on success */
       if (_mi_getenv("MIMALLOC_PROF_DUMP_FORMAT", fmt_buf, sizeof(fmt_buf)) == 0) prof_dump_at_exit_format = prof_parse_dump_format(fmt_buf);
     }
   }
@@ -20513,7 +20513,7 @@ static void prof_auto_start(void) {
     if (mi_option_is_enabled(mi_option_prof)) { const bool started = mi_prof_start(0); MI_UNUSED(started); }
     (void)_mi_getenv("MIMALLOC_PROF_DUMP_AT_EXIT", prof_dump_at_exit, sizeof(prof_dump_at_exit));
     /* So pure-env users (no mi_prof_start_ex call at all) still get profile.proto exit dumps. */
-    char fmt_buf[32];
+    char fmt_buf[32] = {0};  /* zeroed: GCC cannot see that _mi_getenv fills it on success */
     if (_mi_getenv("MIMALLOC_PROF_DUMP_FORMAT", fmt_buf, sizeof(fmt_buf)) == 0) prof_dump_at_exit_format = prof_parse_dump_format(fmt_buf);
   }
 }


### PR DESCRIPTION
**Fixes a red `main`.** `rust-native` has been failing on all three platforms since #72 merged.

## Cause

#72 fixed a `-Wmaybe-uninitialized` warning in `src/profile.c` but did not carry the change into `rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c`. `xtask check` correctly reported:

```
DRIFT: .../vendor/mimalloc-pprof-amalgamated.c does not match a fresh
amalgamation of src/static.c and its local includes.
```

**Rule 2 is precisely why this needs its own commit** — C-core and `rust/` paths never mix, so any C change requires a Rust-only follow-up. That follow-up is the step I skipped.

## The fix

`soldr cargo run -p xtask -- amalgamate-c`. Diff is 3 lines: the two `fmt_buf` initializers and the generated-from SHA (`e6f47a41` → `be5e067f`). `xtask check` now passes.

## How this nearly stayed hidden

Two things worth recording, because both will recur:

1. **The docs-only PR #81 merged with zero checks** — the workflow `paths:` filters exclude `README.md`, so nothing re-ran `rust-native` at merge time. The breakage was already on main from #72 and simply wasn't surfaced by the next PR.
2. **I initially misdiagnosed it as the known macOS `setup-soldr` EPIPE flake.** That EPIPE was real and in the macOS log — but ubuntu and windows had failed for this completely different reason. Reading one platform's log and generalizing is what made it look like a known-benign flake.

A follow-up worth considering: have `c-unit` fail if `xtask check` reports drift, so a C-only PR cannot merge while leaving the vendored copy stale. Filed separately rather than bundled here.