### PR TITLE
fix(ci): accept use-after-poison as the ASan verdict (fixes red main)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -83,7 +83,13 @@ jobs:
             echo "::error::the harness failed (rc=$rc) but produced no AddressSanitizer report -- ASan is not the oracle here, so this control proves nothing about the sanitizer."
             exit 1
           fi
-          if ! echo "$out" | grep -qE "AddressSanitizer: heap-use-after-free"; then
+          # "use-after-poison", not "heap-use-after-free": mimalloc's blocks come out of
+          # its own arena and MI_OVERRIDE=OFF, so ASan never saw an allocation it owns --
+          # it knows the block only through mimalloc's manual ASAN_POISON_MEMORY_REGION
+          # in mi_track_free_size. use-after-poison IS the correct verdict here. Both
+          # spellings accepted so this does not turn red if the override setting or the
+          # tracking path changes; either one means ASan saw the freed block.
+          if ! echo "$out" | grep -qE "AddressSanitizer: (heap-)?use-after-(free|poison)"; then
             echo "::error::got an AddressSanitizer report, but not the planted use-after-free; that is a different bug."
             exit 1
           fi


### PR DESCRIPTION
**Fixes `fuzz` on `main`, which is currently red.**

#138 was merged at its red commit while the follow-up correction was still on the branch, so `main` landed the anchored ASan check together with an assertion that is too specific. This is that correction, unchanged.

## What the red run showed

The anchored control fired, and ASan reported:

```
SUMMARY: AddressSanitizer: use-after-poison ... in plant_bug
```

not `heap-use-after-free`. **That is the correct verdict.** With `MI_OVERRIDE=OFF`, mimalloc's blocks come out of its own arena, so ASan never saw an allocation it owns — it knows the block only through the manual `ASAN_POISON_MEMORY_REGION` in `mi_track_free_size`. `use-after-poison` is exactly what ASan should say about manually poisoned memory.

So the finding stands and is now positively confirmed: **ASan is a live oracle on mimalloc's heap.** That was the open question, and the answer is yes.

## Change

Accept either spelling:

```bash
grep -qE "AddressSanitizer: (heap-)?use-after-(free|poison)"
```

The load-bearing half is untouched — the anchored `(ERROR|SUMMARY): AddressSanitizer:` header, which is what the old control never had.

## Note

The red run was the control working as designed: it caught an over-specific expectation on its first outing instead of passing regardless. That is the behaviour the whole exercise was after, so it is worth not papering over.
