### PR TITLE
rust: regenerate the vendored amalgamation after zero-tracking (#79)

### DIFF
--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit be5e067f of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit fba9f8cc of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -510,6 +510,7 @@ typedef enum mi_option_e {
   mi_option_prof_seed,                  // profiler sampling PRNG seed; 0 = nondeterministic (=0)
   mi_option_prof_max_bytes,             // budget (in bytes) for profiler-internal arena memory; 0 = unbudgeted (=0)
   mi_option_memory_events,              // enable opt-in allocation-change accounting/callbacks (MIMALLOC_MEMORY_EVENTS) (=0)
+  mi_option_purge_zeroes,               // treat decommit-purged slices as zeroed, letting mi_zalloc skip its memset (=0, experimental)
   _mi_option_last,
   // legacy option names
   mi_option_large_os_pages = mi_option_allow_large_os_pages,
@@ -10795,6 +10796,19 @@ static bool mi_arena_purge(mi_arena_t* arena, size_t slice_index, size_t slice_c
   if (needs_recommit) {
     // no longer committed
     mi_bitmap_clearN(arena->slices_committed, slice_index, slice_count);
+    // Experimental (#67, mi_option_purge_zeroes, default off): decommitted memory reads
+    // back zero when it is recommitted, so the slices are no longer dirty. Clearing the
+    // dirty bits lets the next allocation see memid->initially_zero, which in turn lets
+    // mi_zalloc skip its memset (alloc.c: `if (!page->free_is_zero) memset(...)`).
+    //
+    // Reached only on the `needs_recommit` branch, i.e. only when we genuinely
+    // decommitted. A *reset* (MADV_FREE / MEM_RESET) may preserve contents, and a custom
+    // commit_fun makes no zeroing promise at all -- claiming zero in either case would
+    // hand dirty memory to mi_zalloc, which is silent heap corruption rather than a
+    // visible failure. Hence both guards.
+    if (arena->commit_fun == NULL && mi_option_is_enabled(mi_option_purge_zeroes)) {
+      mi_bitmap_clearN(arena->slices_dirty, slice_index, slice_count);
+    }
     // we just counted in the purge to decommit all, but the some part was not committed so adjust that here
     // mi_subproc_stat_decrease(arena->subproc, committed, mi_size_of_slices(slice_count - already_committed));
   }
@@ -16160,6 +16174,7 @@ static mi_option_desc_t mi_options[_mi_option_last] =
   ,{ 0,      MI_OPTION_UNINIT, MI_OPTION(prof_seed) }
   ,{ 0,      MI_OPTION_UNINIT, MI_OPTION(prof_max_bytes) }        // budget for profiler-internal arena memory; 0 = unbudgeted
   ,{ 0,      MI_OPTION_UNINIT, MI_OPTION(memory_events) }         // opt-in allocation-change accounting/callbacks; read lazily by memory-events.c, not at startup
+  ,{ 0,      MI_OPTION_UNINIT, MI_OPTION(purge_zeroes) }           // experimental (#67): treat decommit-purged slices as zeroed so mi_zalloc can skip its memset
 };
 
 static void mi_option_init(mi_option_desc_t* desc);

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit e6f47a41 of the three public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit fba9f8cc of the three public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------
@@ -494,6 +494,7 @@ typedef enum mi_option_e {
   mi_option_prof_seed,                  // profiler sampling PRNG seed; 0 = nondeterministic (=0)
   mi_option_prof_max_bytes,             // budget (in bytes) for profiler-internal arena memory; 0 = unbudgeted (=0)
   mi_option_memory_events,              // enable opt-in allocation-change accounting/callbacks (MIMALLOC_MEMORY_EVENTS) (=0)
+  mi_option_purge_zeroes,               // treat decommit-purged slices as zeroed, letting mi_zalloc skip its memset (=0, experimental)
   _mi_option_last,
   // legacy option names
   mi_option_large_os_pages = mi_option_allow_large_os_pages,

--- a/rust/mimalloc-pprof/vendor/mimalloc.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc.h
@@ -491,6 +491,7 @@ typedef enum mi_option_e {
   mi_option_prof_seed,                  // profiler sampling PRNG seed; 0 = nondeterministic (=0)
   mi_option_prof_max_bytes,             // budget (in bytes) for profiler-internal arena memory; 0 = unbudgeted (=0)
   mi_option_memory_events,              // enable opt-in allocation-change accounting/callbacks (MIMALLOC_MEMORY_EVENTS) (=0)
+  mi_option_purge_zeroes,               // treat decommit-purged slices as zeroed, letting mi_zalloc skip its memset (=0, experimental)
   _mi_option_last,
   // legacy option names
   mi_option_large_os_pages = mi_option_allow_large_os_pages,


### PR DESCRIPTION
**Fixes a red `rust-native` on `v4`.**

#79 (zero-tracking) added `mi_option_purge_zeroes` to `include/mimalloc.h` and changed `src/arena.c` / `src/options.c`, but none of it reached the vendored copies. `xtask check` reports drift on all three:

```
DRIFT: vendor/mimalloc-pprof-amalgamated.c does not match a fresh amalgamation of src/static.c
DRIFT: vendor/mimalloc-pprof-amalgamated.h does not match a fresh amalgamation of the public headers
DRIFT: vendor/mimalloc.h does not match include/mimalloc.h
```

The diff is exactly #79's surface: the enum entry, its options-table row, and the guarded dirty-bit clear in the purge path. `xtask check` is now clean.

## Worth stating plainly

**This is the second time I have made this exact mistake** — the first broke `main` after #72 and was fixed in #85. Rule 2 (never mix C-core and `rust/` paths in one commit) means every C change needs a Rust-only follow-up commit, and forgetting it is invisible until a downstream job fails, often on a later PR that didn't cause it.

#88 tracks making CI catch this **on the PR** rather than after the merge. Until that lands this stays a manual step, and my having repeated it is the argument for prioritizing it.