### PR TITLE
fix: restore MI_GUARDED's debug default and add the rate=1 CI run (#116, #131)

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -85,10 +85,16 @@ jobs:
           fi
       - run: cmake --build build-guarded --parallel
       - run: ctest --test-dir build-guarded --output-on-failure --timeout 900
-      # NOT added yet: a run at MIMALLOC_GUARDED_SAMPLE_RATE=1. It is currently RED --
-      # mimalloc reports "double free detected" and test-memory-events' allocation count
-      # goes wrong. Adding it red, or with continue-on-error, is how a gate becomes
-      # decoration; it goes in with the fix. Tracked on #116.
+      # Guard every in-range allocation instead of 1-in-4000, so the guarded path is
+      # actually exercised rather than sampled into. Withheld earlier over two problems,
+      # both now resolved: the count assertion was T7's size-class scoping breaking under
+      # guarding (fixed in #133), and the "double free detected" line turned out to be
+      # EXPECTED output -- test-memory-events deliberately double-frees to verify
+      # mimalloc's detector no-ops before our hook runs (#131).
+      - name: Suite with guarding forced on every allocation
+        env:
+          MIMALLOC_GUARDED_SAMPLE_RATE: "1"
+        run: ctest --test-dir build-guarded --output-on-failure --timeout 900
 
   ctest-pprof-off:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,22 +374,12 @@ endif()
 
 # NOTE: `!` is NOT negation in CMake -- `!MI_GUARDED` parses as a variable name, and an
 # undefined variable is false, so the original `if(MI_DEBUG AND !MI_GUARDED)` was ALWAYS
-# false. And `set(MI_GUARDED=ON)` creates a variable literally named `MI_GUARDED=ON`
-# rather than setting anything. Either defect alone disabled this block; together it
-# could never fire, so MI_GUARDED was never on despite being documented as default-on in
-# debug builds (see issue #116). Both verified experimentally.
-#
-# The auto-enable is deliberately NOT restored yet. Turning it on surfaced a real
-# interaction bug: at MIMALLOC_GUARDED_SAMPLE_RATE=1 the suite reports
-# "double free detected" from mimalloc's own checker and our memory-events allocation
-# count goes wrong (test-memory-events.c:378). At the default 1-in-4000 rate the suite
-# passes -- which would make that failure RARE AND NONDETERMINISTIC in every debug build,
-# which is worse than it being off. Restore the auto-enable once that is understood.
-#
-# `-DMI_GUARDED=ON` now works as intended, which is what the constructs below were
-# supposed to provide all along.
+# false. And `set(MI_GUARDED=ON)` created a variable literally named `MI_GUARDED=ON`.
+# Either defect alone disabled this block, so MI_GUARDED was never on despite being
+# documented as default-on in debug builds (issue #116).
 if(MI_DEBUG AND NOT MI_GUARDED)
-  message(STATUS "MI_GUARDED auto-enable is disabled pending the guarded/memory-events interaction bug; pass -DMI_GUARDED=ON explicitly to opt in")
+  message(STATUS "Enable MI_GUARDED (since MI_DEBUG=ON)")
+  set(MI_GUARDED ON)
 endif()
 if(MI_GUARDED)
   message(STATUS "Compile guard pages behind certain object allocations (MI_GUARDED=ON)")


### PR DESCRIPTION
Closes #131. Completes #116.

**Both were held back on a misdiagnosis of mine.**

## The "double free" was expected output

I reported `mimalloc: error: double free detected` as an unexplained defect, withheld the rate=1 CI job over it, and held back MI_GUARDED's documented debug default.

Bisecting the test phases (a bitmask harness over the ten `test_*` calls) isolated it to `test_event_correctness` — which **deliberately double-frees**:

```c
#if defined(MI_DEBUG) && (MI_DEBUG > 0)
  void* a = mi_malloc(64);
  mi_free(a);
  evt_ctx_reset(&ctx);
  mi_free(a);  /* double free: mi_check_is_double_free must detect and no-op before the
                  _mi_memevt_on_free hook is ever reached. ... EAGAIN is a
                  silent-by-default diagnostic here. */
  assert(ctx.counts[MI_MEMORY_FREE] == 0);
#endif
```

The message is the **point of the test**. And it is unrelated to guarding — it reproduces in a Debug build with MI_GUARDED absent entirely, which is what finally settled it.

I nearly drew a second wrong conclusion en route: an earlier "it happens without guarding too" check used a binary with MI_GUARDED **compiled in**, so dropping the env var still left guarding active at the default 1-in-4000 rate. Only a build configured without it was decisive.

## The other half was real, and is fixed

T7's size-class scoping genuinely broke under guarding — fixed in #133.

## So the hold-back reason is gone

| Configuration | Result |
|---|---|
| Debug, guarding auto-enabled, default rate | **18/18** |
| same build, `MIMALLOC_GUARDED_SAMPLE_RATE=1` | **18/18** |

MI_GUARDED once again defaults on in debug builds as documented, and CI runs the suite with guarding forced on **every** in-range allocation rather than sampled into.
