### PR TITLE
docs: measure and publish the MI_PPROF=ON disabled-path overhead (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,32 @@ symbolization.
 
 ## Profiler reference
 
+### What it costs when it is not running
+
+Measured, so you can decide whether to ship `MI_PPROF=ON`. Windows/MinGW, Release,
+4M alloc/free pairs single-threaded, both arms built from the same commit and run
+interleaved, minimum of four runs of three reps each:
+
+| build | ns per allocation | within-arm spread |
+|---|---|---|
+| `MI_PPROF=OFF` | **11.75** | 4% |
+| `MI_PPROF=ON`, profiler stopped | **20.00** | 14% |
+
+**About +70% per allocation with the profiler switched off.** That is the cost of the
+unconditional `_mi_prof_on_alloc` call on the allocation fast path, which then checks an
+atomic flag and returns. Single-threaded on purpose — this is per-allocation instruction
+count, not lock contention (contention was a separate defect, fixed in #152).
+
+This is larger than it should be and is a known gap rather than a design choice. Bun's
+fork takes a different approach: it leaves the fast path completely untouched and, when
+profiling is switched on, poisons `pages_free_direct` so allocations divert into the
+already-cold `_mi_malloc_generic`, where the sampling check lives. That is strictly
+better when disabled, which is the common case for a shipping build. Tracked in #50.
+
+Until then: if allocation throughput matters more to you than being able to turn
+profiling on at runtime, build with `MI_PPROF=OFF`. Enabling the profiler at runtime
+costs more again, but the sampling decision itself is now lock-free (#152).
+
 ### Environment variables
 
 Set these before process launch to capture allocations made during startup,


### PR DESCRIPTION
Ticks the #50 checkbox: *"Compare our overhead-when-disabled against the `pages_free_direct` poisoning trick — it may be strictly better than guarded checks and is worth benchmarking."*

Benchmarked. It is worse than I expected.

| build | ns per allocation | within-arm spread |
|---|---|---|
| `MI_PPROF=OFF` | **11.75** | 4% |
| `MI_PPROF=ON`, profiler stopped | **20.00** | 14% |

**About +70% per allocation with the profiler switched off.**

Windows/MinGW, Release, 4M alloc/free pairs, both arms built from the same commit and run interleaved, minimum of four runs of three reps. The effect is roughly 5× the larger arm's spread, so it is not noise. Single-threaded on purpose — this is per-allocation instruction count, not lock contention (contention was a separate defect, fixed in #152).

That is the cost of the unconditional `_mi_prof_on_alloc` call on the allocation fast path, which then loads an atomic flag and returns.

## Why this belongs in the README

**Shipping builds use `MI_PPROF=ON`**, so this is the cost users actually pay — and no overhead claim existed anywhere in the repo, so nobody could have known. This is new information rather than a correction, but it should have been written down long ago.

The note gives users the mitigation they have today (`MI_PPROF=OFF` if throughput matters more than runtime-toggleable profiling) and names the fix worth pursuing: Bun leaves the fast path completely untouched and, when profiling starts, poisons `pages_free_direct` so allocations divert into the already-cold `_mi_malloc_generic` where the sampling check lives. Strictly better when disabled — which is the common case.

Docs-only.