### PR TITLE
docs: record why the capture path needs no reentrancy guard (#128 D1/D2)

### DIFF
--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit ddb3f6c7 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit c9b24702 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -20845,6 +20845,31 @@ static bool stack_grow(void) {
   return true;
 }
 
+/* Why this path needs no reentrancy guard and no in-process symbolizer (issue #128,
+   D1/D2 -- audited against upstream's three attempts at allocation-site capture in
+   dev-trace, dev-slice-trace and dev-debug).
+
+   Upstream hit two hazards here and we avoid both BY CONSTRUCTION, which is worth
+   recording so neither gets "fixed" back in:
+
+   1. CAPTURE MUST NOT ALLOCATE. Upstream wrapped its capture in mi_recurse_enter/exit
+      plus _mi_preloading() because backtrace()/backtrace_symbols() allocate, so
+      capturing from inside the allocator re-enters through pthread/dl paths. Every
+      branch below writes into a caller-supplied buffer and allocates nothing:
+      RtlCaptureStackBackTrace on Windows, backtrace() with a caller buffer on Apple
+      (libSystem strips PAC bits and does not allocate), and a manual frame-pointer
+      walk everywhere else. There is therefore no allocation to recurse through.
+
+   2. WE NEVER SYMBOLIZE IN-PROCESS. Upstream had to move SymInitialize/SymCleanup out
+      of the per-trace path into process init because the dbghelp Sym* API is not
+      thread-safe and a per-call SymCleanup tears down state another thread may be
+      mid-lookup on. This fork calls no dbghelp API at all: profile-maps.c emits the
+      loaded-module ranges and pprof resolves symbols offline against the PDB. Upstream
+      also deliberately LEAKS backtrace_symbols() output, having concluded that calling
+      free() on it from inside the allocator is unsafe -- we never call it.
+
+   Keep it that way. Adding an in-process symbolizer, or any capture that allocates,
+   reintroduces both hazards on the platform this fork cares most about. */
 #ifdef _WIN32
 #include <windows.h>
 size_t _mi_prof_stack_capture(void** pcs, size_t capacity) {

--- a/src/profile-stack.c
+++ b/src/profile-stack.c
@@ -52,6 +52,31 @@ static bool stack_grow(void) {
   return true;
 }
 
+/* Why this path needs no reentrancy guard and no in-process symbolizer (issue #128,
+   D1/D2 -- audited against upstream's three attempts at allocation-site capture in
+   dev-trace, dev-slice-trace and dev-debug).
+
+   Upstream hit two hazards here and we avoid both BY CONSTRUCTION, which is worth
+   recording so neither gets "fixed" back in:
+
+   1. CAPTURE MUST NOT ALLOCATE. Upstream wrapped its capture in mi_recurse_enter/exit
+      plus _mi_preloading() because backtrace()/backtrace_symbols() allocate, so
+      capturing from inside the allocator re-enters through pthread/dl paths. Every
+      branch below writes into a caller-supplied buffer and allocates nothing:
+      RtlCaptureStackBackTrace on Windows, backtrace() with a caller buffer on Apple
+      (libSystem strips PAC bits and does not allocate), and a manual frame-pointer
+      walk everywhere else. There is therefore no allocation to recurse through.
+
+   2. WE NEVER SYMBOLIZE IN-PROCESS. Upstream had to move SymInitialize/SymCleanup out
+      of the per-trace path into process init because the dbghelp Sym* API is not
+      thread-safe and a per-call SymCleanup tears down state another thread may be
+      mid-lookup on. This fork calls no dbghelp API at all: profile-maps.c emits the
+      loaded-module ranges and pprof resolves symbols offline against the PDB. Upstream
+      also deliberately LEAKS backtrace_symbols() output, having concluded that calling
+      free() on it from inside the allocator is unsafe -- we never call it.
+
+   Keep it that way. Adding an in-process symbolizer, or any capture that allocates,
+   reintroduces both hazards on the platform this fork cares most about. */
 #ifdef _WIN32
 #include <windows.h>
 size_t _mi_prof_stack_capture(void** pcs, size_t capacity) {


### PR DESCRIPTION
Resolves **D0, D1 and D2** of #128. Comment only; no behaviour change.

## D0's premise was false

#128 blocked all of section D on *"make `rust/` readable to analysis — it is untracked and contains only `target/`."*

**`rust/` is fully tracked — 33 files**, including `Cargo.toml`, `mimalloc-pprof/` and `xtask/`. The sweep agents read an empty directory because they ran during the window when the working tree had been destroyed. So D1 and D2 were answerable all along.

## D1 and D2: both hazards avoided by construction

Upstream attempted allocation-site capture three times (`dev-trace`, `dev-slice-trace`, `dev-debug`) and hit two problems. We avoid both — and that is worth recording *in the file*, so nobody reading upstream's version "fixes" it back in:

**Capture must not allocate.** Upstream wrapped capture in `mi_recurse_enter/exit` plus `_mi_preloading()` because `backtrace()`/`backtrace_symbols()` allocate, so capturing from inside the allocator re-enters via pthread/dl. Every branch here writes into a **caller-supplied buffer** and allocates nothing: `RtlCaptureStackBackTrace` (Windows), `backtrace()` with a caller buffer (Apple), manual frame-pointer walk (everywhere else). There is no allocation to recurse through.

**We never symbolize in-process.** Upstream had to hoist `SymInitialize`/`SymCleanup` into process init because dbghelp's `Sym*` API is not thread-safe and a per-call `SymCleanup` tears down state another thread may be mid-lookup on. **We call no dbghelp API at all** — `profile-maps.c` emits module ranges and pprof resolves offline against the PDB. Upstream also *deliberately leaks* `backtrace_symbols()` output, having concluded freeing it inside the allocator is unsafe; we never call it.

Verified by grep: zero hits for `dbghelp`/`SymInitialize`/`SymCleanup`/`backtrace_symbols` anywhere in `src/`.

17/17 ctest green.