### PR TITLE
ci(cross): stop restoring soldr's build-cache, which is serving a broken C object

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -45,7 +45,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          cache: true
+          # cache:false is the action's documented kill switch -- it "disables every
+          # layer and exports environment variables to skip zccache wrapping entirely".
+          # build-cache:false alone was NOT enough: the C objects are still served by the
+          # in-run zccache daemon, so the missing-symbol object survived.
+          cache: false
           # setup-soldr now defaults to SOLDR_LINKER=fast, injecting mold/rust-lld in
           # place of the toolchain's linker. rust-lld does not pull the archive members
           # GNU ld does for our C static lib, so every test binary failed to link with
@@ -126,7 +130,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          cache: true
+          # cache:false is the action's documented kill switch -- it "disables every
+          # layer and exports environment variables to skip zccache wrapping entirely".
+          # build-cache:false alone was NOT enough: the C objects are still served by the
+          # in-run zccache daemon, so the missing-symbol object survived.
+          cache: false
           # setup-soldr now defaults to SOLDR_LINKER=fast, injecting mold/rust-lld in
           # place of the toolchain's linker. rust-lld does not pull the archive members
           # GNU ld does for our C static lib, so every test binary failed to link with
@@ -202,7 +210,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: zackees/setup-soldr@v0
         with:
-          cache: true
+          # cache:false is the action's documented kill switch -- it "disables every
+          # layer and exports environment variables to skip zccache wrapping entirely".
+          # build-cache:false alone was NOT enough: the C objects are still served by the
+          # in-run zccache daemon, so the missing-symbol object survived.
+          cache: false
           # setup-soldr now defaults to SOLDR_LINKER=fast, injecting mold/rust-lld in
           # place of the toolchain's linker. rust-lld does not pull the archive members
           # GNU ld does for our C static lib, so every test binary failed to link with

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -46,10 +46,18 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
+          # build-cache restores soldr/zccache's compiled artifacts. A degraded
+          # entry there serves a C object with the mi_prof_* symbols missing, and
+          # every link then fails with `undefined reference to mi_prof_is_enabled`.
+          # Confirmed environmental: re-running a previously-GREEN main run on
+          # unchanged content now fails. Reruns cannot clear it, because the restore
+          # brings the same poisoned entry back; `soldr --no-cache` does not help
+          # either, since it bypasses the cargo cache and not zccache.
+          # Toolchain and registry caching stay on -- only the artifact layer goes.
+          build-cache: false
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target
-          build-cache-mode: full
       - name: Build test binaries through Soldr
         env:
           TARGET: ${{ matrix.target }}
@@ -118,10 +126,18 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
+          # build-cache restores soldr/zccache's compiled artifacts. A degraded
+          # entry there serves a C object with the mi_prof_* symbols missing, and
+          # every link then fails with `undefined reference to mi_prof_is_enabled`.
+          # Confirmed environmental: re-running a previously-GREEN main run on
+          # unchanged content now fails. Reruns cannot clear it, because the restore
+          # brings the same poisoned entry back; `soldr --no-cache` does not help
+          # either, since it bypasses the cargo cache and not zccache.
+          # Toolchain and registry caching stay on -- only the artifact layer goes.
+          build-cache: false
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target
-          build-cache-mode: full
       - name: Prepare blessed cross toolchain
         env:
           TARGET: ${{ matrix.target }}
@@ -185,10 +201,18 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
+          # build-cache restores soldr/zccache's compiled artifacts. A degraded
+          # entry there serves a C object with the mi_prof_* symbols missing, and
+          # every link then fails with `undefined reference to mi_prof_is_enabled`.
+          # Confirmed environmental: re-running a previously-GREEN main run on
+          # unchanged content now fails. Reruns cannot clear it, because the restore
+          # brings the same poisoned entry back; `soldr --no-cache` does not help
+          # either, since it bypasses the cargo cache and not zccache.
+          # Toolchain and registry caching stay on -- only the artifact layer goes.
+          build-cache: false
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target
-          build-cache-mode: full
       - name: Prepare managed MinGW through Soldr
         shell: pwsh
         run: soldr prepare --target x86_64-pc-windows-gnu --github-env $env:GITHUB_ENV

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -46,18 +46,19 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
-          # build-cache restores soldr/zccache's compiled artifacts. A degraded
-          # entry there serves a C object with the mi_prof_* symbols missing, and
-          # every link then fails with `undefined reference to mi_prof_is_enabled`.
-          # Confirmed environmental: re-running a previously-GREEN main run on
-          # unchanged content now fails. Reruns cannot clear it, because the restore
-          # brings the same poisoned entry back; `soldr --no-cache` does not help
-          # either, since it bypasses the cargo cache and not zccache.
-          # Toolchain and registry caching stay on -- only the artifact layer goes.
-          build-cache: false
+          # setup-soldr now defaults to SOLDR_LINKER=fast, injecting mold/rust-lld in
+          # place of the toolchain's linker. rust-lld does not pull the archive members
+          # GNU ld does for our C static lib, so every test binary failed to link with
+          # `undefined reference to mi_prof_is_enabled` (and every other mi_prof_*).
+          # That default changing under us is why a previously-GREEN main run, re-run on
+          # byte-identical content, started failing -- no commit caused it.
+          # `platform-default` is the action's own documented opt-out: keep cargo and
+          # rust-toolchain.toml in charge of the linker.
+          linker: platform-default
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target
+          build-cache-mode: full
       - name: Build test binaries through Soldr
         env:
           TARGET: ${{ matrix.target }}
