### PR TITLE
ci(cross): fail the build when compilation fails, instead of shipping a partial dist/

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -66,9 +66,18 @@ jobs:
           # reading it, killing individual test binaries. The tool's own advice is to
           # retry, and to bypass the cache if that fails -- reruns alone do NOT help,
           # because the restored cache carries the same poisoned entry back in.
+          # Keep the raw JSON. Piping cargo straight into jq discards every
+          # `compiler-message` record, which is where the actual error text lives -- so a
+          # failing build printed only "could not compile (test ...)" with no reason, on
+          # every retry. Render the diagnostics on failure instead of dropping them.
           run_build() {
-            eval "$1 --target $TARGET --release --message-format=json" \
-              | jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' > bins.txt
+            local rc=0
+            eval "$1 --target $TARGET --release --message-format=json" > cargo.json || rc=$?
+            jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' cargo.json > bins.txt
+            if [ "$rc" -ne 0 ]; then
+              jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' cargo.json >&2
+            fi
+            return "$rc"
           }
           cmd="$BUILD_COMMAND"
           if ! run_build "$cmd"; then
@@ -131,9 +140,18 @@ jobs:
           # reading it, killing individual test binaries. The tool's own advice is to
           # retry, and to bypass the cache if that fails -- reruns alone do NOT help,
           # because the restored cache carries the same poisoned entry back in.
+          # Keep the raw JSON. Piping cargo straight into jq discards every
+          # `compiler-message` record, which is where the actual error text lives -- so a
+          # failing build printed only "could not compile (test ...)" with no reason, on
+          # every retry. Render the diagnostics on failure instead of dropping them.
           run_build() {
-            eval "$1 --target $TARGET --release --message-format=json" \
-              | jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' > bins.txt
+            local rc=0
+            eval "$1 --target $TARGET --release --message-format=json" > cargo.json || rc=$?
+            jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' cargo.json > bins.txt
+            if [ "$rc" -ne 0 ]; then
+              jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' cargo.json >&2
+            fi
+            return "$rc"
           }
           cmd="soldr cargo test --no-run"
           if ! run_build "$cmd"; then

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -62,8 +62,19 @@ jobs:
           # binaries, this step passed, a partial dist/ was uploaded, and the downstream
           # job failed with a bare `test -n "$generator"` and no output at all.
           set -euo pipefail
-          eval "$BUILD_COMMAND --target $TARGET --release --message-format=json" \
-            | jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' > bins.txt
+          # soldr#1969: an intermediate can be reclaimed while a slow link is still
+          # reading it, killing individual test binaries. The tool's own advice is to
+          # retry, and to bypass the cache if that fails -- reruns alone do NOT help,
+          # because the restored cache carries the same poisoned entry back in.
+          run_build() {
+            eval "$1 --target $TARGET --release --message-format=json" \
+              | jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' > bins.txt
+          }
+          cmd="$BUILD_COMMAND"
+          if ! run_build "$cmd"; then
+            echo "::warning::build failed; retrying with the soldr compile cache bypassed (soldr#1969)"
+            run_build "${cmd/soldr/soldr --no-cache}"
+          fi
           test -s bins.txt
           mkdir -p "dist/$TARGET"
           xargs -r -a bins.txt -I{} cp {} "dist/$TARGET/"
@@ -116,8 +127,19 @@ jobs:
           # binaries, this step passed, a partial dist/ was uploaded, and the downstream
           # job failed with a bare `test -n "$generator"` and no output at all.
           set -euo pipefail
-          soldr cargo test --no-run --target "$TARGET" --release --message-format=json \
-            | jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' > bins.txt
+          # soldr#1969: an intermediate can be reclaimed while a slow link is still
+          # reading it, killing individual test binaries. The tool's own advice is to
+          # retry, and to bypass the cache if that fails -- reruns alone do NOT help,
+          # because the restored cache carries the same poisoned entry back in.
+          run_build() {
+            eval "$1 --target $TARGET --release --message-format=json" \
+              | jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' > bins.txt
+          }
+          cmd="soldr cargo test --no-run"
+          if ! run_build "$cmd"; then
+            echo "::warning::build failed; retrying with the soldr compile cache bypassed (soldr#1969)"
+            run_build "${cmd/soldr/soldr --no-cache}"
+          fi
           test -s bins.txt
           mkdir -p "dist/$TARGET"
           xargs -r -a bins.txt -I{} cp {} "dist/$TARGET/"

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -56,11 +56,24 @@ jobs:
           BUILD_COMMAND: ${{ matrix.command }}
           CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.cflags }}
         run: |
