### PR TITLE
fix(ci): the fuzz ASan control was satisfied by libFuzzer's own boilerplate

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -70,11 +70,24 @@ jobs:
             echo "::error::the fuzzer did NOT find the planted overflow -- the harness is not exercising the allocator."
             exit 1
           fi
-          if ! echo "$out" | grep -qiE "AddressSanitizer|heap-buffer-overflow"; then
-            echo "::error::the harness failed (rc=$rc) but produced no AddressSanitizer report; that is a different bug."
+          # ANCHORED, and deliberately not case-insensitive. The previous form was
+          #     grep -qiE "AddressSanitizer|heap-buffer-overflow"
+          # which matched libFuzzer's own boilerplate:
+          #     "Combine libFuzzer with AddressSanitizer or similar for better crash reports."
+          # -- i.e. the string that satisfied "ASan is working" was libFuzzer telling us
+          # ASan was NOT the detector. Every run since this control landed passed on a
+          # bare "SUMMARY: libFuzzer: deadly signal" (mimalloc's mi_check_padding calling
+          # abort()), with zero AddressSanitizer reports. Second time this exact control
+          # was fooled by that NOTE, so match only a real report header.
+          if ! echo "$out" | grep -qE "^(==[0-9]+==)?(ERROR|SUMMARY): AddressSanitizer:"; then
+            echo "::error::the harness failed (rc=$rc) but produced no AddressSanitizer report -- ASan is not the oracle here, so this control proves nothing about the sanitizer."
             exit 1
           fi
-          echo "positive control fired: the fuzzer found the planted overflow (rc=$rc)"
+          if ! echo "$out" | grep -qE "AddressSanitizer: heap-use-after-free"; then
+            echo "::error::got an AddressSanitizer report, but not the planted use-after-free; that is a different bug."
+            exit 1
+          fi
+          echo "positive control fired: ASan reported the planted use-after-free (rc=$rc)"
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/test/fuzz/fuzz_alloc_ops.c
+++ b/test/fuzz/fuzz_alloc_ops.c
@@ -81,16 +81,39 @@ static size_t rd_align(reader_t* r) {
 }
 
 #if MI_FUZZ_PLANT_BUG
-/* Positive control (CI only, -DMI_FUZZ_PLANT_BUG=ON). A deliberate one-byte overflow
-   on an easily-reachable input, so the fuzz job can demonstrate that the harness
-   actually finds bugs. A fuzzer that has never found anything is indistinguishable
-   from one that is not running the code under test -- and this repository has now
-   shipped six checks that were silently verifying nothing.
+/* Positive control (CI only, -DMI_FUZZ_PLANT_BUG=ON). A deliberate defect on an
+   easily-reachable input, so the fuzz job can demonstrate that the harness actually
+   finds bugs. A fuzzer that has never found anything is indistinguishable from one
+   that is not running the code under test -- and this repository has now shipped
+   several checks that were silently verifying nothing.
    Kept in the harness rather than in src/, so production code is never built with a
-   planted defect and the control cannot escape into a release. */
+   planted defect and the control cannot escape into a release.
+
+   This is a use-after-free, NOT the one-past-the-end overflow it used to be. The
+   overflow could never have proven what the control claims to prove, because
+   AddressSanitizer cannot see it:
+
+     mi_track_malloc_size(p,reqsize,size,zero) -> ASAN_UNPOISON_MEMORY_REGION(p,size)
+
+   unpoisons the whole *block*, not the requested bytes, so in a debug build (where
+   the block carries MI_PADDING) writing at p[requested] lands in memory ASan has
+   been told is valid. Every CI run bore this out: the crash was mimalloc's own
+   mi_check_padding calling abort() at free time, reported by libFuzzer as
+   "deadly signal", with no AddressSanitizer report anywhere.
+
+   A use-after-free is the right shape, because freeing is the one place mimalloc
+   hands ASan a poison call:
+
+     mi_track_free_size(p,size) -> ASAN_POISON_MEMORY_REGION(p,size)
+
+   so touching a freed block must produce a genuine "ERROR: AddressSanitizer:
+   heap-use-after-free". That makes ASan -- the oracle fuzz.yml is built around --
+   the thing being demonstrated, rather than mimalloc's padding check standing in
+   for it. */
 static void plant_bug(void* p, size_t requested) {
   if (p != NULL && requested == 64) {
-    ((unsigned char*)p)[requested] = 0xAA;   /* one past the end -- ASan must catch */
+    mi_free(p);
+    ((volatile unsigned char*)p)[0] = 0xAA;   /* freed block: ASan must report UAF */
   }
 }
 #endif


### PR DESCRIPTION
## A control that passed on the text saying it shouldn't

`fuzz.yml`'s positive control ends every run with:

```
positive control fired: the fuzzer found the planted overflow (rc=77)
```

The crash it fires on is not an AddressSanitizer report:

```
==2982== ERROR: libFuzzer: deadly signal
    #6  abort
    #7  mi_error_default      src/options.c:586
    #9  mi_check_padding      src/free.c:648
SUMMARY: libFuzzer: deadly signal
```

I checked six consecutive runs. `ERROR: AddressSanitizer` appears **zero** times in any of them.

The guard meant to catch exactly this was:

```bash
grep -qiE "AddressSanitizer|heap-buffer-overflow"
```

which matches libFuzzer's own boilerplate on every signal crash:

> `NOTE: libFuzzer has rudimentary signal handlers.`
> `      Combine libFuzzer with AddressSanitizer or similar for better crash reports.`

The string satisfying "ASan is working" was **libFuzzer stating that ASan is not the detector**. Unanchored, case-insensitive, so prose counted.

This is the **second** time this control was fooled by that NOTE. The earlier fix added `AddressSanitizer` to the pattern without noticing the word appears in the text it was meant to reject — a fix that reproduced the bug it was fixing.

## The plant was also testing the wrong thing

Anchoring alone would just turn the job red, because ASan genuinely cannot see the planted overflow:

```c
#define mi_track_malloc_size(p,reqsize,size,zero)  ASAN_UNPOISON_MEMORY_REGION(p,size)
```

It unpoisons the whole **block**, not the requested bytes. In a debug build the block carries `MI_PADDING`, so `p[requested]` lands in memory ASan has been told is valid. ASan was correct to stay silent; the assertion was wrong. What actually caught it was `mi_check_padding` — which fires only at free, only for writes landing in padding, and is compiled out of release builds.

Freeing is the one place mimalloc hands ASan a poison call:

```c
#define mi_track_free_size(p,size)  ASAN_POISON_MEMORY_REGION(p,size)
```

so the plant is now a **use-after-free**, which must produce a real `heap-use-after-free`. That makes ASan — the oracle `fuzz.yml` is built around — the thing being demonstrated, instead of mimalloc's padding check standing in for it.

## Changes

1. Anchor the match to a report header, drop `-i`: `^(==[0-9]+==)?(ERROR|SUMMARY): AddressSanitizer:`, plus a second assertion that it is the *planted* defect rather than some other ASan finding.
2. Replace the planted overflow with a use-after-free.

## What this does not claim

The fuzzer was never a no-op — `rc=77` shows it reaches and breaks the allocator, and coverage grows normally (354 new units in 60k runs). What was unverified is narrower and load-bearing: that **ASan is a live oracle**. `fuzz.yml`'s header asserts it; nothing tested it.

The merge decision is the CI result on this PR. If the control cannot fire for the right reason, it should stay red rather than be relaxed.
