### PR TITLE
docs: bring the README CI-gates table up to date (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,18 +275,35 @@ small/large boundary, huge-allocation churn, and degenerate arguments
 
 ### CI gates
 
-Every gate below runs on each PR and is a **hard failure**. Each one also runs a
-*positive control* — a deliberately broken input that the gate must catch — because a
-gate that has never been observed to fire proves nothing. That is not a hypothetical
-standard: two of these gates were silently doing nothing when first written, and the
-controls are what caught them.
+Every gate below runs on each PR and is a **hard failure**. Where a gate can have a
+*positive control* — a deliberately broken input it must catch — it has one, because a
+gate that has never been observed to fire proves nothing.
+
+That is not a hypothetical standard. **Seven gates in this repository were found to be
+verifying nothing**, each discovered by asking "has this ever actually failed?":
+
+- the arm64 instruction scanner matched nothing at all and reported "clean"
+- the memory-gate's leak control existed but was never invoked
+- the ASan job's branch filter excluded every branch we work on
+- the cross-build pipeline discarded its own diagnostics
+- `MI_TRACK_ASAN` silently self-disabled when its header was missing
+- `MI_GUARDED` was documented as default-on in debug builds and had **never once** been
+  enabled — two independent dead CMake constructs
+- the fuzz job's "did ASan report this?" check matched libFuzzer's own boilerplate line
+  *"Combine libFuzzer with AddressSanitizer…"* — so the string proving ASan worked was
+  libFuzzer saying it was not in use
 
 | Gate | What it catches | Positive control |
 |---|---|---|
 | **memory-gate** (`ci/memory_gate.py`) | peak memory or thread-count regressions vs a committed per-platform baseline | builds a copy with an injected leak; the gate must fail — verified at +212% / +98% / +27% on linux/windows/macos |
-| **isa-baseline** (`ci/check_isa_baseline.py`) | binaries containing instructions above the CPU baseline, which SIGILL on older hardware | builds with `MI_OPT_ARCH=ON`; the scanner must fire |
-| **ctest matrix** | correctness on ubuntu / windows-MSVC / windows-MinGW / macos, `MI_PPROF` on and off, plus shared-library and `MI_DEBUG_FULL` builds | — |
+| **isa-baseline** (`ci/check_isa_baseline.py`) | binaries containing instructions above the CPU baseline, which SIGILL on older hardware | builds with `MI_OPT_ARCH=ON`; the scanner must fire. The parser also self-tests against x86 and arm64 fixtures on every run |
+| **ctest matrix** | correctness on ubuntu / windows-MSVC / windows-MinGW / macos, `MI_PPROF` on and off, `MI_DEBUG_FULL`, and shared-library builds on all three of ubuntu, MSVC and MinGW | — |
+| **ctest-guarded** | the `MI_GUARDED` guard-page path, run twice: at the default sample rate and again with `MIMALLOC_GUARDED_SAMPLE_RATE=1` so every eligible allocation is guarded | configure step greps the resolved compiler defines for `MI_GUARDED=1`, since the original bug was the flag never reaching the compiler |
+| **asan** | use-after-free, overflow and leaks under AddressSanitizer | — |
+| **fuzz** (`test/fuzz/`) | crashes from structured random allocator-API sequences, with ASan as the oracle | builds with a planted use-after-free and requires an anchored `(ERROR\|SUMMARY): AddressSanitizer:` report naming it |
+| **amalgamation-drift** | a C change that never reached the vendored copy the Rust crate compiles — which broke `main` twice before this gate existed | — |
 | **python-lint** | the gate scripts themselves — `ruff` + `pyright --strict` | — |
+| **zero-tracking** | correctness and footprint of `mi_option_purge_zeroes`, reported as paired interleaved A/B medians with the within-arm spread alongside | — |
 
 Two details worth stating, because both were assumptions that measurement overturned:
 
@@ -294,10 +311,14 @@ Two details worth stating, because both were assumptions that measurement overtu
   binary span 6–12% on CI runners. The memory gate therefore compares the **minimum of
   four runs** and prints the observed spread every time, warning if it ever approaches
   the tolerance. A gate that flakes gets ignored, and an ignored gate is worse than none.
-- **The gate scripts are gating code.** Both silent failures above were Python bugs, not
-  C bugs — the arm64 instruction scanner matched nothing at all and reported "clean".
-  Hence `pyright --strict` over `ci/`, with the result schema declared rather than
-  indexed by hope.
+- **The gate scripts are gating code.** Several of the silent failures above were Python
+  or YAML bugs rather than C bugs — the arm64 instruction scanner matched nothing at all
+  and reported "clean". Hence `pyright --strict` over `ci/`, with the result schema
+  declared rather than indexed by hope.
+- **Match report headers, not prose.** The fuzz control's `grep -qiE "AddressSanitizer"`
+  was satisfied by libFuzzer's advice *to use* AddressSanitizer. Assertions about tool
+  output should anchor on that tool's actual report format (`^(==[0-9]+==)?(ERROR|SUMMARY):`),
+  never on a keyword that can appear in an explanatory sentence.
 
 ## What this fork carries, and where each piece came from
 


### PR DESCRIPTION
Completes the last outstanding item of #101 — the README promise from #61 that it would reflect what landed.

The table listed **four** gates; there are **nine**. Missing entirely: `asan`, `fuzz`, `ctest-guarded`, `amalgamation-drift`, `zero-tracking`. The `ctest matrix` row also predated MSVC-shared going green (#69) and MinGW-shared.

It also corrects a claim of my own. The prose said *"two of these gates were silently doing nothing when first written"*. The real figure is **seven**, and enumerating them is more useful than the count:

- the arm64 instruction scanner matched nothing at all and reported "clean"
- the memory-gate's leak control existed but was never invoked
- the ASan job's branch filter excluded every branch we work on
- the cross-build pipeline discarded its own diagnostics
- `MI_TRACK_ASAN` silently self-disabled when its header was missing
- `MI_GUARDED` was documented default-on in debug builds and had **never once** been enabled
- the fuzz job's "did ASan report this?" check matched libFuzzer's own boilerplate

The last one generalises, so it is now recorded as a rule: assertions about a tool's output must anchor on that tool's **report format**, not on a keyword that can appear in an explanatory sentence. `grep -qiE "AddressSanitizer"` was satisfied by libFuzzer advising us *to use* AddressSanitizer.

Docs-only.