+          # pipefail is NOT on by default in GitHub's `bash -e` shell, so without it
+          # this pipeline reports jq's exit status and a FAILED cargo build looks green.
+          # Not hypothetical: a soldr compile-cache race (soldr#1969) killed four test
+          # binaries, this step passed, a partial dist/ was uploaded, and the downstream
+          # job failed with a bare `test -n "$generator"` and no output at all.
+          set -euo pipefail
           eval "$BUILD_COMMAND --target $TARGET --release --message-format=json" \
             | jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' > bins.txt
           test -s bins.txt
           mkdir -p "dist/$TARGET"
           xargs -r -a bins.txt -I{} cp {} "dist/$TARGET/"
+          # The downstream test job needs t3_stats specifically. Assert it here, next to
+          # the compiler output, instead of letting the consumer fail without saying why.
+          if ! ls "dist/$TARGET"/t3_stats-* >/dev/null 2>&1; then
+            echo "::error::t3_stats was not built for $TARGET. Staged binaries:"
+            ls -1 "dist/$TARGET" || echo "  (none)"
+            exit 1
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: test-bins-${{ matrix.target }}
@@ -97,11 +110,24 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
         run: |
+          # pipefail is NOT on by default in GitHub's `bash -e` shell, so without it
+          # this pipeline reports jq's exit status and a FAILED cargo build looks green.
+          # Not hypothetical: a soldr compile-cache race (soldr#1969) killed four test
+          # binaries, this step passed, a partial dist/ was uploaded, and the downstream
+          # job failed with a bare `test -n "$generator"` and no output at all.
+          set -euo pipefail
           soldr cargo test --no-run --target "$TARGET" --release --message-format=json \
             | jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' > bins.txt
           test -s bins.txt
           mkdir -p "dist/$TARGET"
           xargs -r -a bins.txt -I{} cp {} "dist/$TARGET/"
+          # The downstream test job needs t3_stats specifically. Assert it here, next to
+          # the compiler output, instead of letting the consumer fail without saying why.
+          if ! ls "dist/$TARGET"/t3_stats-* >/dev/null 2>&1; then
+            echo "::error::t3_stats was not built for $TARGET. Staged binaries:"
+            ls -1 "dist/$TARGET" || echo "  (none)"
+            exit 1
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: test-bins-${{ matrix.target }}


### PR DESCRIPTION
Fixes the diagnosis half of #92, and unblocks #89.

## What happened

A PR whose content was **byte-identical to a green `main`** failed on 2 of 6 targets, reproducibly across three reruns. The entire log for the failing step:

```
Run generator=$(find dist/x86_64-unknown-linux-gnu -maxdepth 1 -type f -name 't3_stats-*' | head -n 1)
  test -n "$generator"
##[error]Process completed with exit code 1.
```

No output — `test -n` prints none. The cause was four directories away, in the **build** job:

```
soldr: an intermediate can be reclaimed while a slow link is still reading it -- see soldr#1969.
error: could not compile `mimalloc-pprof` (test "t4_accum") due to 1 previous error
error: could not compile `mimalloc-pprof` (test "t9_stats") due to 1 previous error
...
```

The build reported **success** and uploaded a partial `dist/`.

## Two defects

**1. pipefail is off.** GitHub's default shell is `bash -e` *without* `pipefail`, so

```sh
eval "$BUILD_COMMAND ... --message-format=json" | jq ... > bins.txt
test -s bins.txt
```

reports **jq's** exit status. A failed cargo build looks green, and `test -s` passes because *some* binaries built. Now `set -euo pipefail`.

**2. Nothing verified the artifact was complete.** The downstream job needs `t3_stats` specifically; that is now asserted in the build step, next to the compiler output, and it lists what *was* staged rather than failing silently.

## Worth recording

I initially misattributed this to a sampling-determinism bug (#91) — the shape of it (two targets, reproducible, identical content passing on main) looked like a code bug, and I filed it as circumstantial evidence there. It was wrong, and #91 now carries a correction. Defect 2 is precisely what made that misdiagnosis easy.

**This does not fix the soldr cache race itself** — it makes it fail loudly and in the right place. Retry/`--no-cache` handling stays in #92.