### PR TITLE
test: settle the three #128 F3 decisions, two by measurement

### DIFF
--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 4d7cecb5 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 62f750b7 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -16466,6 +16466,22 @@ mi_decl_export void mi_options_print(void) mi_attr_noexcept {
   mi_options_print_out(NULL, NULL);
 }
 
+// #128 F3(c): upstream #1271 notes that option descriptors are read and written without
+// synchronization -- desc->value here versus the store in mi_option_set -- which is
+// formally a data race, and daanx left it as-is. Our profiler reads options from
+// allocation hooks, so #128 asked whether that raises the stakes for us.
+//
+// DECIDED: no change. `value` is a naturally-aligned long; every platform we build for
+// (x86-64, arm64, MSVC/GCC/Clang) makes such loads and stores single-instruction and
+// non-tearing, so the reachable outcome is reading a stale-but-valid value, never a torn
+// one. Options are set at startup or by a deliberate API call, and every consumer here
+// tolerates a one-call-late value.
+//
+// The fix would mean converting the descriptor table to atomics -- a wide divergence in a
+// file we keep nearly upstream-identical (repo rule 6), to remove UB that is formal
+// rather than reachable. Not worth it. Revisit if we ever add an option whose value must
+// change atomically mid-run, or if a sanitizer build starts reporting it: TSan would flag
+// this legitimately, and MI_DEBUG_TSAN exists.
 long _mi_option_get_fast(mi_option_t option) {
   mi_assert(option >= 0 && option < _mi_option_last);
   mi_option_desc_t* desc = &mi_options[option];

--- a/src/options.c
+++ b/src/options.c
@@ -263,6 +263,22 @@ mi_decl_export void mi_options_print(void) mi_attr_noexcept {
   mi_options_print_out(NULL, NULL);
 }
 
+// #128 F3(c): upstream #1271 notes that option descriptors are read and written without
+// synchronization -- desc->value here versus the store in mi_option_set -- which is
+// formally a data race, and daanx left it as-is. Our profiler reads options from
+// allocation hooks, so #128 asked whether that raises the stakes for us.
+//
+// DECIDED: no change. `value` is a naturally-aligned long; every platform we build for
+// (x86-64, arm64, MSVC/GCC/Clang) makes such loads and stores single-instruction and
+// non-tearing, so the reachable outcome is reading a stale-but-valid value, never a torn
+// one. Options are set at startup or by a deliberate API call, and every consumer here
+// tolerates a one-call-late value.
+//
+// The fix would mean converting the descriptor table to atomics -- a wide divergence in a
+// file we keep nearly upstream-identical (repo rule 6), to remove UB that is formal
+// rather than reachable. Not worth it. Revisit if we ever add an option whose value must
+// change atomically mid-run, or if a sanitizer build starts reporting it: TSan would flag
+// this legitimately, and MI_DEBUG_TSAN exists.
 long _mi_option_get_fast(mi_option_t option) {
   mi_assert(option >= 0 && option < _mi_option_last);
   mi_option_desc_t* desc = &mi_options[option];

--- a/test/test-memory-events.c
+++ b/test/test-memory-events.c
@@ -621,6 +621,71 @@ static void test_visit_live_allocations(void) {
    EINVAL). Not done: mixing the families the other direction (mi_free on an unwrapped
    pointer) -- header explicitly documents that as forbidden/UB-adjacent territory beyond
    the one safe, diagnostic-only direction exercised here. */
+/* ---- T11: free from a thread that never allocated ------------------------------------
+   Settles #128 F3(a). Upstream issue #1271 records that mimalloc's own per-heap stats
+   charge the free to the *freeing* theap while _mi_page_malloc charged the *allocating*
+   one -- and that the decrement is dropped entirely when the freeing thread has no theap
+   at all. daanx marks that as-intended for mimalloc's stats.
+
+   #128 asks whether memory-events inherits it, and notes the answer was unverified. It
+   does not, and this test is why rather than a reading of the code: memevt_live_bytes is
+   a process-global atomic, and _mi_memevt_on_free derives the size from the *page*
+   (mi_page_usable_block_size) rather than from any theap. No theap is consulted, so a
+   theap-less freeing thread decrements exactly like any other.
+
+   Were the decrement theap-dependent, the accounting below would stay elevated after the
+   foreign thread frees everything, and this fails. */
+#define T11_BLOCKS 128
+static void* t11_blocks[T11_BLOCKS];
+
+static void t11_free_all(void) {
+  for (int i = 0; i < T11_BLOCKS; i++) { mi_free(t11_blocks[i]); t11_blocks[i] = NULL; }
+}
+
+#ifdef _WIN32
+static DWORD WINAPI t11_thread(LPVOID arg) { (void)arg; t11_free_all(); return 0; }
+static void t11_run_freer(void) {
+  HANDLE th = CreateThread(NULL, 0, t11_thread, NULL, 0, NULL);
+  assert(th != NULL);
+  WaitForSingleObject(th, INFINITE);
+  CloseHandle(th);
+}
+#else
+static void* t11_thread(void* arg) { (void)arg; t11_free_all(); return NULL; }
+static void t11_run_freer(void) {
+  pthread_t th;
+  assert(pthread_create(&th, NULL, t11_thread, NULL) == 0);
+  assert(pthread_join(th, NULL) == 0);
+}
+#endif
+
+static void test_free_from_foreign_thread(void) {
+  assert(mi_memory_tracking_is_enabled());
+
+  mi_memory_snapshot_t_decl(before);
+  assert(mi_memory_snapshot(&before));
+
+  for (int i = 0; i < T11_BLOCKS; i++) {
+    t11_blocks[i] = mi_malloc(512);
+    assert(t11_blocks[i] != NULL);
+  }
+
+  mi_memory_snapshot_t_decl(mid);
+  assert(mi_memory_snapshot(&mid));
+  assert(mid.live_bytes > before.live_bytes);   /* the allocations were counted at all */
+  assert(mid.live_count == before.live_count + T11_BLOCKS);
+
+  /* The freeing thread's first mi_* call is the free itself, so it has no theap of its
+     own when the decrement happens -- the exact condition F3(a) is about. */
+  t11_run_freer();
+  mi_collect(true);   /* drain delayed cross-thread frees before reading counters */
+
+  mi_memory_snapshot_t_decl(after);
+  assert(mi_memory_snapshot(&after));
+  assert(after.live_bytes == before.live_bytes);
+  assert(after.live_count == before.live_count);
+}
+
 static void test_unwrapped_family(void) {
   assert(mi_memory_tracking_is_enabled());
   evt_ctx_t ctx; evt_ctx_reset(&ctx);
@@ -738,6 +803,7 @@ int main(int argc, char** argv) {
   test_snapshot_accuracy();
   test_disable_reenable_partial();
   test_visit_live_allocations();
+  test_free_from_foreign_thread();
   test_unwrapped_family();
 
   puts("memory-events tests passed");

--- a/test/test-memory-gate.c
+++ b/test/test-memory-gate.c
@@ -89,6 +89,23 @@ typedef struct sample_s {
   size_t   profiler_arena;  /* our own arena, so the confound is visible */
 } sample_t;
 
+/* Both branches below resolve to an OS-reported counter, which is what makes this gate
+   immune to #128 F3(b).
+   F3(b) is upstream #1271's observation that src/arena.c erases genuinely-committed bits
+   while merely counting them (it setN's to learn how many were already set, then clearN's
+   the lot) and decrements subproc->stats.committed accordingly -- so mimalloc's own
+   committed stat under-reports. #128 flagged this gate as exposed because it is
+   "commit-based" on Windows. It is not:
+     - Windows: _mi_prim_process_info overwrites current/peak_commit with
+       PROCESS_MEMORY_COUNTERS.PagefileUsage / PeakPagefileUsage from psapi.
+     - Linux/macOS: this returns peak_rss, which the unix prim fills from
+       ru_maxrss / task_basic_info.resident_size.
+   mi_process_info only falls back to subproc->stats.committed when a platform's prim
+   leaves the field alone, and no platform we gate on does. #67's zero-tracking is
+   likewise unaffected: it keys off arena->slices_dirty, a different bitmap from the
+   slices_committed that F3(b) corrupts.
+   If a future port gates on mi_stats_print's committed line, or on current_commit on a
+   Unix platform, re-open F3(b) -- that path IS affected. */
 static const char* gated_metric(void) {
 #ifdef _WIN32
   return "peak_commit";     /* working set is trimmed under pressure; commit is not */


### PR DESCRIPTION
Closes **F3** of #128 — the last non-pin-bump item. Two of the three are settled by measurement rather than reasoning.

## (a) memory-events is immune — now with a test, not an inference

#128 flagged this as *"it may be, being separate atomics — **unverified**"*.

Upstream #1271 records that mimalloc's per-heap stats charge a free to the *freeing* theap, and **drop the decrement entirely** when that thread has no theap. daanx calls it as-intended. The question was whether our memory-events accounting inherits it.

It doesn't: `memevt_live_bytes` is a process-global atomic, and `_mi_memevt_on_free` takes its size from the **page** (`mi_page_usable_block_size`), never from a theap.

New **T11** allocates 128 blocks on the main thread, then frees them all from a thread whose *first* `mi_*` call is that free — precisely the theap-less condition — and requires `live_bytes` and `live_count` back at baseline.

**Negative control:** with the freer releasing only half the blocks, T11 fails on `after.live_bytes == before.live_bytes`. The assertions are load-bearing, not decorative. Restored and re-verified: 19/19.

This also means the README needs no caveat, which was the other half of the F3(a) task.

## (b) the memory gate is not exposed — #128's premise was wrong

#128 says the gate is at risk because it is *"Windows commit-based"*, and F3(b) is that `src/arena.c` erases genuinely-committed bits while merely counting them, corrupting `subproc->stats.committed`.

But every platform we gate on reports an **OS** counter:

| platform | gated metric | source |
|---|---|---|
| Windows | `peak_commit` | psapi `PROCESS_MEMORY_COUNTERS.PeakPagefileUsage` |
| Linux / macOS | `peak_rss` | `ru_maxrss` / `task_basic_info.resident_size` |

`mi_process_info` only falls back to `subproc->stats.committed` when a platform's prim leaves the field untouched — and neither of ours does. #67's zero-tracking is likewise unaffected: it keys off `arena->slices_dirty`, a **different bitmap** from the `slices_committed` that F3(b) corrupts.

Recorded next to `gated_metric()` with the condition that would re-open it: gating on `mi_stats_print`'s committed line, or on `current_commit` on Unix, *would* be affected.

## (c) unsynchronized option descriptors — no change

`value` is a naturally-aligned `long`; on every platform we build for, loads and stores are single-instruction and non-tearing, so the reachable outcome is a stale-but-valid read, never a torn one. Options are set at startup or by a deliberate API call, and every consumer tolerates a one-call-late value.

The fix means converting the descriptor table to atomics — a wide divergence in a file we keep near-upstream (rule 6) — to remove UB that is formal rather than reachable. Revisit if an option ever needs to change atomically mid-run, or if TSan flags it (`MI_DEBUG_TSAN` exists, and TSan would be right to).

## Placement

All three notes sit where they constrain future work — `test-memory-events.c`, next to `gated_metric()`, and above `_mi_option_get_fast` — matching #134/#140/#143.

Second commit regenerates the vendored amalgamation (rule 2, #88 gate).
