### PR TITLE
feat(rust): expose the zeroing realloc family, and test profiler accounting (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,27 @@ target_link_libraries(my_app PRIVATE mimalloc-static)
 > Rust binary using the crate's vendored allocator must not also link the root
 > CMake library.
 
+### Reallocation, including the zeroing forms
+
+Beyond `mi_realloc`, mimalloc provides variants that Rust's `GlobalAlloc` cannot express
+and that are easy to miss:
+
+| Function | What it does |
+|---|---|
+| `mi_rezalloc(p, n)` | grow/shrink **and zero the newly-exposed tail** |
+| `mi_recalloc(p, count, size)` | same, in `calloc`'s element-count form |
+| `mi_rezalloc_aligned`, `mi_recalloc_aligned` | aligned variants |
+| `mi_expand(p, n)` | grow **in place only** — returns `NULL` rather than moving, leaving `p` valid |
+
+The zeroing forms save a `memset` you would otherwise write by hand. One subtlety worth
+knowing: they zero from the block's old **usable** size, not from the size you
+originally requested. A block requested at 64 bytes may be usable to 80, so growing it
+to 70 is served in place with nothing zeroed. If you need a specific range zeroed,
+capture `mi_usable_size` before the call.
+
+All of these are available from Rust as `mimalloc_pprof::{rezalloc, recalloc, expand,
+usable_size}`.
+
 ### Build flags for usable stacks
 
 The profiler walks **your application's** frames, so the flags that matter are the ones

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -119,6 +119,82 @@ pub unsafe fn unwrapped_realloc(p: *mut u8, new_size: usize, alignment: usize) -
     unsafe { sys::mi_unwrapped_realloc(p.cast(), new_size, alignment).cast() }
 }
 
+/// Grow or shrink an allocation, zeroing any newly-exposed tail.
+///
+/// Thin wrapper around `mi_rezalloc`. This is the operation Rust's [`GlobalAlloc`]
+/// cannot express — that trait has no `grow_zeroed` — so without it a caller has to
+/// grow and then `memset` by hand, repeating work the allocator has already done, and
+/// (with zero-tracking) work it may be able to skip entirely.
+///
+/// # What is actually zeroed
+///
+/// **Not** `[old_requested_size, new_size)`. mimalloc measures from the block's old
+/// *usable* size, so the slack between what you asked for and what the block actually
+/// holds is left untouched:
+///
+/// ```text
+/// requested 64  ->  usable 80  ->  rezalloc to 70
+/// bytes [64,70) are NOT zeroed: the grow was served in place, within the old block
+/// ```
+///
+/// The guarantee is: everything past [`usable_size`] of the *original* block is zero.
+/// If you need a specific range zeroed, capture [`usable_size`] before the call and
+/// zero the remainder yourself.
+///
+/// (This is documented so precisely because a fuzz harness asserted the intuitive
+/// version and was falsified within seconds — see issue #87.)
+///
+/// # Safety
+///
+/// - `p` must be null, or a pointer from the **plain** allocation family — the global
+///   allocator, [`sys::mi_malloc`], or a previous [`rezalloc`]/[`recalloc`] — that has
+///   not been freed.
+/// - **Not interchangeable with [`unwrapped_malloc`]/[`unwrapped_realloc`].** Those
+///   place a header before the pointer, so passing one here fails the pointer check
+///   (`mi_usable_size: invalid pointer`) rather than working by accident.
+/// - After this call `p` is consumed: do not read, write, or free it again, whether or
+///   not the return value is null.
+/// - On failure a null pointer is returned and `p` is left valid and unfreed.
+pub unsafe fn rezalloc(p: *mut u8, new_size: usize) -> *mut u8 {
+    unsafe { sys::mi_rezalloc(p.cast(), new_size).cast() }
+}
+
+/// Grow or shrink an allocation to `count * size` bytes, zeroing any newly-exposed tail.
+///
+/// The [`rezalloc`] contract applies, including what is and is not zeroed. Thin wrapper
+/// around `mi_recalloc`; the element-count form exists to mirror `calloc`.
+///
+/// # Safety
+///
+/// Same contract as [`rezalloc`].
+pub unsafe fn recalloc(p: *mut u8, count: usize, size: usize) -> *mut u8 {
+    unsafe { sys::mi_recalloc(p.cast(), count, size).cast() }
+}
+
+/// Try to grow an allocation **in place**, without moving it.
+///
+/// Returns a null pointer if the block cannot be extended where it is — in which case
+/// `p` remains valid and unchanged, unlike [`rezalloc`]. Useful when moving would be
+/// more expensive than falling back to a different strategy.
+///
+/// # Safety
+///
+/// - `p` must be a pointer from this allocator that has not been freed.
+/// - Unlike [`rezalloc`], `p` is **not** consumed: on failure it is still live and must
+///   still be freed.
+pub unsafe fn expand(p: *mut u8, new_size: usize) -> *mut u8 {
+    unsafe { sys::mi_expand(p.cast(), new_size).cast() }
+}
+
+/// Bytes actually available in an allocation, which may exceed what was requested.
+///
+/// # Safety
+///
+/// `p` must be a live pointer from this allocator.
+pub unsafe fn usable_size(p: *const u8) -> usize {
+    unsafe { sys::mi_usable_size(p.cast()) }
+}
+
 /// Turn on sampled heap profiling at the default sample rate.
 ///
 /// Convenience entry point for wiring profiling to a command-line flag:

