### PR TITLE
ci: run the full suite on v4 as well as main

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -2,7 +2,7 @@ name: c-unit
 
 on:
   push:
-    branches: [main]
+    branches: [main, v4]
   pull_request:
     paths:
       - 'src/**'

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -11,7 +11,7 @@ on:
       - rust/**
       - .github/workflows/cross.yml
   push:
-    branches: [main]
+    branches: [main, v4]
     paths:
       - src/**
       - include/**

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -8,7 +8,7 @@ name: python-lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, v4]
   pull_request:
     paths:
       - 'ci/**'

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -2,7 +2,7 @@ name: rust-native
 
 on:
   push:
-    branches: [main]
+    branches: [main, v4]
   pull_request:
     paths:
       - 'rust/**'


### PR DESCRIPTION
The `v4` branch is cut per #61 (rev 4). Every workflow triggered only on `push: branches: [main]`, so v4 would have had PR coverage but **no post-merge runs** — the exact gap that let a stale vendored amalgamation sit red on `main` after #72 (#88).

Adds `v4` to the push triggers for `c-unit`, `cross`, `python-lint`, and `rust-native`.

One thing to watch, flagged rather than left to be discovered: the `memory-gate` baselines in `ci/memory-baselines/` are committed per-platform against **v3's** numbers. A new upstream pin (#80) may legitimately move them — that PR should state whether they moved and why, not silently re-baseline.