### PR TITLE
docs: bootstrap fix filed upstream as microsoft/mimalloc#1351 (#50)

### DIFF
--- a/docs/upstreaming.md
+++ b/docs/upstreaming.md
@@ -176,7 +176,15 @@ that the `mi_heap_new` / `mi_subproc_new` bootstrap fix above is still needed up
 those are exactly the two tests it addresses, and they are exactly the two that fail.
 
 Order to propose in: bootstrap fix first, then the MinGW job, so the job lands green.
-Not yet filed.
+
+**Bootstrap fix: FILED as [microsoft/mimalloc#1351](https://github.com/microsoft/mimalloc/pull/1351)**
+(2026-08-02), cut from `upstream/dev3` tip. Two `mi_thread_init()` calls, in
+`mi_heap_new_in_arena` and `mi_subproc_new`. Verified on that tree in upstream's own
+`basic` configuration: **2/6 failing before, 6/6 after**. The PR also flags #1349 and
+offers the MinGW job as a follow-up, explicitly noting it would be red today and so
+should land after the fixes.
+
+**MinGW CI job: still unfiled**, and now correctly sequenced behind #1351.
 
 ## Posture on upstream PR #1266 (competing profiler)
 


### PR DESCRIPTION
Second upstream PR from this work: [microsoft/mimalloc#1351](https://github.com/microsoft/mimalloc/pull/1351).

Cut from `upstream/dev3` tip and verified **on that tree**, in upstream's own `basic` configuration (`Debug`, `MI_DEBUG_FULL=ON`) under MinGW-w64 GCC 12.2:

| | result |
|---|---|
| stock `upstream/dev3` | 67% passed — **2 of 6 failed** (`test-stress-heaps`, `test-stress-subprocs`, both `0xc0000409`) |
| with the fix | **100% passed, 0 failed** |

The fix is two `mi_thread_init()` calls, in `mi_heap_new_in_arena` and `mi_subproc_new`. Both can be the first mimalloc call in a process, and both then allocate from a main heap that does not exist yet. Platforms with a library constructor mask it, which is why it only surfaces on Windows.

Sent **without** the #128 B1 subproc-heap-leak fix that sits adjacent in our tree, so the PR is a single concern.

The PR also flags #1349 and offers the MinGW CI job as a follow-up — stating plainly that it would be red today and should therefore land *after* the fixes, which is the sequencing recorded here last iteration.

**MinGW CI job remains unfiled**, now correctly queued behind #1351.

Docs-only.