### PR TITLE
perf(profiler): make the sampling decision without taking the global lock (#78)

### DIFF
--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 97c448e4 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2a9c2c34 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -20908,14 +20908,36 @@ void _mi_prof_on_alloc(mi_theap_t* theap, mi_page_t* page, void* p, size_t size)
   prof_auto_start();
   if mi_likely(!mi_atomic_load_relaxed(&prof_enabled)) return;
   if (prof_callback_depth > 0) return;
-  mi_lock_acquire(&prof_lock);
-  if (!mi_atomic_load_relaxed(&prof_enabled)) { mi_lock_release(&prof_lock); return; }
+
+  // The sampling DECISION is thread-local and is made without taking prof_lock.
+  //
+  // This used to acquire prof_lock first and decide afterwards, so every allocating
+  // thread serialized on one global lock on every allocation while profiling was
+  // enabled -- not just on the roughly 1-in-(rate) that actually sample. That is a
+  // process-wide bottleneck in exactly the configuration users turn on to diagnose a
+  // performance problem. Found by comparing against oven-sh/mimalloc's profiler (#78),
+  // whose countdown is likewise thread-local.
+  //
+  // Everything read or written below is per-theap: bytes_since_sample, next_threshold,
+  // generation, and the PRNG state prof_threshold() advances. prof_generation and
+  // prof_rate are written only under prof_lock in mi_prof_start_ex; reading a stale
+  // generation here merely delays a counter reset by one allocation, which is harmless.
+  //
+  // prof_rate IS load-bearing though: prof_threshold() computes `% (rate * 2)`, so a
+  // rate of 0 -- which is what a concurrent mi_prof_stop leaves behind -- would divide
+  // by zero. Under the old code the lock plus the re-check of prof_enabled made that
+  // unreachable. Now it has to be checked explicitly.
   mi_profiler_tld_t* tld = &theap->tld->profiler;
   if (tld->generation != prof_generation) { tld->bytes_since_sample = 0; tld->next_threshold = 0; tld->random = 0; tld->generation = prof_generation; }
+  if (prof_rate == 0) return;   // stopped concurrently; prof_threshold would divide by zero
   tld->bytes_since_sample += size;
   if (tld->next_threshold == 0) tld->next_threshold = prof_threshold(theap->tld);
-  if (tld->bytes_since_sample < tld->next_threshold) { mi_lock_release(&prof_lock); return; }
+  if mi_likely(tld->bytes_since_sample < tld->next_threshold) return;   // the common case: no lock taken at all
   tld->bytes_since_sample = 0; tld->next_threshold = prof_threshold(theap->tld);
+
+  // Only an actual sample touches the shared record/stack/page state.
+  mi_lock_acquire(&prof_lock);
+  if (!mi_atomic_load_relaxed(&prof_enabled)) { mi_lock_release(&prof_lock); return; }
   mi_prof_record_t* rec = prof_record_alloc();
   if (rec != NULL) {
     rec->stack = _mi_prof_stack_intern();

--- a/src/profile.c
+++ b/src/profile.c
@@ -827,14 +827,36 @@ void _mi_prof_on_alloc(mi_theap_t* theap, mi_page_t* page, void* p, size_t size)
   prof_auto_start();
   if mi_likely(!mi_atomic_load_relaxed(&prof_enabled)) return;
   if (prof_callback_depth > 0) return;
-  mi_lock_acquire(&prof_lock);
-  if (!mi_atomic_load_relaxed(&prof_enabled)) { mi_lock_release(&prof_lock); return; }
+
+  // The sampling DECISION is thread-local and is made without taking prof_lock.
+  //
+  // This used to acquire prof_lock first and decide afterwards, so every allocating
+  // thread serialized on one global lock on every allocation while profiling was
+  // enabled -- not just on the roughly 1-in-(rate) that actually sample. That is a
+  // process-wide bottleneck in exactly the configuration users turn on to diagnose a
+  // performance problem. Found by comparing against oven-sh/mimalloc's profiler (#78),
+  // whose countdown is likewise thread-local.
+  //
+  // Everything read or written below is per-theap: bytes_since_sample, next_threshold,
+  // generation, and the PRNG state prof_threshold() advances. prof_generation and
+  // prof_rate are written only under prof_lock in mi_prof_start_ex; reading a stale
+  // generation here merely delays a counter reset by one allocation, which is harmless.
+  //
+  // prof_rate IS load-bearing though: prof_threshold() computes `% (rate * 2)`, so a
+  // rate of 0 -- which is what a concurrent mi_prof_stop leaves behind -- would divide
+  // by zero. Under the old code the lock plus the re-check of prof_enabled made that
+  // unreachable. Now it has to be checked explicitly.
   mi_profiler_tld_t* tld = &theap->tld->profiler;
   if (tld->generation != prof_generation) { tld->bytes_since_sample = 0; tld->next_threshold = 0; tld->random = 0; tld->generation = prof_generation; }
+  if (prof_rate == 0) return;   // stopped concurrently; prof_threshold would divide by zero
   tld->bytes_since_sample += size;
   if (tld->next_threshold == 0) tld->next_threshold = prof_threshold(theap->tld);
-  if (tld->bytes_since_sample < tld->next_threshold) { mi_lock_release(&prof_lock); return; }
+  if mi_likely(tld->bytes_since_sample < tld->next_threshold) return;   // the common case: no lock taken at all
   tld->bytes_since_sample = 0; tld->next_threshold = prof_threshold(theap->tld);
+
+  // Only an actual sample touches the shared record/stack/page state.
+  mi_lock_acquire(&prof_lock);
+  if (!mi_atomic_load_relaxed(&prof_enabled)) { mi_lock_release(&prof_lock); return; }
   mi_prof_record_t* rec = prof_record_alloc();
   if (rec != NULL) {
     rec->stack = _mi_prof_stack_intern();


### PR DESCRIPTION
The highest-value item the #78 Bun comparison surfaced, and it is **our** defect, not an import.

## The problem

`_mi_prof_on_alloc` acquired `prof_lock` **before** comparing against the sampling threshold. So while profiling was enabled, every allocating thread serialized on one process-wide lock on **every allocation** — not just the ~1-in-(rate) that actually sample. A global bottleneck in precisely the configuration users turn on to diagnose a performance problem.

Bun's profiler makes the same decision from a thread-local countdown with no lock, which is what made ours visible. **No code imported** — this is our own restructuring.

## Why it is safe

Everything the decision touches is per-theap: `bytes_since_sample`, `next_threshold`, `generation`, and the PRNG state `prof_threshold()` advances. `prof_generation` and `prof_rate` are written only under `prof_lock` in `mi_prof_start_ex`; reading a stale generation just delays a counter reset by one allocation.

**One hazard the lock had been hiding:** `prof_threshold()` computes `% (rate * 2)`, so a `prof_rate` of 0 — what a concurrent `mi_prof_stop` leaves behind — divides by zero. The old code was protected by holding the lock and re-checking `prof_enabled`. The new code checks `prof_rate` explicitly.

## Measurement

Both arms built from the same commit, run **interleaved**, minimum of 3, 200k alloc/free per thread at a 512 KiB sample rate:

| threads | before | after | speedup |
|---|---|---|---|
| 1 | 0.0110 s | 0.0110 s | **1.0× — the control** |
| 4 | 0.0500 s | 0.0180 s | **2.8×** |
| 8 | 0.1230 s | 0.0300 s | **4.1×** |

The single-threaded arm is the control that matters: **no change**. That is what separates "removed lock contention" from "got faster for some other reason". The effect appears only as threads contend — the signature of the defect being fixed.

21/21 locally. Second commit regenerates the vendored amalgamation.