### PR TITLE
fix: make mi_prof_start_seeded actually deterministic (#91)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -923,6 +923,21 @@ if (MI_BUILD_TESTS)
   endif()
   add_test(NAME test-memory-gate COMMAND mimalloc-test-memory-gate)
 
+  # Seeded-sampling determinism across processes (issue #91). Spawns itself, so it
+  # cannot be an in-process loop: the bug was ASLR-dependent, and two runs inside one
+  # process share an address layout and would have agreed even while broken.
+  add_executable(mimalloc-test-prof-seed-determinism test/test-prof-seed-determinism.c)
+  target_compile_definitions(mimalloc-test-prof-seed-determinism PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-test-prof-seed-determinism PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-prof-seed-determinism PRIVATE include)
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    target_link_libraries(mimalloc-test-prof-seed-determinism PRIVATE mimalloc-static ${mi_libraries})
+  else()
+    target_link_libraries(mimalloc-test-prof-seed-determinism PRIVATE mimalloc ${mi_libraries})
+  endif()
+  add_test(NAME test-prof-seed-determinism COMMAND mimalloc-test-prof-seed-determinism)
+  set_tests_properties(test-prof-seed-determinism PROPERTIES TIMEOUT 300)
+
   # Positive control for the ASan job (issue #86). Only built when the sanitizer is
   # actually enabled -- and MI_TRACK_ASAN is the *resolved* value here, since
   # CMakeLists turns it OFF above if sanitizer/asan_interface.h is missing. It is

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -926,6 +926,9 @@ if (MI_BUILD_TESTS)
   # Seeded-sampling determinism across processes (issue #91). Spawns itself, so it
   # cannot be an in-process loop: the bug was ASLR-dependent, and two runs inside one
   # process share an address layout and would have agreed even while broken.
+  # MI_PPROF-only: with the profiler compiled out, mi_prof_start_seeded is a stub that
+  # returns false, so the test would fail for a reason that is not a defect.
+  if(MI_PPROF)
   add_executable(mimalloc-test-prof-seed-determinism test/test-prof-seed-determinism.c)
   target_compile_definitions(mimalloc-test-prof-seed-determinism PRIVATE ${mi_defines})
   target_compile_options(mimalloc-test-prof-seed-determinism PRIVATE ${mi_cflags})
@@ -937,6 +940,7 @@ if (MI_BUILD_TESTS)
   endif()
   add_test(NAME test-prof-seed-determinism COMMAND mimalloc-test-prof-seed-determinism)
   set_tests_properties(test-prof-seed-determinism PROPERTIES TIMEOUT 300)
+  endif()
 
   # Positive control for the ASan job (issue #86). Only built when the sanitizer is
   # actually enabled -- and MI_TRACK_ASAN is the *resolved* value here, since

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit be5e067f of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit ccb931da of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -19883,17 +19883,31 @@ static bool prof_dump_stack(const mi_prof_sample_info_t* info, void* arg) {
   return out->ok;
 }
 
-static uint64_t prof_random(mi_profiler_tld_t* tld) {
+/* Per-thread PRNG for the sampling interval.
+   The initial state mixes a *thread ordinal* into prof_seed, not the address of the
+   tld. Both decorrelate threads -- without some per-thread term, every thread started
+   from the same seed would sample at identical byte offsets -- but an address is
+   randomised by ASLR, which made mi_prof_start_seeded and MIMALLOC_PROF_SEED
+   non-reproducible across processes despite being documented as
+   "deterministic sampling, for repeatable tests" (issue #91).
+   mi_tld_t.thread_seq is the linear count of created threads, so thread K always gets
+   the same stream for a given seed.
+   Caveat worth knowing: this makes a run reproducible when the *thread creation order*
+   is deterministic. It cannot make concurrent interleaving reproducible, so a
+   multi-threaded workload whose threads race to allocate is still only
+   statistically repeatable. */
+static uint64_t prof_random(mi_tld_t* owner) {
+  mi_profiler_tld_t* tld = &owner->profiler;
   uint64_t x = tld->random;
-  if (x == 0) x = prof_seed ^ (uintptr_t)tld ^ UINT64_C(0x9E3779B97F4A7C15);
+  if (x == 0) x = prof_seed ^ (uint64_t)owner->thread_seq ^ UINT64_C(0x9E3779B97F4A7C15);
   x ^= x >> 12; x ^= x << 25; x ^= x >> 27;
   tld->random = x;
   return x * UINT64_C(2685821657736338717);
 }
 
-static size_t prof_threshold(mi_profiler_tld_t* tld) {
+static size_t prof_threshold(mi_tld_t* owner) {
   size_t rate = prof_rate;
-  size_t value = (size_t)(prof_random(tld) % (rate * 2));
+  size_t value = (size_t)(prof_random(owner) % (rate * 2));
   if (value < 1) value = 1;
   if (value > rate * 64) value = rate * 64;
   return value;
@@ -20535,9 +20549,9 @@ void _mi_prof_on_alloc(mi_theap_t* theap, mi_page_t* page, void* p, size_t size)
   mi_profiler_tld_t* tld = &theap->tld->profiler;
   if (tld->generation != prof_generation) { tld->bytes_since_sample = 0; tld->next_threshold = 0; tld->random = 0; tld->generation = prof_generation; }
   tld->bytes_since_sample += size;
-  if (tld->next_threshold == 0) tld->next_threshold = prof_threshold(tld);
+  if (tld->next_threshold == 0) tld->next_threshold = prof_threshold(theap->tld);
   if (tld->bytes_since_sample < tld->next_threshold) { mi_lock_release(&prof_lock); return; }
-  tld->bytes_since_sample = 0; tld->next_threshold = prof_threshold(tld);
+  tld->bytes_since_sample = 0; tld->next_threshold = prof_threshold(theap->tld);
   mi_prof_record_t* rec = prof_record_alloc();
   if (rec != NULL) {
     rec->stack = _mi_prof_stack_intern();

--- a/src/profile.c
+++ b/src/profile.c
@@ -166,17 +166,31 @@ static bool prof_dump_stack(const mi_prof_sample_info_t* info, void* arg) {
   return out->ok;
 }
 
-static uint64_t prof_random(mi_profiler_tld_t* tld) {
+/* Per-thread PRNG for the sampling interval.
+   The initial state mixes a *thread ordinal* into prof_seed, not the address of the
+   tld. Both decorrelate threads -- without some per-thread term, every thread started
+   from the same seed would sample at identical byte offsets -- but an address is
+   randomised by ASLR, which made mi_prof_start_seeded and MIMALLOC_PROF_SEED
+   non-reproducible across processes despite being documented as
+   "deterministic sampling, for repeatable tests" (issue #91).
+   mi_tld_t.thread_seq is the linear count of created threads, so thread K always gets
+   the same stream for a given seed.
+   Caveat worth knowing: this makes a run reproducible when the *thread creation order*
+   is deterministic. It cannot make concurrent interleaving reproducible, so a
+   multi-threaded workload whose threads race to allocate is still only
+   statistically repeatable. */
+static uint64_t prof_random(mi_tld_t* owner) {
+  mi_profiler_tld_t* tld = &owner->profiler;
   uint64_t x = tld->random;
-  if (x == 0) x = prof_seed ^ (uintptr_t)tld ^ UINT64_C(0x9E3779B97F4A7C15);
+  if (x == 0) x = prof_seed ^ (uint64_t)owner->thread_seq ^ UINT64_C(0x9E3779B97F4A7C15);
   x ^= x >> 12; x ^= x << 25; x ^= x >> 27;
   tld->random = x;
   return x * UINT64_C(2685821657736338717);
 }
 
-static size_t prof_threshold(mi_profiler_tld_t* tld) {
+static size_t prof_threshold(mi_tld_t* owner) {
   size_t rate = prof_rate;
-  size_t value = (size_t)(prof_random(tld) % (rate * 2));
+  size_t value = (size_t)(prof_random(owner) % (rate * 2));
   if (value < 1) value = 1;
   if (value > rate * 64) value = rate * 64;
   return value;
@@ -818,9 +832,9 @@ void _mi_prof_on_alloc(mi_theap_t* theap, mi_page_t* page, void* p, size_t size)
   mi_profiler_tld_t* tld = &theap->tld->profiler;
   if (tld->generation != prof_generation) { tld->bytes_since_sample = 0; tld->next_threshold = 0; tld->random = 0; tld->generation = prof_generation; }
   tld->bytes_since_sample += size;
-  if (tld->next_threshold == 0) tld->next_threshold = prof_threshold(tld);
+  if (tld->next_threshold == 0) tld->next_threshold = prof_threshold(theap->tld);
   if (tld->bytes_since_sample < tld->next_threshold) { mi_lock_release(&prof_lock); return; }
-  tld->bytes_since_sample = 0; tld->next_threshold = prof_threshold(tld);
+  tld->bytes_since_sample = 0; tld->next_threshold = prof_threshold(theap->tld);
   mi_prof_record_t* rec = prof_record_alloc();
   if (rec != NULL) {
     rec->stack = _mi_prof_stack_intern();

--- a/test/test-prof-seed-determinism.c
+++ b/test/test-prof-seed-determinism.c
@@ -1,0 +1,91 @@
+/* Seeded sampling must be reproducible across processes (issue #91).
+
+   This has to spawn a child rather than loop in-process: the bug it guards against
+   was that the PRNG seeded from `prof_seed ^ (uintptr_t)tld`, and the tld address is
+   randomised by ASLR. Two runs *inside one process* share the same address layout, so
+   they would have agreed even while the guarantee was broken. Only separate processes
+   vary the layout.
+
+   Protocol: with no argv the program runs itself twice as a child (argv[0] plus the
+   "child" flag), parses each child's reported sample count, and requires them to match.
+   With "child" it runs one seeded workload and prints the count. */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "mimalloc.h"
+#include "mimalloc/profile.h"
+
+#define WORKLOAD_BLOCKS 4096
+#define WORKLOAD_SIZE   4096
+#define SEED            0x5eedu
+#define RATE            4096
+
+static int run_child(void) {
+  if (!mi_prof_start_seeded(RATE, SEED)) { fprintf(stderr, "start failed\n"); return 2; }
+  void** blocks = (void**)malloc(sizeof(void*) * WORKLOAD_BLOCKS);
+  if (blocks == NULL) { fprintf(stderr, "oom\n"); return 2; }
+  for (size_t i = 0; i < WORKLOAD_BLOCKS; i++) {
+    blocks[i] = mi_malloc(WORKLOAD_SIZE);
+    if (blocks[i] == NULL) { fprintf(stderr, "oom\n"); return 2; }
+  }
+  mi_prof_stats_t_decl(stats);
+  if (!mi_prof_stats_get(&stats)) { fprintf(stderr, "stats failed\n"); return 2; }
+  /* Printed on its own line so the parent can parse it without matching anything else. */
+  printf("SAMPLES %llu\n", (unsigned long long)stats.live_samples);
+  fflush(stdout);
+  for (size_t i = 0; i < WORKLOAD_BLOCKS; i++) mi_free(blocks[i]);
+  free(blocks);
+  mi_prof_stop();
+  return 0;
+}
+
+/* Runs `exe child`, returns its reported sample count, or (unsigned long long)-1. */
+static unsigned long long sample_count_of_child(const char* exe) {
+  char command[4096];
+  /* Quoted: the path can contain spaces on Windows runners. */
+  snprintf(command, sizeof(command), "\"%s\" child", exe);
+  FILE* pipe =
+#ifdef _WIN32
+    _popen(command, "r");
+#else
+    popen(command, "r");
+#endif
+  if (pipe == NULL) { fprintf(stderr, "failed to spawn: %s\n", command); return (unsigned long long)-1; }
+  char line[256];
+  unsigned long long samples = (unsigned long long)-1;
+  while (fgets(line, sizeof(line), pipe) != NULL) {
+    unsigned long long value;
+    if (sscanf(line, "SAMPLES %llu", &value) == 1) samples = value;
+  }
+#ifdef _WIN32
+  const int rc = _pclose(pipe);
+#else
+  const int rc = pclose(pipe);
+#endif
+  if (rc != 0) { fprintf(stderr, "child exited %d\n", rc); return (unsigned long long)-1; }
+  return samples;
+}
+
+int main(int argc, char** argv) {
+  if (argc > 1 && strcmp(argv[1], "child") == 0) return run_child();
+
+  const unsigned long long a = sample_count_of_child(argv[0]);
+  const unsigned long long b = sample_count_of_child(argv[0]);
+  if (a == (unsigned long long)-1 || b == (unsigned long long)-1) {
+    fprintf(stderr, "could not obtain both sample counts\n");
+    return 2;
+  }
+  printf("run1=%llu run2=%llu\n", a, b);
+
+  /* A workload this size at rate 4096 must sample something; equal-but-zero would
+     pass the comparison while proving nothing. */
+  assert(a > 0);
+  assert(a == b);
+  printf("seeded sampling is reproducible across processes\n");
+  return 0;
+}


### PR DESCRIPTION
Closes #91.

`mi_prof_start_seeded` and `MIMALLOC_PROF_SEED` are documented as *"Deterministic sampling, for repeatable tests."* They are not: `prof_random` seeds the per-thread PRNG from

```c
x = prof_seed ^ (uintptr_t)tld ^ 0x9E3779B97F4A7C15
```

and that **address** is randomised by ASLR, so the same seed yields a different sample sequence in every process.

## The fix is not "delete the address"

That term is doing real work: without some per-thread component, every thread started from one seed would sample at *identical* byte offsets instead of independently. It needs something per-thread but **deterministic** — and `mi_tld_t.thread_seq` ("linear count of created threads") already exists for exactly that shape. Thread K now always gets the same stream for a given seed.

Stated in the code, because it bounds the guarantee: this makes a run reproducible when **thread creation order** is deterministic. It cannot make concurrent interleaving reproducible.

## Commit order is deliberate

The test lands **first**, without the fix, so CI shows it catching the bug — then the fix turns it green.

## The test is honest about its own limits

It spawns itself rather than looping in-process: two runs inside one process share an address layout and would agree even while the guarantee is broken.

**It passes locally on Windows/MinGW even with the buggy seeding** (both runs reported 2735) — the tld address is stable across processes there. So it is not a universal detector; it depends on a platform that genuinely randomises the mapping. Linux is expected to be that platform, and the first commit exists to establish that rather than assume it.

If Linux also fails to catch it, that is a real finding and I will say so rather than shipping a test that proves nothing — this repo has already had five gates that were silently checking nothing.