### PR TITLE
test: make T7 valid under MI_GUARDED (#131, partial)

### DIFF
--- a/test/test-memory-events.c
+++ b/test/test-memory-events.c
@@ -375,6 +375,27 @@ static void test_concurrency(void) {
     total_free_count  += t7_results[i].free_count;
     total_free_bytes  += t7_results[i].free_bytes;
   }
+  /* Guarded allocations break this test's scoping premise, not its subject.
+     T7 isolates its own traffic by filtering events to the single block-size class
+     `t7_usable` (see the comment above). With MI_GUARDED active, an allocation of
+     t7_block_size may be served from a guarded block that spans a guard page and
+     therefore reports a DIFFERENT size -- so the filter rejects the test's own events
+     and the tallies come out short. The hooks are fine; the size-based filter is what
+     stops working. Issue #131.
+     Checked at runtime rather than on the MI_GUARDED define, because guarding is
+     additionally gated by the sample rate: a build can have MI_GUARDED=1 and still
+     never guard anything. */
+  const bool guarding_active = (mi_option_get(mi_option_guarded_sample_rate) != 0);
+  if (guarding_active) {
+    /* Still assert the invariant that does survive: allocations and frees must PAIR.
+       That is what T7 exists to check under concurrency, and it holds regardless of
+       which size class each event lands in. */
+    assert(total_alloc_count == total_free_count);
+    assert(total_alloc_bytes == total_free_bytes);
+    fprintf(stderr, "T7: guarding active -- size-class equality skipped, pairing verified\n");
+    return;
+  }
+
   assert(total_alloc_count == (uint64_t)T7_THREADS * T7_PER_THREAD);
   assert(total_free_count == (uint64_t)T7_THREADS * T7_PER_THREAD);
   assert(total_alloc_bytes == (uint64_t)T7_THREADS * T7_PER_THREAD * t7_usable);


### PR DESCRIPTION
Partial fix for #131 — the count assertion. **The double-free report is not fixed and #131 stays open.**

## What was actually wrong with the count

T7 isolates its own traffic by filtering memory-events to a single block-size class (`t7_usable`), because with `MI_MALLOC_OVERRIDE` the hooks also see libc-internal traffic. With guarding active, an allocation of `t7_block_size` may be served from a **guarded block spanning a guard page**, which reports a different size — so the filter rejects the test's own events and the tallies come up short.

**The hooks are fine; the size-based scoping is what stops working.**

Under guarding it now asserts the invariant that survives and is what T7 exists to check: **allocations and frees must pair** under concurrency. That holds regardless of size class.

Detected at runtime via `mi_option_guarded_sample_rate` rather than on the `MI_GUARDED` define, because guarding is *additionally* gated by the sample rate — a build can have `MI_GUARDED=1` and never guard anything.

Full suite is now **17/17 at `MIMALLOC_GUARDED_SAMPLE_RATE=1`**.

## What is deliberately still broken

mimalloc still prints, on that same run:

```
error: double free detected of block ... with size 80
```

and **the suite passes anyway**. That is exactly why the `rate=1` CI job stays out: a job that goes green while the allocator reports a double free is worse than no job at all.

Narrowed, but not attributed:

- does **not** reproduce with the same 8×2000 workload alone under guarding
- does **not** reproduce with memory-events merely enabled
- so it needs more of the test's state — callbacks installed, or an earlier phase

Still open between our hooks, mimalloc's guarded path, and the test itself. I did not want to guess.