### PR TITLE
release: mimalloc-pprof 0.9.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cc",
  "regex",

--- a/rust/mimalloc-pprof/CHANGELOG.md
+++ b/rust/mimalloc-pprof/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.9.1
+
+Hardening release. No API changes -- everything here is a fix or a CI gate.
+
+- **Fix: shared-library builds were broken.** Four test targets hardcoded
+  `mimalloc-static`, so a `-DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF` build failed to
+  link with `cannot find -lmimalloc-static` (#62, #68). This is the one that unbreaks
+  someone.
+- Fix: `-Wmaybe-uninitialized` on `fmt_buf` in `src/profile.c` (#72).
+- `MI_PROF_CONFIG_OVERRIDE` is now tested against a hostile ambient environment for
+  *every* env-backed field, not just `sample_interval` (#65, #73). The documented way to
+  be immune to process-global `MIMALLOC_*` is now covered by tests rather than by
+  assertion.
+- New CI gates, each with a positive control proving it can actually fail: peak-memory
+  and thread-counter regression gate with per-platform baselines (#63), CPU-baseline
+  instruction scanner for portable builds (#64), AddressSanitizer with an
+  allocator-mediated use-after-free control (#86), vendored-amalgamation drift guard
+  (#88), and `ruff` + `pyright --strict` over the CI scripts (#74).
+
+Four of those gates were found to be silently checking nothing when first written; the
+controls are why that was noticed. See the README's "CI gates" section.
+
 ## 0.8.0
 
 First real release of `mimalloc-pprof`.

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimalloc-pprof"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT"
 description = "mimalloc global allocator with pprof-compatible sampled heap profiling"


### PR DESCRIPTION
Closes #82.

Everything from the #61 hardening pass is merged but **unpublished** — crates.io still serves 0.9.0, from before that work. This bumps the crate so it actually reaches users.

## Version decisions, stated rather than implied

- **0.9.1, not 0.10.0** — no API was added or changed. `mi_option_purge_zeroes` (#67) *is* new public API, but it landed on `v4`, not here.
- **`MI_MALLOC_VERSION` stays at `30403`.** It tracks the *upstream engine* version, and the pin is unchanged (#80 still open), so moving it would misreport which mimalloc actually ships.

## Contents, leading with the fix that unbreaks someone

- **Shared-library builds were broken.** Four test targets hardcoded `mimalloc-static`, so `-DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF` failed to link with `cannot find -lmimalloc-static` (#62, #68).
- `-Wmaybe-uninitialized` on `fmt_buf` in `src/profile.c` (#72).
- `MI_PROF_CONFIG_OVERRIDE` now tested against a hostile ambient environment for **every** env-backed field (#65, #73).
- New CI gates, each with a positive control: memory/counter regression gate (#63), ISA baseline scanner (#64), **AddressSanitizer** (#86), amalgamation drift guard (#88), `ruff` + `pyright --strict` (#74).

## ASan validated first, per the stated goal

Publishing was gated on ASan actually working, not merely existing. #98 landed it and the run confirms all three layers:

```
-- Compile with address sanitizer support (MI_TRACK_ASAN=ON)
ASan confirmed linked into build-asan/mimalloc-test-api
100% tests passed, 0 tests failed out of 13
==8132==ERROR: AddressSanitizer: use-after-poison ... in main
positive control fired: ASan caught the use-after-free (rc=1)
```

**13/13 under ASan with no findings**, and the control proves mimalloc is poisoning freed blocks — i.e. ASan sees our allocations, not just that it is linked.

## Release procedure

Merge this, then push the `v0.9.1` tag, which is what `auto-release.yml` treats as a real release. A `workflow_dispatch` dry run goes first.