### PR TITLE
chore: add benchmark-report.html to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ ide/vs20??/.vs
 ide/vs20??/VTune*
 out/
 rust/target/
+rust/benchmark-report.html
 docs/
 *.zip
 *.tar


### PR DESCRIPTION
Prevents the dashboard-generated HTML report from showing as untracked.