--- a/rust/mimalloc-pprof/src/sys.rs
+++ b/rust/mimalloc-pprof/src/sys.rs
@@ -118,6 +118,25 @@ unsafe extern "C" {
     pub fn mi_malloc_aligned(size: usize, alignment: usize) -> *mut c_void;
     pub fn mi_zalloc_aligned(size: usize, alignment: usize) -> *mut c_void;
     pub fn mi_realloc_aligned(p: *mut c_void, newsize: usize, alignment: usize) -> *mut c_void;
+    // Zeroing reallocation (issue #83). These grow a block AND zero the new tail, which
+    // `GlobalAlloc` cannot express -- it has no `grow_zeroed` -- so a Rust caller would
+    // otherwise grow and `memset` by hand, redoing work mimalloc has already done.
+    //
+    // What they zero is NOT [old_requested, new): mimalloc measures from the block's
+    // old *usable* size, so the slack between requested and usable is left as-is. A
+    // block requested at 64 bytes may be usable to 80, and growing to 70 is served in
+    // place with nothing zeroed. See `prof::rezalloc` for the safe-wrapper docs.
+    pub fn mi_rezalloc(p: *mut c_void, newsize: usize) -> *mut c_void;
+    pub fn mi_recalloc(p: *mut c_void, newcount: usize, size: usize) -> *mut c_void;
+    pub fn mi_rezalloc_aligned(p: *mut c_void, newsize: usize, alignment: usize) -> *mut c_void;
+    pub fn mi_recalloc_aligned(
+        p: *mut c_void,
+        newcount: usize,
+        size: usize,
+        alignment: usize,
+    ) -> *mut c_void;
+    /// Grow in place only; returns NULL if the block cannot be extended without moving.
+    pub fn mi_expand(p: *mut c_void, newsize: usize) -> *mut c_void;
     pub fn mi_usable_size(p: *const c_void) -> usize;
     pub fn mi_prof_start(sample_rate: usize) -> bool;
     pub fn mi_prof_start_seeded(sample_rate: usize, seed: u64) -> bool;

--- a/rust/mimalloc-pprof/tests/t16_rezalloc.rs
+++ b/rust/mimalloc-pprof/tests/t16_rezalloc.rs
@@ -1,0 +1,93 @@
+//! Zeroing reallocation from Rust, and profiler accounting across the realloc matrix
+//! (issue #83).
+//!
+//! Two halves, because #83 had two halves:
+//!
+//! 1. `mi_rezalloc` / `mi_recalloc` were unreachable from Rust at all — `GlobalAlloc`
+//!    has no `grow_zeroed`, so a caller had to grow and `memset` by hand.
+//! 2. Profiler accounting on the realloc paths was *unverified*. The hooks are named
+//!    for the in-place case (`_mi_prof_on_realloc_in_place`) while a separate moving
+//!    path exists, so "does a sampled block survive a realloc correctly" was an open
+//!    question rather than a tested one.
+//!
+//! Note these use the PLAIN allocation family (`mi_malloc`/`mi_free`), not
+//! `unwrapped_*`. The two are not interchangeable: `unwrapped_*` puts a header before
+//! the pointer, so handing one of those to `mi_rezalloc` trips
+//! `mi_usable_size: invalid pointer`. The first draft of this test made exactly that
+//! mistake and crashed, which is why `rezalloc`'s safety docs now name the family.
+
+mod common;
+
+use mimalloc_pprof::{prof, sys};
+
+/// The zeroing contract, stated the way mimalloc actually implements it.
+///
+/// Deliberately measured from the old **usable** size, not the old requested size.
+/// A fuzz harness asserted the intuitive version and was falsified in seconds (#87):
+/// mimalloc zeroes from `_mi_usable_size(p)`, so the slack between requested and
+/// usable is left alone.
+#[test]
+fn rezalloc_zeroes_past_the_old_usable_size() {
+    unsafe {
+        let n_old = 64usize;
+        let p = sys::mi_malloc(n_old).cast::<u8>();
+        assert!(!p.is_null());
+        // Dirty the whole usable block so a missing zeroing cannot pass by luck.
+        let usable_old = mimalloc_pprof::usable_size(p);
+        assert!(usable_old >= n_old);
+        std::ptr::write_bytes(p, 0xA5, usable_old);
+
+        let n_new = usable_old + 4096; // force a genuine grow past the old block
+        let q = mimalloc_pprof::rezalloc(p, n_new);
+        assert!(!q.is_null());
+
+        for i in usable_old..n_new {
+            assert_eq!(*q.add(i), 0, "byte {i} past the old usable size was not zeroed");
+        }
+        sys::mi_free(q.cast());
+    }
+}
+
+#[test]
+fn recalloc_matches_rezalloc_for_the_grown_tail() {
+    unsafe {
+        let p = sys::mi_malloc(32).cast::<u8>();
+        assert!(!p.is_null());
+        let usable_old = mimalloc_pprof::usable_size(p);
+        std::ptr::write_bytes(p, 0x5A, usable_old);
+
+        let count = 64usize;
+        let each = 64usize;
+        assert!(count * each > usable_old);
+        let q = mimalloc_pprof::recalloc(p, count, each);
+        assert!(!q.is_null());
+        for i in usable_old..(count * each) {
+            assert_eq!(*q.add(i), 0, "byte {i} was not zeroed by recalloc");
+        }
+        sys::mi_free(q.cast());
+    }
+}
+
+/// `expand` must not move, and must leave `p` live when it declines.
+#[test]
+fn expand_never_moves_and_leaves_p_valid_on_failure() {
+    unsafe {
+        let p = sys::mi_malloc(64).cast::<u8>();
+        assert!(!p.is_null());
+        *p = 0x42;
+
+        // Absurdly large: must fail rather than move.
+        let q = mimalloc_pprof::expand(p, 1 << 40);
+        assert!(q.is_null(), "expand must return null rather than move the block");
+        // p is still live and unchanged -- this is what distinguishes it from rezalloc.
+        assert_eq!(*p, 0x42);
+
+        // A grow within the existing usable size should succeed in place.
+        let usable = mimalloc_pprof::usable_size(p);
+        let r = mimalloc_pprof::expand(p, usable);
+        if !r.is_null() {
+            assert_eq!(r, p, "expand must not move the block");
+        }
+        sys::mi_free(p.cast());
+    }
+}

--- a/rust/mimalloc-pprof/tests/t17_realloc_profiling.rs
+++ b/rust/mimalloc-pprof/tests/t17_realloc_profiling.rs
@@ -1,0 +1,69 @@
+//! Profiler accounting across the realloc matrix (issue #83, second half).
+//!
+//! In its own file, and that is load-bearing rather than tidiness: cargo runs the tests
+//! within one binary CONCURRENTLY, while `prof::stats()` reports process-wide live
+//! sampling. Sharing a binary with the `t16_rezalloc` allocation tests made this read
+//! their allocations as its own and fail with a phantom +1 leak. Each `tests/*.rs` is a
+//! separate binary, so isolating the file isolates the profiler state.
+//!
+//! Verified before splitting: probing each resize path on its own gives delta=0 for
+//! no-resize, grow, shrink, rezalloc and recalloc alike -- no path leaks a sample.
+
+mod common;
+
+use mimalloc_pprof::{prof, sys};
+
+/// The half of #83 that was unverified: sampled allocations must survive the whole
+/// realloc matrix without the profiler dropping or double-counting them.
+///
+/// Uses a small sample rate so blocks are reliably sampled, and asserts the invariant
+/// that actually matters — that live sample bookkeeping returns to its starting point
+/// once everything is freed. A leak or a double-count both violate that, while a raw
+/// count comparison mid-sequence would be probabilistic and flaky.
+#[test]
+fn profiler_accounting_survives_the_realloc_matrix() {
+    common::start(4096, 0x83);
+
+    let before = prof::stats();
+
+    unsafe {
+        let mut blocks: Vec<*mut u8> = Vec::new();
+        for round in 0..64usize {
+            let p = sys::mi_malloc(8192).cast::<u8>();
+            assert!(!p.is_null());
+
+            // Cycle through every resize path, including the moving and in-place cases.
+            let q = match round % 4 {
+                0 => sys::mi_realloc(p.cast(), 16384).cast::<u8>(), // grow, likely moves
+                1 => sys::mi_realloc(p.cast(), 128).cast::<u8>(),   // shrink, in place
+                2 => mimalloc_pprof::rezalloc(p, 32768),             // zeroing grow
+                _ => mimalloc_pprof::recalloc(p, 512, 64),           // zeroing grow, count form
+            };
+            assert!(!q.is_null());
+            blocks.push(q);
+        }
+        for b in blocks {
+            sys::mi_free(b.cast());
+        }
+    }
+
+    let after = prof::stats();
+
+    // Everything allocated above has been freed, so live sampling must be back where it
+    // started. Growth here would mean a resize path leaked a sample record; a decrease
+    // would mean one was released twice.
+    assert_eq!(
+        after.live_samples, before.live_samples,
+        "live sample count changed across a fully-freed realloc matrix \
+         (before={}, after={})",
+        before.live_samples, after.live_samples
+    );
+    assert_eq!(
+        after.live_bytes, before.live_bytes,
+        "live sampled bytes changed across a fully-freed realloc matrix \
+         (before={}, after={})",
+        before.live_bytes, after.live_bytes
+    );
+
+    prof::stop();
+}


### PR DESCRIPTION
Closes #83. Two halves, matching the issue.

## 1. The zeroing realloc family was unreachable from Rust

`grep -rn "rezalloc\|recalloc" rust/` returned **zero hits**. `GlobalAlloc` has no `grow_zeroed`, so a Rust caller had to grow and `memset` by hand — redoing work the allocator already does, and (with zero-tracking) work it may be able to skip entirely.

Now exposed in `sys` and as safe wrappers: `rezalloc`, `recalloc`, `expand`, `usable_size`.

## 2. Profiler accounting on the realloc paths was unverified

The hooks are named for the in-place case (`_mi_prof_on_realloc_in_place`) while a separate moving path exists, so "does a sampled block survive a resize" was an open question rather than a tested one.

**It does.** Probing each path in isolation gives  for no-resize, grow, shrink, rezalloc and recalloc alike. Now asserted by `t17_realloc_profiling`.

## The zeroing contract, stated precisely because the intuitive version is wrong

These zero from the block's **old usable size**, not the old requested size:

```text
requested 64  ->  usable 80  ->  rezalloc to 70
bytes [64,70) are NOT zeroed -- the grow was served inside the old block
```

The fuzz harness (#87) asserted the intuitive version and was falsified within seconds. That is now in the wrapper docs, the sys docs, and the README.

## Two mistakes the tests caught, both now documented

- **The first draft passed `unwrapped_malloc` pointers to `mi_rezalloc`** and crashed with `mi_usable_size: invalid pointer`. Those are *separate allocation families* — `unwrapped_*` puts a header before the pointer. `rezalloc`'s safety section now names the family instead of vaguely saying "from this allocator".
- **The accounting test read a phantom +1 leak** when it shared a binary with the allocation tests. cargo runs tests within one binary **concurrently** while `prof::stats()` is process-wide, so it was counting its siblings' allocations. It lives in its own file now; each `tests/*.rs` is a separate binary. I isolated each resize path before splitting, rather than assuming it was noise.

Rust and README changes are separate commits per rule 2. Full Rust suite green locally.