### PR TITLE
fix(test): clear callbacks before returning; MSVC shared now green (fixes #69)

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -118,11 +118,20 @@ jobs:
   # bug -- MIMALLOC_MEMORY_EVENTS env activation fails in an MSVC DLL build, tracked in
   # issue #69 -- and adding it red, or with continue-on-error, is how a gate becomes
   # decoration. It goes in with the fix. win-gnu shared runs below and is green.
+  # windows-latest (MSVC) is in this matrix as a DIAGNOSTIC for #69 -- it is expected to
+  # fail on test-memory-events-env-enabled until that issue is fixed. It is here rather
+  # than deferred because #69's hypothesis (env resolution racing DLL init) was never
+  # confirmed: "I do not have MSVC locally and could not reproduce it outside CI ... Do
+  # not fix it on my say-so -- confirm first." CI *is* the MSVC machine. This job plus
+  # the [env-check] lines in test-memory-events.c are the confirmation step.
+  # It must not stay red: either it goes green with the fix, or windows-latest comes back
+  # out of this matrix. Do NOT add continue-on-error -- see the note below on why a
+  # permanently-yellow job is worse than an absent one.
   ctest-shared:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/test/test-memory-events.c
+++ b/test/test-memory-events.c
@@ -706,9 +706,19 @@ static int run_env_enabled_check(void) {
           (int)installed, (int)ctx.counts[MI_MEMORY_ALLOCATE], (int)ctx.counts[MI_MEMORY_FREE],
           (q != NULL ? "ok" : "NULL"));
   fflush(stderr);
-  if (q == NULL) { fprintf(stderr, "second alloc failed\n"); fflush(stderr); mi_free(p); return 4; }
-  if (ctx.counts[MI_MEMORY_ALLOCATE] != 1) { fprintf(stderr, "callback did not fire after lazy env activation\n"); fflush(stderr); mi_free(p); mi_free(q); return 5; }
+  if (q == NULL) { fprintf(stderr, "second alloc failed\n"); fflush(stderr); mi_memory_set_callbacks(NULL); mi_free(p); return 4; }
+  if (ctx.counts[MI_MEMORY_ALLOCATE] != 1) { fprintf(stderr, "callback did not fire after lazy env activation\n"); fflush(stderr); mi_memory_set_callbacks(NULL); mi_free(p); mi_free(q); return 5; }
 
+  /* MUST clear before returning: `ctx` is a stack local, and the callbacks registered
+     above hold its address. Leaving them installed means any allocation after this frame
+     dies -- CRT teardown, DLL_PROCESS_DETACH, atexit -- calls on_change with a dangling
+     pointer and writes through it.
+     This is the root cause of #69, and it is a defect in this test rather than in
+     mimalloc. Every other case here already does it; T7 even spells out why
+     ("ctx is about to go out of scope"). This one was missed, and only the MSVC DLL
+     build allocates during teardown often enough to notice: the process ran the whole
+     check successfully, returned 0 from main, and still exited non-zero. */
+  mi_memory_set_callbacks(NULL);
   mi_free(p);
   mi_free(q);
   return 0;

--- a/test/test-memory-events.c
+++ b/test/test-memory-events.c
@@ -30,10 +30,16 @@ static void on_change(const mi_memory_change_t* change, void* arg) {
   ctx->last[change->kind] = *change;
 }
 
-static void evt_install(evt_ctx_t* ctx) {
+/* Returns whether registration succeeded. The result used to be swallowed by an
+   assert(), which is compiled out under NDEBUG -- so a failing mi_memory_set_callbacks
+   turned into "callbacks silently never installed" in exactly the Release builds where
+   #69 shows up. Callers that do not care may ignore the value. */
+static bool evt_install(evt_ctx_t* ctx) {
   mi_memory_callbacks_t cbs;
   for (int i = 0; i < MI_MEMORY_CHANGE_COUNT; i++) { cbs.handlers[i] = on_change; cbs.args[i] = ctx; }
-  assert(mi_memory_set_callbacks(&cbs));
+  const bool ok = mi_memory_set_callbacks(&cbs);
+  assert(ok);
+  return ok;
 }
 
 /* ---- T1: disabled by default -------------------------------------------------------------
@@ -694,10 +700,14 @@ static int run_env_enabled_check(void) {
   if (!mi_memory_tracking_is_enabled()) { fprintf(stderr, "tracking not enabled after lazy env read\n"); mi_free(p); return 3; }
 
   evt_ctx_t ctx; evt_ctx_reset(&ctx);
-  evt_install(&ctx);
+  const bool installed = evt_install(&ctx);
   void* q = mi_malloc(32);
-  if (q == NULL) { fprintf(stderr, "second alloc failed\n"); mi_free(p); return 4; }
-  if (ctx.counts[MI_MEMORY_ALLOCATE] != 1) { fprintf(stderr, "callback did not fire after lazy env activation\n"); mi_free(p); mi_free(q); return 5; }
+  fprintf(stderr, "[env-check] evt_install=%d  after second alloc: ALLOCATE=%d FREE=%d  q=%s\n",
+          (int)installed, (int)ctx.counts[MI_MEMORY_ALLOCATE], (int)ctx.counts[MI_MEMORY_FREE],
+          (q != NULL ? "ok" : "NULL"));
+  fflush(stderr);
+  if (q == NULL) { fprintf(stderr, "second alloc failed\n"); fflush(stderr); mi_free(p); return 4; }
+  if (ctx.counts[MI_MEMORY_ALLOCATE] != 1) { fprintf(stderr, "callback did not fire after lazy env activation\n"); fflush(stderr); mi_free(p); mi_free(q); return 5; }
 
   mi_free(p);
   mi_free(q);

--- a/test/test-memory-events.c
+++ b/test/test-memory-events.c
@@ -672,9 +672,25 @@ static int run_env_enabled_check(void) {
     return 1;
   }
   /* Nothing must have touched the allocator yet in this fresh process; the very first
-     allocation hook below is what triggers the lazy env resolution. */
+     allocation hook below is what triggers the lazy env resolution.
+
+     That assumption is exactly what is in question on an MSVC DLL build (#69), where
+     allocations happen during DLL_PROCESS_ATTACH and CRT init, before main. So dump the
+     inputs before drawing any conclusion: a bare "tracking not enabled" cannot tell
+     "the option never saw the environment" from "the option saw it but the once had
+     already cached disabled". */
+  fprintf(stderr, "[env-check] getenv(MIMALLOC_MEMORY_EVENTS)=\"%s\"  option_is_enabled(before first alloc)=%d  tracking_is_enabled(before)=%d\n",
+          getenv("MIMALLOC_MEMORY_EVENTS"),
+          (int)mi_option_is_enabled(mi_option_memory_events),
+          (int)mi_memory_tracking_is_enabled());
+  fflush(stderr);
+
   void* p = mi_malloc(64);
   if (p == NULL) { fprintf(stderr, "alloc failed\n"); return 2; }
+  fprintf(stderr, "[env-check] after first alloc: option_is_enabled=%d  tracking_is_enabled=%d\n",
+          (int)mi_option_is_enabled(mi_option_memory_events),
+          (int)mi_memory_tracking_is_enabled());
+  fflush(stderr);
   if (!mi_memory_tracking_is_enabled()) { fprintf(stderr, "tracking not enabled after lazy env read\n"); mi_free(p); return 3; }
 
   evt_ctx_t ctx; evt_ctx_reset(&ctx);


### PR DESCRIPTION
**Fixes #69.** The root cause is not what the issue hypothesised, and the "no MSVC hardware" blocker was never real — `windows-latest` runners *are* MSVC machines.

#69 said: *"I do not have MSVC locally and could not reproduce it outside CI, so the above is a hypothesis consistent with the evidence, not a confirmed root cause. Do not fix it on my say-so — confirm first."* So this PR confirmed first, and the hypothesis was wrong.

## Run 1 — the hypothesis is refuted

#69 proposed that allocations during `DLL_PROCESS_ATTACH` trigger the lazy env resolution before `main`, caching *disabled* permanently. Adding the MSVC-shared job plus input dumps produced:

```
[env-check] getenv(MIMALLOC_MEMORY_EVENTS)="1"  option_is_enabled(before first alloc)=1  tracking_is_enabled(before)=1
[env-check] after first alloc: option_is_enabled=1  tracking_is_enabled=1
```

Tracking is **already enabled before the first allocation**. DLL-init allocations do resolve it early — and they resolve it *correctly*. The env path was never broken.

## Run 2 — every assertion passes, and the test still fails

```
[env-check] evt_install=1  after second alloc: ALLOCATE=1 FREE=0  q=ok
```

`installed=1`, `ALLOCATE=1` (exactly what's required), `q` non-NULL. `run_env_enabled_check` **returns 0** — and the process still exits non-zero. So the failure is after `main`, in teardown.

## Root cause: a dangling stack pointer in the test

`run_env_enabled_check` registers callbacks holding the address of a **stack-local** `evt_ctx_t`, and never clears them. Once the frame dies, any later allocation — CRT teardown, `DLL_PROCESS_DETACH`, `atexit` — calls `on_change` with a dangling pointer and writes through it.

An MSVC DLL build allocates during teardown; the static and MinGW builds don't. That is precisely why this one configuration failed while ubuntu-shared, win-gnu-shared and every static build passed — the detail #69 correctly flagged as significant but attributed to the wrong mechanism.

**Every other test in the file already clears its callbacks.** T7 even spells out why: `/* ctx is about to go out of scope */`. This single case was missed.

The defect is in the test, not in `src/memory-events.c`. No allocator change was needed.

## Result

| job | before | after |
|---|---|---|
| `ctest-shared (windows-latest)` | **fail** | **pass** |
| `ctest-shared (ubuntu-latest)` | pass | pass |
| `ctest-shared-win-gnu` | pass | pass |

17/17 green.

## What stays behind

- **`windows-latest` is now a permanent member of the `ctest-shared` matrix.** #68 deferred it rather than merge it red or `continue-on-error`, on the grounds that a permanently-yellow job is how gates get ignored. It now goes in green, as that issue intended.
- **`evt_install` returns its result** instead of swallowing `mi_memory_set_callbacks` inside an `assert()`. That is another silent-failure hazard of the kind this repo keeps finding.
- **The `[env-check]` diagnostics stay.** They cost one line of stderr on a passing run and were what distinguished three candidate causes here.
