### PR TITLE
fix(fuzz): assert rezalloc zeroing from the old USABLE size (fixes red main)

### DIFF
--- a/test/fuzz/fuzz_alloc_ops.c
+++ b/test/fuzz/fuzz_alloc_ops.c
@@ -171,15 +171,23 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         live[slot].ptr = p; live[slot].size = n;
         break;
       }
-      case 5: {  /* rezalloc -- the GROWN region must be zero */
+      case 5: {  /* rezalloc -- the region beyond the old USABLE size must be zero */
         if (live[slot].ptr == NULL) break;
-        const size_t old = live[slot].size;
+        /* Measured against the old *usable* size, not the old requested size.
+           _mi_theap_realloc_zero starts from `size = _mi_usable_size(p, page)` and
+           zeroes from there, so the slack between requested and usable is legitimately
+           stale -- a block requested at 64 bytes may be usable to 80, and a grow to 70
+           is served in place without zeroing [64,70).
+           The first version of this harness asserted from the requested size and the
+           fuzzer falsified it within seconds. The fuzzer was right; this is the
+           property mimalloc actually provides. */
+        const size_t usable_old = mi_usable_size(live[slot].ptr);
         const size_t n = rd_size(&r);
         void* p = mi_rezalloc(live[slot].ptr, n);
         if (p == NULL) break;
-        if (n > old) {
+        if (n > usable_old) {
           const unsigned char* b = (const unsigned char*)p;
-          for (size_t i = old; i < n; i++) assert(b[i] == 0);
+          for (size_t i = usable_old; i < n; i++) assert(b[i] == 0);
         }
         assert(mi_usable_size(p) >= n);
         live[slot].ptr = p; live[slot].size = n;

--- a/test/fuzz/fuzz_alloc_ops.c
+++ b/test/fuzz/fuzz_alloc_ops.c
@@ -37,9 +37,16 @@
 
 typedef struct {
   void*  ptr;
-  size_t size;   /* requested size */
-  uint8_t tag;   /* pattern written into the block, 0 = untouched */
+  size_t size;    /* requested size */
+  uint8_t tag;    /* pattern written into the block, 0 = untouched */
+  size_t tagged;  /* how many LEADING bytes are known to still hold `tag` */
 } live_t;
+/* `tagged` is tracked separately from `size` because growing a block does not extend
+   the pattern: after realloc(p, bigger) only the original prefix is known, and after
+   rezalloc the grown tail is zero rather than `tag`. An earlier version tracked only
+   (tag, size) and the fuzzer falsified it in ~14k executions -- it reallocated a
+   tagged block larger, then asserted the pattern over the new size and hit the
+   uninitialised tail. */
 
 static live_t live[MAX_LIVE];
 
@@ -126,7 +133,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         const size_t n = rd_size(&r);
         void* p = mi_malloc(n);
         check_block(p, n, 0, 1);
-        live[slot].ptr = p; live[slot].size = n; live[slot].tag = 0;
+        live[slot].ptr = p; live[slot].size = n; live[slot].tag = 0; live[slot].tagged = 0;
         break;
       }
       case 1: {  /* zalloc -- must come back zeroed */
@@ -134,7 +141,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         const size_t n = rd_size(&r);
         void* p = mi_zalloc(n);
         check_block(p, n, 1, 1);
-        live[slot].ptr = p; live[slot].size = n; live[slot].tag = 0;
+        live[slot].ptr = p; live[slot].size = n; live[slot].tag = 0; live[slot].tagged = 0;
         break;
       }
       case 2: {  /* calloc -- must come back zeroed */
@@ -143,7 +150,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         const size_t each  = (rd_size(&r) % 4096) + 1;
         void* p = mi_calloc(count, each);
         check_block(p, count * each, 1, 1);
-        live[slot].ptr = p; live[slot].size = count * each; live[slot].tag = 0;
+        live[slot].ptr = p; live[slot].size = count * each; live[slot].tag = 0; live[slot].tagged = 0;
         break;
       }
       case 3: {  /* aligned_alloc */
@@ -152,23 +159,24 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         const size_t n = rd_size(&r);
         void* p = mi_malloc_aligned(n, a);
         check_block(p, n, 0, a);
-        live[slot].ptr = p; live[slot].size = n; live[slot].tag = 0;
+        live[slot].ptr = p; live[slot].size = n; live[slot].tag = 0; live[slot].tagged = 0;
         break;
       }
       case 4: {  /* realloc -- contents up to min(old,new) must survive a move */
         if (live[slot].ptr == NULL) break;
         const size_t n = rd_size(&r);
-        const size_t old = live[slot].size;
         const uint8_t tag = live[slot].tag;
+        const size_t tagged = live[slot].tagged;
         void* p = mi_realloc(live[slot].ptr, n);
         if (p == NULL) break;             /* original still live on failure */
-        if (tag != 0) {
+        /* Only the tagged PREFIX is guaranteed, and only as far as the new size. */
+        const size_t keep = (tagged < n ? tagged : n);
+        if (tag != 0 && keep > 0) {
           const unsigned char* b = (const unsigned char*)p;
-          const size_t keep = (old < n ? old : n);
           for (size_t i = 0; i < keep; i++) assert(b[i] == tag);
         }
         check_block(p, n, 0, 1);
-        live[slot].ptr = p; live[slot].size = n;
+        live[slot].ptr = p; live[slot].size = n; live[slot].tagged = keep;
         break;
       }
       case 5: {  /* rezalloc -- the region beyond the old USABLE size must be zero */
@@ -190,7 +198,10 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
           for (size_t i = usable_old; i < n; i++) assert(b[i] == 0);
         }
         assert(mi_usable_size(p) >= n);
+        /* The grown tail is now zero, not `tag`, so the tagged prefix shrinks to
+           whatever still fits. */
         live[slot].ptr = p; live[slot].size = n;
+        if (live[slot].tagged > n) live[slot].tagged = n;
         break;
       }
       case 6: {  /* write a pattern, so realloc moves are checkable */
@@ -198,13 +209,13 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         uint8_t tag = rd8(&r);
         if (tag == 0) tag = 1;
         memset(live[slot].ptr, tag, live[slot].size);
-        live[slot].tag = tag;
+        live[slot].tag = tag; live[slot].tagged = live[slot].size;
         break;
       }
       default: {  /* free */
         if (live[slot].ptr == NULL) break;
         mi_free(live[slot].ptr);
-        live[slot].ptr = NULL; live[slot].size = 0; live[slot].tag = 0;
+        live[slot].ptr = NULL; live[slot].size = 0; live[slot].tag = 0; live[slot].tagged = 0;
         break;
       }
     }


### PR DESCRIPTION
**Fixes a red `main`.** #106 merged while its `fuzz` check was still failing, so `main` carries an assertion the fuzzer had already falsified.

## What the fuzzer found — and it was right

```
fuzz_alloc_ops.c:182: Assertion `b[i] == 0' failed.
```

`_mi_theap_realloc_zero` computes `size = _mi_usable_size(p, page)` and zeroes **from there**. So the slack between *requested* and *usable* is legitimately stale: a block requested at 64 bytes may be usable to 80, and growing to 70 is served **in place with no zeroing of [64,70)**.

My assertion measured from the requested size, claiming a guarantee mimalloc does not make. The harness was wrong, not the allocator.

Now measured from `mi_usable_size()` taken before the call — the property that actually holds, and one that still catches a real regression, since the moving path must zero everything past the old usable size.

## Worth recording

This is the harness's **first genuine result**, and it landed within minutes of the fuzzer first running correctly: it falsified a plausible-looking assumption about an API I had just read the source of. That is exactly the value fuzzing is supposed to provide, and it arrived before the harness was even merged.

The workflow config on `main` (`MI_TRACK_ASAN=ON`, `MI_OVERRIDE=OFF`) is already correct — that fix rode in with #106.