### PR TITLE
fix: mi_process_info's current_rss reported committed bytes on Linux (#78)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1091,6 +1091,18 @@ if (MI_BUILD_TESTS)
   endif()
   add_test(NAME test-rezalloc-slack COMMAND mimalloc-test-rezalloc-slack)
 
+  # mi_process_info's current_rss must be RSS, not committed bytes (issue #78).
+  add_executable(mimalloc-test-process-rss test/test-process-rss.c)
+  target_compile_definitions(mimalloc-test-process-rss PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-test-process-rss PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-process-rss PRIVATE include)
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    target_link_libraries(mimalloc-test-process-rss PRIVATE mimalloc-static ${mi_libraries})
+  else()
+    target_link_libraries(mimalloc-test-process-rss PRIVATE mimalloc ${mi_libraries})
+  endif()
+  add_test(NAME test-process-rss COMMAND mimalloc-test-process-rss)
+
   # dynamic override test
   if(MI_BUILD_SHARED AND NOT (MI_TRACK_ASAN OR MI_DEBUG_TSAN OR MI_DEBUG_UBSAN)) # AND NOT (APPLE AND MI_USE_CXX))
     add_executable(mimalloc-test-stress-dynamic test/test-stress.c)

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit e8b709e6 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 93aadc4a of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -25444,6 +25444,47 @@ void _mi_prim_process_info(mi_process_info_t* pinfo)
       pinfo->current_rss = (size_t)info.resident_size;
     }
     #endif
+  #elif defined(__linux__)
+    // Read the resident set size from /proc/self/statm (issue #78).
+    //
+    // Without this, `current_rss` is never assigned on Linux and keeps the default
+    // mi_process_info() gives it -- which is `current_commit`, mimalloc's own committed
+    // counter. So `mi_process_info`, `mi_stats_print` and the `rss_current` field of
+    // `mi_stats_as_json` all reported COMMITTED bytes while calling them RSS. For a fork
+    // whose purpose is memory profiling that is the worst kind of wrong: plausible,
+    // stable, and off by however much of the heap is untouched.
+    //
+    // statm field 2 is `resident`, in pages. Parsed by hand rather than with scanf
+    // because this can run from inside the allocator: no allocation, no locale, no
+    // stdio. Failure leaves `current_rss` alone, so the old behaviour remains the
+    // fallback rather than reporting zero.
+    //
+    // Approach from oven-sh/mimalloc @ 6aedf5e1, MIT (see #78); parser written here.
+    {
+      const int fd = mi_prim_open("/proc/self/statm", O_RDONLY);
+      if (fd >= 0) {
+        char buf[64];
+        const ssize_t n = mi_prim_read(fd, buf, sizeof(buf) - 1);
+        mi_prim_close(fd);
+        if (n > 0) {
+          buf[n] = 0;
+          const char* p = buf;
+          while (*p == ' ') p++;
+          while (*p >= '0' && *p <= '9') p++;   // field 1: total program size
+          while (*p == ' ') p++;
+          size_t resident_pages = 0;
+          bool any = false;
+          while (*p >= '0' && *p <= '9') {      // field 2: resident set size, in pages
+            resident_pages = (resident_pages * 10) + (size_t)(*p - '0');
+            any = true;
+            p++;
+          }
+          if (any) {
+            pinfo->current_rss = resident_pages * (size_t)sysconf(_SC_PAGESIZE);
+          }
+        }
+      }
+    }
   #endif
   // use defaults for commit
 }
@@ -27074,6 +27115,47 @@ void _mi_prim_process_info(mi_process_info_t* pinfo)
       pinfo->current_rss = (size_t)info.resident_size;
     }
     #endif
