### PR TITLE
fix(benchmarks): make phase 1 runner truthful

### DIFF
--- a/rust/bench-harness/src/bin/stress-child.rs
+++ b/rust/bench-harness/src/bin/stress-child.rs
@@ -1,0 +1,53 @@
+//! Test/development stress-child protocol adapter.
+//!
+//! Production calls use `dashboard --stress-child`; this tiny binary lets the
+//! harness integration tests exercise the same strict stdin/stdout protocol.
+
+fn main() {
+    if let Some(mode) = std::env::var_os("BENCH_HARNESS_TEST_RESPONSE") {
+        match mode.to_string_lossy().as_ref() {
+            "partial" => {
+                print!("{{");
+                return;
+            }
+            "nonfinite" => {
+                print!("{{\"elapsed_secs\":1e999}}");
+                return;
+            }
+            "extra" => {
+                print!("{{}}\n{{}}");
+                return;
+            }
+            "zero" | "zero-elapsed" | "checksum-mismatch" | "timeout-report" | "crash-report" => {
+                let mut input = String::new();
+                use std::io::Read;
+                std::io::stdin()
+                    .read_to_string(&mut input)
+                    .expect("read request");
+                let request: stress_harness::StressChildRequest =
+                    serde_json::from_str(&input).expect("parse request");
+                let mut result = stress_harness::run_child_request(request).expect("run request");
+                match mode.to_string_lossy().as_ref() {
+                    "zero" => result.ops_completed = 0,
+                    "zero-elapsed" => result.elapsed_secs = 0.0,
+                    "checksum-mismatch" => {
+                        result.observed_checksum = result.expected_checksum.wrapping_add(1)
+                    }
+                    "timeout-report" => result.timed_out = true,
+                    "crash-report" => result.crashed = true,
+                    _ => unreachable!(),
+                }
+                print!(
+                    "{}",
+                    serde_json::to_string(&result).expect("serialize result")
+                );
+                return;
+            }
+            _ => {}
+        }
+    }
+    if let Err(error) = stress_harness::run_stdio_child() {
+        eprintln!("stress-child rejected request: {error}");
+        std::process::exit(1);
+    }
+}

--- a/rust/bench-harness/src/lib.rs
+++ b/rust/bench-harness/src/lib.rs
@@ -22,10 +22,14 @@
 //!   stable reference hardware per the #170 acceptance criteria.
 
 use serde::{Deserialize, Serialize};
+use std::ffi::OsString;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 // Re-export the stress harness types we build on.
-pub use stress_harness::{ScenarioType, StressConfig};
+pub use stress_harness::{ExecutionMode, ScenarioType, StressConfig};
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -64,6 +68,44 @@ pub struct BenchConfig {
     #[serde(default)]
     pub serialized: bool,
 }
