### PR TITLE
docs: document mi_heap_visit_blocks' thread-safety precondition (#78)

### DIFF
--- a/include/mimalloc.h
+++ b/include/mimalloc.h
@@ -322,6 +322,26 @@ typedef struct mi_heap_area_s {
 // reference for output shape only. Background reading; no code to take.
 typedef bool (mi_cdecl mi_block_visit_fun)(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, void* arg);
 
+// THREAD SAFETY (#78): these are NOT safe to call while other threads are freeing into
+// `heap`. The implementation says so only in an internal comment -- `_mi_heap_visit_blocks`
+// in src/arena.c reads `heap->os_abandoned_pages` under `os_abandoned_pages_lock`, then
+// walks the `page->next` chain with the lock RELEASED, above the comment "technically we
+// don't need the initial lock as we assume we are the only thread running in this
+// subproc".
+//
+// Under that assumption the unlocked walk is correct. But nothing in this header said so,
+// and nothing enforces it: a caller who visits a heap while another thread performs the
+// last `mi_free` into one of its OS-allocated abandoned pages can have that page unlinked
+// and unmapped between the `next` read and its use.
+//
+// The #78 inventory listed this as an outright use-after-free "in code we ship". That
+// overstates it -- it is reachable only by violating a precondition the implementation
+// does hold, which upstream simply never wrote down here. Documented rather than locked:
+// taking the lock across the whole walk would serialise visiting against every free on
+// the heap, and the callers that matter (heap teardown, our profiler's snapshot) do
+// satisfy the precondition.
+//
+// If you need to visit a live heap concurrently, that is not supported today.
 mi_decl_export bool   mi_heap_visit_blocks(mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 mi_decl_export bool   mi_heap_visit_abandoned_blocks(mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 4e492e9e of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 56e8f2de of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -341,6 +341,26 @@ typedef struct mi_heap_area_s {
 // reference for output shape only. Background reading; no code to take.
 typedef bool (mi_cdecl mi_block_visit_fun)(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, void* arg);
 
+// THREAD SAFETY (#78): these are NOT safe to call while other threads are freeing into
+// `heap`. The implementation says so only in an internal comment -- `_mi_heap_visit_blocks`
+// in src/arena.c reads `heap->os_abandoned_pages` under `os_abandoned_pages_lock`, then
+// walks the `page->next` chain with the lock RELEASED, above the comment "technically we
+// don't need the initial lock as we assume we are the only thread running in this
+// subproc".
+//
+// Under that assumption the unlocked walk is correct. But nothing in this header said so,
+// and nothing enforces it: a caller who visits a heap while another thread performs the
+// last `mi_free` into one of its OS-allocated abandoned pages can have that page unlinked
+// and unmapped between the `next` read and its use.
+//
+// The #78 inventory listed this as an outright use-after-free "in code we ship". That
+// overstates it -- it is reachable only by violating a precondition the implementation
+// does hold, which upstream simply never wrote down here. Documented rather than locked:
+// taking the lock across the whole walk would serialise visiting against every free on
+// the heap, and the callers that matter (heap teardown, our profiler's snapshot) do
+// satisfy the precondition.
+//
+// If you need to visit a live heap concurrently, that is not supported today.
 mi_decl_export bool   mi_heap_visit_blocks(mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 mi_decl_export bool   mi_heap_visit_abandoned_blocks(mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 4d5c07e9 of the three public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 56e8f2de of the three public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------
@@ -325,6 +325,26 @@ typedef struct mi_heap_area_s {
 // reference for output shape only. Background reading; no code to take.
 typedef bool (mi_cdecl mi_block_visit_fun)(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, void* arg);
 
+// THREAD SAFETY (#78): these are NOT safe to call while other threads are freeing into
+// `heap`. The implementation says so only in an internal comment -- `_mi_heap_visit_blocks`
+// in src/arena.c reads `heap->os_abandoned_pages` under `os_abandoned_pages_lock`, then
+// walks the `page->next` chain with the lock RELEASED, above the comment "technically we
+// don't need the initial lock as we assume we are the only thread running in this
+// subproc".
+//
+// Under that assumption the unlocked walk is correct. But nothing in this header said so,
+// and nothing enforces it: a caller who visits a heap while another thread performs the
+// last `mi_free` into one of its OS-allocated abandoned pages can have that page unlinked
+// and unmapped between the `next` read and its use.
+//
+// The #78 inventory listed this as an outright use-after-free "in code we ship". That
+// overstates it -- it is reachable only by violating a precondition the implementation
+// does hold, which upstream simply never wrote down here. Documented rather than locked:
+// taking the lock across the whole walk would serialise visiting against every free on
+// the heap, and the callers that matter (heap teardown, our profiler's snapshot) do
+// satisfy the precondition.
+//
+// If you need to visit a live heap concurrently, that is not supported today.
 mi_decl_export bool   mi_heap_visit_blocks(mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 mi_decl_export bool   mi_heap_visit_abandoned_blocks(mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 

--- a/rust/mimalloc-pprof/vendor/mimalloc.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc.h
@@ -322,6 +322,26 @@ typedef struct mi_heap_area_s {
 // reference for output shape only. Background reading; no code to take.
 typedef bool (mi_cdecl mi_block_visit_fun)(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, void* arg);
 
+// THREAD SAFETY (#78): these are NOT safe to call while other threads are freeing into
+// `heap`. The implementation says so only in an internal comment -- `_mi_heap_visit_blocks`
+// in src/arena.c reads `heap->os_abandoned_pages` under `os_abandoned_pages_lock`, then
+// walks the `page->next` chain with the lock RELEASED, above the comment "technically we
+// don't need the initial lock as we assume we are the only thread running in this
+// subproc".
+//
+// Under that assumption the unlocked walk is correct. But nothing in this header said so,
+// and nothing enforces it: a caller who visits a heap while another thread performs the
+// last `mi_free` into one of its OS-allocated abandoned pages can have that page unlinked
+// and unmapped between the `next` read and its use.
+//
+// The #78 inventory listed this as an outright use-after-free "in code we ship". That
+// overstates it -- it is reachable only by violating a precondition the implementation
+// does hold, which upstream simply never wrote down here. Documented rather than locked:
+// taking the lock across the whole walk would serialise visiting against every free on
+// the heap, and the callers that matter (heap teardown, our profiler's snapshot) do
+// satisfy the precondition.
+//
+// If you need to visit a live heap concurrently, that is not supported today.
 mi_decl_export bool   mi_heap_visit_blocks(mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 mi_decl_export bool   mi_heap_visit_abandoned_blocks(mi_heap_t* heap, bool visit_blocks, mi_block_visit_fun* visitor, void* arg);
 


### PR DESCRIPTION
Last of the three Bun inventory findings — and verifying it myself **changed the conclusion**, which is the lesson from #161 where I propagated an agent's analysis without working it through and merged an incorrect mechanism.

## What the inventory claimed

An outright use-after-free in code we ship: `_mi_heap_visit_blocks` reads `heap->os_abandoned_pages` under `os_abandoned_pages_lock`, then walks the `page->next` chain **with the lock released**, so a concurrent last `mi_free` can unlink and unmap a page between the `next` read and its use.

## What is actually there

The walk is exactly as described. What the inventory omitted is the comment sitting directly above it:

```c
// (technically we don't need the initial lock as we assume we are the only thread running in this subproc)
```

Under that precondition the unlocked walk is **correct by construction**, and the callers that matter — heap teardown, our profiler's snapshot — satisfy it.

So this is a **documented-precondition gap, not an unqualified UAF**. It is reachable only by violating an assumption the implementation genuinely does hold, and which upstream simply never wrote down where callers would see it: `mi_heap_visit_blocks` and `mi_heap_visit_abandoned_blocks` carried **no thread-safety note at all** in the public header.

## Documented rather than locked

Holding `os_abandoned_pages_lock` across the whole walk would serialise visiting against **every free on the heap** — a real, permanent cost to remove a hazard that no supported usage reaches. The precondition is now stated in `mimalloc.h`, along with where it comes from and what happens if you violate it.

If you need to visit a live heap concurrently, that is not supported today, and now the header says so.

21/21 locally. Second commit regenerates the vendored headers.
