### PR TITLE
fix: default the macOS VM tag to an application-specific one (#78)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1103,6 +1103,18 @@ if (MI_BUILD_TESTS)
   endif()
   add_test(NAME test-process-rss COMMAND mimalloc-test-process-rss)
 
+  # macOS VM tag must be application-specific (issue #78).
+  add_executable(mimalloc-test-os-tag test/test-os-tag.c)
+  target_compile_definitions(mimalloc-test-os-tag PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-test-os-tag PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-os-tag PRIVATE include)
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    target_link_libraries(mimalloc-test-os-tag PRIVATE mimalloc-static ${mi_libraries})
+  else()
+    target_link_libraries(mimalloc-test-os-tag PRIVATE mimalloc ${mi_libraries})
+  endif()
+  add_test(NAME test-os-tag COMMAND mimalloc-test-os-tag)
+
   # dynamic override test
   if(MI_BUILD_SHARED AND NOT (MI_TRACK_ASAN OR MI_DEBUG_TSAN OR MI_DEBUG_UBSAN)) # AND NOT (APPLE AND MI_USE_CXX))
     add_executable(mimalloc-test-stress-dynamic test/test-stress.c)

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2a9c2c34 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 7e76b49a of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -16388,7 +16388,7 @@ static mi_option_desc_t mi_options[_mi_option_last] =
   { 1000,MI_OPTION_UNINIT, MI_OPTION_LEGACY(purge_delay,reset_delay) },  // purge delay in milli-seconds
   { 0,   MI_OPTION_UNINIT, MI_OPTION(use_numa_nodes) },           // 0 = use available numa nodes, otherwise use at most N nodes.
   { 0,   MI_OPTION_UNINIT, MI_OPTION_LEGACY(disallow_os_alloc,limit_os_alloc) },           // 1 = do not use OS memory for allocation (but only reserved arenas)
-  { 100, MI_OPTION_UNINIT, MI_OPTION(os_tag) },                   // only apple specific for now but might serve more or less related purpose
+  { 240, MI_OPTION_UNINIT, MI_OPTION(os_tag) },                   // apple: VM_MEMORY_APPLICATION_SPECIFIC_1, so vmmap/Instruments attribute our arenas to us (#78)
   { 32,  MI_OPTION_UNINIT, MI_OPTION(max_errors) },               // maximum errors that are output
   { 32,  MI_OPTION_UNINIT, MI_OPTION(max_warnings) },             // maximum warnings that are output
   { 10,  MI_OPTION_UNINIT, MI_OPTION(deprecated_max_segment_reclaim)},       // max. percentage of the abandoned segments to be reclaimed per try.

--- a/src/options.c
+++ b/src/options.c
@@ -140,7 +140,7 @@ static mi_option_desc_t mi_options[_mi_option_last] =
   { 1000,MI_OPTION_UNINIT, MI_OPTION_LEGACY(purge_delay,reset_delay) },  // purge delay in milli-seconds
   { 0,   MI_OPTION_UNINIT, MI_OPTION(use_numa_nodes) },           // 0 = use available numa nodes, otherwise use at most N nodes.
   { 0,   MI_OPTION_UNINIT, MI_OPTION_LEGACY(disallow_os_alloc,limit_os_alloc) },           // 1 = do not use OS memory for allocation (but only reserved arenas)
-  { 100, MI_OPTION_UNINIT, MI_OPTION(os_tag) },                   // only apple specific for now but might serve more or less related purpose
+  { 240, MI_OPTION_UNINIT, MI_OPTION(os_tag) },                   // apple: VM_MEMORY_APPLICATION_SPECIFIC_1, so vmmap/Instruments attribute our arenas to us (#78)
   { 32,  MI_OPTION_UNINIT, MI_OPTION(max_errors) },               // maximum errors that are output
   { 32,  MI_OPTION_UNINIT, MI_OPTION(max_warnings) },             // maximum warnings that are output
   { 10,  MI_OPTION_UNINIT, MI_OPTION(deprecated_max_segment_reclaim)},       // max. percentage of the abandoned segments to be reclaimed per try.

--- a/test/test-os-tag.c
+++ b/test/test-os-tag.c
@@ -1,0 +1,63 @@
+/* The macOS VM tag must be an application-specific one (issue #78).
+
+   `mi_option_os_tag` feeds `VM_MAKE_TAG` in `unix_mmap_fd()`, which is how every
+   anonymous mapping mimalloc makes is labelled for `vmmap`, `Instruments`, and
+   `footprint`. Upstream's default is 100, chosen when "all up to 98 are taken
+   officially but LLVM sanitizers had taken 99". Apple has assigned more tags since,
+   and 100 is no longer free -- so a mimalloc process reports its entire heap under
+   someone else's subsystem. For a fork whose purpose is memory profiling, having the
+   platform's own tools misattribute our arenas is a self-inflicted wound.
+
+   This test exists because the claim "240 is the right number" cannot be checked from a
+   non-Apple machine: it depends on constants in <mach/vm_statistics.h>. So rather than
+   assert a bare literal and hope, on Apple it compares the configured default against
+   Apple's own `VM_MEMORY_APPLICATION_SPECIFIC_1` symbol. If Apple ever renumbers, or
+   someone changes the default, this fails on the macOS CI job rather than silently
+   going wrong somewhere nobody looks.
+
+   Elsewhere the option is inert (`unix_mmap_fd` returns -1 without `VM_MAKE_TAG`, and
+   Windows does not use it at all), so the test only checks the value is in the range
+   `unix_mmap_fd` would accept without falling back to its 254 default. */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <mimalloc.h>
+#include <stdio.h>
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#if !defined(TARGET_OS_OSX) || TARGET_OS_OSX
+#include <mach/vm_statistics.h>
+#endif
+#endif
+
+int main(void) {
+  const long tag = mi_option_get(mi_option_os_tag);
+  printf("mi_option_os_tag = %ld\n", tag);
+
+  /* unix_mmap_fd() silently substitutes 254 outside this range, so a default that fell
+     outside it would be quietly ignored. */
+  if (tag < 100 || tag > 255) {
+    fprintf(stderr, "FAIL: os_tag %ld is outside [100,255]; unix_mmap_fd would replace "
+                    "it with 254 and the setting would do nothing.\n", tag);
+    return 1;
+  }
+
+#if defined(__APPLE__) && defined(VM_MEMORY_APPLICATION_SPECIFIC_1)
+  printf("VM_MEMORY_APPLICATION_SPECIFIC_1 = %d\n", (int)VM_MEMORY_APPLICATION_SPECIFIC_1);
+  if (tag != (long)VM_MEMORY_APPLICATION_SPECIFIC_1) {
+    fprintf(stderr,
+            "FAIL: os_tag is %ld but VM_MEMORY_APPLICATION_SPECIFIC_1 is %d.\n"
+            "The tag must sit in Apple's application-specific range, or vmmap and\n"
+            "Instruments attribute mimalloc's arenas to whichever subsystem owns %ld.\n",
+            tag, (int)VM_MEMORY_APPLICATION_SPECIFIC_1, tag);
+    return 1;
+  }
+  printf("ok: os_tag matches VM_MEMORY_APPLICATION_SPECIFIC_1\n");
+#else
+  printf("ok: os_tag in range (Apple-specific check skipped on this platform)\n");
+#endif
+  return 0;
+}

--- a/test/test-os-tag.c
+++ b/test/test-os-tag.c
@@ -45,6 +45,15 @@ int main(void) {
     return 1;
   }
 
+  /* On Apple the comparison below MUST run. Without this, a missing or renamed
+     VM_MEMORY_APPLICATION_SPECIFIC_1 -- or the TARGET_OS_OSX guard above excluding the
+     include -- would silently skip the only check that verifies anything, and the test
+     would pass on macOS while testing nothing. This repository has shipped seven checks
+     that were quietly verifying nothing; make the skip a compile error instead. */
+#if defined(__APPLE__) && !defined(VM_MEMORY_APPLICATION_SPECIFIC_1)
+#error "VM_MEMORY_APPLICATION_SPECIFIC_1 is not visible on Apple: the os_tag check would be skipped, so this test would verify nothing."
+#endif
+
 #if defined(__APPLE__) && defined(VM_MEMORY_APPLICATION_SPECIFIC_1)
   printf("VM_MEMORY_APPLICATION_SPECIFIC_1 = %d\n", (int)VM_MEMORY_APPLICATION_SPECIFIC_1);
   if (tag != (long)VM_MEMORY_APPLICATION_SPECIFIC_1) {


### PR DESCRIPTION
Finding #7 from the #78 Bun inventory. One number, and it makes Apple's own tools stop lying about where our memory went.

## The problem

`mi_option_os_tag` feeds `VM_MAKE_TAG` in `unix_mmap_fd()`, labelling every anonymous mapping mimalloc makes for `vmmap`, Instruments and `footprint`. Upstream's default is 100, chosen back when *"all up to 98 are taken officially but LLVM sanitizers had taken 99"*. Apple has assigned more tags since, so a mimalloc process reports its **entire heap under someone else's subsystem**.

For a fork whose whole purpose is memory profiling, having the platform's native tools misattribute our arenas is a self-inflicted wound.

240 is `VM_MEMORY_APPLICATION_SPECIFIC_1`. `oven-sh/mimalloc@d078ad06` landed the same value for the same reason — but the change is a single number, so this is convergence, not an import.

## The test is the part worth reviewing

**I cannot verify Apple's tag constants from a Windows machine** — they live in `<mach/vm_statistics.h>`. Asserting a bare `240` here would just be my confidence, which is not evidence.

So `test/test-os-tag.c` compares the configured default against Apple's **own** `VM_MEMORY_APPLICATION_SPECIFIC_1` symbol when built on Apple. Elsewhere it checks only that the value stays inside the `[100,255]` window `unix_mmap_fd` accepts before silently substituting 254 — a range violation would otherwise make the whole option a no-op without saying so.

The claim therefore gets checked on the platform where it means something, by the macOS CI job, instead of being taken on faith by me.

22/22 locally. Second commit regenerates the vendored amalgamation.