+
+/// Explicit, production-locatable child program used for every benchmark
+/// sample. The program must accept one [`stress_harness::StressChildRequest`]
+/// on stdin and emit exactly one JSON response on stdout.
+#[derive(Debug, Clone)]
+pub struct ChildProgram {
+    pub program: PathBuf,
+    pub arguments: Vec<OsString>,
+    pub environment: Vec<(OsString, OsString)>,
+}
+
+/// A measurement rejection. No rejected sample can enter a [`BenchResult`].
+#[derive(Debug)]
+pub enum BenchError {
+    InvalidConfig(String),
+    Spawn(std::io::Error),
+    WriteRequest(std::io::Error),
+    Timeout { seconds: u64 },
+    NonZeroChild,
+    InvalidChildResponse(String),
+    InvalidSample(String),
+}
+
+impl std::fmt::Display for BenchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidConfig(message)
+            | Self::InvalidChildResponse(message)
+            | Self::InvalidSample(message) => f.write_str(message),
+            Self::Spawn(error) => write!(f, "spawn stress child: {error}"),
+            Self::WriteRequest(error) => write!(f, "write stress child request: {error}"),
+            Self::Timeout { seconds } => write!(f, "stress child timed out after {seconds}s"),
+            Self::NonZeroChild => f.write_str("stress child exited unsuccessfully"),
+        }
+    }
+}
+
+impl std::error::Error for BenchError {}
 
 fn default_alloc_min() -> usize {
     16
@@ -272,15 +314,16 @@ pub struct BenchResult {
 // Runner
 // ---------------------------------------------------------------------------
 
-/// Run a full benchmark (warmup + measurement) and return aggregated results.
-pub fn run_benchmark(config: BenchConfig) -> BenchResult {
+/// Run every warmup and measurement round in a fresh watchdog-owned child.
+/// Invalid, partial, or malformed results are rejected before aggregation.
+pub fn run_benchmark(config: BenchConfig, child: &ChildProgram) -> Result<BenchResult, BenchError> {
+    validate_benchmark_config(&config)?;
     let metadata = BenchMetadata::capture();
     let total_rounds = config.warmup_rounds + config.measurement_rounds;
     let mut samples = Vec::with_capacity(config.measurement_rounds);
 
     for round in 0..total_rounds {
         let is_warmup = round < config.warmup_rounds;
-        let round_start = Instant::now();
 
         let stress_cfg = StressConfig {
             name: format!("{}-round-{}", config.name, round),
@@ -289,159 +332,160 @@ pub fn run_benchmark(config: BenchConfig) -> BenchResult {
             operation_count: config.operation_count,
             allocation_size_min: config.allocation_size_min,
             allocation_size_max: config.allocation_size_max,
-            max_duration_secs: config.max_duration_secs,
         };
 
-        let stress_result = if config.serialized {
-            // Planted-slower control: force all allocations through a Mutex.
-            run_serialized(stress_cfg, config.scenario)
-        } else {
-            stress_harness::run_scenario(stress_cfg, config.scenario)
+        let request = stress_harness::StressChildRequest {
+            protocol_version: stress_harness::CHILD_PROTOCOL_VERSION,
+            config: stress_cfg,
+            scenario: config.scenario,
+            execution_mode: if config.serialized {
+                ExecutionMode::SerializedControl
+            } else {
+                ExecutionMode::Normal
+            },
         };
+        let stress_result =
+            run_child_sample(child, &request, config.max_duration_secs.unwrap_or(60))?;
 
-        let elapsed = round_start.elapsed().as_secs_f64();
+        let elapsed = stress_result.elapsed_secs;
         let ops = stress_result.ops_completed;
+        validate_stress_result(&stress_result, &request.config)?;
 
         if !is_warmup {
-            let tput = if elapsed > 0.0 {
-                ops as f64 / elapsed
-            } else {
-                f64::INFINITY
-            };
+            let tput = ops as f64 / elapsed;
+            let ns_per_op = (elapsed * 1e9) / ops as f64;
+            if !tput.is_finite() || !ns_per_op.is_finite() || tput <= 0.0 || ns_per_op <= 0.0 {
+                return Err(BenchError::InvalidSample(
+                    "sample has non-finite or non-positive throughput".into(),
+                ));
+            }
             samples.push(BenchSample {
                 round: round - config.warmup_rounds,
                 ops_completed: ops,
                 elapsed_secs: elapsed,
                 throughput_ops_per_sec: tput,
-                throughput_ns_per_op: if ops > 0 {
-                    (elapsed * 1e9) / ops as f64
-                } else {
-                    f64::INFINITY
-                },
+                throughput_ns_per_op: ns_per_op,
             });
         }
     }
 
     let summary = compute_summary(&samples);
-    let repro = format!(
-        "cargo test -p bench-harness --release -- --nocapture --test-threads=1"
-    );
+    let repro = format!("cargo test -p bench-harness --release -- --nocapture --test-threads=1");
 
-    BenchResult {
+    Ok(BenchResult {
         config,
         metadata,
         samples,
         summary,
         reproduction_command: repro,
+    })
+}
+
+fn validate_benchmark_config(config: &BenchConfig) -> Result<(), BenchError> {
+    StressConfig {
+        name: config.name.clone(),
+        seed: config.seed,
+        worker_count: config.worker_count,
+        operation_count: config.operation_count,
+        allocation_size_min: config.allocation_size_min,
+        allocation_size_max: config.allocation_size_max,
+    }
+    .validate()
+    .map_err(|error| BenchError::InvalidConfig(error.to_string()))?;
+    if config.measurement_rounds == 0 {
+        return Err(BenchError::InvalidConfig(
+            "measurement_rounds must be greater than zero".into(),
+        ));
+    }
+    if config.max_duration_secs == Some(0) {
+        return Err(BenchError::InvalidConfig(
+            "max_duration_secs must be greater than zero".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn run_child_sample(
+    child: &ChildProgram,
+    request: &stress_harness::StressChildRequest,
+    timeout_secs: u64,
+) -> Result<stress_harness::StressResult, BenchError> {
+    let request = serde_json::to_vec(request).map_err(|error| {
+        BenchError::InvalidConfig(format!("serialize stress-child request: {error}"))
+    })?;
+    let mut process = Command::new(&child.program)
+        .args(&child.arguments)
+        .envs(child.environment.iter().map(|(key, value)| (key, value)))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(BenchError::Spawn)?;
+    process
+        .stdin
+        .take()
+        .expect("child stdin piped")
+        .write_all(&request)
+        .map_err(BenchError::WriteRequest)?;
+
+    let started = Instant::now();
+    loop {
+        match process.try_wait().map_err(BenchError::Spawn)? {
+            Some(status) => {
+                let output = process.wait_with_output().map_err(BenchError::Spawn)?;
+                if !status.success() {
+                    return Err(BenchError::NonZeroChild);
+                }
+                return serde_json::from_slice(&output.stdout).map_err(|error| {
+                    BenchError::InvalidChildResponse(format!(
+                        "expected exactly one JSON response: {error}"
+                    ))
+                });
+            }
+            None if started.elapsed() >= Duration::from_secs(timeout_secs) => {
+                let _ = process.kill();
+                let _ = process.wait();
+                return Err(BenchError::Timeout {
+                    seconds: timeout_secs,
+                });
+            }
+            None => std::thread::sleep(Duration::from_millis(10)),
+        }
     }
 }
 
-// ---------------------------------------------------------------------------
-// Planted-slower (serialized) path
-// ---------------------------------------------------------------------------
-
-/// Run the same workload shape but force every allocation through a global
-/// [`std::sync::Mutex`], effectively serialising all workers.  This is the
-/// planted-slower control that any statistical comparison must reject.
-fn run_serialized(
-    config: StressConfig,
-    scenario: ScenarioType,
-) -> stress_harness::StressResult {
-    use std::sync::{Arc, Barrier, Mutex};
-    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-    use std::thread;
-
-    let worker_count = config.worker_count.max(1);
-    let ops_completed = Arc::new(AtomicU64::new(0));
-    let simultaneous = Arc::new(AtomicUsize::new(0));
-    let max_simultaneous = Arc::new(AtomicUsize::new(0));
-    let serial_lock = Arc::new(Mutex::new(()));
-
-    let ready = Arc::new(Barrier::new(worker_count));
-    let running = Arc::new(Barrier::new(worker_count + 1));
-
-    let mut handles = Vec::with_capacity(worker_count);
-    for wid in 0..worker_count {
-        let cfg = config.clone();
-        let ops = Arc::clone(&ops_completed);
-        let sim = Arc::clone(&simultaneous);
-        let max_sim = Arc::clone(&max_simultaneous);
-        let rb = Arc::clone(&ready);
-        let run_b = Arc::clone(&running);
-        let lock = Arc::clone(&serial_lock);
-
-        handles.push(thread::spawn(move || {
-            rb.wait();
-            let cur = sim.fetch_add(1, Ordering::SeqCst) + 1;
-            max_sim.fetch_max(cur, Ordering::SeqCst);
-            run_b.wait();
-
-            let per_worker = (cfg.operation_count / worker_count).max(1);
-            let mut rng = stress_harness::SeededRng::new(
-                cfg.seed.wrapping_add(wid as u64),
-            );
-
-            match scenario {
-                ScenarioType::AllocFree => {
-                    for _ in 0..per_worker {
-                        let _guard = lock.lock().unwrap();
-                        let sz = cfg.allocation_size_min
-                            + rng.next_usize(
-                                cfg.allocation_size_max
-                                    - cfg.allocation_size_min
-                                    + 1,
-                            );
-                        let v = vec![0u8; sz];
-                        drop(v); // alloc + free inside the lock
-                        drop(_guard);
-                        ops.fetch_add(1, Ordering::Relaxed);
-                    }
-                }
-                ScenarioType::Sawtooth => {
-                    const BATCH: usize = 1024;
-                    let mut held: Vec<Vec<u8>> = Vec::with_capacity(BATCH);
-                    for i in 0..per_worker {
-                        let _guard = lock.lock().unwrap();
-                        let sz = cfg.allocation_size_min
-                            + rng.next_usize(
-                                cfg.allocation_size_max
-                                    - cfg.allocation_size_min
-                                    + 1,
-                            );
-                        held.push(vec![0u8; sz]);
-                        drop(_guard);
-                        ops.fetch_add(1, Ordering::Relaxed);
-                        if held.len() >= BATCH || i == per_worker - 1 {
-                            held.clear();
-                        }
-                    }
-                }
-                ScenarioType::Hang => loop {
-                    thread::sleep(Duration::from_secs(1));
-                },
-            }
-
-            sim.fetch_sub(1, Ordering::SeqCst);
-        }));
+fn validate_stress_result(
+    result: &stress_harness::StressResult,
+    requested_config: &StressConfig,
+) -> Result<(), BenchError> {
+    if result.timed_out || result.crashed {
+        return Err(BenchError::InvalidSample(
+            "stress child reported timeout or crash".into(),
+        ));
     }
-
-    // Main thread waits on the same barrier so all workers proceed.
-    running.wait();
-    std::thread::sleep(Duration::from_millis(5));
-
-    for h in handles {
-        let _ = h.join();
+    if &result.config != requested_config {
+        return Err(BenchError::InvalidSample(
+            "stress child response configuration does not match its request".into(),
+        ));
     }
-
-    stress_harness::StressResult {
-        config,
-        max_simultaneous_workers: max_simultaneous.load(Ordering::SeqCst),
-        ops_completed: ops_completed.load(Ordering::Relaxed),
-        timed_out: false,
-        crashed: false,
-        elapsed_secs: 0.0, // measured externally
-        reproduction_command: String::new(),
+    if result.ops_completed == 0 || result.ops_completed != requested_config.operation_count as u64
+    {
+        return Err(BenchError::InvalidSample(format!(
+            "stress child completed {} operations; expected {}",
+            result.ops_completed, requested_config.operation_count
+        )));
     }
+    if result.observed_checksum != result.expected_checksum {
+        return Err(BenchError::InvalidSample(
+            "stress child reported a checksum mismatch".into(),
+        ));
+    }
+    if !result.elapsed_secs.is_finite() || result.elapsed_secs <= 0.0 {
+        return Err(BenchError::InvalidSample(
+            "stress child has non-finite or non-positive elapsed time".into(),
+        ));
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -475,7 +519,11 @@ fn compute_summary(samples: &[BenchSample]) -> BenchSummary {
     };
     let min_tput = tputs.iter().cloned().fold(f64::INFINITY, f64::min);
     let max_tput = tputs.iter().cloned().fold(0.0_f64, f64::max);
-    let mean_ns = if mean > 0.0 { 1e9 / mean } else { f64::INFINITY };
+    let mean_ns = if mean > 0.0 {
+        1e9 / mean
+    } else {
+        f64::INFINITY
+    };
 
     BenchSummary {
         rounds: n,
@@ -492,11 +540,7 @@ fn compute_summary(samples: &[BenchSample]) -> BenchSummary {
 /// Returns `true` when the A/B comparison confidently identifies `slower` as
 /// meaningfully slower than `baseline`.  Uses Welch's t-test at the given
 /// significance level (default 0.01).
-pub fn is_significantly_slower(
-    baseline: &BenchResult,
-    slower: &BenchResult,
-    alpha: f64,
-) -> bool {
+pub fn is_significantly_slower(baseline: &BenchResult, slower: &BenchResult, alpha: f64) -> bool {
     let a: Vec<f64> = baseline
         .samples
         .iter()

--- a/rust/bench-harness/tests/planted_control.rs
+++ b/rust/bench-harness/tests/planted_control.rs
@@ -1,11 +1,21 @@
 //! Planted-slower control — proves the benchmark harness can statistically
 //! distinguish a normal concurrent run from a deliberately serialised one.
 
-use bench_harness::{is_significantly_slower, run_benchmark, BenchConfig, ScenarioType};
+use bench_harness::{
+    is_significantly_slower, run_benchmark, BenchConfig, ChildProgram, ScenarioType,
+};
 use mimalloc_pprof::MiMalloc;
 
 #[global_allocator]
 static ALLOCATOR: MiMalloc = MiMalloc;
+
+fn stress_child() -> ChildProgram {
+    ChildProgram {
+        program: env!("CARGO_BIN_EXE_stress-child").into(),
+        arguments: Vec::new(),
+        environment: Vec::new(),
+    }
+}
 
 #[test]
 fn planted_serialized_control_is_rejected() {
@@ -24,18 +34,20 @@ fn planted_serialized_control_is_rejected() {
     };
 
     // Run the normal (unserialised) benchmark.
-    let normal = run_benchmark(base_config.clone());
+    let normal =
+        run_benchmark(base_config.clone(), &stress_child()).expect("valid normal benchmark");
 
     // Run the planted-slower (serialised) benchmark.
     let mut serial_cfg = base_config.clone();
     serial_cfg.serialized = true;
     serial_cfg.name = "planted-control-serialized".into();
-    let serialized = run_benchmark(serial_cfg);
+    let serialized =
+        run_benchmark(serial_cfg, &stress_child()).expect("valid serialized benchmark");
 
     // The serialised run must be significantly slower (α = 0.05).
     let significantly_slower = is_significantly_slower(&normal, &serialized, 0.05);
-    let ratio = serialized.summary.mean_throughput_ops_per_sec
-        / normal.summary.mean_throughput_ops_per_sec;
+    let ratio =
+        serialized.summary.mean_throughput_ops_per_sec / normal.summary.mean_throughput_ops_per_sec;
 
     println!(
         "Planted control: normal={:.0} ops/s, serialized={:.0} ops/s, ratio={:.3}, \

--- a/rust/bench-harness/tests/rejections.rs
+++ b/rust/bench-harness/tests/rejections.rs
@@ -1,0 +1,119 @@
+use bench_harness::{run_benchmark, BenchConfig, BenchError, ChildProgram, ScenarioType};
+use std::ffi::OsString;
+
+fn config() -> BenchConfig {
+    BenchConfig {
+        name: "rejection-control".into(),
+        seed: 7,
+        worker_count: 2,
+        operation_count: 10,
+        allocation_size_min: 16,
+        allocation_size_max: 32,
+        warmup_rounds: 0,
+        measurement_rounds: 2,
+        max_duration_secs: Some(10),
+        scenario: ScenarioType::AllocFree,
+        serialized: false,
+    }
+}
+
+fn child(response: Option<&str>) -> ChildProgram {
+    let mut environment = Vec::new();
+    if let Some(response) = response {
+        environment.push((
+            OsString::from("BENCH_HARNESS_TEST_RESPONSE"),
+            response.into(),
+        ));
+    }
+    ChildProgram {
+        program: env!("CARGO_BIN_EXE_stress-child").into(),
+        arguments: Vec::new(),
+        environment,
+    }
+}
+
+#[test]
+fn benchmark_rejects_zero_measurement_rounds() {
+    let mut invalid = config();
+    invalid.measurement_rounds = 0;
+    assert!(matches!(
+        run_benchmark(invalid, &child(None)),
+        Err(BenchError::InvalidConfig(_))
+    ));
+}
+
+#[test]
+fn benchmark_rejects_partial_or_extra_child_output() {
+    assert!(matches!(
+        run_benchmark(config(), &child(Some("partial"))),
+        Err(BenchError::InvalidChildResponse(_))
+    ));
+    assert!(matches!(
+        run_benchmark(config(), &child(Some("extra"))),
+        Err(BenchError::InvalidChildResponse(_))
+    ));
+    assert!(matches!(
+        run_benchmark(config(), &child(Some("nonfinite"))),
+        Err(BenchError::InvalidChildResponse(_))
+    ));
+}
+
+#[test]
+fn benchmark_rejects_zero_completed_operations() {
+    assert!(matches!(
+        run_benchmark(config(), &child(Some("zero"))),
+        Err(BenchError::InvalidSample(_))
+    ));
+}
+
+#[test]
+fn benchmark_rejects_zero_elapsed_or_checksum_mismatch() {
+    assert!(matches!(
+        run_benchmark(config(), &child(Some("zero-elapsed"))),
+        Err(BenchError::InvalidSample(_))
+    ));
+    assert!(matches!(
+        run_benchmark(config(), &child(Some("checksum-mismatch"))),
+        Err(BenchError::InvalidSample(_))
+    ));
+}
+
+#[test]
+fn benchmark_rejects_reported_timeout_or_crash() {
+    assert!(matches!(
+        run_benchmark(config(), &child(Some("timeout-report"))),
+        Err(BenchError::InvalidSample(_))
+    ));
+    assert!(matches!(
+        run_benchmark(config(), &child(Some("crash-report"))),
+        Err(BenchError::InvalidSample(_))
+    ));
+}
+
+#[test]
+fn benchmark_kills_and_reaps_hanging_child() {
+    let mut hanging = config();
+    hanging.scenario = ScenarioType::Hang;
+    hanging.worker_count = 1;
+    hanging.operation_count = 1;
+    hanging.measurement_rounds = 1;
+    hanging.max_duration_secs = Some(1);
+    assert!(matches!(
+        run_benchmark(hanging, &child(None)),
+        Err(BenchError::Timeout { seconds: 1 })
+    ));
+    assert!(
+        run_benchmark(config(), &child(None)).is_ok(),
+        "a killed child must not leak work into the next sample"
+    );
+}
+
+#[test]
+fn successful_result_preserves_every_raw_sample() {
+    let result = run_benchmark(config(), &child(None)).expect("valid child samples");
+    assert_eq!(result.samples.len(), 2);
+    assert!(result
+        .samples
+        .iter()
+        .all(|sample| sample.ops_completed == 10));
+}

--- a/rust/bench-harness/tests/throughput.rs
+++ b/rust/bench-harness/tests/throughput.rs
@@ -1,11 +1,19 @@
 //! Throughput benchmark — warmup + measurement rounds, machine-readable
 //! output, and build/host metadata recording.
 
-use bench_harness::{run_benchmark, BenchConfig, ScenarioType};
+use bench_harness::{run_benchmark, BenchConfig, ChildProgram, ScenarioType};
 use mimalloc_pprof::MiMalloc;
 
 #[global_allocator]
 static ALLOCATOR: MiMalloc = MiMalloc;
+
+fn stress_child() -> ChildProgram {
+    ChildProgram {
+        program: env!("CARGO_BIN_EXE_stress-child").into(),
+        arguments: Vec::new(),
+        environment: Vec::new(),
+    }
+}
 
 #[test]
 fn throughput_benchmark_with_metadata() {
@@ -23,16 +31,22 @@ fn throughput_benchmark_with_metadata() {
         serialized: false,
     };
 
-    let result = run_benchmark(config);
+    let result = run_benchmark(config, &stress_child()).expect("valid benchmark configuration");
 
     // Verify metadata was captured.
-    assert!(!result.metadata.commit.is_empty(), "commit should be recorded");
+    assert!(
+        !result.metadata.commit.is_empty(),
+        "commit should be recorded"
+    );
     assert!(
         result.metadata.rustc.contains("rustc"),
         "rustc version should be recorded, got: {}",
         result.metadata.rustc
     );
-    assert!(!result.metadata.cpu_model.is_empty(), "cpu model should be recorded");
+    assert!(
+        !result.metadata.cpu_model.is_empty(),
+        "cpu model should be recorded"
+    );
     assert!(!result.metadata.os.is_empty(), "os should be recorded");
 
     // Verify measurement rounds.

--- a/rust/dashboard/src/main.rs
+++ b/rust/dashboard/src/main.rs
@@ -3,7 +3,7 @@
 //!
 //! Part of #171 "perf: publish a bounded four-allocator benchmark dashboard".
 
-use bench_harness::{run_benchmark, BenchConfig, BenchResult, ScenarioType};
+use bench_harness::{run_benchmark, BenchConfig, BenchResult, ChildProgram, ScenarioType};
 use mimalloc_pprof::MiMalloc;
 use serde::Serialize;
 use std::time::Duration;
@@ -41,7 +41,7 @@ const PR_SENTINEL_CARDS: &[ScenarioCard] = &[
     ScenarioCard {
         id: "small-mixed",
         name: "Small mixed (8–1024 B)",
-        description: "Multi-thread, log-distributed sizes — exercises size-class lookup.",
+        description: "Multi-thread, uniformly distributed sizes — exercises size-class lookup.",
         worker_count: 4,
         operation_count: 2_000_000,
         allocation_size_min: 8,
@@ -69,9 +69,9 @@ const PR_SENTINEL_CARDS: &[ScenarioCard] = &[
         scenario: ScenarioType::Sawtooth,
     },
     ScenarioCard {
-        id: "cross-thread-free",
-        name: "Cross-thread free",
-        description: "Allocate in one thread, drop in another — exercises remote-free paths.",
+        id: "cross-thread-free-pending",
+        name: "Cross-thread free (pending)",
+        description: "Pending a real cross-thread-free workload; this sentinel does not report remote-free results.",
         worker_count: 4,
         operation_count: 500_000,
         allocation_size_min: 16,
@@ -124,10 +124,23 @@ fn run_card(card: &ScenarioCard) -> BenchResult {
         scenario: card.scenario,
         serialized: false,
     };
-    run_benchmark(config)
+    let child = ChildProgram {
+        program: std::env::current_exe().expect("locate dashboard child executable"),
+        arguments: vec!["--stress-child".into()],
+        environment: Vec::new(),
+    };
+    run_benchmark(config, &child).expect("valid sentinel benchmark configuration")
 }
 
 fn main() {
+    if std::env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new("--stress-child")) {
+        if let Err(error) = stress_harness::run_stdio_child() {
+            eprintln!("dashboard stress child rejected request: {error}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
     eprintln!("=== mimalloc-pprof PR sentinel benchmark ===");
     let start = std::time::Instant::now();
 
@@ -164,9 +177,7 @@ fn main() {
 
         eprintln!(
             "  {:.0} ops/s ({:.1} ns/op), CV={:.1}%",
-            cr.mean_throughput_ops_per_sec,
-            cr.mean_ns_per_op,
-            cr.cv_percent,
+            cr.mean_throughput_ops_per_sec, cr.mean_ns_per_op, cr.cv_percent,
         );
 
         card_results.push(cr);
@@ -211,11 +222,7 @@ fn generate_html(d: &DashboardOutput, elapsed: Duration) -> String {
     <td class="num">{:.1}</td>
 </tr>
 "#,
-            c.card_id,
-            c.card_name,
-            c.mean_throughput_ops_per_sec,
-            c.mean_ns_per_op,
-            c.cv_percent,
+            c.card_id, c.card_name, c.mean_throughput_ops_per_sec, c.mean_ns_per_op, c.cv_percent,
         ));
     }
 

--- a/rust/dashboard/tests/stress_child.rs
+++ b/rust/dashboard/tests/stress_child.rs
@@ -1,0 +1,48 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+use stress_harness::{
+    ExecutionMode, ScenarioType, StressChildRequest, StressConfig, CHILD_PROTOCOL_VERSION,
+};
+
+#[test]
+fn dashboard_stress_child_accepts_one_request_and_emits_one_response() {
+    let request = StressChildRequest {
+        protocol_version: CHILD_PROTOCOL_VERSION,
+        config: StressConfig {
+            name: "dashboard-child-e2e".into(),
+            seed: 42,
+            worker_count: 2,
+            operation_count: 10,
+            allocation_size_min: 16,
+            allocation_size_max: 32,
+        },
+        scenario: ScenarioType::AllocFree,
+        execution_mode: ExecutionMode::Normal,
+    };
+    let mut child = Command::new(env!("CARGO_BIN_EXE_dashboard"))
+        .arg("--stress-child")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn dashboard child");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(serde_json::to_string(&request).unwrap().as_bytes())
+        .expect("send request");
+    let output = child.wait_with_output().expect("reap dashboard child");
+    assert!(output.status.success());
+    let result: stress_harness::StressResult =
+        serde_json::from_slice(&output.stdout).expect("one strict JSON response");
+    assert_eq!(result.ops_completed, 10);
+    assert!(result.elapsed_secs.is_finite() && result.elapsed_secs > 0.0);
+}
+
+#[test]
+fn dashboard_has_no_false_cross_thread_or_log_distribution_claim() {
+    let source = include_str!("../src/main.rs");
+    assert!(!source.contains("log-distributed"));
+    assert!(!source.contains("id: \"cross-thread-free\","));
+    assert!(source.contains("cross-thread-free-pending"));
+}

--- a/rust/stress-harness/src/lib.rs
+++ b/rust/stress-harness/src/lib.rs
@@ -14,8 +14,9 @@
 //! the RED/GREEN gate that proves the harness is exercising real concurrency.
 
 use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Barrier};
+use std::sync::{Arc, Barrier, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -24,7 +25,7 @@ use std::time::{Duration, Instant};
 // ---------------------------------------------------------------------------
 
 /// Configuration for a stress scenario run.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StressConfig {
     /// Human-readable scenario name (e.g. "tiny-hot-path", "cross-thread-free").
     pub name: String,
@@ -40,9 +41,6 @@ pub struct StressConfig {
     /// Maximum allocation size in bytes.
     #[serde(default = "default_alloc_max")]
     pub allocation_size_max: usize,
-    /// Hard wall-clock limit for the run; exceeded → timed-out kill.
-    #[serde(default)]
-    pub max_duration_secs: Option<u64>,
 }
 
 fn default_alloc_min() -> usize {
@@ -50,6 +48,53 @@ fn default_alloc_min() -> usize {
 }
 fn default_alloc_max() -> usize {
     4096
+}
+
+/// Invalid workload configuration, rejected before threads are created.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StressError {
+    ZeroWorkers,
+    ZeroOperations,
+    InsufficientOperationsForWorkers,
+    InvalidAllocationRange,
+    UnsupportedProtocolVersion(u32),
+}
+
+impl std::fmt::Display for StressError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ZeroWorkers => f.write_str("worker_count must be greater than zero"),
+            Self::ZeroOperations => f.write_str("operation_count must be greater than zero"),
+            Self::InsufficientOperationsForWorkers => {
+                f.write_str("operation_count must be at least worker_count")
+            }
+            Self::InvalidAllocationRange => {
+                f.write_str("allocation_size_min must not exceed allocation_size_max")
+            }
+            Self::UnsupportedProtocolVersion(version) => {
+                write!(f, "unsupported stress-child protocol version {version}")
+            }
+        }
+    }
+}
+impl std::error::Error for StressError {}
+
+impl StressConfig {
+    pub fn validate(&self) -> Result<(), StressError> {
+        if self.worker_count == 0 {
+            return Err(StressError::ZeroWorkers);
+        }
+        if self.operation_count == 0 {
+            return Err(StressError::ZeroOperations);
+        }
+        if self.operation_count < self.worker_count {
+            return Err(StressError::InsufficientOperationsForWorkers);
+        }
+        if self.allocation_size_min > self.allocation_size_max {
+            return Err(StressError::InvalidAllocationRange);
+        }
+        Ok(())
+    }
 }
 
 /// The result of executing a [`StressConfig`] against a [`ScenarioType`].
@@ -61,6 +106,10 @@ pub struct StressResult {
     pub max_simultaneous_workers: usize,
     /// Total operations completed before exit / timeout / crash.
     pub ops_completed: u64,
+    /// Deterministic checksum observed from touched workload memory.
+    pub observed_checksum: u64,
+    /// Deterministic checksum expected from the versioned workload sequence.
+    pub expected_checksum: u64,
     /// True if the watchdog killed the run.
     pub timed_out: bool,
     /// True if the child process exited with a non-zero code or signal.
@@ -82,6 +131,31 @@ pub enum ScenarioType {
     Sawtooth,
     /// Sleep forever — a positive control for the watchdog path.
     Hang,
+}
+
+/// The workload implementation selected by a child request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExecutionMode {
+    Normal,
+    SerializedControl,
+}
+
+/// Current wire format version for one isolated workload request.
+pub const CHILD_PROTOCOL_VERSION: u32 = 1;
+
+/// Versioned request accepted by the production stress-child entry point.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StressChildRequest {
+    pub protocol_version: u32,
+    pub config: StressConfig,
+    pub scenario: ScenarioType,
+    pub execution_mode: ExecutionMode,
+}
+
+#[derive(Default)]
+struct StartGateState {
+    parked_workers: usize,
+    released: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -118,67 +192,120 @@ impl SeededRng {
 // In-process executor
 // ---------------------------------------------------------------------------
 
-/// Run `scenario` in-process with the given config, returning a machine-readable
-/// [`StressResult`].  All workers are barrier-synchronised so their allocation
-/// work genuinely overlaps.
-pub fn run_scenario(config: StressConfig, scenario: ScenarioType) -> StressResult {
-    let started = Instant::now();
-    let worker_count = config.worker_count.max(1);
+/// Run in-process without a hard timeout. Use a child process when a workload
+/// must be forcibly bounded.
+pub fn run_scenario(
+    config: StressConfig,
+    scenario: ScenarioType,
+) -> Result<StressResult, StressError> {
+    run_with_mode(config, scenario, ExecutionMode::Normal)
+}
 
+/// Execute a versioned child request after validating its protocol version.
+pub fn run_child_request(request: StressChildRequest) -> Result<StressResult, StressError> {
+    if request.protocol_version != CHILD_PROTOCOL_VERSION {
+        return Err(StressError::UnsupportedProtocolVersion(
+            request.protocol_version,
+        ));
+    }
+    run_with_mode(request.config, request.scenario, request.execution_mode)
+}
+
+fn run_with_mode(
+    config: StressConfig,
+    scenario: ScenarioType,
+    execution_mode: ExecutionMode,
+) -> Result<StressResult, StressError> {
+    config.validate()?;
+    let workers = config.worker_count;
     let simultaneous = Arc::new(AtomicUsize::new(0));
-    let max_simultaneous = Arc::new(AtomicUsize::new(0));
-    let ops_completed = Arc::new(AtomicU64::new(0));
-
-    let ready_barrier = Arc::new(Barrier::new(worker_count));
-    let running_barrier = Arc::new(Barrier::new(worker_count + 1)); // +1 for main
-
-    let mut handles = Vec::with_capacity(worker_count);
-
-    for wid in 0..worker_count {
+    let maximum = Arc::new(AtomicUsize::new(0));
+    let completed = Arc::new(AtomicU64::new(0));
+    let observed_checksum = Arc::new(AtomicU64::new(0));
+    let expected_checksum = Arc::new(AtomicU64::new(0));
+    let serial_lock = Arc::new(std::sync::Mutex::new(()));
+    let ready = Arc::new(Barrier::new(workers + 1));
+    let start_gate = Arc::new((Mutex::new(StartGateState::default()), Condvar::new()));
+    let complete = Arc::new(Barrier::new(workers + 1));
+    let mut handles = Vec::with_capacity(workers);
+    for worker in 0..workers {
         let cfg = config.clone();
-        let sim = Arc::clone(&simultaneous);
-        let max_sim = Arc::clone(&max_simultaneous);
-        let ops = Arc::clone(&ops_completed);
-        let rb = Arc::clone(&ready_barrier);
-        let run_b = Arc::clone(&running_barrier);
-
+        let simultaneous = Arc::clone(&simultaneous);
+        let maximum = Arc::clone(&maximum);
+        let completed = Arc::clone(&completed);
+        let observed_checksum = Arc::clone(&observed_checksum);
+        let expected_checksum = Arc::clone(&expected_checksum);
+        let serial_lock = Arc::clone(&serial_lock);
+        let ready = Arc::clone(&ready);
+        let start_gate = Arc::clone(&start_gate);
+        let complete = Arc::clone(&complete);
         handles.push(thread::spawn(move || {
-            // 1. All workers rendezvous — nobody starts before everyone is here.
-            rb.wait();
-
-            // 2. Atomically bump the "in flight" counter.
-            let cur = sim.fetch_add(1, Ordering::SeqCst) + 1;
-            max_sim.fetch_max(cur, Ordering::SeqCst);
-
-            // 3. Signal main that we're past the counter increment.
-            run_b.wait();
-
-            // 4. Do the actual work.
-            let per_worker = (cfg.operation_count / worker_count).max(1);
-            let mut rng = SeededRng::new(cfg.seed.wrapping_add(wid as u64));
-
+            let mut rng = SeededRng::new(cfg.seed.wrapping_add(worker as u64));
+            let mut held = (scenario == ScenarioType::Sawtooth).then(|| Vec::with_capacity(1024));
+            ready.wait();
+            #[cfg(debug_assertions)]
+            if worker == 0 {
+                if let Ok(milliseconds) = std::env::var("STRESS_HARNESS_TEST_PRE_PARK_DELAY_MS") {
+                    if let Ok(milliseconds) = milliseconds.parse::<u64>() {
+                        thread::sleep(Duration::from_millis(milliseconds));
+                    }
+                }
+            }
+            let (gate_state, gate_ready) = &*start_gate;
+            let mut gate = gate_state.lock().expect("start gate lock poisoned");
+            gate.parked_workers += 1;
+            // The coordinator and parked workers share this condition; wake
+            // all so a worker cannot consume the readiness notification.
+            gate_ready.notify_all();
+            while !gate.released {
+                gate = gate_ready.wait(gate).expect("start gate wait poisoned");
+            }
+            drop(gate);
+            let current = simultaneous.fetch_add(1, Ordering::SeqCst) + 1;
+            maximum.fetch_max(current, Ordering::SeqCst);
+            let operation_count =
+                cfg.operation_count / workers + usize::from(worker < cfg.operation_count % workers);
             match scenario {
                 ScenarioType::AllocFree => {
-                    for _ in 0..per_worker {
-                        let sz = cfg.allocation_size_min
-                            + rng.next_usize(
-                                cfg.allocation_size_max - cfg.allocation_size_min + 1,
-                            );
-                        let _v = vec![0u8; sz];
-                        ops.fetch_add(1, Ordering::Relaxed);
+                    for _ in 0..operation_count {
+                        let serial_guard = (execution_mode == ExecutionMode::SerializedControl)
+                            .then(|| {
+                                serial_lock
+                                    .lock()
+                                    .expect("serialized control lock poisoned")
+                            });
+                        let size = cfg.allocation_size_min
+                            + rng.next_usize(cfg.allocation_size_max - cfg.allocation_size_min + 1);
+                        let expected = (size as u8).wrapping_add(worker as u8);
+                        let mut allocation = vec![0u8; size];
+                        allocation[0] = expected;
+                        observed_checksum.fetch_add(allocation[0] as u64, Ordering::Relaxed);
+                        expected_checksum.fetch_add(expected as u64, Ordering::Relaxed);
+                        drop(allocation);
+                        drop(serial_guard);
+                        completed.fetch_add(1, Ordering::Relaxed);
                     }
                 }
                 ScenarioType::Sawtooth => {
-                    const BATCH: usize = 1024;
-                    let mut held: Vec<Vec<u8>> = Vec::with_capacity(BATCH);
-                    for i in 0..per_worker {
-                        let sz = cfg.allocation_size_min
-                            + rng.next_usize(
-                                cfg.allocation_size_max - cfg.allocation_size_min + 1,
-                            );
-                        held.push(vec![0u8; sz]);
-                        ops.fetch_add(1, Ordering::Relaxed);
-                        if held.len() >= BATCH || i == per_worker - 1 {
+                    let held = held.as_mut().expect("sawtooth control state preallocated");
+                    for index in 0..operation_count {
+                        let serial_guard = (execution_mode == ExecutionMode::SerializedControl)
+                            .then(|| {
+                                serial_lock
+                                    .lock()
+                                    .expect("serialized control lock poisoned")
+                            });
+                        let size = cfg.allocation_size_min
+                            + rng.next_usize(cfg.allocation_size_max - cfg.allocation_size_min + 1);
+                        let expected = (size as u8).wrapping_add(worker as u8);
+                        let mut allocation = vec![0u8; size];
+                        allocation[0] = expected;
+                        observed_checksum.fetch_add(allocation[0] as u64, Ordering::Relaxed);
+                        expected_checksum.fetch_add(expected as u64, Ordering::Relaxed);
+                        held.push(allocation);
+                        drop(serial_guard);
+                        completed.fetch_add(1, Ordering::Relaxed);
+                        if held.len() == 1024 || index + 1 == operation_count {
                             held.clear();
                         }
                     }
@@ -187,47 +314,44 @@ pub fn run_scenario(config: StressConfig, scenario: ScenarioType) -> StressResul
                     thread::sleep(Duration::from_secs(1));
                 },
             }
-
-            sim.fetch_sub(1, Ordering::SeqCst);
+            simultaneous.fetch_sub(1, Ordering::SeqCst);
+            complete.wait();
         }));
     }
-
-    // 5. Wait for all workers to reach the post-increment barrier.
-    running_barrier.wait();
-    // Tiny grace period so the last straggler has time to register.
-    thread::sleep(Duration::from_millis(5));
-
-    // 6. Join all threads (or time out).
-    let timed_out = if let Some(max_secs) = config.max_duration_secs {
-        let deadline = started + Duration::from_secs(max_secs);
-        let mut all_done = false;
-        while !all_done && Instant::now() < deadline {
-            all_done = handles.iter().all(|h| h.is_finished());
-            if !all_done {
-                thread::sleep(Duration::from_millis(10));
-            }
+    // Debug-test-only setup delay used to prove that pre-start coordination is
+    // outside the reported interval. It is never present in release builds.
+    #[cfg(debug_assertions)]
+    if let Ok(milliseconds) = std::env::var("STRESS_HARNESS_TEST_SETUP_DELAY_MS") {
+        if let Ok(milliseconds) = milliseconds.parse::<u64>() {
+            thread::sleep(Duration::from_millis(milliseconds));
         }
-        !all_done
-    } else {
-        for h in handles {
-            let _ = h.join();
-        }
-        false
-    };
-
-    let elapsed = started.elapsed().as_secs_f64();
-
-    StressResult {
-        config: config.clone(),
-        max_simultaneous_workers: max_simultaneous.load(Ordering::SeqCst),
-        ops_completed: ops_completed.load(Ordering::Relaxed),
-        timed_out,
-        crashed: false,
-        elapsed_secs: elapsed,
-        reproduction_command: format!(
-            "cargo test -p stress-harness -- --nocapture --test-threads=1"
-        ),
     }
+    ready.wait();
+    let (gate_state, gate_ready) = &*start_gate;
+    let mut gate = gate_state.lock().expect("start gate lock poisoned");
+    while gate.parked_workers < workers {
+        gate = gate_ready.wait(gate).expect("start gate wait poisoned");
+    }
+    let started = Instant::now();
+    gate.released = true;
+    gate_ready.notify_all();
+    drop(gate);
+    complete.wait();
+    let elapsed_secs = started.elapsed().as_secs_f64();
+    for handle in handles {
+        let _ = handle.join();
+    }
+    Ok(StressResult {
+        config,
+        max_simultaneous_workers: maximum.load(Ordering::SeqCst),
+        ops_completed: completed.load(Ordering::Relaxed),
+        observed_checksum: observed_checksum.load(Ordering::Relaxed),
+        expected_checksum: expected_checksum.load(Ordering::Relaxed),
+        timed_out: false,
+        crashed: false,
+        elapsed_secs,
+        reproduction_command: "cargo test -p stress-harness -- --nocapture --test-threads=1".into(),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -250,8 +374,7 @@ pub fn run_in_child_process(
     scenario: ScenarioType,
     watchdog_secs: u64,
 ) -> StressResult {
-    let input_json = serde_json::to_string(&(&config, scenario))
-        .expect("serialise child input");
+    let input_json = serde_json::to_string(&(&config, scenario)).expect("serialise child input");
 
     // Build the reproduction command before we consume config.
     let repro = format!(
@@ -260,8 +383,8 @@ pub fn run_in_child_process(
 
     // Spawn the *same test binary* directly (not via `cargo test`) to avoid
     // lock-file collisions when a prior child was killed.
-    let test_binary = std::env::current_exe()
-        .unwrap_or_else(|_| std::path::PathBuf::from("stress-harness-test"));
+    let test_binary =
+        std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("stress-harness-test"));
 
     let mut child = std::process::Command::new(&test_binary)
         .args(["--nocapture", "child_process_isolation"])
@@ -296,9 +419,7 @@ pub fn run_in_child_process(
                         .rev()
                         .find(|l| l.trim_start().starts_with('{'))
                     {
-                        if let Ok(result) =
-                            serde_json::from_str::<StressResult>(line)
-                        {
+                        if let Ok(result) = serde_json::from_str::<StressResult>(line) {
                             return result;
                         }
                     }
@@ -308,6 +429,8 @@ pub fn run_in_child_process(
                     config,
                     max_simultaneous_workers: 0,
                     ops_completed: 0,
+                    observed_checksum: 0,
+                    expected_checksum: 0,
                     timed_out: false,
                     crashed: !status.success(),
                     elapsed_secs: elapsed,
@@ -322,6 +445,8 @@ pub fn run_in_child_process(
                         config,
                         max_simultaneous_workers: 0,
                         ops_completed: 0,
+                        observed_checksum: 0,
+                        expected_checksum: 0,
                         timed_out: true,
                         crashed: false,
                         elapsed_secs: started.elapsed().as_secs_f64(),
@@ -335,6 +460,8 @@ pub fn run_in_child_process(
                     config,
                     max_simultaneous_workers: 0,
                     ops_completed: 0,
+                    observed_checksum: 0,
+                    expected_checksum: 0,
                     timed_out: false,
                     crashed: true,
                     elapsed_secs: started.elapsed().as_secs_f64(),
@@ -345,13 +472,31 @@ pub fn run_in_child_process(
     }
 }
 
+/// Serve one strict production child request on stdin and write exactly one
+/// JSON [`StressResult`] to stdout. Diagnostics are returned to the caller so
+/// the binary can write them to stderr without corrupting the protocol.
+pub fn run_stdio_child() -> Result<(), String> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .map_err(|error| format!("read stress-child request: {error}"))?;
+    let request: StressChildRequest = serde_json::from_str(&input)
+        .map_err(|error| format!("invalid stress-child request: {error}"))?;
+    let result = run_child_request(request).map_err(|error| error.to_string())?;
+    let response = serde_json::to_string(&result)
+        .map_err(|error| format!("serialize stress-child response: {error}"))?;
+    std::io::stdout()
+        .write_all(response.as_bytes())
+        .map_err(|error| format!("write stress-child response: {error}"))?;
+    Ok(())
+}
+
 /// Entry-point for child-process mode.  Call this at the top of a test
 /// function that checks `CHILD_ENV_VAR`.  Deserialises the scenario config
 /// from the env var, runs it, prints the JSON result to stdout, and exits
 /// the process.
 pub fn run_child_mode() -> ! {
-    let input_json =
-        std::env::var(CHILD_ENV_VAR).expect("CHILD_ENV_VAR not set in child mode");
+    let input_json = std::env::var(CHILD_ENV_VAR).expect("CHILD_ENV_VAR not set in child mode");
     let (config, scenario): (StressConfig, ScenarioType) =
         serde_json::from_str(&input_json).expect("deserialise child input");
 
@@ -360,8 +505,17 @@ pub fn run_child_mode() -> ! {
         config.name, config.worker_count, config.seed
     );
 
-    let result = run_scenario(config, scenario);
-    let json = serde_json::to_string(&result).expect("serialise result");
-    println!("{}", json);
-    std::process::exit(if result.crashed { 1 } else { 0 });
+    match run_scenario(config, scenario) {
+        Ok(result) => {
+            println!(
+                "{}",
+                serde_json::to_string(&result).expect("serialise result")
+            );
+            std::process::exit(if result.crashed { 1 } else { 0 });
+        }
+        Err(error) => {
+            eprintln!("[stress-harness child] rejected configuration: {error}");
+            std::process::exit(1);
+        }
+    }
 }

--- a/rust/stress-harness/tests/allocator_scenario.rs
+++ b/rust/stress-harness/tests/allocator_scenario.rs
@@ -29,11 +29,10 @@ fn concurrent_alloc_free_with_profiler_snapshots() {
         operation_count: 200_000,
         allocation_size_min: 16,
         allocation_size_max: 8192,
-        max_duration_secs: Some(30),
     };
 
     // Run the workload.
-    let result = run_scenario(config, ScenarioType::AllocFree);
+    let result = run_scenario(config, ScenarioType::AllocFree).expect("valid configuration");
 
     // Verify the harness saw real concurrency.
     assert!(

--- a/rust/stress-harness/tests/concurrency_oracle.rs
+++ b/rust/stress-harness/tests/concurrency_oracle.rs
@@ -14,7 +14,6 @@ fn make_config(name: &str, workers: usize) -> StressConfig {
         operation_count: 100_000,
         allocation_size_min: 16,
         allocation_size_max: 256,
-        max_duration_secs: Some(30),
     }
 }
 
@@ -23,7 +22,8 @@ fn red_single_worker_reports_no_concurrency() {
     let result = run_scenario(
         make_config("oracle-single-worker", 1),
         ScenarioType::AllocFree,
-    );
+    )
+    .expect("valid configuration");
     assert!(
         result.max_simultaneous_workers < 2,
         "RED FAIL: single worker reported max_simultaneous_workers={}, expected < 2",
@@ -39,7 +39,8 @@ fn green_multi_worker_reports_real_concurrency() {
     let result = run_scenario(
         make_config("oracle-multi-worker", workers),
         ScenarioType::AllocFree,
-    );
+    )
+    .expect("valid configuration");
     assert!(
         result.max_simultaneous_workers >= 2,
         "GREEN FAIL: {} workers reported max_simultaneous_workers={}, expected >= 2",
@@ -56,4 +57,24 @@ fn green_multi_worker_reports_real_concurrency() {
         completed >= expected / 2,
         "only {completed}/{expected} ops completed"
     );
+}
+
+#[test]
+fn exact_operation_count_with_remainder() {
+    let mut config = make_config("exact-operation-count", 3);
+    config.operation_count = 10;
+    let result = run_scenario(config, ScenarioType::AllocFree).expect("valid configuration");
+    assert_eq!(result.ops_completed, 10);
+}
+
+#[test]
+fn rejects_zero_operations_and_workers() {
+    let mut config = make_config("zero-workers", 0);
+    assert!(config.validate().is_err());
+    config.worker_count = 1;
+    config.operation_count = 0;
+    assert!(config.validate().is_err());
+    config.operation_count = 1;
+    config.worker_count = 2;
+    assert!(config.validate().is_err());
 }

--- a/rust/stress-harness/tests/timing_contract.rs
+++ b/rust/stress-harness/tests/timing_contract.rs
@@ -1,0 +1,62 @@
+use std::time::Instant;
+use stress_harness::{run_scenario, ScenarioType, StressConfig};
+
+fn tiny_config() -> StressConfig {
+    StressConfig {
+        name: "timing-contract".into(),
+        seed: 1,
+        worker_count: 1,
+        operation_count: 1,
+        allocation_size_min: 16,
+        allocation_size_max: 16,
+    }
+}
+
+#[test]
+fn timed_interval_excludes_setup_delay() {
+    std::env::set_var("STRESS_HARNESS_TEST_SETUP_DELAY_MS", "100");
+    let outer_started = Instant::now();
+    let result = run_scenario(tiny_config(), ScenarioType::AllocFree).expect("valid configuration");
+    std::env::remove_var("STRESS_HARNESS_TEST_SETUP_DELAY_MS");
+
+    assert!(
+        outer_started.elapsed().as_millis() >= 100,
+        "test hook must delay setup"
+    );
+    assert!(
+        result.elapsed_secs < 0.050,
+        "reported interval included pre-start setup: {}",
+        result.elapsed_secs
+    );
+}
+
+#[test]
+fn timed_interval_excludes_delay_between_ready_and_start_gate() {
+    let mut config = tiny_config();
+    config.worker_count = 2;
+    config.operation_count = 2;
+    std::env::set_var("STRESS_HARNESS_TEST_PRE_PARK_DELAY_MS", "100");
+    let outer_started = Instant::now();
+    let result = run_scenario(config, ScenarioType::AllocFree).expect("valid configuration");
+    std::env::remove_var("STRESS_HARNESS_TEST_PRE_PARK_DELAY_MS");
+
+    assert!(
+        outer_started.elapsed().as_millis() >= 100,
+        "test hook must delay pre-start parking"
+    );
+    assert!(
+        result.elapsed_secs < 0.050,
+        "reported interval included pre-start gate delay: {}",
+        result.elapsed_secs
+    );
+}
+
+#[test]
+fn timed_interval_has_no_fixed_grace_floor() {
+    let result = run_scenario(tiny_config(), ScenarioType::AllocFree).expect("valid configuration");
+    assert!(
+        result.elapsed_secs < 0.004,
+        "reported interval has a fixed grace/poll floor: {}",
+        result.elapsed_secs
+    );
+}

--- a/rust/stress-harness/tests/watchdog_control.rs
+++ b/rust/stress-harness/tests/watchdog_control.rs
@@ -4,9 +4,7 @@
 //! - A planted hang is killed by the watchdog and reports `timed_out: true`.
 //! - A clean short run exits normally and reports `timed_out: false`.
 
-use stress_harness::{
-    run_in_child_process, ScenarioType, StressConfig, CHILD_ENV_VAR,
-};
+use stress_harness::{run_in_child_process, ScenarioType, StressConfig, CHILD_ENV_VAR};
 
 // ---------------------------------------------------------------------------
 // Child-mode entry point — invoked when CHILD_ENV_VAR is set
@@ -36,7 +34,6 @@ fn watchdog_kills_planted_hang() {
         operation_count: 1,
         allocation_size_min: 16,
         allocation_size_max: 16,
-        max_duration_secs: Some(60),
     };
 
     let result = run_in_child_process(config, ScenarioType::Hang, 10);
@@ -60,15 +57,11 @@ fn watchdog_passes_clean_short_run() {
         operation_count: 10_000,
         allocation_size_min: 16,
         allocation_size_max: 64,
-        max_duration_secs: Some(60),
     };
 
     let result = run_in_child_process(config, ScenarioType::AllocFree, 30);
 
-    assert!(
-        !result.timed_out,
-        "clean short run should not time out"
-    );
+    assert!(!result.timed_out, "clean short run should not time out");
     assert!(!result.crashed, "clean short run should not crash");
     assert!(
         result.ops_completed > 0,


### PR DESCRIPTION
Closes #178

Implements the approved versioned dashboard stress-child protocol. Every benchmark warmup and measured round now executes in a fresh watchdog-owned child with strict single-JSON stdout validation, exact operation accounting, checksum validation, and typed rejection of invalid output.

The runner timer starts only after all workers are parked at the coordinator-controlled start gate. The dashboard removes false log-distribution/cross-thread-free claims and labels the pending card accurately.

Validation:
- soldr cargo fmt --all -- --check
- soldr cargo test --locked
- soldr cargo run -p xtask -- check
- local dashboard sentinel: 28.78s