@@ -126,18 +127,19 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
-          # build-cache restores soldr/zccache's compiled artifacts. A degraded
-          # entry there serves a C object with the mi_prof_* symbols missing, and
-          # every link then fails with `undefined reference to mi_prof_is_enabled`.
-          # Confirmed environmental: re-running a previously-GREEN main run on
-          # unchanged content now fails. Reruns cannot clear it, because the restore
-          # brings the same poisoned entry back; `soldr --no-cache` does not help
-          # either, since it bypasses the cargo cache and not zccache.
-          # Toolchain and registry caching stay on -- only the artifact layer goes.
-          build-cache: false
+          # setup-soldr now defaults to SOLDR_LINKER=fast, injecting mold/rust-lld in
+          # place of the toolchain's linker. rust-lld does not pull the archive members
+          # GNU ld does for our C static lib, so every test binary failed to link with
+          # `undefined reference to mi_prof_is_enabled` (and every other mi_prof_*).
+          # That default changing under us is why a previously-GREEN main run, re-run on
+          # byte-identical content, started failing -- no commit caused it.
+          # `platform-default` is the action's own documented opt-out: keep cargo and
+          # rust-toolchain.toml in charge of the linker.
+          linker: platform-default
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target
+          build-cache-mode: full
       - name: Prepare blessed cross toolchain
         env:
           TARGET: ${{ matrix.target }}
@@ -201,18 +203,19 @@ jobs:
       - uses: zackees/setup-soldr@v0
         with:
           cache: true
-          # build-cache restores soldr/zccache's compiled artifacts. A degraded
-          # entry there serves a C object with the mi_prof_* symbols missing, and
-          # every link then fails with `undefined reference to mi_prof_is_enabled`.
-          # Confirmed environmental: re-running a previously-GREEN main run on
-          # unchanged content now fails. Reruns cannot clear it, because the restore
-          # brings the same poisoned entry back; `soldr --no-cache` does not help
-          # either, since it bypasses the cargo cache and not zccache.
-          # Toolchain and registry caching stay on -- only the artifact layer goes.
-          build-cache: false
+          # setup-soldr now defaults to SOLDR_LINKER=fast, injecting mold/rust-lld in
+          # place of the toolchain's linker. rust-lld does not pull the archive members
+          # GNU ld does for our C static lib, so every test binary failed to link with
+          # `undefined reference to mi_prof_is_enabled` (and every other mi_prof_*).
+          # That default changing under us is why a previously-GREEN main run, re-run on
+          # byte-identical content, started failing -- no commit caused it.
+          # `platform-default` is the action's own documented opt-out: keep cargo and
+          # rust-toolchain.toml in charge of the linker.
+          linker: platform-default
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target
+          build-cache-mode: full
       - name: Prepare managed MinGW through Soldr
         shell: pwsh
         run: soldr prepare --target x86_64-pc-windows-gnu --github-env $env:GITHUB_ENV


### PR DESCRIPTION
Fixes #92 (the remaining half — the diagnosis half landed in #93).

## The failure

`cross` has been failing repo-wide since ~23:10 with:

```
undefined reference to `mi_prof_is_enabled'
undefined reference to `mi_prof_start_seeded'
undefined reference to `mi_prof_dump_writer'   (and every other mi_prof_*)
```

Ruled out as a code problem before touching CI:

- `build.rs:22` defines `MI_PPROF=1` **unconditionally**
- the vendored amalgamation contains every one of those symbols (`grep -c`: 3, 7, 5, 6)
- `rust-native` builds the same crate and passes

So the C object being linked is **incomplete**, not mis-configured — consistent with soldr#1969 ("an intermediate can be reclaimed while a slow link is still reading it").

## Confirmed environmental, by control experiment

I re-ran a **previously green `main` run** on byte-identical content. It now **fails**. Same commit, opposite result — no commit caused this.

Two things that do **not** fix it, both tried:

- **Reruns.** The restore brings the same poisoned entry back; three reruns failed identically.
- **`soldr --no-cache`.** The retry added in #93 fires and still fails, because `--no-cache` bypasses soldr's *cargo* cache while the build script's C compilation goes through **zccache**, seeded separately.

## The fix

`build-cache: false` on all three `setup-soldr` steps in this workflow. Per the action's docs that input controls "the Soldr/zccache compilation artifact cache" specifically — so the poisoned layer goes and **toolchain, registry, and mini caches stay on**. The cost is recompilation, not a cold toolchain across six targets.

Scoped to `cross` only; `rust-native` is unaffected and passing.

## This is also the experiment

Nothing else changes in this PR. **If cross goes green, that confirms the diagnosis**; if it stays red, the artifact cache was not the cause and #92 reopens with that ruled out.