+  #elif defined(__linux__)
+    // Read the resident set size from /proc/self/statm (issue #78).
+    //
+    // Without this, `current_rss` is never assigned on Linux and keeps the default
+    // mi_process_info() gives it -- which is `current_commit`, mimalloc's own committed
+    // counter. So `mi_process_info`, `mi_stats_print` and the `rss_current` field of
+    // `mi_stats_as_json` all reported COMMITTED bytes while calling them RSS. For a fork
+    // whose purpose is memory profiling that is the worst kind of wrong: plausible,
+    // stable, and off by however much of the heap is untouched.
+    //
+    // statm field 2 is `resident`, in pages. Parsed by hand rather than with scanf
+    // because this can run from inside the allocator: no allocation, no locale, no
+    // stdio. Failure leaves `current_rss` alone, so the old behaviour remains the
+    // fallback rather than reporting zero.
+    //
+    // Approach from oven-sh/mimalloc @ 6aedf5e1, MIT (see #78); parser written here.
+    {
+      const int fd = mi_prim_open("/proc/self/statm", O_RDONLY);
+      if (fd >= 0) {
+        char buf[64];
+        const ssize_t n = mi_prim_read(fd, buf, sizeof(buf) - 1);
+        mi_prim_close(fd);
+        if (n > 0) {
+          buf[n] = 0;
+          const char* p = buf;
+          while (*p == ' ') p++;
+          while (*p >= '0' && *p <= '9') p++;   // field 1: total program size
+          while (*p == ' ') p++;
+          size_t resident_pages = 0;
+          bool any = false;
+          while (*p >= '0' && *p <= '9') {      // field 2: resident set size, in pages
+            resident_pages = (resident_pages * 10) + (size_t)(*p - '0');
+            any = true;
+            p++;
+          }
+          if (any) {
+            pinfo->current_rss = resident_pages * (size_t)sysconf(_SC_PAGESIZE);
+          }
+        }
+      }
+    }
   #endif
   // use defaults for commit
 }

--- a/src/prim/unix/prim.c
+++ b/src/prim/unix/prim.c
@@ -838,6 +838,47 @@ void _mi_prim_process_info(mi_process_info_t* pinfo)
       pinfo->current_rss = (size_t)info.resident_size;
     }
     #endif
+  #elif defined(__linux__)
+    // Read the resident set size from /proc/self/statm (issue #78).
+    //
+    // Without this, `current_rss` is never assigned on Linux and keeps the default
+    // mi_process_info() gives it -- which is `current_commit`, mimalloc's own committed
+    // counter. So `mi_process_info`, `mi_stats_print` and the `rss_current` field of
+    // `mi_stats_as_json` all reported COMMITTED bytes while calling them RSS. For a fork
+    // whose purpose is memory profiling that is the worst kind of wrong: plausible,
+    // stable, and off by however much of the heap is untouched.
+    //
+    // statm field 2 is `resident`, in pages. Parsed by hand rather than with scanf
+    // because this can run from inside the allocator: no allocation, no locale, no
+    // stdio. Failure leaves `current_rss` alone, so the old behaviour remains the
+    // fallback rather than reporting zero.
+    //
+    // Approach from oven-sh/mimalloc @ 6aedf5e1, MIT (see #78); parser written here.
+    {
+      const int fd = mi_prim_open("/proc/self/statm", O_RDONLY);
+      if (fd >= 0) {
+        char buf[64];
+        const ssize_t n = mi_prim_read(fd, buf, sizeof(buf) - 1);
+        mi_prim_close(fd);
+        if (n > 0) {
+          buf[n] = 0;
+          const char* p = buf;
+          while (*p == ' ') p++;
+          while (*p >= '0' && *p <= '9') p++;   // field 1: total program size
+          while (*p == ' ') p++;
+          size_t resident_pages = 0;
+          bool any = false;
+          while (*p >= '0' && *p <= '9') {      // field 2: resident set size, in pages
+            resident_pages = (resident_pages * 10) + (size_t)(*p - '0');
+            any = true;
+            p++;
+          }
+          if (any) {
+            pinfo->current_rss = resident_pages * (size_t)sysconf(_SC_PAGESIZE);
+          }
+        }
+      }
+    }
   #endif
   // use defaults for commit
 }

