### PR TITLE
docs: add hero text, with the 'first' claim corrected to one that holds (#110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # mimalloc-pprof
 
+> ## mimalloc with native pprof-compatible heap profiling — on Windows, Linux, and macOS alike.
+>
+> **The one mimalloc heap profiler that runs natively on Windows.** Upstream mimalloc
+> has no profiler at all, and the only other known implementation
+> ([Bun's](https://github.com/oven-sh/mimalloc), surveyed in
+> [`MIMALLOC_FORKS.md`](MIMALLOC_FORKS.md)) is POSIX-only — its stack capture is guarded
+> behind glibc/Apple `<execinfo.h>`.
+
 A fork of [microsoft/mimalloc](https://github.com/microsoft/mimalloc) that adds
 **pprof-compatible sampled heap profiling**, with native Windows as a first-class
 target alongside Linux and macOS.

--- a/rust/mimalloc-pprof/README.md
+++ b/rust/mimalloc-pprof/README.md
@@ -1,5 +1,12 @@
 # mimalloc-pprof
 
+> ## mimalloc with native pprof-compatible heap profiling — on Windows, Linux, and macOS alike.
+>
+> **The one mimalloc heap profiler that runs natively on Windows.** Upstream mimalloc
+> has no profiler at all, and the only other known implementation
+> ([Bun's](https://github.com/oven-sh/mimalloc)) is POSIX-only — its stack capture is
+> guarded behind glibc/Apple `<execinfo.h>`.
+
 [mimalloc](https://github.com/microsoft/mimalloc) as a Rust global allocator, with
 **pprof-compatible sampled heap profiling** built in. Windows is a first-class
 target alongside Linux and macOS.


### PR DESCRIPTION
Closes #110.

## The requested wording does not hold, and our own repo says so

Proposed: *"The **first** cross-platform allocator that combines mimalloc with native pprof-compatible heap profiling, including Windows."*

I checked before writing it. **Bun's fork carries a pprof-compatible sampling heap profiler** — `src/prof.c`, +686 lines, built on the same `dev3` base — and `MIMALLOC_FORKS.md` already describes it as:

> **Direct prior art for this repository.** Bun independently built a pprof sampling profiler on the same `dev3` base and independently arrived at our core invariant…

Shipping "first" would have put a superlative in the README that is contradicted by a document sitting next to it in the same repo. That is worse than no hero text, because the README's credibility rests on its measured claims and specific bug reports.

## What does hold: the Windows half

Bun's stack capture is guarded behind glibc/Apple `<execinfo.h>` — **POSIX only**. Upstream mimalloc has no profiler at all. So the differentiator is real, it just is not primacy:

> ## mimalloc with native pprof-compatible heap profiling — on Windows, Linux, and macOS alike.
>
> **The one mimalloc heap profiler that runs natively on Windows.** Upstream mimalloc has no profiler at all, and the only other known implementation ([Bun's](https://github.com/oven-sh/mimalloc), surveyed in [`MIMALLOC_FORKS.md`](MIMALLOC_FORKS.md)) is POSIX-only — its stack capture is guarded behind glibc/Apple `<execinfo.h>`.

It keeps the shape and punch of the original, leads with the genuine differentiator, and **cites its own evidence** so a skeptical reader can check it in two clicks.

"The one … that runs natively on Windows" is still a strong claim, but it is one backed by the survey and stated as *known* implementations rather than an unbounded universal.

## Also

Applied to `rust/mimalloc-pprof/README.md` as well — that is what renders on crates.io, and #110 asked for both.

If you would rather ship the original wording as-is, say so and I will — but I did not want to merge an unverifiable superlative silently.