### PR TITLE
ci: actually run AddressSanitizer, with a control that proves it works (#86)

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,0 +1,86 @@
+name: asan
+
+# Issue #86. The repo inherited an ASan job in test.yaml whose trigger is
+# `push: branches: ['dev*']` -- our branches are main/v2/v4, and there is no
+# pull_request trigger at all, so it has never run on a single commit of this fork.
+# Inherited configuration that looks like coverage and provides none.
+#
+# This job is ours, runs on PRs, and is a hard failure.
+
+on:
+  push:
+    branches: [main, v4]
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'test/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/asan.yml'
+
+jobs:
+  asan:
+    name: address sanitizer
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v4
+
+      # MI_TRACK_ASAN silently turns itself OFF if sanitizer/asan_interface.h is
+      # missing, which would leave this job green while sanitizing nothing. Fail
+      # here instead, on the configure output that says which way it resolved.
+      - name: Configure (and prove ASan actually enabled)
+        run: |
+          set -euo pipefail
+          cmake -B build-asan -DCMAKE_BUILD_TYPE=Debug \
+                -DMI_PPROF=ON -DMI_DEBUG_FULL=ON -DMI_TRACK_ASAN=ON 2>&1 | tee configure.log
+          if ! grep -q "Compile with address sanitizer support (MI_TRACK_ASAN=ON)" configure.log; then
+            echo "::error::MI_TRACK_ASAN did not survive configure -- the sanitizer is NOT enabled."
+            grep -i "sanitizer" configure.log || true
+            exit 1
+          fi
+
+      - run: cmake --build build-asan --parallel
+
+      # Flags are not the artifact. Check the shipped binary really links ASan.
+      - name: Verify __asan_init is present in the built binaries
+        run: |
+          set -euo pipefail
+          exe=$(find build-asan -name 'mimalloc-test-api' -type f | head -1)
+          test -n "$exe"
+          if ! nm -C "$exe" 2>/dev/null | grep -q "__asan_init"; then
+            echo "::error::$exe does not reference __asan_init -- ASan is not linked in."
+            exit 1
+          fi
+          echo "ASan confirmed linked into $exe"
+
+      - name: ctest under ASan
+        run: ctest --test-dir build-asan --output-on-failure --timeout 600
+
+      # A sanitizer that has never been observed to catch anything is
+      # indistinguishable from one that is misconfigured. This program reads freed
+      # heap memory through mi_free; ASan must abort it. Passing cleanly means
+      # mimalloc is not telling ASan about our allocations, even if ASan is linked.
+      - name: Positive control -- ASan must catch a use-after-free
+        run: |
+          set -uo pipefail
+          exe=$(find build-asan -name 'mimalloc-test-asan-control' -type f | head -1)
+          if [ -z "$exe" ]; then
+            echo "::error::the ASan control binary was not built, so MI_TRACK_ASAN was off at generate time."
+            exit 1
+          fi
+          set +e
+          out=$("$exe" 2>&1); rc=$?
+          set -e
+          echo "$out"
+          if [ $rc -eq 0 ]; then
+            echo "::error::the control exited 0 -- ASan did NOT catch a use-after-free."
+            exit 1
+          fi
+          if ! echo "$out" | grep -qiE "AddressSanitizer|use-after-poison|heap-use-after-free"; then
+            echo "::error::the control failed (rc=$rc) but produced no AddressSanitizer report; that is a different bug."
+            exit 1
+          fi
+          echo "positive control fired: ASan caught the use-after-free (rc=$rc)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -922,6 +922,23 @@ if (MI_BUILD_TESTS)
     target_link_libraries(mimalloc-test-memory-gate PRIVATE Threads::Threads)
   endif()
   add_test(NAME test-memory-gate COMMAND mimalloc-test-memory-gate)
+
+  # Positive control for the ASan job (issue #86). Only built when the sanitizer is
+  # actually enabled -- and MI_TRACK_ASAN is the *resolved* value here, since
+  # CMakeLists turns it OFF above if sanitizer/asan_interface.h is missing. It is
+  # deliberately NOT an add_test: it must abort, so CI runs it directly and fails if
+  # it exits cleanly.
+  if(MI_TRACK_ASAN)
+    add_executable(mimalloc-test-asan-control test/test-asan-control.c)
+    target_compile_definitions(mimalloc-test-asan-control PRIVATE ${mi_defines})
+    target_compile_options(mimalloc-test-asan-control PRIVATE ${mi_cflags})
+    target_include_directories(mimalloc-test-asan-control PRIVATE include)
+    if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+      target_link_libraries(mimalloc-test-asan-control PRIVATE mimalloc-static ${mi_libraries})
+    else()
+      target_link_libraries(mimalloc-test-asan-control PRIVATE mimalloc ${mi_libraries})
+    endif()
+  endif()
   set_tests_properties(test-memory-gate PROPERTIES TIMEOUT 900)
 
   # Degenerate memory patterns and memory-bound regression guards (issue #47).

--- a/test/test-asan-control.c
+++ b/test/test-asan-control.c
@@ -1,0 +1,50 @@
+/* Positive control for the ASan job (issue #86).
+
+   This program deliberately reads freed heap memory. It MUST abort with an
+   AddressSanitizer report; CI fails if it exits cleanly.
+
+   Why a dedicated program rather than trusting the job:
+
+   1. `MI_TRACK_ASAN` silently turns itself OFF when `sanitizer/asan_interface.h`
+      is missing (CMakeLists.txt: "Cannot find ... install address sanitizer
+      support first"), so a misconfigured runner produces a green ASan job that
+      sanitizes nothing.
+   2. Linking ASan is not the same as mimalloc *using* it. With MI_TRACK_ASAN=1
+      mimalloc poisons blocks on free; without it, freed blocks stay in mimalloc's
+      own free list and a read-after-free is invisible to ASan because the
+      allocator, not the OS, owns that memory. Only an allocator-mediated
+      use-after-free proves the integration is live.
+
+   So this is the check that distinguishes "ASan is on" from "ASan is on AND
+   mimalloc is telling it about our allocations". A gate never observed to fire
+   proves nothing, and this repository has shipped four that were silently
+   checking nothing. */
+
+#include <mimalloc.h>
+#include <stdio.h>
+
+int main(void) {
+  /* Large enough to be a distinct block, small enough to stay in the normal
+     small-object path that MI_TRACK_ASAN instruments. */
+  volatile unsigned char* p = (volatile unsigned char*)mi_malloc(64);
+  if (p == NULL) {
+    fprintf(stderr, "control: allocation failed\n");
+    return 2;
+  }
+  p[0] = 42;
+  mi_free((void*)p);
+
+  /* The read below is the point of this program. */
+  fprintf(stderr, "control: reading freed memory -- ASan must report this\n");
+  fflush(stderr);
+  const unsigned char observed = p[0];
+
+  /* Reached only if ASan did NOT trap, i.e. the sanitizer integration is not
+     working. Report it as a failure rather than exiting 0. */
+  fprintf(stderr,
+          "control: FAILED -- read freed memory as 0x%02x with no ASan report.\n"
+          "         Either MI_TRACK_ASAN silently turned OFF at configure time,\n"
+          "         or mimalloc is not poisoning blocks on free.\n",
+          observed);
+  return 1;
+}


### PR DESCRIPTION
Closes #86.

The repo **already had** an ASan job — inherited in `test.yaml` — and it has **never run on a single commit of this fork**. Its trigger is `push: branches: ['dev*']` with no `pull_request` trigger; our branches are `main`/`v2`/`v4`.

## Three checks, because two separate things silently no-op

**1. `MI_TRACK_ASAN` disables itself.** `CMakeLists.txt:300-303` turns it OFF when `sanitizer/asan_interface.h` is missing and only prints a warning. A misconfigured runner yields a green ASan job that sanitizes nothing. The job now greps the configure output and fails if it resolved OFF.

**2. Flags are not the artifact.** It checks the built binary actually references `__asan_init`.

**3. Linking ASan ≠ mimalloc using it.** This is the subtle one. With `MI_TRACK_ASAN=1` mimalloc poisons blocks on free; **without** it, a freed block stays in mimalloc's own free list and a read-after-free is *invisible* to ASan — the allocator owns that memory, not the OS. So a generic UAF test would pass either way.

`test/test-asan-control.c` does an **allocator-mediated** use-after-free (`mi_malloc` → `mi_free` → read) and must abort with an ASan report. That is what distinguishes "ASan is on" from "ASan is on **and** sees our allocations."

The control is built only when `MI_TRACK_ASAN` survives configure, and is deliberately not an `add_test` since it is required to abort.

## Why the control isn't optional

This repository has now shipped **four** gates that were silently checking nothing — an instruction scanner matching no lines, an uninvoked leak control, this very ASan job excluding every branch we use, and a build pipeline discarding its own diagnostics. Adding a fifth unverified one would be worse than adding none.

**Blocks #82 (release 0.9.1)** — per the goal, ASan validates before publishing.