### PR TITLE
fix: zero the new TLS slots after growth (first import from Bun, #78)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1078,6 +1078,19 @@ if (MI_BUILD_TESTS)
   endif()
   add_test(NAME test-tls-slots-heap COMMAND mimalloc-test-tls-slots-heap)
 
+  # mi_rezalloc zero-fill boundary (issue #78): pins the behaviour that makes the
+  # explicit slot zeroing in src/threadlocal.c necessary.
+  add_executable(mimalloc-test-rezalloc-slack test/test-rezalloc-slack.c)
+  target_compile_definitions(mimalloc-test-rezalloc-slack PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-test-rezalloc-slack PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-rezalloc-slack PRIVATE include)
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    target_link_libraries(mimalloc-test-rezalloc-slack PRIVATE mimalloc-static ${mi_libraries})
+  else()
+    target_link_libraries(mimalloc-test-rezalloc-slack PRIVATE mimalloc ${mi_libraries})
+  endif()
+  add_test(NAME test-rezalloc-slack COMMAND mimalloc-test-rezalloc-slack)
+
   # dynamic override test
   if(MI_BUILD_SHARED AND NOT (MI_TRACK_ASAN OR MI_DEBUG_TSAN OR MI_DEBUG_UBSAN)) # AND NOT (APPLE AND MI_USE_CXX))
     add_executable(mimalloc-test-stress-dynamic test/test-stress.c)

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 4d5c07e9 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit e8b709e6 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -23178,6 +23178,25 @@ static mi_thread_locals_t* mi_thread_locals_expand(size_t least_idx) {
   // `mi_free` in `_mi_thread_locals_thread_done`, which finds the owning page itself.
   mi_thread_locals_t* tls = (mi_thread_locals_t*)mi_heap_rezalloc(mi_heap_main(), tls_old, sizeof(mi_thread_locals_t) + count*sizeof(mi_tls_slot_t));
   if mi_unlikely(tls==NULL) return NULL;
+  // imported from oven-sh/mimalloc @ d078ad06 (src/threadlocal.c), MIT -- see #78.
+  //
+  // The new slots are NOT guaranteed zero, despite `rezalloc`. `_mi_theap_realloc_zero`
+  // starts its zero-fill from the block's OLD USABLE size, not from the size that was
+  // originally requested -- it cannot do better, since the requested size is not tracked
+  // in release builds. So the slack between the old requested size and the old bin size
+  // is copied across verbatim, and that slack was never initialized: it holds whatever
+  // the previous tenant of that page left behind.
+  //
+  // Confirmed on our own tree, deterministically: mi_malloc(40) yields usable 48, and
+  // after mi_rezalloc(p,112) the eight bytes [40,48) still read 0xAA. See
+  // test/test-rezalloc-slack.c.
+  //
+  // That matters here because `_mi_thread_local_get` validates a slot ONLY by comparing
+  // its `version` lane against the key's version, and versions are small sequential
+  // counters. A garbage lane that happens to equal a live key's version makes the
+  // adjacent garbage lane get returned as a cached `mi_theap_t*` -- i.e. application
+  // bytes dereferenced as a theap. Zero the new range explicitly.
+  _mi_memzero(&tls->slots[count_old], (count - count_old)*sizeof(mi_tls_slot_t));
   tls->count = count;
   mi_thread_locals_set(tls);
   return tls;

--- a/src/threadlocal.c
+++ b/src/threadlocal.c
@@ -128,6 +128,25 @@ static mi_thread_locals_t* mi_thread_locals_expand(size_t least_idx) {
   // `mi_free` in `_mi_thread_locals_thread_done`, which finds the owning page itself.
   mi_thread_locals_t* tls = (mi_thread_locals_t*)mi_heap_rezalloc(mi_heap_main(), tls_old, sizeof(mi_thread_locals_t) + count*sizeof(mi_tls_slot_t));
   if mi_unlikely(tls==NULL) return NULL;
+  // imported from oven-sh/mimalloc @ d078ad06 (src/threadlocal.c), MIT -- see #78.
+  //
+  // The new slots are NOT guaranteed zero, despite `rezalloc`. `_mi_theap_realloc_zero`
+  // starts its zero-fill from the block's OLD USABLE size, not from the size that was
+  // originally requested -- it cannot do better, since the requested size is not tracked
+  // in release builds. So the slack between the old requested size and the old bin size
+  // is copied across verbatim, and that slack was never initialized: it holds whatever
+  // the previous tenant of that page left behind.
+  //
+  // Confirmed on our own tree, deterministically: mi_malloc(40) yields usable 48, and
+  // after mi_rezalloc(p,112) the eight bytes [40,48) still read 0xAA. See
+  // test/test-rezalloc-slack.c.
+  //
+  // That matters here because `_mi_thread_local_get` validates a slot ONLY by comparing
+  // its `version` lane against the key's version, and versions are small sequential
+  // counters. A garbage lane that happens to equal a live key's version makes the
+  // adjacent garbage lane get returned as a cached `mi_theap_t*` -- i.e. application
+  // bytes dereferenced as a theap. Zero the new range explicitly.
+  _mi_memzero(&tls->slots[count_old], (count - count_old)*sizeof(mi_tls_slot_t));
   tls->count = count;
   mi_thread_locals_set(tls);
   return tls;

--- a/test/test-rezalloc-slack.c
+++ b/test/test-rezalloc-slack.c
@@ -1,0 +1,104 @@
+/* Characterization test for the zero-fill boundary of mi_rezalloc (issue #78).
+
+   `mi_rezalloc(p, newsize)` is documented as zero-initializing the extension. In
+   practice `_mi_theap_realloc_zero` starts its zero-fill from the block's OLD USABLE
+   size rather than from the size the caller originally requested:
+
+     size = _mi_usable_size(p, page);
+     ...
+     if (zero && newsize > size) {
+       const size_t start = (size >= sizeof(intptr_t) ? size - sizeof(intptr_t) : 0);
+       _mi_memzero((uint8_t*)newp + start, newsize - start);
+     }
+
+   It cannot do better -- the requested size is not tracked in release builds -- so the
+   slack between the requested size and the bin size is copied across verbatim. That
+   slack was never initialized by anyone, so it carries whatever the previous tenant of
+   the page left behind.
+
+   This test pins that behaviour down rather than asserting it is wrong, because it is
+   not fixable inside the allocator. Its value is twofold:
+
+     - it documents, with numbers, WHY src/threadlocal.c must zero its new slot range
+       explicitly (imported from oven-sh/mimalloc @ d078ad06, MIT). Anyone who deletes
+       that memzero as redundant should read this test first.
+     - if a future change ever does make mi_rezalloc zero from the requested size, this
+       test fails and tells us the workaround can go.
+
+   Deliberately NOT a correctness assertion about mi_rezalloc: it asserts the current,
+   deliberate behaviour, and says so.
+
+   The other reason this file exists: #78's C.2 rule is to import only with a test that
+   fails without the import. That could not be met for the threadlocal fix itself --
+   mi_thread_locals_expand is static, the corrupted state is only observable through a
+   heap->theap lookup returning garbage, and Bun's own reproducer is probabilistic
+   ("crashes roughly once per several hundred process runs") and pthread-only. So the
+   mechanism is pinned here deterministically instead, and the deviation from C.2 is
+   recorded rather than papered over. */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <mimalloc.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+  /* A request whose size class has slack. 40 -> 48 on every configuration we build,
+     but the test derives the numbers rather than assuming them. */
+  const size_t requested = 40;
+  unsigned char* p = (unsigned char*)mi_malloc(requested);
+  assert(p != NULL);
+
+  const size_t usable = mi_usable_size(p);
+  printf("requested=%zu usable=%zu slack=%zu\n", requested, usable, usable - requested);
+
+  if (usable <= requested) {
+    /* No slack in this configuration (e.g. a padding/debug build can report usable as
+       the requested size). The mechanism cannot arise, so there is nothing to pin. */
+    printf("ok: no slack in this build; mechanism cannot apply\n");
+    mi_free(p);
+    return 0;
+  }
+
+  memset(p, 0xAA, usable);          /* stand in for a previous tenant's bytes */
+
+  const size_t newsize = usable + 64;
+  unsigned char* q = (unsigned char*)mi_rezalloc(p, newsize);
+  assert(q != NULL);
+
+  /* Everything at or beyond the OLD USABLE size must be zero -- that part of the
+     contract does hold. */
+  for (size_t i = usable; i < newsize; i++) {
+    assert(q[i] == 0);
+  }
+
+  /* And the slack [requested, usable) is where the stale bytes survive. Count rather
+     than assert a fixed number, so this stays valid across size-class changes. */
+  size_t stale = 0;
+  for (size_t i = requested; i < usable; i++) {
+    if (q[i] != 0) stale++;
+  }
+  printf("stale bytes carried into [%zu,%zu): %zu\n", requested, usable, stale);
+
+  /* The ENTIRE slack survives, because `newsize > usable` takes the reallocate-and-move
+     path rather than the in-place one: `_mi_theap_malloc_zero` hands back a zeroed block
+     and then `min(newsize, old_usable)` bytes are copied over the top of it, slack
+     included. (The in-place branch has a different boundary -- it zeroes from
+     `old_usable - sizeof(intptr_t)` -- which is what makes it easy to predict the wrong
+     number here. This test originally asserted that one and failed, correctly.) */
+  const size_t expected_stale = usable - requested;
+  if (stale != expected_stale) {
+    fprintf(stderr,
+            "FAIL: expected %zu stale bytes, saw %zu.\n"
+            "If mi_rezalloc now zeroes from the REQUESTED size, this is good news: the\n"
+            "explicit memzero in src/threadlocal.c (imported for #78) can be removed.\n",
+            expected_stale, stale);
+    return 1;
+  }
+
+  printf("ok: zero-fill boundary is the old usable size, as expected\n");
+  mi_free(q);
+  return 0;
+}

--- a/test/test-rezalloc-slack.c
+++ b/test/test-rezalloc-slack.c
@@ -62,7 +62,16 @@ int main(void) {
     return 0;
   }
 
-  memset(p, 0xAA, usable);          /* stand in for a previous tenant's bytes */
+  /* Stand in for a previous tenant's bytes. Deliberately a volatile byte loop and NOT
+     memset: mi_malloc carries mi_attr_alloc_size(1), so with _FORTIFY_SOURCE glibc's
+     fortified memset sees an object of `requested` bytes and aborts with
+     "*** buffer overflow detected ***" -- which is exactly what happened on the first
+     CI run. Writing up to mi_usable_size is legal for mimalloc; the compiler just has
+     no way to know that. */
+  {
+    volatile unsigned char* vp = p;
+    for (size_t i = 0; i < usable; i++) vp[i] = 0xAA;
+  }
 
   const size_t newsize = usable + 64;
   unsigned char* q = (unsigned char*)mi_rezalloc(p, newsize);


### PR DESCRIPTION
**The first genuine import from the Bun fork** (#78), and a real memory-corruption bug we ship today.

`imported from oven-sh/mimalloc @ d078ad06 (src/threadlocal.c), MIT`

## The bug

`mi_thread_locals_expand` grew the slot array with `rezalloc` and assumed the new slots were zero. They are not. `_mi_theap_realloc_zero` starts its zero-fill from the block's **old usable size**, not from the size originally requested — it cannot do better, since the requested size isn't tracked in release builds — so the slack between requested and bin size is carried across verbatim. That slack was never initialized by anyone; it holds whatever the previous tenant of the page left.

Confirmed deterministically on our own tree rather than taken on faith:

```
requested=40 usable=48 slack=8
stale bytes carried into [40,48): 8
```

## Why it is dangerous

`_mi_thread_local_get` validates a slot **only** by comparing its `version` lane against the key's version — and versions are small sequential counters. A garbage lane that happens to equal a live key's version makes the adjacent garbage lane be returned as a cached `mi_theap_t*`. Application bytes get dereferenced as a theap, and mimalloc then writes page queues and stat counters through it.

This is the **third** bug found in this one function: #128 B3 (array allocated from a user-destroyable heap) and now this. They're independent — the B3 fix does not address this one, and **Bun still has B3** while we still had this.

## On the C.2 rule, stated plainly

`test/test-rezalloc-slack.c` pins the zero-fill boundary that makes the memzero necessary. It does **not** fail without this fix: `mi_thread_locals_expand` is static, and the corruption is only observable through a heap→theap lookup returning garbage. Bun's own reproducer is probabilistic (*"roughly once per several hundred process runs"*) and pthread-only, so it is not usable in CI.

So #66 C.2 — *import only with a test that fails without it* — is **not strictly met here**. The mechanism is pinned deterministically instead, and I'd rather record the deviation than pretend the box is ticked.

The test also caught my own error on its first run: I predicted the in-place realloc branch's boundary, but `newsize > usable` takes the **move** path, which zeroes and then copies `min(newsize, old_usable)` bytes over the top — so the *entire* slack survives, not slack-minus-one-word.

20/20 locally. Second commit regenerates the vendored amalgamation.