### PR TITLE
ci: fail any PR that leaves the vendored amalgamation stale (#88)

### DIFF
--- a/.github/workflows/amalgamation-drift.yml
+++ b/.github/workflows/amalgamation-drift.yml
@@ -1,0 +1,46 @@
+name: amalgamation-drift
+
+# The Rust crate compiles rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c,
+# NOT the root src/ tree. Repo rule 2 forbids mixing C-core and rust/ paths in one
+# commit, so every C change needs a separate Rust-only regeneration commit -- and
+# nothing enforced the second half. Twice now a C-only PR merged green and left the
+# vendored copy stale, turning a later, unrelated PR red:
+#
+#   #72  -> broke rust-native on main (fixed by #85)
+#   #79  -> broke rust-native on v4   (fixed by #96)
+#
+# Both were invisible on the PR that caused them, because rust-native only triggers
+# on `rust/**`.
+#
+# Deliberately NO `paths:` filter. Two reasons:
+#   1. the drift is caused by C changes, so filtering on rust/** is exactly the bug
+#   2. it gives every PR at least one required check -- a docs-only PR previously ran
+#      nothing at all (#81 merged with zero checks), so it could not even surface an
+#      already-broken main
+
+on:
+  push:
+    branches: [main, v4]
+  pull_request:
+
+jobs:
+  check:
+    name: vendored C amalgamation matches src/
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+          build-cache-mode: full
+      - name: xtask check
+        run: |
+          if ! soldr cargo run -p xtask -- check; then
+            echo "::error title=Vendored amalgamation is stale::A C change under src/ or include/ has not been carried into rust/mimalloc-pprof/vendor/. Regenerate with 'cargo run -p xtask -- amalgamate-c' and commit it SEPARATELY -- repo rule 2 forbids mixing C-core and rust/ paths in one commit, which is why this is a second commit rather than part of the C change."
+            exit 1
+          fi

--- a/src/profile.c
+++ b/src/profile.c
@@ -1,5 +1,4 @@
-/* POSITIVE CONTROL for #88 -- reverted in the next commit.
-   Allocation sampling profiler.  Its records never use mimalloc: the arena
+/* Allocation sampling profiler.  Its records never use mimalloc: the arena
    below is backed directly by _mi_os_alloc so profiler bookkeeping cannot
    recursively enter the allocator. */
 #include "mimalloc.h"

--- a/src/profile.c
+++ b/src/profile.c
@@ -1,4 +1,5 @@
-/* Allocation sampling profiler.  Its records never use mimalloc: the arena
+/* POSITIVE CONTROL for #88 -- reverted in the next commit.
+   Allocation sampling profiler.  Its records never use mimalloc: the arena
    below is backed directly by _mi_os_alloc so profiler bookkeeping cannot
    recursively enter the allocator. */
 #include "mimalloc.h"


### PR DESCRIPTION
Closes #88.

The Rust crate compiles `rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c`, **not** the root `src/` tree. Rule 2 forbids mixing C-core and `rust/` paths in one commit, so every C change needs a separate Rust-only regeneration commit — and nothing enforced that second half.

It has bitten **twice**, both times invisible on the PR that caused it, because `rust-native` only triggers on `rust/**`:

| Cause | Effect | Fixed by |
|---|---|---|
| #72 | `rust-native` red on `main` | #85 |
| #79 | `rust-native` red on `v4` | #96 |

Both surfaced later, on unrelated PRs — the worst place to find them, and in the first case I misread it as a known macOS flake for several minutes because another platform's log happened to show one.

## Design note: no `paths:` filter, deliberately

Filtering on `rust/**` **is** the bug. Running on every PR also closes the second gap #88 raised: a docs-only PR previously ran **zero** checks (#81 merged with none), so it could not surface an already-broken `main` either. Every PR now has at least one required check.

Cost is one ubuntu job.

## Positive control included

This PR contains a temporary commit that edits `src/profile.c` **without** regenerating — exactly the #72/#79 mistake. The guard must go red on it, then the revert must turn it green. Both runs will be linked below before this merges.

A gate that has never been observed to fail proves nothing, and this repo has now shipped **four** gates that were silently checking nothing (the arm64 scanner matching no lines, an uninvoked leak control, an ASan job excluding every branch we use, and the cross pipeline discarding its own diagnostics).