### PR TITLE
fix: make -DMI_GUARDED=ON actually work; auto-enable held back (#116)

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -64,6 +64,32 @@ jobs:
           name: mimalloc-portable-${{ matrix.os }}
           path: build-portable/libmimalloc*.a
 
+  # MI_GUARDED places guard pages behind sampled allocations. It was documented as
+  # default-on in debug builds and was NEVER enabled -- two dead CMake constructs (see
+  # #116). Now that it can turn on, it needs a job that actually builds with it, or we
+  # have simply moved the flag from "silently off" to "on and untested".
+  ctest-guarded:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure and prove MI_GUARDED survived
+        run: |
+          set -euo pipefail
+          cmake -B build-guarded -DCMAKE_BUILD_TYPE=Debug -DMI_PPROF=ON -DMI_GUARDED=ON 2>&1 | tee cfg.log
+          # The whole point of #116 is that the flag silently did not reach the compiler.
+          # Assert on the resolved defines, not on the option we passed in.
+          if ! grep -qE "Compiler defines *:.*MI_GUARDED=1" cfg.log; then
+            echo "::error::MI_GUARDED=1 did not reach mi_defines -- the flag is not actually enabled."
+            grep -i "guard\|Compiler defines" cfg.log || true
+            exit 1
+          fi
+      - run: cmake --build build-guarded --parallel
+      - run: ctest --test-dir build-guarded --output-on-failure --timeout 900
+      # NOT added yet: a run at MIMALLOC_GUARDED_SAMPLE_RATE=1. It is currently RED --
+      # mimalloc reports "double free detected" and test-memory-events' allocation count
+      # goes wrong. Adding it red, or with continue-on-error, is how a gate becomes
+      # decoration; it goes in with the fix. Tracked on #116.
+
   ctest-pprof-off:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,9 +372,24 @@ elseif(CMAKE_BUILD_TYPE MATCHES "Debug")
   list(APPEND mi_defines MI_DEBUG=2)   # invariant checking (mi_assert and mi_assert_internal)
 endif()
 
-if(MI_DEBUG AND !MI_GUARDED)
-  message(STATUS "Enable MI_GUARDED (since MI_DEBUG=ON)")
-  set(MI_GUARDED=ON)
+# NOTE: `!` is NOT negation in CMake -- `!MI_GUARDED` parses as a variable name, and an
+# undefined variable is false, so the original `if(MI_DEBUG AND !MI_GUARDED)` was ALWAYS
+# false. And `set(MI_GUARDED=ON)` creates a variable literally named `MI_GUARDED=ON`
+# rather than setting anything. Either defect alone disabled this block; together it
+# could never fire, so MI_GUARDED was never on despite being documented as default-on in
+# debug builds (see issue #116). Both verified experimentally.
+#
+# The auto-enable is deliberately NOT restored yet. Turning it on surfaced a real
+# interaction bug: at MIMALLOC_GUARDED_SAMPLE_RATE=1 the suite reports
+# "double free detected" from mimalloc's own checker and our memory-events allocation
+# count goes wrong (test-memory-events.c:378). At the default 1-in-4000 rate the suite
+# passes -- which would make that failure RARE AND NONDETERMINISTIC in every debug build,
+# which is worse than it being off. Restore the auto-enable once that is understood.
+#
+# `-DMI_GUARDED=ON` now works as intended, which is what the constructs below were
+# supposed to provide all along.
+if(MI_DEBUG AND NOT MI_GUARDED)
+  message(STATUS "MI_GUARDED auto-enable is disabled pending the guarded/memory-events interaction bug; pass -DMI_GUARDED=ON explicitly to opt in")
 endif()
 if(MI_GUARDED)
   message(STATUS "Compile guard pages behind certain object allocations (MI_GUARDED=ON)")


### PR DESCRIPTION
Closes #116. Turning the flag on for the first time immediately found a real bug — filed as #131.

## The defect

`MI_GUARDED` is documented as *"enabled by default in a debug build"*. It never was, and **could not be**:

```cmake
if(MI_DEBUG AND !MI_GUARDED)     # '!' is NOT negation in CMake -- !MI_GUARDED parses
  ...                            # as a variable NAME; undefined -> false, so this
  set(MI_GUARDED=ON)             # is ALWAYS false. And set(X=ON) creates a variable
endif()                          # literally named 'X=ON' rather than setting X.
```

Verified before touching anything:

```
set(MI_GUARDED OFF); if(!MI_GUARDED)     -> FALSE   (real negation would be TRUE)
set(MI_GUARDED OFF); set(MI_GUARDED=ON)  -> MI_GUARDED is still OFF
```

Either defect alone disables the block; CMake warns on neither, which is why it survived. The code is upstream's, verbatim at our pin.

`-DMI_GUARDED=ON` now works — verified on the **resolved defines**, not the option passed in, since the entire point of this issue is that the flag silently did not reach the compiler:

```
-- Compiler defines : ...;MI_DEBUG=2;MI_GUARDED=1;...
```

## The auto-enable is deliberately NOT restored

Turning guarding on surfaced a real interaction bug (#131): at `MIMALLOC_GUARDED_SAMPLE_RATE=1`, mimalloc's own checker reports `double free detected` and our memory-events allocation count fails its assertion.

**At the default 1-in-4000 rate the suite passes 17/17.** That is precisely the argument for holding back: restoring the auto-enable would make that failure *rare and nondeterministic* in every debug build — harder to diagnose than the feature simply being off.

## CI

Adds `ctest-guarded`: builds with `-DMI_GUARDED=ON`, **asserts `MI_GUARDED=1` actually reached `mi_defines`**, and runs the suite.

The `SAMPLE_RATE=1` run is **not** included while it is red. Adding it red, or with `continue-on-error`, is how a gate becomes decoration — it goes in with #131's fix.

## Honest limits

I could not demonstrate a guard page actually faulting: with rate=1, precise=1 and in-range sizes, a read one byte past `mi_usable_size` did not trap across 64 allocations. That is probably my probe — guarded blocks carry alignment slack — but I am not claiming end-to-end proof I do not have. #131 covers the behaviour that *is* demonstrably wrong.