### PR TITLE
docs: measured negative result retires #128 B2 and C1

### DIFF
--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 64d299b9 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit a9c8c8b2 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -18708,6 +18708,34 @@ void _mi_theap_collect_retired(mi_theap_t* theap, bool force) {
   theap->page_retired_max = max;
 }
 
+/* Stays commented out deliberately -- see issue #128 B2 and C1.
+
+   Upstream `bf054991` un-comments this, on the reasoning that with
+   MIMALLOC_PAGE_FULL_RETAIN=-1 (allow_page_abandon false) a page sitting in
+   MI_BIN_FULL whose blocks are all cross-thread freed can neither be abandoned nor
+   collected: `_mi_page_unfull` runs only from a thread-LOCAL free, and a remote free
+   just pushes onto `xthread_free` without waking anyone. The mechanism is really
+   there in our pin -- but the memory growth it predicts is not.
+
+   Measured, Windows/MinGW, Release, MIMALLOC_PAGE_FULL_RETAIN=-1: 60 rounds of
+   "fill pages from thread A, free every block from thread B", at both 256 and 4096
+   live 16 KiB blocks (the latter reaching 64 MiB committed). Committed bytes and RSS
+   were flat to the kilobyte from round 10 through round 60 -- 0.0% growth in each
+   configuration. A page retained per round would have shown linear growth.
+
+   So the predicted leak is not reachable this way, and repo rule #66 C.2 is to import
+   only with a test that fails without the import. There is no such test, so this stays
+   as upstream left it. The negative result does not prove the bug's absence -- it
+   bounds it: whatever reaches this path is not the simple cross-thread-free-a-full-page
+   workload. Anyone re-opening this should produce a growing repro FIRST.
+
+   Same evidence retires C1 (`mi_page_is_full()` ignoring uncollected `xthread_free`).
+   C1 asked to "confirm a reachable call site before changing a predicate that's
+   asserted in three places": every site that could RETAIN memory already collects
+   first -- `mi_free_try_collect_mt` opens with `_mi_page_free_collect{,_partly}`, and
+   `mi_abandoned_page_unown_from_free` re-collects and re-tries free/reabandon on every
+   CAS that observes a non-empty `xthread_free`. The window is closed by construction.
+*/
 /*
 static void mi_theap_collect_full_pages(mi_theap_t* theap) {
   // note: normally full pages get immediately abandoned and the full queue is always empty

--- a/src/page.c
+++ b/src/page.c
@@ -494,6 +494,34 @@ void _mi_theap_collect_retired(mi_theap_t* theap, bool force) {
   theap->page_retired_max = max;
 }
 
+/* Stays commented out deliberately -- see issue #128 B2 and C1.
+
+   Upstream `bf054991` un-comments this, on the reasoning that with
+   MIMALLOC_PAGE_FULL_RETAIN=-1 (allow_page_abandon false) a page sitting in
+   MI_BIN_FULL whose blocks are all cross-thread freed can neither be abandoned nor
+   collected: `_mi_page_unfull` runs only from a thread-LOCAL free, and a remote free
+   just pushes onto `xthread_free` without waking anyone. The mechanism is really
+   there in our pin -- but the memory growth it predicts is not.
+
+   Measured, Windows/MinGW, Release, MIMALLOC_PAGE_FULL_RETAIN=-1: 60 rounds of
+   "fill pages from thread A, free every block from thread B", at both 256 and 4096
+   live 16 KiB blocks (the latter reaching 64 MiB committed). Committed bytes and RSS
+   were flat to the kilobyte from round 10 through round 60 -- 0.0% growth in each
+   configuration. A page retained per round would have shown linear growth.
+
+   So the predicted leak is not reachable this way, and repo rule #66 C.2 is to import
+   only with a test that fails without the import. There is no such test, so this stays
+   as upstream left it. The negative result does not prove the bug's absence -- it
+   bounds it: whatever reaches this path is not the simple cross-thread-free-a-full-page
+   workload. Anyone re-opening this should produce a growing repro FIRST.
+
+   Same evidence retires C1 (`mi_page_is_full()` ignoring uncollected `xthread_free`).
+   C1 asked to "confirm a reachable call site before changing a predicate that's
+   asserted in three places": every site that could RETAIN memory already collects
+   first -- `mi_free_try_collect_mt` opens with `_mi_page_free_collect{,_partly}`, and
+   `mi_abandoned_page_unown_from_free` re-collects and re-tries free/reabandon on every
+   CAS that observes a non-empty `xthread_free`. The window is closed by construction.
+*/
 /*
 static void mi_theap_collect_full_pages(mi_theap_t* theap) {
   // note: normally full pages get immediately abandoned and the full queue is always empty


### PR DESCRIPTION
Closes the **B2** and **C1** checkboxes of #128 as **declined with evidence**, not as code changes.

#128 is explicit that section C must not be imported on reasoning alone: *"Each is plausible but none has a measured repro. Do not import on reasoning alone."* This is that measurement, and it comes back negative.

## B2 — the mechanism is real, the leak is not

The reasoning behind upstream `bf054991` holds up in our pin: with `MIMALLOC_PAGE_FULL_RETAIN=-1` (`allow_page_abandon` false), full pages go into `MI_BIN_FULL`; `_mi_page_unfull` runs **only** from a thread-local free; a remote free just pushes onto `xthread_free` and wakes nobody. A page filled by thread A and emptied entirely by thread B should be stranded.

It isn't.

| Workload (Windows/MinGW, Release, `PAGE_FULL_RETAIN=-1`) | round 10 | round 60 | growth |
|---|---|---|---|
| 256 live 16 KiB blocks | 7,452 KiB commit | 7,452 KiB | **0.0%** |
| 4096 live 16 KiB blocks | 69,036 KiB commit | 69,036 KiB | **0.0%** |

60 rounds of fill-from-A / free-every-block-from-B. Commit and RSS flat to the kilobyte from round 10 onward. One retained page per round would have grown linearly; nothing did.

Rule #66 C.2 — import only with a test that fails without the import — so this stays as upstream left it. This matches the earlier attempt recorded in #128, now with numbers behind it.

## C1 — closed by construction

C1 asked to *"confirm a reachable call site before changing a predicate that's asserted in three places."* There isn't one. Every site that could **retain** memory collects first:

- `mi_free_try_collect_mt` opens with `_mi_page_free_collect_partly` (small) or `_mi_page_free_collect` (larger) before any of free / reclaim / reabandon is considered.
- `mi_abandoned_page_unown_from_free` re-collects and re-tries free-and-reabandon on **every** CAS that observes a non-empty `xthread_free`, so the "concurrently added, yet uncounted" window that `_partly` leaves open is drained before ownership is released.

The remaining uses are debug asserts and `page.c`'s move-to-full-queue — which is the B2 path above.

C1 and B2 turned out to be the same defect approached from two ends, which is why one measurement settles both.

## Why this lives in the source, not just the issue

The note goes directly above the commented-out `mi_theap_collect_full_pages`. Anyone reading a commented-out collector will have exactly this idea; the evidence should be where they are, not in an issue they would have to know to search for. Same reasoning as #134.

## What this does not claim

Not a proof of absence — a bound. Whatever reaches that path is not the simple cross-thread-free-a-full-page workload. Anyone re-opening this should lead with a growing repro.

Second commit regenerates the vendored amalgamation (repo rule 2, #88 gate).
