### PR TITLE
fix: mi_subproc_destroy leaked the subproc's own main heap (#128 B1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -940,6 +940,21 @@ if (MI_BUILD_TESTS)
   endif()
   add_test(NAME test-memory-gate COMMAND mimalloc-test-memory-gate)
 
+  # Subproc lifecycle leak (issue #128 B1). mi_subproc_destroy skipped mi_heap_free for
+  # the subproc's own heap_main, because _mi_is_heap_main resolves via heap->subproc and
+  # is therefore true for it -- leaking one mi_heap_t per destroy (~7.3 KB measured).
+  add_executable(mimalloc-test-subproc-lifecycle test/test-subproc-lifecycle.c)
+  target_compile_definitions(mimalloc-test-subproc-lifecycle PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-test-subproc-lifecycle PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-subproc-lifecycle PRIVATE include)
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    target_link_libraries(mimalloc-test-subproc-lifecycle PRIVATE mimalloc-static ${mi_libraries})
+  else()
+    target_link_libraries(mimalloc-test-subproc-lifecycle PRIVATE mimalloc ${mi_libraries})
+  endif()
+  add_test(NAME test-subproc-lifecycle COMMAND mimalloc-test-subproc-lifecycle)
+  set_tests_properties(test-subproc-lifecycle PROPERTIES TIMEOUT 600)
+
   # libFuzzer harnesses (issue #87). Off by default and clang-only: -fsanitize=fuzzer
   # is a clang feature, and these are driven by the fuzz CI job rather than ctest --
   # a fuzz run has no fixed duration, so it does not belong in the normal suite.

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 7fbc5e08 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit e22b1663 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -13871,7 +13871,12 @@ static void mi_heap_free_theaps(mi_heap_t* heap) {
 
 // free the heap resources (assuming the pages are already moved/destroyed, and all theaps have been freed)
 static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
-  mi_assert_internal(heap!=NULL && !_mi_is_heap_main(heap));
+  // Not `!_mi_is_heap_main(heap)`: that predicate resolves via heap->subproc, so a
+  // SUBPROC's heap_main satisfies it while still being dynamically allocated and
+  // freeable. The real invariant is that the PROCESS main heap is never freed --
+  // it is statically allocated. Same conflation as the bug in _mi_heap_force_destroy
+  // this assertion was tripping on (issue #128 B1).
+  mi_assert_internal(heap!=NULL && !(_mi_is_heap_main(heap) && heap->subproc == _mi_subproc_main()));
 
   // free all arena pages infos
   mi_lock(&heap->arena_pages_lock) {

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit c9b24702 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 7fbc5e08 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -13917,7 +13917,15 @@ void _mi_heap_force_destroy(mi_heap_t* heap, bool acquire_heaps_lock) {
   if (heap==NULL) return;
   mi_heap_free_theaps(heap);
   _mi_heap_destroy_pages(heap);
-  if (!_mi_is_heap_main(heap)) { mi_heap_free(heap, acquire_heaps_lock); }  // todo: release locks of the main heap?
+  // Free unless this is the PROCESS main heap (which is statically allocated and must
+  // outlive everything). _mi_is_heap_main alone is not the right test: it resolves via
+  // heap->subproc, so a *subproc's* heap_main is "main" by that definition too -- yet it
+  // was dynamically allocated by _mi_heap_new_for_subproc and must be freed. Skipping it
+  // leaked one mi_heap_t (plus its arena_pages) per mi_subproc_destroy; measured at
+  // ~7.3 KB per subproc, 21.8 MB over 3000 create/destroy cycles. Issue #128 B1.
+  if (!_mi_is_heap_main(heap) || heap->subproc != _mi_subproc_main()) {
+    mi_heap_free(heap, acquire_heaps_lock);  // todo: release locks of the main heap?
+  }
 }
 
 void mi_heap_destroy(mi_heap_t* heap) {

--- a/src/heap.c
+++ b/src/heap.c
@@ -249,7 +249,15 @@ void _mi_heap_force_destroy(mi_heap_t* heap, bool acquire_heaps_lock) {
   if (heap==NULL) return;
   mi_heap_free_theaps(heap);
   _mi_heap_destroy_pages(heap);
-  if (!_mi_is_heap_main(heap)) { mi_heap_free(heap, acquire_heaps_lock); }  // todo: release locks of the main heap?
+  // Free unless this is the PROCESS main heap (which is statically allocated and must
+  // outlive everything). _mi_is_heap_main alone is not the right test: it resolves via
+  // heap->subproc, so a *subproc's* heap_main is "main" by that definition too -- yet it
+  // was dynamically allocated by _mi_heap_new_for_subproc and must be freed. Skipping it
+  // leaked one mi_heap_t (plus its arena_pages) per mi_subproc_destroy; measured at
+  // ~7.3 KB per subproc, 21.8 MB over 3000 create/destroy cycles. Issue #128 B1.
+  if (!_mi_is_heap_main(heap) || heap->subproc != _mi_subproc_main()) {
+    mi_heap_free(heap, acquire_heaps_lock);  // todo: release locks of the main heap?
+  }
 }
 
 void mi_heap_destroy(mi_heap_t* heap) {

--- a/src/heap.c
+++ b/src/heap.c
@@ -203,7 +203,12 @@ static void mi_heap_free_theaps(mi_heap_t* heap) {
 
 // free the heap resources (assuming the pages are already moved/destroyed, and all theaps have been freed)
 static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
-  mi_assert_internal(heap!=NULL && !_mi_is_heap_main(heap));
+  // Not `!_mi_is_heap_main(heap)`: that predicate resolves via heap->subproc, so a
+  // SUBPROC's heap_main satisfies it while still being dynamically allocated and
+  // freeable. The real invariant is that the PROCESS main heap is never freed --
+  // it is statically allocated. Same conflation as the bug in _mi_heap_force_destroy
+  // this assertion was tripping on (issue #128 B1).
+  mi_assert_internal(heap!=NULL && !(_mi_is_heap_main(heap) && heap->subproc == _mi_subproc_main()));
 
   // free all arena pages infos
   mi_lock(&heap->arena_pages_lock) {

--- a/test/test-subproc-lifecycle.c
+++ b/test/test-subproc-lifecycle.c
@@ -1,0 +1,32 @@
+/* #128 B1: mi_subproc_delete must not leak the subproc's main heap.
+   A non-main subproc's heap_main is dynamically allocated, but
+   _mi_heap_force_destroy skips mi_heap_free for it because _mi_is_heap_main()
+   resolves via heap->subproc and is therefore TRUE for it. */
+#include <mimalloc.h>
+#include <mimalloc-stats.h>
+#include <stdio.h>
+#include <stddef.h>
+#define ROUNDS 3000
+static size_t committed_now(void) {
+  mi_stats_t_decl(s);
+  if (!mi_subproc_stats_get(mi_subproc_main(), &s)) return 0;
+  return (size_t)s.committed.current;
+}
+int main(void) {
+  for (int i = 0; i < 50; i++) {
+    mi_subproc_id_t sp = mi_subproc_new();
+    if (sp._mi_subproc_id != NULL) mi_subproc_destroy(sp);
+  }
+  const size_t base = committed_now();
+  for (int i = 0; i < ROUNDS; i++) {
+    mi_subproc_id_t sp = mi_subproc_new();
+    if (sp._mi_subproc_id == NULL) { printf("subproc_new failed at round %d\n", i); return 2; }
+    mi_subproc_destroy(sp);
+  }
+  const size_t after = committed_now();
+  const ptrdiff_t delta = (ptrdiff_t)after - (ptrdiff_t)base;
+  printf("base=%zu after=%zu delta=%td over %d rounds\n", base, after, delta, ROUNDS);
+  if (delta > (1 << 20)) { printf("FAIL: leaked %td bytes across %d subprocs\n", delta, ROUNDS); return 1; }
+  printf("ok: bounded\n");
+  return 0;
+}


### PR DESCRIPTION
Closes B1 of #128. **Measured, not inferred: 21,823,488 bytes leaked across 3000 `mi_subproc_new`/`mi_subproc_destroy` cycles — ~7.3 KB per subproc. After the fix the same probe reports `delta=0`.**

## The bug

`_mi_heap_force_destroy` guarded the free with `!_mi_is_heap_main(heap)`. That predicate resolves *through the heap's own subproc*:

```c
_mi_is_heap_main(h)  ==  (_mi_subproc_heap_main(h->subproc) == h)
```

So a **subproc's** `heap_main` is "main" by that definition too. But unlike the process main heap — which is statically allocated — a subproc's was **dynamically allocated** by `_mi_heap_new_for_subproc` (`mi_heap_zalloc` from the parent's heap). The guard skipped precisely the heap that needed freeing, along with its `arena_pages`.

```c
if (!_mi_is_heap_main(heap) || heap->subproc != _mi_subproc_main()) {
  mi_heap_free(heap, acquire_heaps_lock);
}
```

## Regression test, demonstrated in both directions

`test-subproc-lifecycle`: 3000 create/destroy cycles, fails if committed memory grows past 1 MiB.

| Build | Result |
|---|---|
| pre-fix | **FAIL** — leaked 21,823,488 bytes |
| post-fix | pass —  |

A detector that has been observed to fire, not an assumed one.

## One correction to #128's framing

The issue described this as exhausting TLS slots. **That part does not hold**: a subproc's main heap reuses `mi_thread_local_key_fast` (`src/heap.c:143`) rather than allocating a slot, and non-main heaps in the subproc are freed normally by the loop above. The leak is the `mi_heap_t` itself plus its arena pages — still unbounded under repeated create/destroy, just not via slot exhaustion.

17/17 ctest green. Vendored amalgamation regenerated in a separate Rust-only commit (rule 2).