### PR TITLE
ci(cross): build with plain cargo instead of the soldr wrapper

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -33,7 +33,8 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            command: soldr cargo test --no-run
+            # Plain cargo, not `soldr cargo`: see the comment on cmd= in build-cross.
+            command: cargo test --no-run
             cflags: ""
           - target: aarch64-unknown-linux-gnu
             command: soldr cargo zigbuild --tests
@@ -153,7 +154,19 @@ jobs:
             fi
             return "$rc"
           }
-          cmd="soldr cargo test --no-run"
+          # Plain `cargo`, NOT `soldr cargo`. setup-soldr still provisions the
+          # toolchain above; only the build wrapper is dropped.
+          #
+          # Every `soldr cargo test --no-run` target has been failing to link since
+          # ~23:10 with `undefined reference to mi_prof_is_enabled` and friends, while
+          # the two targets that do NOT use it (aarch64-linux via zigbuild, and the
+          # MinGW job) keep passing. build.rs defines MI_PPROF=1 unconditionally and the
+          # vendored amalgamation contains every missing symbol, so the C is right and
+          # something in the wrapper is dropping it.
+          #
+          # Already tested and disproved: build-cache:false, linker:platform-default,
+          # and cache:false (the action's own "skip zccache wrapping entirely" switch).
+          cmd="cargo test --no-run"
           if ! run_build "$cmd"; then
             echo "::warning::build failed; retrying with the soldr compile cache bypassed (soldr#1969)"
             run_build "${cmd/soldr/soldr --no-cache}"


### PR DESCRIPTION
Experiment **and** candidate fix for #92.

Every target invoked as `soldr cargo test --no-run` has failed to link since ~23:10:

```
undefined reference to `mi_prof_is_enabled'   (and every other mi_prof_*)
```

The two targets that do **not** go through that wrapper keep passing: `aarch64-unknown-linux-gnu` (zigbuild) and the MinGW job. **The split tracks the build command, not the platform** — which random cache corruption cannot explain.

## Already ruled out, each by its own CI run

| Hypothesis | Result |
|---|---|
| `build-cache: false` | still red |
| `linker: platform-default` | still red — driver moved `clang`→`cc`, but `rust-lld` remained |
| `cache: false` (the action's own "skip zccache wrapping entirely") | still red |

And on our side: `build.rs` defines `MI_PPROF=1` **unconditionally** with no target-specific logic, the vendored amalgamation contains every missing symbol (`grep -c`: 3/7/5/6), `main` is drift-free, and `rust-native` builds the same crate green on three platforms.

## This change

`setup-soldr` still provisions the toolchain; only the **build wrapper** is dropped.

It is deliberately falsifiable either way:

- **green** → the cause is inside the wrapper, and we can report it upstream with a precise reproduction
- **still red** → soldr is exonerated, and the next suspect is the runner image

Worth noting the cost if this becomes the permanent fix: we lose soldr's compile caching for these targets, so `cross` gets slower. Given it has been **100% broken for hours** and is currently forcing `--admin` merges on every PR, a slow portability gate beats one that cannot run.