### PR TITLE
fix: allocate the TLS slot array from the main heap (#128 B3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1064,6 +1064,20 @@ if (MI_BUILD_TESTS)
   add_test(NAME test-memory-events-env-enabled COMMAND mimalloc-test-memory-events --env-enabled-check)
   set_tests_properties(test-memory-events-env-enabled PROPERTIES ENVIRONMENT "MIMALLOC_MEMORY_EVENTS=1")
 
+  # thread-local slot array provenance (issue #128 B3): the array must not be
+  # allocated from whatever heap the application happens to have set as its default,
+  # or mi_heap_destroy on that heap frees it while it is still live.
+  add_executable(mimalloc-test-tls-slots-heap test/test-tls-slots-heap.c)
+  target_compile_definitions(mimalloc-test-tls-slots-heap PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-test-tls-slots-heap PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-tls-slots-heap PRIVATE include)
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    target_link_libraries(mimalloc-test-tls-slots-heap PRIVATE mimalloc-static ${mi_libraries})
+  else()
+    target_link_libraries(mimalloc-test-tls-slots-heap PRIVATE mimalloc ${mi_libraries})
+  endif()
+  add_test(NAME test-tls-slots-heap COMMAND mimalloc-test-tls-slots-heap)
+
   # dynamic override test
   if(MI_BUILD_SHARED AND NOT (MI_TRACK_ASAN OR MI_DEBUG_TSAN OR MI_DEBUG_UBSAN)) # AND NOT (APPLE AND MI_USE_CXX))
     add_executable(mimalloc-test-stress-dynamic test/test-stress.c)

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit e22b1663 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 64d299b9 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -23031,7 +23031,15 @@ static mi_thread_locals_t* mi_thread_locals_expand(size_t least_idx) {
     count = least_idx + 1;
   }
   if (count > MI_TLS_IDX_MAX) { return NULL; }  // too large
-  mi_thread_locals_t* tls = (mi_thread_locals_t*)mi_rezalloc(tls_old, sizeof(mi_thread_locals_t) + count*sizeof(mi_tls_slot_t));
+  // Allocate from the main heap explicitly, never from the calling thread's default.
+  // Plain `mi_rezalloc` uses whatever heap the application last passed to
+  // `mi_theap_set_default`, so a later `mi_heap_destroy` on that heap frees this array
+  // while `mi_thread_locals` still points at it -- a use-after-free that is silent
+  // rather than fatal, since the clobbered `count` is huge enough to pass every bounds
+  // check and lookups then just return NULL. See test/test-tls-slots-heap.c (#128 B3).
+  // The main heap cannot be destroyed through any public API. Freeing stays plain
+  // `mi_free` in `_mi_thread_locals_thread_done`, which finds the owning page itself.
+  mi_thread_locals_t* tls = (mi_thread_locals_t*)mi_heap_rezalloc(mi_heap_main(), tls_old, sizeof(mi_thread_locals_t) + count*sizeof(mi_tls_slot_t));
   if mi_unlikely(tls==NULL) return NULL;
   tls->count = count;
   mi_thread_locals_set(tls);

--- a/src/threadlocal.c
+++ b/src/threadlocal.c
@@ -118,7 +118,15 @@ static mi_thread_locals_t* mi_thread_locals_expand(size_t least_idx) {
     count = least_idx + 1;
   }
   if (count > MI_TLS_IDX_MAX) { return NULL; }  // too large
-  mi_thread_locals_t* tls = (mi_thread_locals_t*)mi_rezalloc(tls_old, sizeof(mi_thread_locals_t) + count*sizeof(mi_tls_slot_t));
+  // Allocate from the main heap explicitly, never from the calling thread's default.
+  // Plain `mi_rezalloc` uses whatever heap the application last passed to
+  // `mi_theap_set_default`, so a later `mi_heap_destroy` on that heap frees this array
+  // while `mi_thread_locals` still points at it -- a use-after-free that is silent
+  // rather than fatal, since the clobbered `count` is huge enough to pass every bounds
+  // check and lookups then just return NULL. See test/test-tls-slots-heap.c (#128 B3).
+  // The main heap cannot be destroyed through any public API. Freeing stays plain
+  // `mi_free` in `_mi_thread_locals_thread_done`, which finds the owning page itself.
+  mi_thread_locals_t* tls = (mi_thread_locals_t*)mi_heap_rezalloc(mi_heap_main(), tls_old, sizeof(mi_thread_locals_t) + count*sizeof(mi_tls_slot_t));
   if mi_unlikely(tls==NULL) return NULL;
   tls->count = count;
   mi_thread_locals_set(tls);

--- a/test/test-tls-slots-heap.c
+++ b/test/test-tls-slots-heap.c
@@ -1,0 +1,103 @@
+/* Regression test: the dynamic thread-local slot array must not live in a
+   user-destroyable heap (issue #128 B3, upstream `a5650085`).
+
+   `mi_thread_locals_expand` (src/threadlocal.c) grows the per-thread array that maps
+   a heap's TLS key to that thread's theap. It used plain `mi_rezalloc`, which allocates
+   from *the calling thread's current default theap*. That is whatever the application
+   last passed to `mi_theap_set_default` -- not necessarily the main heap.
+
+   So an application that sets a custom heap as its default and later calls
+   `mi_heap_destroy` on it frees the slot array out from under the allocator, while the
+   thread-local pointer still refers to it. Confirmed against our pin: after the destroy,
+   the array's `count` field read back as 0xCDCDCDCDCDCDCDCD -- the pattern this test's
+   own reuse loop writes.
+
+   The failure is silent, which is why this test does not simply look for a crash. The
+   corrupted `count` is enormous, so every bounds check passes; the version words no
+   longer match, so every lookup returns NULL, and each heap quietly builds a *second*
+   theap. The first one -- and every block already allocated through it -- is orphaned.
+   Nothing reports an error and the process keeps running on a split heap.
+
+   Hence the assertion below is on theap identity, not on liveness: a heap's theap for a
+   given thread must be stable across the destruction of an unrelated heap.
+
+   Upstream's fix is to allocate the array from the main heap, which no user API can
+   destroy. */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <mimalloc.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Enough heaps to force the slot array past its initial 16 entries and through at
+   least two reallocations, so the array that survives to the end is one that was
+   allocated while the custom heap was the default. */
+#define NHEAPS 40
+
+static mi_heap_t*  heaps[NHEAPS];
+static mi_theap_t* theaps_before[NHEAPS];
+
+int main(void) {
+  mi_heap_t* owner = mi_heap_new();
+  assert(owner != NULL);
+
+  /* Everything allocated from here until the reset below comes out of `owner` --
+     including, before the fix, the slot array itself. */
+  mi_theap_t* const prev = mi_theap_set_default(mi_heap_theap(owner));
+
+  for (int i = 0; i < NHEAPS; i++) {
+    heaps[i] = mi_heap_new();
+    assert(heaps[i] != NULL);
+    void* p = mi_heap_malloc(heaps[i], 32);   /* binds a theap into a slot */
+    assert(p != NULL);
+    theaps_before[i] = mi_heap_theap(heaps[i]);
+    assert(theaps_before[i] != NULL);
+  }
+
+  mi_theap_set_default(prev);
+  mi_heap_destroy(owner);   /* frees everything `owner` owns, slot array included */
+
+  /* Hand the released memory back out and stamp it. Without the fix this is what
+     lands on top of the slot array; with the fix it is inert. Sizes are varied
+     because the array's size class depends on how far it grew. */
+  for (int r = 0; r < 200; r++) {
+    for (size_t sz = 16; sz <= 4096; sz *= 2) {
+      void* q = mi_malloc(sz);
+      assert(q != NULL);
+      memset(q, 0xCD, sz);
+    }
+  }
+
+  /* The destroyed heap was unrelated to these, so their theaps must be untouched. */
+  int changed = 0;
+  for (int i = 0; i < NHEAPS; i++) {
+    mi_theap_t* const now = mi_heap_theap(heaps[i]);
+    if (now != theaps_before[i]) {
+      if (changed < 5) {
+        fprintf(stderr,
+                "heap %d: theap changed across an unrelated mi_heap_destroy "
+                "(%p -> %p) -- the thread-local slot array was freed with the "
+                "destroyed heap\n",
+                i, (void*)theaps_before[i], (void*)now);
+      }
+      changed++;
+    }
+  }
+  if (changed != 0) {
+    fprintf(stderr, "FAIL: %d of %d heaps lost their theap binding\n", changed, NHEAPS);
+    return 1;
+  }
+
+  /* And the heaps still work. */
+  for (int i = 0; i < NHEAPS; i++) {
+    void* p = mi_heap_malloc(heaps[i], 32);
+    assert(p != NULL);
+    memset(p, 1, 32);
+  }
+
+  printf("ok: %d heaps kept their theap across an unrelated mi_heap_destroy\n", NHEAPS);
+  return 0;
+}


### PR DESCRIPTION
Closes the **B3** checkbox of #128.

#128 recorded B3 as *"a possible lifetime hazard if a thread sets a non-main default heap and then destroys it; that inference is **unverified** and upstream never framed it that way. Verify before porting."* This verifies it. It is real.

## What happens

`mi_thread_locals_expand` grew the per-thread key→theap array with plain `mi_rezalloc`, which allocates from **the calling thread's current default theap** — whatever the application last passed to `mi_theap_set_default`. Set a custom heap as default, let the array grow, then `mi_heap_destroy` that heap, and the array is freed while `mi_thread_locals` still points at it.

Instrumenting `mi_thread_locals_expand` on our pin showed the array reallocating twice while a custom heap was default, and after the destroy its `count` field read back as `0xCDCDCDCDCDCDCDCD` — the byte pattern the reuse loop writes. Use-after-free, confirmed by observation rather than by reading upstream's diff.

## Why it is worse than a crash

It never crashes. The clobbered `count` is enormous, so every bounds check passes; the version words no longer match, so every lookup returns `NULL`; and each heap silently constructs a **second** theap, orphaning the first along with every block already allocated through it. Nothing is reported and the process keeps running on a split heap.

That is why the test asserts on **theap identity** rather than on liveness or on a crash — a heap's theap must survive the destruction of an unrelated heap. A liveness check passes right through this bug.

## Correcting the other half of B3

B3 also carried an "obvious reading" that this skews profiler output. **It does not** — `mi_subproc_stats_get` sums across heaps, so only a per-heap breakdown would shift. The lifetime hazard was the real half; the reporting concern was not.

## Evidence

| | Result |
|---|---|
| `test-tls-slots-heap` before the fix | **FAIL — 40 of 40 heaps lost their theap binding** |
| after the fix | pass |
| full suite, Debug + `MI_DEBUG_FULL`, MinGW | 19/19 |

## Commits

Two, per repo rule 2 — C-core and `rust/` may not share a commit. The second regenerates the vendored amalgamation, which the #88 drift gate requires and which three earlier PRs forgot.

Upstream reference: `a5650085`.