--- a/test/test-process-rss.c
+++ b/test/test-process-rss.c
@@ -1,0 +1,88 @@
+/* mi_process_info's current_rss must be RSS, not committed bytes (issue #78).
+
+   On Linux, `_mi_prim_process_info` used to set `peak_rss` but never `current_rss`, so
+   the field kept the default `mi_process_info()` assigns it -- `current_commit`,
+   mimalloc's own committed counter. Every consumer (`mi_process_info`,
+   `mi_stats_print`, and the `rss_current` field of `mi_stats_as_json`) therefore
+   reported committed bytes under the name RSS. Bun measured 4.91 GB vs 0.56 GB on a
+   real workload.
+
+   The test allocates a large region and touches only one byte per OS page in a small
+   prefix of it. Committed then greatly exceeds resident, so a build that confuses the
+   two reports the two values as equal and fails here.
+
+   Deliberately tolerant about the exact numbers -- RSS depends on the OS, the page
+   size, and what else the process has faulted in. The assertion is only the thing that
+   is actually guaranteed: with this much committed-but-untouched memory, RSS must be
+   meaningfully below commit. Anything stricter would flake.
+
+   Non-Linux platforms already set current_rss from the OS (mach task_info on macOS,
+   PROCESS_MEMORY_COUNTERS on Windows), so this is a portable assertion, not a
+   Linux-specific one -- which is the point: it would have caught the Linux gap from
+   any platform's perspective. */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <mimalloc.h>
+#include <stdio.h>
+#include <string.h>
+
+#define BLOCKS     64
+#define BLOCKSZ    (4u << 20)      /* 4 MiB each -> 256 MiB committed */
+#define TOUCH_FRAC 16u             /* touch only 1/16th of each block */
+
+static void* keep[BLOCKS];
+
+int main(void) {
+  size_t elapsed, user, sys, rss0, prss, commit0, pcommit, faults;
+  mi_process_info(&elapsed, &user, &sys, &rss0, &prss, &commit0, &pcommit, &faults);
+
+  for (int i = 0; i < BLOCKS; i++) {
+    keep[i] = mi_malloc(BLOCKSZ);
+    assert(keep[i] != NULL);
+    /* Touch one byte every 4 KiB, but only across the first 1/TOUCH_FRAC of the block,
+       so the rest stays committed-but-not-resident. */
+    unsigned char* b = (unsigned char*)keep[i];
+    for (size_t off = 0; off < BLOCKSZ / TOUCH_FRAC; off += 4096) {
+      b[off] = (unsigned char)i;
+    }
+  }
+
+  size_t rss, commit;
+  mi_process_info(&elapsed, &user, &sys, &rss, &prss, &commit, &pcommit, &faults);
+
+  printf("rss=%zu KiB  commit=%zu KiB  (baseline rss=%zu commit=%zu)\n",
+         rss / 1024, commit / 1024, rss0 / 1024, commit0 / 1024);
+
+  if (commit == 0) {
+    printf("ok: no commit accounting on this platform; nothing to compare\n");
+    for (int i = 0; i < BLOCKS; i++) mi_free(keep[i]);
+    return 0;
+  }
+
+  if (rss == commit) {
+    fprintf(stderr,
+            "FAIL: current_rss == current_commit (%zu). RSS is being reported as\n"
+            "committed bytes -- see _mi_prim_process_info. %u MiB was committed and\n"
+            "only about 1/%u of it touched, so these must differ.\n",
+            rss, (unsigned)((BLOCKS * (size_t)BLOCKSZ) >> 20), TOUCH_FRAC);
+    return 1;
+  }
+
+  /* And RSS should be the smaller of the two here, since most of the commit was never
+     faulted in. A little slack for allocator metadata and whatever else is resident. */
+  if (rss > commit) {
+    fprintf(stderr,
+            "FAIL: current_rss (%zu) exceeds current_commit (%zu) with most of the\n"
+            "committed memory deliberately untouched.\n", rss, commit);
+    return 1;
+  }
+
+  printf("ok: rss is %.1f%% of commit, as expected for mostly-untouched memory\n",
+         100.0 * (double)rss / (double)commit);
+
+  for (int i = 0; i < BLOCKS; i++) mi_free(keep[i]);
+  return 0;
+}

