### PR TITLE
release: mimalloc-pprof 0.9.2

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cc",
  "regex",

--- a/rust/mimalloc-pprof/CHANGELOG.md
+++ b/rust/mimalloc-pprof/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.9.2
+
+One behavioural fix: **seeded sampling is now actually reproducible.**
+
+- **Fix: `mi_prof_start_seeded` and `MIMALLOC_PROF_SEED` were not deterministic**
+  ([#91](https://github.com/zackees/mimalloc-pprof/issues/91)). The per-thread sampling
+  PRNG seeded from `prof_seed ^ (uintptr_t)tld` -- the *address* of the thread's
+  allocator state, which ASLR randomises -- so the same seed produced a different sample
+  sequence in every process, while the documentation promised "deterministic sampling,
+  for repeatable tests". It now derives from the thread's creation ordinal
+  (`mi_tld_t.thread_seq`), which is per-thread without being address-dependent.
+
+  If you pinned a seed to get repeatable profiles, **0.9.1 and earlier did not give you
+  one.** This does.
+
+  The guarantee is bounded, and the README now says so: runs reproduce when thread
+  *creation order* is deterministic. Threads racing to allocate remain only
+  statistically repeatable.
+
+  Covered by `test-prof-seed-determinism`, which spawns itself and compares two
+  processes -- an in-process loop shares an address layout and would have passed while
+  the bug was live. Verified to fail without the fix on Linux and macOS.
+
 ## 0.9.1
 
 Hardening release. No API changes -- everything here is a fix or a CI gate.

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimalloc-pprof"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 description = "mimalloc global allocator with pprof-compatible sampled heap profiling"


### PR DESCRIPTION
Patch release carrying one **behavioural** fix: seeded sampling is now actually reproducible (#91).

## Why this needs its own release rather than waiting

0.9.1 shipped **before** #91 landed. Until 0.9.2, `mi_prof_start_seeded` and `MIMALLOC_PROF_SEED` seeded the per-thread PRNG from `prof_seed ^ (uintptr_t)tld` — the ASLR-randomised *address* of the thread's allocator state — so the same seed produced a different sample sequence in every process, while the documentation promised *"deterministic sampling, for repeatable tests"*.

**Anyone who pinned a seed to get repeatable profiles did not have one.** That is a silently-wrong result rather than a visible failure, which is why it warrants a release rather than riding along with the next feature.

## Bounded, and the README says so

Runs reproduce when thread **creation order** is deterministic — each thread's stream derives from the seed plus its creation ordinal. Threads racing to allocate remain only statistically repeatable.

## Version decisions

- **0.9.2, not 0.10.0** — no API change. `mi_option_purge_zeroes` (#67) remains on `v4`.
- **`MI_MALLOC_VERSION` stays `30403`** — the upstream engine is unchanged (#80 open).

## Validation

Covered by `test-prof-seed-determinism`, which spawns itself and compares two processes. An in-process loop would have passed while the bug was live — and did, on Windows, where the address happens to be stable. Confirmed to **fail without the fix** on Linux and macOS (`Assertion 'a == b' failed`) before the fix was applied.

Release path is the one validated for 0.9.1: merge, `workflow_dispatch` dry run, then tag.