### PR TITLE
fix: MSVC shared build MIMALLOC_MEMORY_EVENTS activation (#69)

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -97,6 +97,19 @@ jobs:
       - run: cmake -B build -DMI_PPROF=ON -DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF -DMI_BUILD_OBJECT=OFF
       - run: cmake --build build --config Release
       - run: ctest --test-dir build -C Release --output-on-failure
+      # DIAGNOSTIC (#69): ctest reported the env-activation test as Failed with no output
+      # at all, despite --output-on-failure, so the five distinct stderr messages the test
+      # emits never reached the log. Run the binary directly and print everything, so the
+      # exit code alone tells us which branch fired.
+      - name: "#69 diagnostic: run the env-activation check directly"
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          exe=$(find build -name 'mimalloc-test-memory-events*' -type f | grep -iE '\.exe$|memory-events$' | head -1)
+          echo "binary: $exe"
+          MIMALLOC_MEMORY_EVENTS=1 "$exe" --env-enabled-check
+          echo "exit code: $?  (1=env not set  2=alloc failed  3=tracking not enabled  4=second alloc failed  5=callback did not fire)"
 
   ctest-shared-win-gnu:
     runs-on: windows-latest

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -108,8 +108,15 @@ jobs:
           set +e
           exe=$(find build -name 'mimalloc-test-memory-events*' -type f | grep -iE '\.exe$|memory-events$' | head -1)
           echo "binary: $exe"
-          MIMALLOC_MEMORY_EVENTS=1 "$exe" --env-enabled-check
+          echo "--- does the shell itself export it? ---"
+          export MIMALLOC_MEMORY_EVENTS=1
+          env | grep -i mimalloc || echo "(nothing in env)"
+          echo "--- exported, run via bash ---"
+          "$exe" --env-enabled-check
           echo "exit code: $?  (1=env not set  2=alloc failed  3=tracking not enabled  4=second alloc failed  5=callback did not fire)"
+          echo "--- run via cmd.exe, which sets the variable itself ---"
+          cmd //c "set MIMALLOC_MEMORY_EVENTS=1 && $(cygpath -w "$exe") --env-enabled-check"
+          echo "exit code: $?"
 
   ctest-shared-win-gnu:
     runs-on: windows-latest

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit ccb931da of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 1201a9d8 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -15649,6 +15649,23 @@ void _mi_memevt_suppress_end(void)   { memevt_suppress_depth--; }
 // ---------------------------------------------------------------------------------------
 
 static void memevt_resolve_env(void) {
+  // Do not latch an answer while the C runtime is still coming up (issue #69).
+  //
+  // In an MSVC *shared* build the first allocation happens during DLL_PROCESS_ATTACH,
+  // before the CRT can answer getenv. mimalloc's own option machinery handles that by
+  // leaving the option UNINIT and retrying later -- src/options.c: "on another error,
+  // keep unitialized to try again (can happen during preloading if getenv is not
+  // available)". Our once-guard was stricter: it cached that pre-CRT read permanently,
+  // so MIMALLOC_MEMORY_EVENTS=1 could never take effect no matter when it was set.
+  //
+  // Static builds never saw this because their first allocation really does happen in
+  // main, with the CRT already up -- which is why the whole static suite passed while
+  // the MSVC DLL failed.
+  //
+  // Returning early leaves memevt_state == MEMEVT_UNINIT, so the next allocation
+  // retries. Tracking stays off until then, which is the only honest answer: during
+  // preloading we cannot yet know what the environment says.
+  if (_mi_preloading()) return;
   if (_mi_atomic_once_enter(&memevt_once)) {
     const bool enabled = mi_option_is_enabled(mi_option_memory_events);
     mi_atomic_store_release(&memevt_state, (size_t)(enabled ? MEMEVT_ENABLED : MEMEVT_DISABLED));

--- a/src/memory-events.c
+++ b/src/memory-events.c
@@ -81,6 +81,23 @@ void _mi_memevt_suppress_end(void)   { memevt_suppress_depth--; }
 // ---------------------------------------------------------------------------------------
 
 static void memevt_resolve_env(void) {
+  // Do not latch an answer while the C runtime is still coming up (issue #69).
+  //
+  // In an MSVC *shared* build the first allocation happens during DLL_PROCESS_ATTACH,
+  // before the CRT can answer getenv. mimalloc's own option machinery handles that by
+  // leaving the option UNINIT and retrying later -- src/options.c: "on another error,
+  // keep unitialized to try again (can happen during preloading if getenv is not
+  // available)". Our once-guard was stricter: it cached that pre-CRT read permanently,
+  // so MIMALLOC_MEMORY_EVENTS=1 could never take effect no matter when it was set.
+  //
+  // Static builds never saw this because their first allocation really does happen in
+  // main, with the CRT already up -- which is why the whole static suite passed while
+  // the MSVC DLL failed.
+  //
+  // Returning early leaves memevt_state == MEMEVT_UNINIT, so the next allocation
+  // retries. Tracking stays off until then, which is the only honest answer: during
+  // preloading we cannot yet know what the environment says.
+  if (_mi_preloading()) return;
   if (_mi_atomic_once_enter(&memevt_once)) {
     const bool enabled = mi_option_is_enabled(mi_option_memory_events);
     mi_atomic_store_release(&memevt_state, (size_t)(enabled ? MEMEVT_ENABLED : MEMEVT_DISABLED));


### PR DESCRIPTION
Working #69. **First commit deliberately adds the failing job to capture evidence** — the root cause is explicitly unverified and I have no MSVC locally, so this diagnoses before fixing.

The test already distinguishes five failure modes by stderr (returns 1–5: env not set / alloc failed / tracking not enabled / second alloc failed / callback did not fire), and `--output-on-failure` is already set. What was missing was simply a run.

**Expected red on the first commit.**