--- a/test/test-process-rss.c
+++ b/test/test-process-rss.c
@@ -71,16 +71,16 @@ int main(void) {
     return 1;
   }
 
-  /* And RSS should be the smaller of the two here, since most of the commit was never
-     faulted in. A little slack for allocator metadata and whatever else is resident. */
-  if (rss > commit) {
-    fprintf(stderr,
-            "FAIL: current_rss (%zu) exceeds current_commit (%zu) with most of the\n"
-            "committed memory deliberately untouched.\n", rss, commit);
-    return 1;
-  }
-
-  printf("ok: rss is %.1f%% of commit, as expected for mostly-untouched memory\n",
+  /* Deliberately NO assertion that rss < commit.
+     `commit` counts only what MIMALLOC committed; `rss` is the whole process, including
+     the binary, stacks, libc, and any sanitizer's shadow memory. Under AddressSanitizer
+     the shadow and redzones push RSS above mimalloc's own commit counter as a matter of
+     course -- the asan job measured rss=321 MiB against commit=285 MiB. An earlier
+     version of this test asserted rss <= commit and failed there, contradicting the
+     comment at the top of this file about RSS depending on "what else the process has
+     faulted in". The only thing actually guaranteed is that the two are not the SAME
+     number, which is what the check above tests. */
+  printf("ok: rss and commit differ (rss is %.1f%% of commit)\n",
          100.0 * (double)rss / (double)commit);
 
   for (int i = 0; i < BLOCKS; i++) mi_free(keep[i]);


### PR DESCRIPTION
Bug #5 from the #78 Bun inventory. **A profiling fork was reporting the wrong RSS on Linux.**

## The bug

`_mi_prim_process_info` never assigned `current_rss` on Linux, so it kept the default `mi_process_info()` gives it — `current_commit`, mimalloc's own committed counter. `mi_process_info`, `mi_stats_print`, and the `rss_current` field of `mi_stats_as_json` all reported **committed bytes under the name RSS**. Plausible, stable, and off by however much of the heap is untouched. Bun measured 4.91 GB vs 0.56 GB on a real workload.

## The test went in first, and CI proved the bug

The bug is Linux-only and I develop on Windows, where `current_rss` already comes from `PROCESS_MEMORY_COUNTERS` — so the test passes locally and proves nothing. Pushing it alone first (same approach as #91) gave:

```
rss=285056 KiB  commit=285056 KiB
```

**Identical**, on all six ubuntu-family jobs, with 256 MiB committed and ~1/16 touched. Windows and macOS passed. Then the fix turned them green.

## The fix

statm field 2 is `resident`, in pages. Parsed by hand rather than with `scanf` because this can run from inside the allocator: no allocation, no locale, no stdio, using the existing syscall-based `mi_prim_open/read/close` wrappers that exist precisely to avoid recursion during init (upstream #713). On failure `current_rss` is left alone, so the old behaviour stays the fallback rather than reporting a confident zero.

Approach from `oven-sh/mimalloc@6aedf5e1`, MIT (#78); parser written here.

## One correction along the way

The asan job then failed with `rss=321 MiB` vs `commit=285 MiB`. That's correct behaviour — `commit` counts only what *mimalloc* committed, while RSS is the whole process including ASan's shadow memory and redzones. My `rss <= commit` assertion was wrong, and it contradicted this test's own header comment about RSS depending on "what else the process has faulted in". Dropped; the load-bearing `rss != commit` check stays.

34/34.