### PR TITLE
feat(benchmarks): add four-allocator benchmark producer

### DIFF
--- a/ci/build_benchmark_allocators.py
+++ b/ci/build_benchmark_allocators.py
@@ -1,0 +1,1294 @@
+#!/usr/bin/env python3
+"""Prepare the pinned native allocator sources used by ``benchmark-suite``.
+
+This intentionally contains only deterministic source acquisition and native-library
+build work.  Timed workloads belong in the benchmark child process, never here.
+Archives are checksummed before they are opened, and extraction rejects every link
+and every path which could escape the requested destination.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import shlex
+import shutil
+import stat
+import subprocess
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import cast
+
+EXPECTED_IDS = ("tcmalloc", "jemalloc", "upstream-mimalloc", "mimalloc-pprof")
+SHA256_LENGTH = 64
+GIT_SHA_LENGTH = 40
+CHUNK_SIZE = 1024 * 1024
+ENVIRONMENT_ALLOWLIST = (
+    "AR",
+    "CARGO_HOME",
+    "CC",
+    "CFLAGS",
+    "CXX",
+    "CXXFLAGS",
+    "HOME",
+    "LD",
+    "MAKEFLAGS",
+    "PATH",
+    "RANLIB",
+    "RUSTUP_HOME",
+    "SOURCE_DATE_EPOCH",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+)
+ADAPTER_SYMBOLS = (
+    "bench_allocator_id",
+    "bench_allocator_version",
+    "bench_alloc",
+    "bench_calloc",
+    "bench_realloc",
+    "bench_aligned_alloc",
+    "bench_free",
+    "bench_usable_size",
+)
+COMPETITOR_SYMBOLS = {
+    "tcmalloc": "TCMallocInternalMalloc",
+    "jemalloc": "je_malloc",
+    "upstream-mimalloc": "mi_malloc",
+    "mimalloc-pprof": "mi_malloc",
+}
+
+
+class LockfileError(ValueError):
+    """The checked-in source contract is malformed or no longer immutable."""
+
+
+class ArchiveError(RuntimeError):
+    """An archive did not match its locked bytes or is unsafe to extract."""
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def default_lockfile() -> Path:
+    return repository_root() / "rust" / "benchmark-suite" / "allocators" / "allocator-lock.json"
+
+
+def source_patch_directory() -> Path:
+    return default_lockfile().parent / "patches"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as input_file:
+        while True:
+            block = input_file.read(CHUNK_SIZE)
+            if not block:
+                return digest.hexdigest()
+            digest.update(block)
+
+
+def is_hex_digest(value: object, length: int) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == length
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def require_mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise LockfileError(f"{label} must be an object")
+    return cast(Mapping[str, object], value)
+
+
+def require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise LockfileError(f"{label} must be a non-empty string")
+    return value
+
+
+def require_string_list(value: object, label: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise LockfileError(f"{label} must be a non-empty list of non-empty strings")
+    items = cast(list[object], value)
+    return [require_string(item, f"{label} item") for item in items]
+
+
+def require_commands(value: object, label: str) -> list[list[str]]:
+    if not isinstance(value, list) or not value:
+        raise LockfileError(f"{label} must be a non-empty command list")
+    commands: list[list[str]] = []
+    for index, command in enumerate(cast(list[object], value)):
+        commands.append(require_string_list(command, f"{label}[{index}]"))
+    return commands
+
+
+def validate_source(allocator_id: str, pin: str, source: Mapping[str, object]) -> None:
+    kind = require_string(source.get("kind"), f"{allocator_id}.source.kind")
+    repository = require_string(
+        source.get("canonical_repository"), f"{allocator_id}.source.canonical_repository"
+    )
+    parsed = urllib.parse.urlparse(repository)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
+        raise LockfileError(
+            f"{allocator_id}.source.canonical_repository must be a canonical HTTPS URL"
+        )
+    commit = require_string(source.get("commit"), f"{allocator_id}.source.commit")
+
+    if kind == "checkout":
+        if (
+            allocator_id != "mimalloc-pprof"
+            or pin != "workflow-source"
+            or commit != "workflow-source"
+        ):
+            raise LockfileError("only mimalloc-pprof may use the workflow-source checkout pin")
+        if "archive_url" in source or "archive_sha256" in source:
+            raise LockfileError("workflow-source checkout must not carry a stale archive")
+        return
+
+    if kind != "archive":
+        raise LockfileError(f"{allocator_id}.source.kind must be archive or checkout")
+    if not is_hex_digest(commit, GIT_SHA_LENGTH):
+        raise LockfileError(
+            f"{allocator_id}.source.commit must be a full lowercase 40-character SHA"
+        )
+    archive_url = require_string(source.get("archive_url"), f"{allocator_id}.source.archive_url")
+    parsed_archive = urllib.parse.urlparse(archive_url)
+    if parsed_archive.scheme != "https" or not parsed_archive.netloc or parsed_archive.query:
+        raise LockfileError(
+            f"{allocator_id}.source.archive_url must be an immutable HTTPS archive URL"
+        )
+    archive_sha = source.get("archive_sha256")
+    if not is_hex_digest(archive_sha, SHA256_LENGTH):
+        raise LockfileError(f"{allocator_id}.source.archive_sha256 must be a lowercase SHA-256")
+    if commit[:8] not in archive_url:
+        raise LockfileError(f"{allocator_id}.source.archive_url must name its source commit")
+    if allocator_id == "jemalloc" and pin != f"5.3.1@{commit}":
+        raise LockfileError("jemalloc must record release 5.3.1 and its peeled commit")
+    if allocator_id == "upstream-mimalloc" and pin != "dev3@bcee5a88":
+        raise LockfileError("upstream-mimalloc must remain at dev3@bcee5a88")
+    if allocator_id == "tcmalloc" and pin != commit:
+        raise LockfileError("tcmalloc pin must equal its immutable commit")
+
+
+def source_patch_records(
+    allocator_id: str, patches: Mapping[str, object]
+) -> list[Mapping[str, object]]:
+    source = patches.get("source")
+    if not isinstance(source, list):
+        raise LockfileError(f"{allocator_id}.patches.source must be a list of patch records")
+    validated: list[Mapping[str, object]] = []
+    for index, patch in enumerate(cast(list[object], source)):
+        label = f"{allocator_id}.patches.source[{index}]"
+        record = require_mapping(patch, label)
+        filename = require_string(record.get("file"), f"{label}.file")
+        if (
+            filename != PurePosixPath(filename).name
+            or filename != PureWindowsPath(filename).name
+            or not filename.endswith(".patch")
+        ):
+            raise LockfileError(f"{label}.file must be one .patch filename, not a path")
+        expected_sha256 = record.get("sha256")
+        if not is_hex_digest(expected_sha256, SHA256_LENGTH):
+            raise LockfileError(f"{label}.sha256 must be a lowercase SHA-256")
+        patch_path = source_patch_directory() / filename
+        try:
+            patch_path.resolve(strict=True).relative_to(
+                source_patch_directory().resolve(strict=True)
+            )
+        except (OSError, ValueError) as error:
+            raise LockfileError(
+                f"{label}.file is not a checked-in source patch: {filename}"
+            ) from error
+        if patch_path.is_symlink() or not patch_path.is_file():
+            raise LockfileError(f"{label}.file is not a regular file: {filename}")
+        actual_sha256 = sha256_file(patch_path)
+        if actual_sha256 != expected_sha256:
+            raise LockfileError(
+                f"{label}.sha256 mismatch for {filename}: expected {expected_sha256}, got {actual_sha256}"
+            )
+        validated.append(record)
+    return validated
+
+
+def validate_allocator(record: object) -> Mapping[str, object]:
+    allocator = require_mapping(record, "allocator")
+    allocator_id = require_string(allocator.get("id"), "allocator.id")
+    pin = require_string(allocator.get("pin"), f"{allocator_id}.pin")
+    source = require_mapping(allocator.get("source"), f"{allocator_id}.source")
+    build = require_mapping(allocator.get("build"), f"{allocator_id}.build")
+    validate_source(allocator_id, pin, source)
+    require_string(build.get("system"), f"{allocator_id}.build.system")
+    require_commands(build.get("commands"), f"{allocator_id}.build.commands")
+    require_string_list(build.get("flags"), f"{allocator_id}.build.flags")
+    if allocator_id == "tcmalloc":
+        if build.get("required_tool_version") != "bazel 9.1.0":
+            raise LockfileError("tcmalloc.required_tool_version must be bazel 9.1.0")
+        if not is_hex_digest(build.get("generated_lock_sha256"), SHA256_LENGTH):
+            raise LockfileError("tcmalloc.generated_lock_sha256 must be a lowercase SHA-256")
+    elif "required_tool_version" in build or "generated_lock_sha256" in build:
+        raise LockfileError(f"{allocator_id} must not carry Bazel-specific generated-lock metadata")
+    library = require_string(allocator.get("expected_static_library"), allocator_id)
+    if (
+        not library.startswith("lib")
+        or not library.endswith((".a", ".lo"))
+        or "/" in library
+        or "\\" in library
+    ):
+        raise LockfileError(
+            f"{allocator_id}.expected_static_library must be one .a or Bazel .lo archive filename"
+        )
+    require_string(allocator.get("adapter_kind"), f"{allocator_id}.adapter_kind")
+    require_string(allocator.get("license"), f"{allocator_id}.license")
+    patches = require_mapping(allocator.get("patches"), f"{allocator_id}.patches")
+    source_patches = source_patch_records(allocator_id, patches)
+    build_patches = patches.get("build")
+    if build_patches != []:
+        raise LockfileError(f"{allocator_id}.patches.build must be an empty list")
+    if source.get("kind") == "checkout" and source_patches:
+        raise LockfileError("workflow-source checkout may not be patched by the allocator builder")
+    return allocator
+
+
+def read_lockfile(path: Path) -> list[Mapping[str, object]]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise LockfileError(f"cannot read lockfile {path}: {error}") from error
+    lockfile = require_mapping(parsed, "lockfile")
+    if lockfile.get("schema_version") != 1:
+        raise LockfileError("lockfile.schema_version must be 1")
+    if lockfile.get("target") != "x86_64-unknown-linux-gnu":
+        raise LockfileError("lockfile.target must be x86_64-unknown-linux-gnu")
+    records = lockfile.get("allocators")
+    if not isinstance(records, list):
+        raise LockfileError("lockfile.allocators must be a list")
+    validated = [validate_allocator(record) for record in cast(list[object], records)]
+    ids = tuple(require_string(record.get("id"), "allocator.id") for record in validated)
+    if ids != EXPECTED_IDS:
+        raise LockfileError(f"lockfile allocator IDs must be exactly {EXPECTED_IDS}, got {ids}")
+    return validated
+
+
+def validate_archive_member(member: tarfile.TarInfo) -> PurePosixPath:
+    name = member.name
+    path = PurePosixPath(name)
+    if not name or "\\" in name or path.is_absolute() or ".." in path.parts:
+        raise ArchiveError(f"unsafe archive path: {name!r}")
+    if member.issym() or member.islnk() or member.isdev() or member.isfifo():
+        raise ArchiveError(f"links and special files are forbidden in benchmark archives: {name!r}")
+    if not (member.isdir() or member.isfile()):
+        raise ArchiveError(f"unsupported archive member: {name!r}")
+    return path
+
+
+def descendant(destination: Path, relative: PurePosixPath) -> Path:
+    root = destination.resolve()
+    candidate = root.joinpath(*relative.parts).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as error:
+        raise ArchiveError(f"archive member escapes destination: {relative}") from error
+    return candidate
+
+
+def extract_archive(archive: Path, destination: Path) -> None:
+    if destination.exists():
+        raise ArchiveError(f"refusing to extract into existing destination: {destination}")
+    destination.mkdir(parents=True)
+    try:
+        with tarfile.open(archive, mode="r:*") as bundle:
+            members = bundle.getmembers()
+            safe_members = [(member, validate_archive_member(member)) for member in members]
+            for member, relative in safe_members:
+                output = descendant(destination, relative)
+                if member.isdir():
+                    output.mkdir(parents=True, exist_ok=True)
+                    continue
+                output.parent.mkdir(parents=True, exist_ok=True)
+                input_file = bundle.extractfile(member)
+                if input_file is None:
+                    raise ArchiveError(f"unable to read archive file: {member.name!r}")
+                with input_file, output.open("xb") as output_file:
+                    shutil.copyfileobj(input_file, output_file, length=CHUNK_SIZE)
+                # Preserve only the executable/non-executable distinction. Build
+                # archives commonly contain invoked scripts, while all other mode
+                # bits are normalized for a deterministic and non-privileged tree.
+                output.chmod(0o755 if member.mode & 0o111 else 0o644)
+    except ArchiveError:
+        shutil.rmtree(destination, ignore_errors=True)
+        raise
+    except (OSError, tarfile.TarError) as error:
+        shutil.rmtree(destination, ignore_errors=True)
+        raise ArchiveError(f"cannot safely extract {archive}: {error}") from error
+
+
+def download_archive(url: str, expected_sha256: str, destination: Path) -> None:
+    if destination.exists():
+        if sha256_file(destination) == expected_sha256:
+            return
+        destination.unlink()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.partial")
+    temporary.unlink(missing_ok=True)
+    try:
+        request = urllib.request.Request(
+            url, headers={"User-Agent": "mimalloc-pprof-benchmark-lock/1"}
+        )
+        with (
+            urllib.request.urlopen(request, timeout=120) as response,
+            temporary.open("wb") as output,
+        ):
+            while True:
+                block = response.read(CHUNK_SIZE)
+                if not block:
+                    break
+                output.write(block)
+        actual_sha256 = sha256_file(temporary)
+        if actual_sha256 != expected_sha256:
+            raise ArchiveError(
+                f"archive checksum mismatch for {url}: expected {expected_sha256}, got {actual_sha256}"
+            )
+        temporary.replace(destination)
+    except (OSError, urllib.error.URLError) as error:
+        raise ArchiveError(f"cannot download {url}: {error}") from error
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def archive_filename(record: Mapping[str, object]) -> str:
+    allocator_id = require_string(record.get("id"), "allocator.id")
+    source = require_mapping(record.get("source"), f"{allocator_id}.source")
+    commit = require_string(source.get("commit"), f"{allocator_id}.source.commit")
+    return f"{allocator_id}-{commit}.tar.gz"
+
+
+def first_source_directory(destination: Path) -> Path:
+    entries = sorted(destination.iterdir())
+    if len(entries) != 1 or not entries[0].is_dir():
+        raise ArchiveError(f"archive must contain exactly one source directory: {destination}")
+    return entries[0]
+
+
+def apply_source_patches(
+    record: Mapping[str, object], source_dir: Path, logs: Path
+) -> list[dict[str, str]]:
+    allocator_id = require_string(record.get("id"), "allocator.id")
+    patches = require_mapping(record.get("patches"), f"{allocator_id}.patches")
+    applied: list[dict[str, str]] = []
+    patch_log = logs / f"{allocator_id}-patches.log"
+    patch_records = source_patch_records(allocator_id, patches)
+    if not patch_records:
+        return applied
+    with patch_log.open("w", encoding="utf-8") as log:
+        for patch in patch_records:
+            filename = require_string(patch.get("file"), f"{allocator_id}.patch.file")
+            expected_sha256 = require_string(patch.get("sha256"), f"{allocator_id}.patch.sha256")
+            patch_path = source_patch_directory() / filename
+            command = ["patch", "--batch", "--forward", "--strip=1", "--input", str(patch_path)]
+            log.write("$ " + " ".join(command) + "\n")
+            log.flush()
+            try:
+                subprocess.run(
+                    command,
+                    cwd=source_dir,
+                    env=command_environment(),
+                    check=True,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                )
+            except FileNotFoundError as error:
+                raise ArchiveError(
+                    "source patches require the standard `patch` executable"
+                ) from error
+            except subprocess.CalledProcessError as error:
+                raise ArchiveError(
+                    f"{allocator_id} source patch {filename} did not apply; see {patch_log}"
+                ) from error
+            applied.append({"file": filename, "sha256": expected_sha256})
+    return applied
+
+
+def prepare_sources(
+    records: Iterable[Mapping[str, object]], build_root: Path, logs: Path
+) -> tuple[dict[str, Path], dict[str, list[dict[str, str]]], dict[str, str]]:
+    sources: dict[str, Path] = {}
+    applied_patches: dict[str, list[dict[str, str]]] = {}
+    source_tree_sha256s: dict[str, str] = {}
+    archive_root = build_root / "archives"
+    source_root = build_root / "sources"
+    for record in records:
+        allocator_id = require_string(record.get("id"), "allocator.id")
+        source = require_mapping(record.get("source"), f"{allocator_id}.source")
+        if source.get("kind") == "checkout":
+            ensure_checkout_engine_matches_head()
+            sources[allocator_id] = repository_root()
+            applied_patches[allocator_id] = []
+            source_tree_sha256s[allocator_id] = checkout_tree_sha256()
+            continue
+        archive = archive_root / archive_filename(record)
+        download_archive(
+            require_string(source.get("archive_url"), f"{allocator_id}.source.archive_url"),
+            require_string(source.get("archive_sha256"), f"{allocator_id}.source.archive_sha256"),
+            archive,
+        )
+        unpacked = source_root / allocator_id
+        if unpacked.exists():
+            shutil.rmtree(unpacked)
+        extract_archive(archive, unpacked)
+        source_dir = first_source_directory(unpacked)
+        sources[allocator_id] = source_dir
+        applied_patches[allocator_id] = apply_source_patches(record, source_dir, logs)
+        source_tree_sha256s[allocator_id] = tree_sha256(source_dir)
+    return sources, applied_patches, source_tree_sha256s
+
+
+def command_environment() -> dict[str, str]:
+    environment = {name: os.environ[name] for name in ENVIRONMENT_ALLOWLIST if name in os.environ}
+    # The prescribed soldr Docker harness installs verified CMake/Ninja syslibs
+    # into its persistent soldr volume rather than the base image. Make those
+    # exact binaries visible to the native recipes and retain the resulting PATH
+    # in provenance.
+    soldr_syslib = Path("/root/.soldr/bin/syslib")
+    if soldr_syslib.is_dir():
+        syslib_bins = sorted(
+            (path for path in soldr_syslib.glob("*/*/*/package/bin") if path.is_dir()),
+            reverse=True,
+        )
+        if syslib_bins:
+            inherited = environment.get("PATH", "")
+            environment["PATH"] = os.pathsep.join([*(str(path) for path in syslib_bins), inherited])
+    return environment
+
+
+def benchmark_runtime_environment() -> dict[str, str]:
+    environment = command_environment()
+    environment.update({"MIMALLOC_PROF": "0", "MIMALLOC_MEMORY_EVENTS": "0"})
+    return environment
+
+
+def expand_command(
+    command: Sequence[str], source_dir: Path, build_dir: Path, jobs: int
+) -> list[str]:
+    values = {"source_dir": str(source_dir), "build_dir": str(build_dir), "jobs": str(jobs)}
+    try:
+        return [part.format(**values) for part in command]
+    except KeyError as error:
+        raise LockfileError(f"unsupported build-command placeholder: {error}") from error
+
+
+def tool_version(command: Sequence[str]) -> str:
+    try:
+        result = subprocess.run(
+            [*command, "--version"],
+            env=command_environment(),
+            check=False,
+            capture_output=True,
+            text=True,
+            errors="replace",
+        )
+    except OSError:
+        return "unavailable"
+    output = (result.stdout or result.stderr).splitlines()
+    if result.returncode != 0:
+        return f"exit {result.returncode}"
+    return output[0] if output else f"exit {result.returncode}"
+
+
+def split_tool_command(value: str) -> list[str]:
+    try:
+        command = shlex.split(value, posix=os.name != "nt")
+    except ValueError as error:
+        raise ArchiveError(f"cannot parse tool command {value!r}: {error}") from error
+    if not command:
+        raise ArchiveError("tool command must not be empty")
+    return command
+
+
+def checked_tool_version(command: Sequence[str]) -> str:
+    version = tool_version(command)
+    if version == "unavailable" or version.startswith("exit "):
+        raise ArchiveError(f"cannot identify build tool {list(command)!r}: {version}")
+    return version
+
+
+def compiler_identity(value: str) -> str:
+    command = split_tool_command(value)
+    effective = checked_tool_version(command)
+    if len(command) == 1:
+        return f"{shlex.join(command)} :: {effective}"
+    wrapper = checked_tool_version(command[:1])
+    compiler = checked_tool_version(command[-1:])
+    return (
+        f"command={shlex.join(command)}; effective={effective}; "
+        f"wrapper={wrapper}; compiler={compiler}"
+    )
+
+
+def checkout_commit() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository_root(),
+        env=command_environment(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    commit = result.stdout.strip()
+    if not is_hex_digest(commit, GIT_SHA_LENGTH):
+        raise ArchiveError(f"workflow source did not resolve to a full Git SHA: {commit!r}")
+    return commit
+
+
+def ensure_checkout_engine_matches_head() -> None:
+    command = [
+        "git",
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        "--",
+        "CMakeLists.txt",
+        "cmake",
+        "include",
+        "src",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=repository_root(),
+        env=command_environment(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    dirty = result.stdout.strip()
+    if dirty:
+        raise ArchiveError(
+            "workflow allocator C-engine inputs must match HEAD before benchmarking:\n" + dirty
+        )
+
+
+def checkout_tree_sha256() -> str:
+    result = subprocess.run(
+        ["git", "archive", "--format=tar", "HEAD"],
+        cwd=repository_root(),
+        env=command_environment(),
+        check=True,
+        capture_output=True,
+    )
+    return hashlib.sha256(result.stdout).hexdigest()
+
+
+def source_commit(record: Mapping[str, object], workflow_commit: str) -> str:
+    allocator_id = require_string(record.get("id"), "allocator.id")
+    source = require_mapping(record.get("source"), f"{allocator_id}.source")
+    commit = require_string(source.get("commit"), f"{allocator_id}.source.commit")
+    return workflow_commit if commit == "workflow-source" else commit
+
+
+def adapter_version(record: Mapping[str, object], workflow_commit: str) -> str:
+    pin = require_string(record.get("pin"), "allocator.pin")
+    return workflow_commit if pin == "workflow-source" else pin
+
+
+def bazel_execution_root(source_dir: Path, build_dir: Path) -> Path:
+    result = subprocess.run(
+        ["bazel", f"--output_user_root={build_dir / 'bazel'}", "info", "execution_root"],
+        cwd=source_dir,
+        env=command_environment(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    root = Path(result.stdout.strip()).resolve()
+    if not root.is_dir():
+        raise ArchiveError(f"Bazel execution root does not exist: {root}")
+    return root
+
+
+def adapter_include_directories(allocator_id: str, source_dir: Path, build_dir: Path) -> list[Path]:
+    if allocator_id == "tcmalloc":
+        directories = [
+            source_dir,
+            bazel_execution_root(source_dir, build_dir) / "external" / "abseil-cpp+",
+        ]
+    elif allocator_id == "jemalloc":
+        directories = [source_dir / "include"]
+    else:
+        directories = [source_dir / "include"]
+    missing = [path for path in directories if not path.is_dir()]
+    if missing:
+        raise ArchiveError(f"{allocator_id} adapter include directories are missing: {missing}")
+    return directories
+
+
+def tcmalloc_link_inputs(
+    source_dir: Path, build_dir: Path, primary_library: Path, logs: Path
+) -> tuple[list[tuple[str, Path | str]], list[list[str]]]:
+    query_file = (
+        repository_root() / "rust" / "benchmark-suite" / "native" / "tcmalloc_link_inputs.cquery"
+    ).resolve()
+    command = [
+        "bazel",
+        f"--output_user_root={build_dir / 'bazel'}",
+        "cquery",
+        "--lockfile_mode=error",
+        "--dynamic_mode=off",
+        "-c",
+        "opt",
+        "--copt=-fno-omit-frame-pointer",
+        "//tcmalloc:tcmalloc",
+        "--output=starlark",
+        f"--starlark:file={query_file}",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=source_dir,
+        env=command_environment(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    query_log = logs / "tcmalloc-link-query.log"
+    query_log.write_text(
+        "$ " + " ".join(command) + "\n" + result.stderr,
+        encoding="utf-8",
+    )
+    execution_root = bazel_execution_root(source_dir, build_dir)
+    unresolved_archives: list[tuple[str, str, str]] = []
+    flags: list[tuple[str, str]] = []
+    owners: list[str] = []
+    for line in result.stdout.splitlines():
+        fields = line.split("\t")
+        if len(fields) == 3 and fields[0] in ("archive", "always"):
+            kind, value, owner = fields
+            unresolved_archives.append((kind, value, owner))
+            owners.append(owner)
+        elif len(fields) == 2 and fields[0] == "flag" and fields[1] == "-pthread":
+            flags.append((fields[0], fields[1]))
+        else:
+            raise ArchiveError(f"unsupported TCMalloc cquery link input: {line!r}")
+    unique_owners = list(dict.fromkeys(owners))
+    if not unique_owners:
+        raise ArchiveError("TCMalloc CcInfo closure did not expose static-library owners")
+    closure_command = [
+        "bazel",
+        f"--output_user_root={build_dir / 'bazel'}",
+        "build",
+        "--lockfile_mode=error",
+        "--dynamic_mode=off",
+        "-c",
+        "opt",
+        "--copt=-fno-omit-frame-pointer",
+        *unique_owners,
+    ]
+    with query_log.open("a", encoding="utf-8") as log:
+        log.write("$ " + " ".join(closure_command) + "\n")
+        log.flush()
+        subprocess.run(
+            closure_command,
+            cwd=source_dir,
+            env=command_environment(),
+            check=True,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+
+    inputs: list[tuple[str, Path | str]] = []
+    archives: set[Path] = set()
+    for kind, value, _owner in unresolved_archives:
+        candidate = (execution_root / value).resolve()
+        if not candidate.is_file():
+            raise ArchiveError(f"TCMalloc linker input does not exist: {candidate}")
+        if candidate.read_bytes()[:8] not in (b"!<arch>\n", b"!<thin>\n"):
+            raise ArchiveError(f"TCMalloc linker input is not a static archive: {candidate}")
+        inputs.append((kind, candidate))
+        archives.add(candidate)
+    inputs.extend(flags)
+    if primary_library.resolve() not in archives:
+        raise ArchiveError("TCMalloc CcInfo closure omitted the locked primary libtcmalloc.lo")
+    if len(archives) < 2:
+        raise ArchiveError("TCMalloc link closure did not include its transitive static libraries")
+    return inputs, [command, closure_command]
+
+
+def write_link_manifest(
+    allocator_id: str,
+    source_dir: Path,
+    build_dir: Path,
+    primary_library: Path,
+    build_root: Path,
+    logs: Path,
+) -> tuple[Path, list[list[str]], list[dict[str, object]]]:
+    query_commands: list[list[str]] = []
+    if allocator_id == "tcmalloc":
+        inputs, queries = tcmalloc_link_inputs(source_dir, build_dir, primary_library, logs)
+        query_commands.extend(queries)
+    else:
+        inputs = [("archive", primary_library.resolve())]
+    manifest_dir = build_root / "link-manifests"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest = manifest_dir / f"{allocator_id}.txt"
+    lines: list[str] = []
+    provenance: list[dict[str, object]] = []
+    for kind, value in inputs:
+        if isinstance(value, Path):
+            lines.append(f"{kind}\t{value}")
+            provenance.append(
+                {
+                    "kind": kind,
+                    "path": str(value),
+                    "sha256": sha256_file(value),
+                }
+            )
+        else:
+            lines.append(f"{kind}\t{value}")
+            provenance.append({"kind": kind, "value": value})
+    manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return manifest.resolve(), query_commands, provenance
+
+
+def find_primary_library(record: Mapping[str, object], source_dir: Path, build_dir: Path) -> Path:
+    allocator_id = require_string(record.get("id"), "allocator.id")
+    expected = require_string(record.get("expected_static_library"), allocator_id)
+    build = require_mapping(record.get("build"), f"{allocator_id}.build")
+    system = require_string(build.get("system"), f"{allocator_id}.build.system")
+    if system == "cmake-ninja":
+        candidates = sorted(build_dir.rglob(expected))
+    elif system == "autoconf-make":
+        candidates = [source_dir / "lib" / expected]
+    elif system == "bazel":
+        candidates = [source_dir / "bazel-bin" / "tcmalloc" / expected]
+    else:
+        raise ArchiveError(f"{allocator_id} has unsupported build system {system!r}")
+    existing = [path for path in candidates if path.is_file()]
+    if len(existing) != 1:
+        raise ArchiveError(
+            f"{allocator_id} expected exactly one recipe-local {expected}, found {existing}"
+        )
+    return existing[0].resolve()
+
+
+def run_text(command: Sequence[str], *, cwd: Path) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=command_environment(),
+        check=True,
+        capture_output=True,
+        text=True,
+        errors="replace",
+    )
+    return result.stdout
+
+
+def defined_symbols(binary: Path) -> set[str]:
+    # Release linkers may localize allocator symbols (mimalloc aliases its
+    # override and mi_* entry points at the same address). Inspect all defined
+    # ELF symbols so localization cannot hide either the intended allocator or
+    # an accidental second competitor.
+    output = run_text(["nm", "--defined-only", str(binary)], cwd=binary.parent)
+    symbols: set[str] = set()
+    for line in output.splitlines():
+        fields = line.split()
+        if fields:
+            symbols.add(fields[-1])
+    return symbols
+
+
+def dynamic_dependencies(binary: Path) -> list[str]:
+    output = run_text(["readelf", "-d", str(binary)], cwd=binary.parent)
+    return [line.strip() for line in output.splitlines() if "(NEEDED)" in line]
+
+
+def validate_symbol_identity(
+    allocator_id: str, symbols: set[str], needed: Sequence[str]
+) -> dict[str, object]:
+    missing_adapter = sorted(set(ADAPTER_SYMBOLS) - symbols)
+    if missing_adapter:
+        raise ArchiveError(f"{allocator_id} child is missing adapter symbols: {missing_adapter}")
+    expected_family = COMPETITOR_SYMBOLS[allocator_id]
+    if expected_family not in symbols:
+        raise ArchiveError(
+            f"{allocator_id} child does not define its expected allocator symbol {expected_family}"
+        )
+    forbidden = {
+        symbol
+        for _family_id, symbol in COMPETITOR_SYMBOLS.items()
+        if symbol != expected_family and symbol in symbols
+    }
+    if forbidden:
+        raise ArchiveError(f"{allocator_id} child contains a second allocator: {sorted(forbidden)}")
+    competitor_needed = [
+        line
+        for line in needed
+        if any(name in line.lower() for name in ("tcmalloc", "jemalloc", "mimalloc"))
+    ]
+    if competitor_needed:
+        raise ArchiveError(
+            f"{allocator_id} child dynamically loads a competitor allocator: {competitor_needed}"
+        )
+    return {
+        "expected_allocator_symbol": expected_family,
+        "forbidden_allocator_symbols_absent": sorted(
+            set(COMPETITOR_SYMBOLS.values()) - {expected_family}
+        ),
+        "needed_libraries": needed,
+    }
+
+
+def validate_link_identity(allocator_id: str, binary: Path) -> dict[str, object]:
+    return validate_symbol_identity(
+        allocator_id, defined_symbols(binary), dynamic_dependencies(binary)
+    )
+
+
+def build_child(
+    record: Mapping[str, object],
+    source_dir: Path,
+    build_dir: Path,
+    library: Path,
+    build_root: Path,
+    logs: Path,
+    workflow_commit: str,
+) -> tuple[Path, list[list[str]], list[dict[str, object]], dict[str, object]]:
+    allocator_id = require_string(record.get("id"), "allocator.id")
+    link_manifest, query_commands, link_inputs = write_link_manifest(
+        allocator_id, source_dir, build_dir, library, build_root, logs
+    )
+    target_dir = (build_root / "cargo-target" / allocator_id).resolve()
+    command = [
+        "soldr",
+        "cargo",
+        "build",
+        "--manifest-path",
+        str(repository_root() / "rust" / "Cargo.toml"),
+        "-p",
+        "benchmark-suite",
+        "--bin",
+        "benchmark-child",
+        "--release",
+        "--locked",
+    ]
+    environment = command_environment()
+    environment.update(
+        {
+            "CARGO_TARGET_DIR": str(target_dir),
+            "BENCH_ALLOCATOR_ID": allocator_id,
+            "BENCH_ALLOCATOR_VERSION": adapter_version(record, workflow_commit),
+            "BENCH_ALLOCATOR_SOURCE_SHA": source_commit(record, workflow_commit),
+            "BENCH_ALLOCATOR_LIBRARY": str(library.resolve()),
+            "BENCH_ALLOCATOR_LIBRARY_SHA256": sha256_file(library),
+            "BENCH_ALLOCATOR_INCLUDE_DIRS": os.pathsep.join(
+                str(path.resolve())
+                for path in adapter_include_directories(allocator_id, source_dir, build_dir)
+            ),
+            "BENCH_ALLOCATOR_LINK_MANIFEST": str(link_manifest),
+        }
+    )
+    with (logs / f"{allocator_id}-child.log").open("w", encoding="utf-8") as log:
+        log.write("$ " + " ".join(command) + "\n")
+        log.flush()
+        subprocess.run(
+            command,
+            cwd=repository_root() / "rust",
+            env=environment,
+            check=True,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+    built = target_dir / "release" / "benchmark-child"
+    if not built.is_file():
+        raise ArchiveError(f"Cargo did not produce {allocator_id} benchmark child at {built}")
+    output_dir = build_root / "children" / allocator_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output = output_dir / "benchmark-child"
+    shutil.copyfile(built, output)
+    output.chmod(0o755)
+    link_identity = validate_link_identity(allocator_id, output)
+    return output, [*query_commands, command], link_inputs, link_identity
+
+
+def run_adapter_smoke(
+    allocator_id: str,
+    version: str,
+    source_sha: str,
+    library_sha256: str,
+    binary: Path,
+) -> dict[str, object]:
+    environment = benchmark_runtime_environment()
+    environment["BENCH_CHILD_BINARY_SHA256"] = sha256_file(binary)
+    result = subprocess.run(
+        [str(binary), "--adapter-smoke"],
+        cwd=binary.parent,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    try:
+        parsed = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ArchiveError(f"{allocator_id} adapter smoke did not emit JSON: {error}") from error
+    smoke = require_mapping(parsed, f"{allocator_id} adapter smoke")
+    expected = {
+        "allocator_id": allocator_id,
+        "allocator_version": version,
+        "source_sha": source_sha,
+        "library_sha256": library_sha256,
+        "child_binary_sha256": sha256_file(binary),
+    }
+    for field, value in expected.items():
+        if smoke.get(field) != value:
+            raise ArchiveError(
+                f"{allocator_id} adapter smoke {field} mismatch: "
+                f"expected {value!r}, got {smoke.get(field)!r}"
+            )
+    checksum = smoke.get("checksum")
+    usable_size = smoke.get("usable_size")
+    if not isinstance(checksum, int) or checksum <= 0:
+        raise ArchiveError(f"{allocator_id} adapter smoke checksum is invalid: {checksum!r}")
+    if not isinstance(usable_size, int) or usable_size < 128:
+        raise ArchiveError(f"{allocator_id} adapter smoke usable size is invalid: {usable_size!r}")
+    return dict(smoke)
+
+
+def mimalloc_option_comparison(
+    records: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    by_id = {require_string(record.get("id"), "allocator.id"): record for record in records}
+    upstream = require_mapping(by_id["upstream-mimalloc"].get("build"), "upstream build")
+    fork = require_mapping(by_id["mimalloc-pprof"].get("build"), "fork build")
+    upstream_flags = set(require_string_list(upstream.get("flags"), "upstream flags"))
+    fork_flags = set(require_string_list(fork.get("flags"), "fork flags"))
+    common = {
+        "build_type": "Release",
+        "MI_BUILD_STATIC": "ON",
+        "MI_BUILD_SHARED": "OFF",
+        "MI_BUILD_TESTS": "OFF",
+        "MI_OPT_ARCH": "OFF",
+        "MI_OPT_SIMD": "ON",
+        "optimization": "-O3",
+        "frame_pointers": "-fno-omit-frame-pointer",
+    }
+    expected_common_flags = {
+        "Release",
+        "MI_BUILD_STATIC=ON",
+        "MI_BUILD_SHARED=OFF",
+        "MI_BUILD_TESTS=OFF",
+        "MI_OPT_ARCH=OFF",
+        "MI_OPT_SIMD=ON",
+        "-O3",
+        "-fno-omit-frame-pointer",
+    }
+    if not expected_common_flags.issubset(upstream_flags & fork_flags):
+        raise ArchiveError("upstream/fork mimalloc common build options are not equivalent")
+    upstream_only = upstream_flags - fork_flags
+    fork_only = fork_flags - upstream_flags
+    if upstream_only != {"MI_PPROF=OFF"} or fork_only != {"MI_PPROF=ON"}:
+        raise ArchiveError(
+            "upstream/fork mimalloc options differ outside the intended MI_PPROF field"
+        )
+    return {
+        "equivalent_fields": common,
+        "intentional_difference": {
+            "field": "MI_PPROF",
+            "upstream-mimalloc": "OFF",
+            "mimalloc-pprof": "ON",
+        },
+        "runtime_disabled_state": {
+            "MIMALLOC_PROF": "0",
+            "MIMALLOC_MEMORY_EVENTS": "0",
+        },
+    }
+
+
+def build_records(
+    records: Iterable[Mapping[str, object]], build_root: Path, jobs: int
+) -> dict[str, object]:
+    producer_started = time.perf_counter()
+    records = list(records)
+    logs = build_root / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    sources, applied_patches, source_tree_sha256s = prepare_sources(records, build_root, logs)
+    workflow_commit = checkout_commit()
+    builds: list[dict[str, object]] = []
+    for record in records:
+        allocator_id = require_string(record.get("id"), "allocator.id")
+        source_dir = sources[allocator_id]
+        build_dir = build_root / "build" / allocator_id
+        build_dir.mkdir(parents=True, exist_ok=True)
+        build = require_mapping(record.get("build"), f"{allocator_id}.build")
+        commands = require_commands(build.get("commands"), f"{allocator_id}.build.commands")
+        resolved = [expand_command(command, source_dir, build_dir, jobs) for command in commands]
+        expected_generated_lock = build.get("generated_lock_sha256")
+        generated_lock_verified = expected_generated_lock is None
+        required_tool = build.get("required_tool_version")
+        if required_tool is not None:
+            actual_tool = checked_tool_version([resolved[0][0]])
+            if actual_tool != required_tool:
+                raise ArchiveError(f"{allocator_id} requires {required_tool}, got {actual_tool}")
+        with (logs / f"{allocator_id}.log").open("w", encoding="utf-8") as log:
+            for command in resolved:
+                if "build" in command and not generated_lock_verified:
+                    raise ArchiveError(
+                        f"{allocator_id} generated module lock was not verified before build"
+                    )
+                log.write("$ " + " ".join(command) + "\n")
+                log.flush()
+                subprocess.run(
+                    command,
+                    cwd=source_dir,
+                    env=command_environment(),
+                    check=True,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                )
+                if "--lockfile_mode=update" in command:
+                    generated_lock = source_dir / "MODULE.bazel.lock"
+                    actual_lock_sha256 = sha256_file(generated_lock)
+                    if actual_lock_sha256 != expected_generated_lock:
+                        raise ArchiveError(
+                            f"{allocator_id} generated module lock mismatch: expected "
+                            f"{expected_generated_lock}, got {actual_lock_sha256}"
+                        )
+                    generated_lock_verified = True
+        library = find_primary_library(record, source_dir, build_dir)
+        source_sha = source_commit(record, workflow_commit)
+        version = adapter_version(record, workflow_commit)
+        child, child_commands, link_inputs, link_identity = build_child(
+            record,
+            source_dir,
+            build_dir,
+            library,
+            build_root,
+            logs,
+            workflow_commit,
+        )
+        library_sha256 = sha256_file(library)
+        child_sha256 = sha256_file(child)
+        smoke = run_adapter_smoke(
+            allocator_id,
+            version,
+            source_sha,
+            library_sha256,
+            child,
+        )
+        builds.append(
+            {
+                "id": allocator_id,
+                "version": version,
+                "source_sha": source_sha,
+                "canonical_repository": require_mapping(
+                    record.get("source"), f"{allocator_id}.source"
+                ).get("canonical_repository"),
+                "source_archive_url": require_mapping(
+                    record.get("source"), f"{allocator_id}.source"
+                ).get("archive_url"),
+                "source_archive_sha256": require_mapping(
+                    record.get("source"), f"{allocator_id}.source"
+                ).get("archive_sha256"),
+                "source_directory": str(source_dir),
+                "source_tree_sha256": source_tree_sha256s[allocator_id],
+                "library": str(library),
+                "library_sha256": library_sha256,
+                "child_binary": str(child),
+                "child_binary_sha256": child_sha256,
+                "commands": [*resolved, *child_commands],
+                "build_flags": require_string_list(
+                    build.get("flags"), f"{allocator_id}.build.flags"
+                ),
+                "toolchain": {
+                    "compiler": compiler_identity(
+                        command_environment().get(
+                            "CXX" if allocator_id == "tcmalloc" else "CC",
+                            "c++" if allocator_id == "tcmalloc" else "cc",
+                        )
+                    ),
+                    "linker": compiler_identity(command_environment().get("CC", "cc")),
+                },
+                "source_patches": applied_patches[allocator_id],
+                "link_inputs": link_inputs,
+                "link_identity": link_identity,
+                "adapter_smoke": smoke,
+            }
+        )
+    binary_hashes = [cast(str, build["child_binary_sha256"]) for build in builds]
+    if len(set(binary_hashes)) != len(EXPECTED_IDS):
+        raise ArchiveError("the four allocator child executable hashes are not distinct")
+    build_elapsed_seconds = time.perf_counter() - producer_started
+    if not (0.0 <= build_elapsed_seconds < float("inf")):
+        raise ArchiveError("producer build elapsed time is not finite and nonnegative")
+    return {
+        "schema_version": 1,
+        "build_elapsed_seconds": build_elapsed_seconds,
+        "lockfile_sha256": sha256_file(default_lockfile()),
+        "environment": command_environment(),
+        "tool_versions": {
+            "cc": compiler_identity(command_environment().get("CC", "cc")),
+            "cxx": compiler_identity(command_environment().get("CXX", "c++")),
+            "cmake": checked_tool_version(["cmake"]),
+            "ninja": checked_tool_version(["ninja"]),
+            "bazel": checked_tool_version(["bazel"]),
+            "make": checked_tool_version(["make"]),
+        },
+        "mimalloc_option_comparison": mimalloc_option_comparison(records),
+        "allocators": builds,
+    }
+
+
+def tree_sha256(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise ArchiveError(f"source tree unexpectedly contains a symlink: {relative}")
+        if path.is_dir():
+            digest.update(f"D {relative}\n".encode())
+        elif path.is_file():
+            executable = "X" if path.stat().st_mode & stat.S_IXUSR else "-"
+            digest.update(f"F{executable} {relative} {sha256_file(path)}\n".encode())
+        else:
+            raise ArchiveError(f"source tree has unsupported entry: {relative}")
+    return digest.hexdigest()
+
+
+def selftest() -> int:
+    records = read_lockfile(default_lockfile())
+    if len(records) != len(EXPECTED_IDS):
+        raise AssertionError("valid lockfile did not return every allocator")
+    with tempfile.TemporaryDirectory(prefix="mi-benchmark-allocator-selftest-") as temporary:
+        root = Path(temporary)
+        good = root / "good.tar.gz"
+        with tarfile.open(good, "w:gz") as bundle:
+            payload = b"benchmark source\n"
+            info = tarfile.TarInfo("source/README")
+            info.size = len(payload)
+            bundle.addfile(info, io.BytesIO(payload))
+            script = b"#!/bin/sh\nexit 0\n"
+            info = tarfile.TarInfo("source/configure")
+            info.size = len(script)
+            info.mode = 0o755
+            bundle.addfile(info, io.BytesIO(script))
+        extraction = root / "extract"
+        extract_archive(good, extraction)
+        if (extraction / "source" / "README").read_bytes() != b"benchmark source\n":
+            raise AssertionError("safe archive extraction changed its contents")
+        if os.name != "nt" and not os.access(extraction / "source" / "configure", os.X_OK):
+            raise AssertionError("safe archive extraction removed a build script's executable bit")
+
+        try:
+            download_archive(good.as_uri(), "0" * SHA256_LENGTH, root / "never-extract.tar.gz")
+        except ArchiveError:
+            pass
+        else:
+            raise AssertionError("corrupt archive checksum was accepted")
+        if (root / "never-extract.tar.gz").exists():
+            raise AssertionError("checksum mismatch was retained")
+
+        traversal = root / "traversal.tar"
+        with tarfile.open(traversal, "w") as bundle:
+            info = tarfile.TarInfo("../outside")
+            info.size = 1
+            bundle.addfile(info, io.BytesIO(b"x"))
+        try:
+            extract_archive(traversal, root / "traversal-out")
+        except ArchiveError:
+            pass
+        else:
+            raise AssertionError("path traversal archive was accepted")
+
+        symlink = root / "symlink.tar"
+        with tarfile.open(symlink, "w") as bundle:
+            link = tarfile.TarInfo("source/link")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "README"
+            bundle.addfile(link)
+        try:
+            extract_archive(symlink, root / "symlink-out")
+        except ArchiveError:
+            pass
+        else:
+            raise AssertionError("symlink archive was accepted")
+
+        for invalid_commit in ("main", "c316de3"):
+            try:
+                validate_source(
+                    "tcmalloc",
+                    invalid_commit,
+                    {
+                        "kind": "archive",
+                        "canonical_repository": "https://github.com/google/tcmalloc",
+                        "commit": invalid_commit,
+                        "archive_url": "https://github.com/google/tcmalloc/archive/main.tar.gz",
+                        "archive_sha256": "0" * SHA256_LENGTH,
+                    },
+                )
+            except LockfileError:
+                pass
+            else:
+                raise AssertionError(f"invalid lockfile commit was accepted: {invalid_commit}")
+        valid_symbols = {*ADAPTER_SYMBOLS, COMPETITOR_SYMBOLS["tcmalloc"]}
+        validate_symbol_identity("tcmalloc", valid_symbols, ["libc.so.6"])
+        try:
+            validate_symbol_identity(
+                "tcmalloc",
+                {*valid_symbols, COMPETITOR_SYMBOLS["jemalloc"]},
+                ["libc.so.6"],
+            )
+        except ArchiveError:
+            pass
+        else:
+            raise AssertionError("a child with two allocator symbol families was accepted")
+        try:
+            validate_symbol_identity("jemalloc", {*ADAPTER_SYMBOLS}, ["libc.so.6"])
+        except ArchiveError:
+            pass
+        else:
+            raise AssertionError("a child missing its allocator symbol family was accepted")
+    print(
+        "PASS allocator builder selftest: lock, checksum, traversal, mode, source, and link identity"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lockfile", type=Path, default=default_lockfile())
+    parser.add_argument(
+        "--selftest", action="store_true", help="run offline lock and archive safety tests"
+    )
+    parser.add_argument(
+        "--build-root", type=Path, help="download/extract/build root; enables native builds"
+    )
+    parser.add_argument(
+        "--jobs", type=int, default=1, help="parallel jobs forwarded to native build tools"
+    )
+    args = parser.parse_args()
+    if args.jobs < 1:
+        parser.error("--jobs must be at least one")
+    if args.selftest:
+        return selftest()
+    records = read_lockfile(args.lockfile)
+    if args.build_root is None:
+        print(f"PASS {args.lockfile}: validated {len(records)} immutable allocator records")
+        return 0
+    provenance = build_records(records, args.build_root.resolve(), args.jobs)
+    output = args.build_root / "allocator-provenance.json"
+    output.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"PASS built {len(records)} allocators; wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -22,6 +22,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "benchmark-suite"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["bench-harness", "dashboard", "mimalloc-pprof", "stress-harness", "xtask"]
+members = ["bench-harness", "benchmark-suite", "dashboard", "mimalloc-pprof", "stress-harness", "xtask"]
 resolver = "2"

--- a/rust/benchmark-suite/Cargo.toml
+++ b/rust/benchmark-suite/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "benchmark-suite"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Four-allocator native benchmark producer for mimalloc-pprof"
+build = "build.rs"
+
+[lib]
+name = "benchmark_suite"
+path = "src/lib.rs"
+
+[[bin]]
+name = "benchmark-child"
+path = "src/bin/benchmark-child.rs"
+
+[[bin]]
+name = "benchmark-run"
+path = "src/bin/benchmark-run.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[build-dependencies]
+

--- a/rust/benchmark-suite/allocators/allocator-lock.json
+++ b/rust/benchmark-suite/allocators/allocator-lock.json
@@ -1,0 +1,197 @@
+{
+  "schema_version": 1,
+  "target": "x86_64-unknown-linux-gnu",
+  "allocators": [
+    {
+      "id": "tcmalloc",
+      "pin": "c316de3ee8ffb5aff6547aa10151bc8dda3a2942",
+      "source": {
+        "kind": "archive",
+        "canonical_repository": "https://github.com/google/tcmalloc",
+        "commit": "c316de3ee8ffb5aff6547aa10151bc8dda3a2942",
+        "archive_url": "https://github.com/google/tcmalloc/archive/c316de3ee8ffb5aff6547aa10151bc8dda3a2942.tar.gz",
+        "archive_sha256": "66d2923630f7786c1e64c170de4333da34eba546c4aa675812e723b332110c03"
+      },
+      "build": {
+        "system": "bazel",
+        "required_tool_version": "bazel 9.1.0",
+        "generated_lock_sha256": "5ec8cc791ba4a4ca8841144e4c3a8abf28aec0d289dcfec0f2c10d392349b553",
+        "commands": [
+          [
+            "bazel",
+            "--output_user_root={build_dir}/bazel",
+            "cquery",
+            "--lockfile_mode=update",
+            "--dynamic_mode=off",
+            "-c",
+            "opt",
+            "--copt=-fno-omit-frame-pointer",
+            "//tcmalloc:tcmalloc",
+            "--output=label"
+          ],
+          [
+            "bazel",
+            "--output_user_root={build_dir}/bazel",
+            "build",
+            "--lockfile_mode=error",
+            "--dynamic_mode=off",
+            "-c",
+            "opt",
+            "--copt=-fno-omit-frame-pointer",
+            "//tcmalloc:tcmalloc"
+          ]
+        ],
+        "flags": ["-c opt", "-fno-omit-frame-pointer", "static-only"]
+      },
+      "expected_static_library": "libtcmalloc.lo",
+      "adapter_kind": "cxx-public-api",
+      "license": "Apache-2.0",
+      "patches": {
+        "source": [
+          {
+            "file": "tcmalloc-remove-dev-fuzztest.patch",
+            "sha256": "33f048ab1a867d6fcf40b1e0ed5b6b4d9e8515785c1267b918882fbf231714b4"
+          }
+        ],
+        "build": []
+      }
+    },
+    {
+      "id": "jemalloc",
+      "pin": "5.3.1@81034ce1f1373e37dc865038e1bc8eeecf559ce8",
+      "source": {
+        "kind": "archive",
+        "canonical_repository": "https://github.com/jemalloc/jemalloc",
+        "commit": "81034ce1f1373e37dc865038e1bc8eeecf559ce8",
+        "archive_url": "https://github.com/jemalloc/jemalloc/archive/81034ce1f1373e37dc865038e1bc8eeecf559ce8.tar.gz",
+        "archive_sha256": "33d3a3f7c60bd17656f41711847ffa392dcbee1dcdadebb4915475dcb276b979"
+      },
+      "build": {
+        "system": "autoconf-make",
+        "commands": [
+          [
+            "env",
+            "CFLAGS=-O3 -fno-omit-frame-pointer",
+            "sh",
+            "autogen.sh",
+            "--disable-shared",
+            "--enable-static",
+            "--disable-debug",
+            "--disable-stats",
+            "--with-jemalloc-prefix=je_"
+          ],
+          ["make", "-j{jobs}"]
+        ],
+        "flags": [
+          "--disable-shared",
+          "--enable-static",
+          "--disable-debug",
+          "--disable-stats",
+          "--with-jemalloc-prefix=je_",
+          "-O3",
+          "-fno-omit-frame-pointer"
+        ]
+      },
+      "expected_static_library": "libjemalloc.a",
+      "adapter_kind": "prefixed-c-api",
+      "license": "BSD-2-Clause",
+      "patches": { "source": [], "build": [] }
+    },
+    {
+      "id": "upstream-mimalloc",
+      "pin": "dev3@bcee5a88",
+      "source": {
+        "kind": "archive",
+        "canonical_repository": "https://github.com/microsoft/mimalloc",
+        "commit": "bcee5a88e9311c08b8f93fbce3dcafe2f22a2d26",
+        "archive_url": "https://github.com/microsoft/mimalloc/archive/bcee5a88e9311c08b8f93fbce3dcafe2f22a2d26.tar.gz",
+        "archive_sha256": "d440bbf0d09bd4bb2fecb195fb0c0faa148b890b73bc1afbf534e734edad1189"
+      },
+      "build": {
+        "system": "cmake-ninja",
+        "commands": [
+          [
+            "cmake",
+            "-S",
+            "{source_dir}",
+            "-B",
+            "{build_dir}",
+            "-G",
+            "Ninja",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DMI_BUILD_STATIC=ON",
+            "-DMI_BUILD_SHARED=OFF",
+            "-DMI_BUILD_TESTS=OFF",
+            "-DMI_PPROF=OFF",
+            "-DMI_OPT_ARCH=OFF",
+            "-DMI_OPT_SIMD=ON",
+            "-DCMAKE_C_FLAGS_RELEASE=-O3 -fno-omit-frame-pointer"
+          ],
+          ["cmake", "--build", "{build_dir}", "--parallel", "{jobs}"]
+        ],
+        "flags": [
+          "Release",
+          "MI_BUILD_STATIC=ON",
+          "MI_BUILD_SHARED=OFF",
+          "MI_BUILD_TESTS=OFF",
+          "MI_PPROF=OFF",
+          "MI_OPT_ARCH=OFF",
+          "MI_OPT_SIMD=ON",
+          "-O3",
+          "-fno-omit-frame-pointer"
+        ]
+      },
+      "expected_static_library": "libmimalloc.a",
+      "adapter_kind": "mimalloc-c-api",
+      "license": "MIT",
+      "patches": { "source": [], "build": [] }
+    },
+    {
+      "id": "mimalloc-pprof",
+      "pin": "workflow-source",
+      "source": {
+        "kind": "checkout",
+        "canonical_repository": "https://github.com/zackees/mimalloc-pprof",
+        "commit": "workflow-source"
+      },
+      "build": {
+        "system": "cmake-ninja",
+        "commands": [
+          [
+            "cmake",
+            "-S",
+            "{source_dir}",
+            "-B",
+            "{build_dir}",
+            "-G",
+            "Ninja",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DMI_BUILD_STATIC=ON",
+            "-DMI_BUILD_SHARED=OFF",
+            "-DMI_BUILD_TESTS=OFF",
+            "-DMI_PPROF=ON",
+            "-DMI_OPT_ARCH=OFF",
+            "-DMI_OPT_SIMD=ON",
+            "-DCMAKE_C_FLAGS_RELEASE=-O3 -fno-omit-frame-pointer"
+          ],
+          ["cmake", "--build", "{build_dir}", "--parallel", "{jobs}"]
+        ],
+        "flags": [
+          "Release",
+          "MI_BUILD_STATIC=ON",
+          "MI_BUILD_SHARED=OFF",
+          "MI_BUILD_TESTS=OFF",
+          "MI_PPROF=ON",
+          "MI_OPT_ARCH=OFF",
+          "MI_OPT_SIMD=ON",
+          "-O3",
+          "-fno-omit-frame-pointer"
+        ]
+      },
+      "expected_static_library": "libmimalloc.a",
+      "adapter_kind": "mimalloc-pprof-c-api",
+      "license": "MIT",
+      "patches": { "source": [], "build": [] }
+    }
+  ]
+}

--- a/rust/benchmark-suite/allocators/patches/tcmalloc-remove-dev-fuzztest.patch
+++ b/rust/benchmark-suite/allocators/patches/tcmalloc-remove-dev-fuzztest.patch
@@ -1,0 +1,10 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -26,7 +26,6 @@
+ bazel_dep(name = "re2", version = "2025-11-05.bcr.1", repo_name = "com_googlesource_code_re2")
+ bazel_dep(name = "rules_cc", version = "0.2.9")
+ 
+-bazel_dep(name = "fuzztest", version = "20260629.0", dev_dependency = True, repo_name = "com_google_fuzztest")
+ bazel_dep(name = "google_benchmark", version = "1.9.5", dev_dependency = True, repo_name = "com_github_google_benchmark")
+ bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True, repo_name = "com_google_googletest")
+ bazel_dep(name = "rules_fuzzing", version = "0.5.2", dev_dependency = True)

--- a/rust/benchmark-suite/build.rs
+++ b/rust/benchmark-suite/build.rs
@@ -1,0 +1,312 @@
+use std::env;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const LINK_ENV: &[&str] = &[
+    "BENCH_ALLOCATOR_ID",
+    "BENCH_ALLOCATOR_VERSION",
+    "BENCH_ALLOCATOR_SOURCE_SHA",
+    "BENCH_ALLOCATOR_LIBRARY",
+    "BENCH_ALLOCATOR_LIBRARY_SHA256",
+    "BENCH_ALLOCATOR_INCLUDE_DIRS",
+    "BENCH_ALLOCATOR_LINK_MANIFEST",
+];
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(benchmark_native_adapter)");
+    for name in LINK_ENV {
+        println!("cargo:rerun-if-env-changed={name}");
+    }
+    println!("cargo:rerun-if-env-changed=CC");
+    println!("cargo:rerun-if-env-changed=CXX");
+    println!("cargo:rerun-if-env-changed=AR");
+    println!("cargo:rerun-if-changed=native/allocator_adapter.h");
+    println!("cargo:rerun-if-changed=native/adapter_mimalloc.c");
+    println!("cargo:rerun-if-changed=native/adapter_jemalloc.c");
+    println!("cargo:rerun-if-changed=native/adapter_tcmalloc.cc");
+
+    let present = LINK_ENV
+        .iter()
+        .filter(|name| env::var_os(name).is_some())
+        .count();
+    if present == 0 {
+        emit_unlinked_identity();
+        return;
+    }
+    if present != LINK_ENV.len() {
+        panic!(
+            "native benchmark child link requires all of {}; refusing a partial identity",
+            LINK_ENV.join(", ")
+        );
+    }
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("Cargo target OS");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("Cargo target architecture");
+    if target_os != "linux" || target_arch != "x86_64" {
+        panic!(
+            "native benchmark children support only x86_64 Linux, got {target_arch}-{target_os}"
+        );
+    }
+
+    let allocator_id = required_env("BENCH_ALLOCATOR_ID");
+    let allocator_version = required_env("BENCH_ALLOCATOR_VERSION");
+    let source_sha = required_env("BENCH_ALLOCATOR_SOURCE_SHA");
+    let library_sha = required_env("BENCH_ALLOCATOR_LIBRARY_SHA256");
+    validate_identity(&allocator_id, &allocator_version, &source_sha, &library_sha);
+
+    let primary_library = canonical_file(&required_env("BENCH_ALLOCATOR_LIBRARY"));
+    require_archive(&primary_library);
+    let manifest = canonical_file(&required_env("BENCH_ALLOCATOR_LINK_MANIFEST"));
+    let link_inputs = parse_link_manifest(&manifest, &primary_library);
+    let include_dirs = parse_include_dirs(&required_env("BENCH_ALLOCATOR_INCLUDE_DIRS"));
+    let adapter_archive = compile_adapter(&allocator_id, &allocator_version, &include_dirs);
+
+    println!("cargo:rustc-cfg=benchmark_native_adapter");
+    println!("cargo:rustc-env=BENCH_ALLOCATOR_ID={allocator_id}");
+    println!("cargo:rustc-env=BENCH_ALLOCATOR_VERSION={allocator_version}");
+    println!("cargo:rustc-env=BENCH_ALLOCATOR_SOURCE_SHA={source_sha}");
+    println!("cargo:rustc-env=BENCH_ALLOCATOR_LIBRARY_SHA256={library_sha}");
+
+    // Absolute archives and an explicit group retain Bazel's complete TCMalloc
+    // closure and make the actual final link auditable from the build log.
+    println!("cargo:rustc-link-arg-bin=benchmark-child=-Wl,--start-group");
+    println!(
+        "cargo:rustc-link-arg-bin=benchmark-child={}",
+        adapter_archive.display()
+    );
+    for input in link_inputs {
+        match input {
+            LinkInput::Archive { path, always_link } => {
+                if always_link {
+                    println!("cargo:rustc-link-arg-bin=benchmark-child=-Wl,--whole-archive");
+                }
+                println!(
+                    "cargo:rustc-link-arg-bin=benchmark-child={}",
+                    path.display()
+                );
+                if always_link {
+                    println!("cargo:rustc-link-arg-bin=benchmark-child=-Wl,--no-whole-archive");
+                }
+            }
+            LinkInput::Flag(flag) => {
+                println!("cargo:rustc-link-arg-bin=benchmark-child={flag}");
+            }
+        }
+    }
+    println!("cargo:rustc-link-arg-bin=benchmark-child=-Wl,--end-group");
+    if allocator_id == "tcmalloc" {
+        println!("cargo:rustc-link-arg-bin=benchmark-child=-lstdc++");
+        println!("cargo:rustc-link-arg-bin=benchmark-child=-pthread");
+        println!("cargo:rustc-link-arg-bin=benchmark-child=-ldl");
+        println!("cargo:rustc-link-arg-bin=benchmark-child=-lm");
+    }
+}
+
+fn emit_unlinked_identity() {
+    println!("cargo:rustc-env=BENCH_ALLOCATOR_ID=unlinked-test-adapter");
+    println!("cargo:rustc-env=BENCH_ALLOCATOR_VERSION=unlinked");
+    println!("cargo:rustc-env=BENCH_ALLOCATOR_SOURCE_SHA=unlinked");
+    println!("cargo:rustc-env=BENCH_ALLOCATOR_LIBRARY_SHA256=unlinked");
+}
+
+fn required_env(name: &str) -> String {
+    let value = env::var(name).unwrap_or_else(|_| panic!("missing {name}"));
+    if value.is_empty() || value.contains(['\n', '\r', '\0']) {
+        panic!("{name} must be a non-empty single-line value");
+    }
+    value
+}
+
+fn validate_identity(id: &str, version: &str, source_sha: &str, library_sha: &str) {
+    const IDS: &[&str] = &[
+        "tcmalloc",
+        "jemalloc",
+        "upstream-mimalloc",
+        "mimalloc-pprof",
+    ];
+    if !IDS.contains(&id) {
+        panic!("unsupported BENCH_ALLOCATOR_ID {id:?}");
+    }
+    if !is_lower_hex(source_sha, 40) {
+        panic!("BENCH_ALLOCATOR_SOURCE_SHA must be a full lowercase Git SHA");
+    }
+    if !is_lower_hex(library_sha, 64) {
+        panic!("BENCH_ALLOCATOR_LIBRARY_SHA256 must be a lowercase SHA-256");
+    }
+    if version.len() > 128
+        || !version
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"._@+-".contains(&byte))
+    {
+        panic!("BENCH_ALLOCATOR_VERSION contains unsupported characters");
+    }
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn canonical_file(value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if !path.is_absolute() {
+        panic!(
+            "native link inputs must use absolute paths: {}",
+            path.display()
+        );
+    }
+    let canonical = fs::canonicalize(&path)
+        .unwrap_or_else(|error| panic!("cannot resolve {}: {error}", path.display()));
+    if !canonical.is_file() {
+        panic!("native link input is not a file: {}", canonical.display());
+    }
+    canonical
+}
+
+fn require_archive(path: &Path) {
+    let bytes =
+        fs::read(path).unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
+    if !bytes.starts_with(b"!<arch>\n") && !bytes.starts_with(b"!<thin>\n") {
+        panic!(
+            "native allocator input is not a static archive: {}",
+            path.display()
+        );
+    }
+}
+
+fn parse_include_dirs(value: &str) -> Vec<PathBuf> {
+    env::split_paths(OsStr::new(value))
+        .map(|path| {
+            let canonical = fs::canonicalize(&path).unwrap_or_else(|error| {
+                panic!("cannot resolve include {}: {error}", path.display())
+            });
+            if !canonical.is_dir() {
+                panic!(
+                    "adapter include input is not a directory: {}",
+                    canonical.display()
+                );
+            }
+            canonical
+        })
+        .collect()
+}
+
+enum LinkInput {
+    Archive { path: PathBuf, always_link: bool },
+    Flag(String),
+}
+
+fn parse_link_manifest(path: &Path, primary: &Path) -> Vec<LinkInput> {
+    let input = fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
+    let mut result = Vec::new();
+    let mut found_primary = false;
+    for (index, line) in input.lines().enumerate() {
+        let (kind, value) = line
+            .split_once('\t')
+            .unwrap_or_else(|| panic!("{}:{} must be KIND<TAB>VALUE", path.display(), index + 1));
+        match kind {
+            "archive" | "always" => {
+                let archive = canonical_file(value);
+                require_archive(&archive);
+                found_primary |= archive == primary;
+                result.push(LinkInput::Archive {
+                    path: archive,
+                    always_link: kind == "always",
+                });
+            }
+            "flag" => {
+                if value.is_empty()
+                    || value.contains(char::is_whitespace)
+                    || !value.starts_with('-')
+                {
+                    panic!("{}:{} has an unsafe linker flag", path.display(), index + 1);
+                }
+                result.push(LinkInput::Flag(value.to_owned()));
+            }
+            _ => panic!(
+                "{}:{} has unknown link-input kind {kind:?}",
+                path.display(),
+                index + 1
+            ),
+        }
+    }
+    if result.is_empty() || !found_primary {
+        panic!("link manifest must contain the locked primary allocator archive");
+    }
+    result
+}
+
+fn compile_adapter(id: &str, version: &str, includes: &[PathBuf]) -> PathBuf {
+    let manifest_dir = PathBuf::from(required_env("CARGO_MANIFEST_DIR"));
+    let out_dir = PathBuf::from(required_env("OUT_DIR"));
+    let (source_name, compiler_var, compiler_default, cxx) = match id {
+        "tcmalloc" => ("adapter_tcmalloc.cc", "CXX", "c++", true),
+        "jemalloc" => ("adapter_jemalloc.c", "CC", "cc", false),
+        "upstream-mimalloc" | "mimalloc-pprof" => ("adapter_mimalloc.c", "CC", "cc", false),
+        _ => unreachable!(),
+    };
+    let source = manifest_dir.join("native").join(source_name);
+    let object = out_dir.join("benchmark_allocator_adapter.o");
+    let archive = out_dir.join("libbenchmark_allocator_adapter.a");
+    let compiler = env::var(compiler_var).unwrap_or_else(|_| compiler_default.to_owned());
+    let mut command = tool_command(&compiler, compiler_var);
+    command
+        .arg("-c")
+        .arg(&source)
+        .arg("-o")
+        .arg(&object)
+        .arg("-O3")
+        .arg("-fno-omit-frame-pointer")
+        .arg("-fPIC")
+        .arg("-I")
+        .arg(manifest_dir.join("native"))
+        .arg(format!("-DBENCH_ALLOCATOR_ID=\"{id}\""))
+        .arg(format!("-DBENCH_ALLOCATOR_VERSION=\"{version}\""));
+    if cxx {
+        command.arg("-std=c++17");
+    } else {
+        command.arg("-std=c11");
+    }
+    for include in includes {
+        command.arg("-I").arg(include);
+    }
+    let status = command
+        .status()
+        .unwrap_or_else(|error| panic!("cannot execute adapter compiler {compiler}: {error}"));
+    if !status.success() {
+        panic!("adapter compiler exited with {status}");
+    }
+    let ar = env::var("AR").unwrap_or_else(|_| "ar".to_owned());
+    let status = tool_command(&ar, "AR")
+        .arg("crs")
+        .arg(&archive)
+        .arg(&object)
+        .status()
+        .unwrap_or_else(|error| panic!("cannot execute archive tool {ar}: {error}"));
+    if !status.success() {
+        panic!("adapter archive tool exited with {status}");
+    }
+    archive
+}
+
+fn tool_command(value: &str, variable: &str) -> Command {
+    let parts: Vec<_> = value.split_ascii_whitespace().collect();
+    if parts.is_empty()
+        || parts.iter().any(|part| {
+            part.is_empty()
+                || part
+                    .bytes()
+                    .any(|byte| matches!(byte, b'\'' | b'"' | b'`' | b'$' | b';' | b'|' | b'&'))
+        })
+    {
+        panic!("{variable} has an unsupported compiler-wrapper command: {value:?}");
+    }
+    let mut command = Command::new(parts[0]);
+    command.args(&parts[1..]);
+    command
+}

--- a/rust/benchmark-suite/native/adapter_jemalloc.c
+++ b/rust/benchmark-suite/native/adapter_jemalloc.c
@@ -1,0 +1,64 @@
+#include "allocator_adapter.h"
+
+#include <errno.h>
+
+#include <jemalloc/jemalloc.h>
+
+/* The static jemalloc build is configured with --with-jemalloc-prefix=je_. */
+#ifndef BENCH_ALLOCATOR_VERSION
+#error "BENCH_ALLOCATOR_VERSION must be a string literal supplied by the benchmark build"
+#endif
+
+static int bench_prepare_aligned_alloc(void** out, size_t alignment) {
+  if (out == NULL) {
+    return EINVAL;
+  }
+  *out = NULL;
+
+  /* Normalize all adapters to posix_memalign's alignment contract. */
+  if (alignment < sizeof(void*) || (alignment & (alignment - 1)) != 0) {
+    return EINVAL;
+  }
+  return 0;
+}
+
+const char* bench_allocator_id(void) {
+  return "jemalloc";
+}
+
+const char* bench_allocator_version(void) {
+  return BENCH_ALLOCATOR_VERSION;
+}
+
+void* bench_alloc(size_t size) {
+  return je_malloc(size);
+}
+
+void* bench_calloc(size_t count, size_t size) {
+  return je_calloc(count, size);
+}
+
+void* bench_realloc(void* ptr, size_t size) {
+  return je_realloc(ptr, size);
+}
+
+int bench_aligned_alloc(void** out, size_t alignment, size_t size) {
+  const int error = bench_prepare_aligned_alloc(out, alignment);
+  if (error != 0) {
+    return error;
+  }
+
+  const int result = je_posix_memalign(out, alignment, size);
+  if (result != 0) {
+    *out = NULL;
+  }
+  return result;
+}
+
+void bench_free(void* ptr) {
+  je_free(ptr);
+}
+
+size_t bench_usable_size(void* ptr) {
+  return (ptr == NULL ? 0 : je_malloc_usable_size(ptr));
+}

--- a/rust/benchmark-suite/native/adapter_mimalloc.c
+++ b/rust/benchmark-suite/native/adapter_mimalloc.c
@@ -1,0 +1,74 @@
+#include "allocator_adapter.h"
+
+#include <errno.h>
+
+#include "mimalloc.h"
+
+/*
+  The same source builds both mimalloc children.  build.rs supplies string
+  literals for the lockfile ID (upstream-mimalloc or mimalloc-pprof) and source
+  identity, making a stale/wrong adapter build fail at compile time instead of
+  silently changing a measurement's identity.
+*/
+#ifndef BENCH_ALLOCATOR_ID
+#error "BENCH_ALLOCATOR_ID must be a string literal supplied by the benchmark build"
+#endif
+
+#ifndef BENCH_ALLOCATOR_VERSION
+#error "BENCH_ALLOCATOR_VERSION must be a string literal supplied by the benchmark build"
+#endif
+
+static int bench_prepare_aligned_alloc(void** out, size_t alignment) {
+  if (out == NULL) {
+    return EINVAL;
+  }
+  *out = NULL;
+
+  /* This is the portable posix_memalign domain used by every adapter. */
+  if (alignment < sizeof(void*) || (alignment & (alignment - 1)) != 0) {
+    return EINVAL;
+  }
+  return 0;
+}
+
+const char* bench_allocator_id(void) {
+  return BENCH_ALLOCATOR_ID;
+}
+
+const char* bench_allocator_version(void) {
+  return BENCH_ALLOCATOR_VERSION;
+}
+
+void* bench_alloc(size_t size) {
+  return mi_malloc(size);
+}
+
+void* bench_calloc(size_t count, size_t size) {
+  return mi_calloc(count, size);
+}
+
+void* bench_realloc(void* ptr, size_t size) {
+  return mi_realloc(ptr, size);
+}
+
+int bench_aligned_alloc(void** out, size_t alignment, size_t size) {
+  const int error = bench_prepare_aligned_alloc(out, alignment);
+  if (error != 0) {
+    return error;
+  }
+
+  void* const ptr = mi_malloc_aligned(size, alignment);
+  if (ptr == NULL) {
+    return ENOMEM;
+  }
+  *out = ptr;
+  return 0;
+}
+
+void bench_free(void* ptr) {
+  mi_free(ptr);
+}
+
+size_t bench_usable_size(void* ptr) {
+  return (ptr == NULL ? 0 : mi_usable_size(ptr));
+}

--- a/rust/benchmark-suite/native/adapter_tcmalloc.cc
+++ b/rust/benchmark-suite/native/adapter_tcmalloc.cc
@@ -1,0 +1,67 @@
+#include "allocator_adapter.h"
+
+#include <cerrno>
+
+#include <tcmalloc/tcmalloc.h>
+
+#ifndef BENCH_ALLOCATOR_VERSION
+#error "BENCH_ALLOCATOR_VERSION must be a string literal supplied by the benchmark build"
+#endif
+
+namespace {
+
+int bench_prepare_aligned_alloc(void** out, size_t alignment) {
+  if (out == nullptr) {
+    return EINVAL;
+  }
+  *out = nullptr;
+
+  /* Normalize all adapters to posix_memalign's alignment contract. */
+  if (alignment < sizeof(void*) || (alignment & (alignment - 1)) != 0) {
+    return EINVAL;
+  }
+  return 0;
+}
+
+}  // namespace
+
+extern "C" const char* bench_allocator_id(void) {
+  return "tcmalloc";
+}
+
+extern "C" const char* bench_allocator_version(void) {
+  return BENCH_ALLOCATOR_VERSION;
+}
+
+extern "C" void* bench_alloc(size_t size) {
+  return TCMallocInternalMalloc(size);
+}
+
+extern "C" void* bench_calloc(size_t count, size_t size) {
+  return TCMallocInternalCalloc(count, size);
+}
+
+extern "C" void* bench_realloc(void* ptr, size_t size) {
+  return TCMallocInternalRealloc(ptr, size);
+}
+
+extern "C" int bench_aligned_alloc(void** out, size_t alignment, size_t size) {
+  const int error = bench_prepare_aligned_alloc(out, alignment);
+  if (error != 0) {
+    return error;
+  }
+
+  const int result = TCMallocInternalPosixMemalign(out, alignment, size);
+  if (result != 0) {
+    *out = nullptr;
+  }
+  return result;
+}
+
+extern "C" void bench_free(void* ptr) {
+  TCMallocInternalFree(ptr);
+}
+
+extern "C" size_t bench_usable_size(void* ptr) {
+  return (ptr == nullptr ? 0 : TCMallocInternalMallocSize(ptr));
+}

--- a/rust/benchmark-suite/native/allocator_adapter.h
+++ b/rust/benchmark-suite/native/allocator_adapter.h
@@ -1,0 +1,33 @@
+/*
+  A deliberately small, allocator-neutral ABI for benchmark children.
+
+  Each child links one implementation of these symbols.  `NULL` from a
+  pointer-returning function is an allocation failure and invalidates the
+  sample; the workload must not substitute a second allocator.  The aligned
+  form returns POSIX-style error codes and accepts an arbitrary requested size
+  (it deliberately does not round the size up to the alignment).
+*/
+#ifndef MIMALLOC_PPROF_BENCHMARK_SUITE_ALLOCATOR_ADAPTER_H
+#define MIMALLOC_PPROF_BENCHMARK_SUITE_ALLOCATOR_ADAPTER_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char* bench_allocator_id(void);
+const char* bench_allocator_version(void);
+
+void* bench_alloc(size_t size);
+void* bench_calloc(size_t count, size_t size);
+void* bench_realloc(void* ptr, size_t size);
+int bench_aligned_alloc(void** out, size_t alignment, size_t size);
+void bench_free(void* ptr);
+size_t bench_usable_size(void* ptr);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif  /* MIMALLOC_PPROF_BENCHMARK_SUITE_ALLOCATOR_ADAPTER_H */

--- a/rust/benchmark-suite/native/tcmalloc_link_inputs.cquery
+++ b/rust/benchmark-suite/native/tcmalloc_link_inputs.cquery
@@ -1,0 +1,12 @@
+def format(target):
+    cc_info = providers(target)["@@rules_cc+//cc/private:cc_info.bzl%CcInfo"]
+    lines = []
+    for linker_input in cc_info.linking_context.linker_inputs.to_list():
+        for library in linker_input.libraries:
+            archive = library.static_library or library.pic_static_library
+            if archive:
+                kind = "always" if library.alwayslink else "archive"
+                lines.append(kind + "\t" + archive.path + "\t" + str(linker_input.owner))
+        for flag in linker_input.user_link_flags:
+            lines.append("flag\t" + flag)
+    return "\n".join(lines)

--- a/rust/benchmark-suite/src/adapter.rs
+++ b/rust/benchmark-suite/src/adapter.rs
@@ -1,0 +1,345 @@
+//! Safe boundary around the one allocator adapter linked into a child process.
+
+#[cfg(benchmark_native_adapter)]
+use std::ffi::CStr;
+use std::fmt;
+use std::ptr::NonNull;
+
+pub const BUILD_ALLOCATOR_ID: &str = env!("BENCH_ALLOCATOR_ID");
+pub const BUILD_ALLOCATOR_VERSION: &str = env!("BENCH_ALLOCATOR_VERSION");
+pub const BUILD_SOURCE_SHA: &str = env!("BENCH_ALLOCATOR_SOURCE_SHA");
+pub const BUILD_LIBRARY_SHA256: &str = env!("BENCH_ALLOCATOR_LIBRARY_SHA256");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LinkedAllocatorIdentity {
+    pub allocator_id: &'static str,
+    pub allocator_version: &'static str,
+    pub source_sha: &'static str,
+    pub library_sha256: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdapterSmoke {
+    pub identity: LinkedAllocatorIdentity,
+    pub checksum: u64,
+    pub usable_size: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdapterError {
+    Unlinked,
+    InvalidIdentity(&'static str),
+    IdentityMismatch {
+        field: &'static str,
+        expected: &'static str,
+        actual: String,
+    },
+    InvalidRequest(&'static str),
+    AllocationFailed(&'static str),
+    AlignedAllocationFailed(i32),
+    ContractViolation(&'static str),
+}
+
+impl fmt::Display for AdapterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unlinked => write!(formatter, "benchmark child has no native allocator adapter"),
+            Self::InvalidIdentity(field) => write!(formatter, "adapter returned invalid {field}"),
+            Self::IdentityMismatch {
+                field,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "linked adapter {field} mismatch: expected {expected:?}, got {actual:?}"
+            ),
+            Self::InvalidRequest(message) => {
+                write!(formatter, "invalid adapter request: {message}")
+            }
+            Self::AllocationFailed(operation) => {
+                write!(formatter, "allocator returned null from {operation}")
+            }
+            Self::AlignedAllocationFailed(code) => {
+                write!(formatter, "aligned allocation failed with errno {code}")
+            }
+            Self::ContractViolation(message) => {
+                write!(formatter, "allocator adapter contract violation: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AdapterError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LinkedAdapter {
+    identity: LinkedAllocatorIdentity,
+}
+
+impl LinkedAdapter {
+    #[cfg(benchmark_native_adapter)]
+    pub fn load() -> Result<Self, AdapterError> {
+        let actual_id = unsafe { checked_identity(bench_allocator_id(), "allocator ID")? };
+        let actual_version = unsafe { checked_identity(bench_allocator_version(), "version")? };
+        if actual_id != BUILD_ALLOCATOR_ID {
+            return Err(AdapterError::IdentityMismatch {
+                field: "ID",
+                expected: BUILD_ALLOCATOR_ID,
+                actual: actual_id.to_owned(),
+            });
+        }
+        if actual_version != BUILD_ALLOCATOR_VERSION {
+            return Err(AdapterError::IdentityMismatch {
+                field: "version",
+                expected: BUILD_ALLOCATOR_VERSION,
+                actual: actual_version.to_owned(),
+            });
+        }
+        Ok(Self {
+            identity: LinkedAllocatorIdentity {
+                allocator_id: BUILD_ALLOCATOR_ID,
+                allocator_version: BUILD_ALLOCATOR_VERSION,
+                source_sha: BUILD_SOURCE_SHA,
+                library_sha256: BUILD_LIBRARY_SHA256,
+            },
+        })
+    }
+
+    #[cfg(not(benchmark_native_adapter))]
+    pub fn load() -> Result<Self, AdapterError> {
+        Err(AdapterError::Unlinked)
+    }
+
+    pub fn identity(&self) -> LinkedAllocatorIdentity {
+        self.identity
+    }
+
+    #[cfg(benchmark_native_adapter)]
+    pub fn alloc(&self, size: usize) -> Result<NonNull<u8>, AdapterError> {
+        if size == 0 {
+            return Err(AdapterError::InvalidRequest(
+                "allocation size must be nonzero",
+            ));
+        }
+        NonNull::new(unsafe { bench_alloc(size) }.cast())
+            .ok_or(AdapterError::AllocationFailed("alloc"))
+    }
+
+    #[cfg(not(benchmark_native_adapter))]
+    pub fn alloc(&self, _size: usize) -> Result<NonNull<u8>, AdapterError> {
+        Err(AdapterError::Unlinked)
+    }
+
+    #[cfg(benchmark_native_adapter)]
+    pub fn calloc(&self, count: usize, size: usize) -> Result<NonNull<u8>, AdapterError> {
+        if count == 0 || size == 0 || count.checked_mul(size).is_none() {
+            return Err(AdapterError::InvalidRequest(
+                "calloc dimensions must be nonzero and cannot overflow",
+            ));
+        }
+        NonNull::new(unsafe { bench_calloc(count, size) }.cast())
+            .ok_or(AdapterError::AllocationFailed("calloc"))
+    }
+
+    #[cfg(not(benchmark_native_adapter))]
+    pub fn calloc(&self, _count: usize, _size: usize) -> Result<NonNull<u8>, AdapterError> {
+        Err(AdapterError::Unlinked)
+    }
+
+    /// The caller must pass a live pointer returned by this adapter. On error,
+    /// the original allocation remains live and must still be freed.
+    #[cfg(benchmark_native_adapter)]
+    pub unsafe fn realloc(
+        &self,
+        pointer: NonNull<u8>,
+        size: usize,
+    ) -> Result<NonNull<u8>, AdapterError> {
+        if size == 0 {
+            return Err(AdapterError::InvalidRequest(
+                "reallocation size must be nonzero",
+            ));
+        }
+        NonNull::new(unsafe { bench_realloc(pointer.as_ptr().cast(), size) }.cast())
+            .ok_or(AdapterError::AllocationFailed("realloc"))
+    }
+
+    #[cfg(not(benchmark_native_adapter))]
+    pub unsafe fn realloc(
+        &self,
+        _pointer: NonNull<u8>,
+        _size: usize,
+    ) -> Result<NonNull<u8>, AdapterError> {
+        Err(AdapterError::Unlinked)
+    }
+
+    #[cfg(benchmark_native_adapter)]
+    pub fn aligned_alloc(
+        &self,
+        alignment: usize,
+        size: usize,
+    ) -> Result<NonNull<u8>, AdapterError> {
+        if size == 0 || alignment < std::mem::size_of::<*const ()>() || !alignment.is_power_of_two()
+        {
+            return Err(AdapterError::InvalidRequest(
+                "aligned allocation requires nonzero size and pointer-sized power-of-two alignment",
+            ));
+        }
+        let mut pointer = std::ptr::null_mut();
+        let result = unsafe { bench_aligned_alloc(&mut pointer, alignment, size) };
+        if result != 0 {
+            return Err(AdapterError::AlignedAllocationFailed(result));
+        }
+        let pointer: NonNull<u8> =
+            NonNull::new(pointer.cast()).ok_or(AdapterError::ContractViolation(
+                "aligned allocation returned success with a null pointer",
+            ))?;
+        if pointer.as_ptr() as usize % alignment != 0 {
+            unsafe { bench_free(pointer.as_ptr().cast()) };
+            return Err(AdapterError::ContractViolation(
+                "aligned allocation returned a misaligned pointer",
+            ));
+        }
+        Ok(pointer)
+    }
+
+    #[cfg(not(benchmark_native_adapter))]
+    pub fn aligned_alloc(
+        &self,
+        _alignment: usize,
+        _size: usize,
+    ) -> Result<NonNull<u8>, AdapterError> {
+        Err(AdapterError::Unlinked)
+    }
+
+    /// The pointer must be live and must have been returned by this adapter.
+    #[cfg(benchmark_native_adapter)]
+    pub unsafe fn free(&self, pointer: NonNull<u8>) {
+        unsafe { bench_free(pointer.as_ptr().cast()) }
+    }
+
+    #[cfg(not(benchmark_native_adapter))]
+    pub unsafe fn free(&self, _pointer: NonNull<u8>) {}
+
+    /// The pointer must be live and must have been returned by this adapter.
+    #[cfg(benchmark_native_adapter)]
+    pub unsafe fn usable_size(&self, pointer: NonNull<u8>) -> usize {
+        unsafe { bench_usable_size(pointer.as_ptr().cast()) }
+    }
+
+    #[cfg(not(benchmark_native_adapter))]
+    pub unsafe fn usable_size(&self, _pointer: NonNull<u8>) -> usize {
+        0
+    }
+
+    pub fn smoke_test(&self) -> Result<AdapterSmoke, AdapterError> {
+        let mut checksum = 0_u64;
+        let original = self.alloc(64)?;
+        unsafe {
+            for index in 0..64 {
+                original
+                    .as_ptr()
+                    .add(index)
+                    .write((index as u8).wrapping_mul(17));
+            }
+        }
+        let grown = match unsafe { self.realloc(original, 128) } {
+            Ok(pointer) => pointer,
+            Err(error) => {
+                unsafe { self.free(original) };
+                return Err(error);
+            }
+        };
+        unsafe {
+            for index in 0..64 {
+                let expected = (index as u8).wrapping_mul(17);
+                let actual = grown.as_ptr().add(index).read();
+                if actual != expected {
+                    self.free(grown);
+                    return Err(AdapterError::ContractViolation(
+                        "realloc did not preserve existing content",
+                    ));
+                }
+                checksum = checksum.wrapping_mul(131).wrapping_add(u64::from(actual));
+            }
+        }
+        let usable_size = unsafe { self.usable_size(grown) };
+        if usable_size < 128 {
+            unsafe { self.free(grown) };
+            return Err(AdapterError::ContractViolation(
+                "usable size is smaller than the requested allocation",
+            ));
+        }
+        unsafe { self.free(grown) };
+
+        let zeroed = self.calloc(32, 4)?;
+        unsafe {
+            for index in 0..128 {
+                let value = zeroed.as_ptr().add(index).read();
+                if value != 0 {
+                    self.free(zeroed);
+                    return Err(AdapterError::ContractViolation(
+                        "calloc returned nonzero bytes",
+                    ));
+                }
+                zeroed.as_ptr().add(index).write(0xa5);
+                checksum = checksum.wrapping_add(0xa5);
+            }
+            self.free(zeroed);
+        }
+
+        let aligned = self.aligned_alloc(256, 513)?;
+        unsafe {
+            aligned.as_ptr().write(0x5a);
+            aligned.as_ptr().add(512).write(0xc3);
+            checksum = checksum.wrapping_add(u64::from(aligned.as_ptr().read()));
+            checksum = checksum.wrapping_add(u64::from(aligned.as_ptr().add(512).read()));
+            self.free(aligned);
+        }
+        Ok(AdapterSmoke {
+            identity: self.identity,
+            checksum,
+            usable_size,
+        })
+    }
+}
+
+#[cfg(benchmark_native_adapter)]
+unsafe fn checked_identity(
+    pointer: *const std::os::raw::c_char,
+    field: &'static str,
+) -> Result<&'static str, AdapterError> {
+    if pointer.is_null() {
+        return Err(AdapterError::InvalidIdentity(field));
+    }
+    unsafe { CStr::from_ptr(pointer) }
+        .to_str()
+        .map_err(|_| AdapterError::InvalidIdentity(field))
+}
+
+#[cfg(benchmark_native_adapter)]
+unsafe extern "C" {
+    fn bench_allocator_id() -> *const std::os::raw::c_char;
+    fn bench_allocator_version() -> *const std::os::raw::c_char;
+    fn bench_alloc(size: usize) -> *mut std::os::raw::c_void;
+    fn bench_calloc(count: usize, size: usize) -> *mut std::os::raw::c_void;
+    fn bench_realloc(pointer: *mut std::os::raw::c_void, size: usize) -> *mut std::os::raw::c_void;
+    fn bench_aligned_alloc(
+        output: *mut *mut std::os::raw::c_void,
+        alignment: usize,
+        size: usize,
+    ) -> i32;
+    fn bench_free(pointer: *mut std::os::raw::c_void);
+    fn bench_usable_size(pointer: *mut std::os::raw::c_void) -> usize;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(benchmark_native_adapter))]
+    #[test]
+    fn ordinary_workspace_build_is_explicitly_unlinked() {
+        assert_eq!(LinkedAdapter::load(), Err(AdapterError::Unlinked));
+        assert_eq!(BUILD_ALLOCATOR_ID, "unlinked-test-adapter");
+    }
+}

--- a/rust/benchmark-suite/src/bin/benchmark-child.rs
+++ b/rust/benchmark-suite/src/bin/benchmark-child.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if let Err(error) = benchmark_suite::child::benchmark_child_main() {
+        eprintln!("benchmark-child rejected request: {error}");
+        std::process::exit(2);
+    }
+}

--- a/rust/benchmark-suite/src/bin/benchmark-run.rs
+++ b/rust/benchmark-suite/src/bin/benchmark-run.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if let Err(error) = benchmark_suite::runner::benchmark_run_main() {
+        eprintln!("benchmark-run failed: {error}");
+        std::process::exit(2);
+    }
+}

--- a/rust/benchmark-suite/src/child.rs
+++ b/rust/benchmark-suite/src/child.rs
@@ -1,0 +1,85 @@
+//! Reusable benchmark-child protocol entrypoint.
+
+use std::io::{Read, Write};
+
+use serde::Serialize;
+
+use crate::adapter::LinkedAdapter;
+use crate::execution::execute_child_request;
+use crate::model::BenchmarkChildRequest;
+
+#[derive(Serialize)]
+struct AdapterSmokeOutput<'a> {
+    allocator_id: &'a str,
+    allocator_version: &'a str,
+    source_sha: &'a str,
+    library_sha256: &'a str,
+    child_binary_sha256: &'a str,
+    checksum: u64,
+    usable_size: usize,
+}
+
+/// Run the strict child protocol using process stdin/stdout. Exactly one JSON
+/// request is accepted and exactly one JSON response is emitted.
+pub fn benchmark_child_main() -> Result<(), String> {
+    let mut arguments = std::env::args_os().skip(1);
+    match arguments.next() {
+        None => run_measurement(),
+        Some(argument) if argument == "--adapter-smoke" && arguments.next().is_none() => {
+            run_adapter_smoke()
+        }
+        Some(_) => Err("usage: benchmark-child [--adapter-smoke]".into()),
+    }
+}
+
+fn run_measurement() -> Result<(), String> {
+    let adapter = LinkedAdapter::load().map_err(|error| error.to_string())?;
+    let mut input = Vec::new();
+    std::io::stdin()
+        .take(1024 * 1024 + 1)
+        .read_to_end(&mut input)
+        .map_err(|error| format!("read benchmark child request: {error}"))?;
+    if input.len() > 1024 * 1024 {
+        return Err("benchmark child request exceeded 1 MiB".into());
+    }
+    let request: BenchmarkChildRequest = serde_json::from_slice(&input)
+        .map_err(|error| format!("expected exactly one benchmark child request: {error}"))?;
+    let response = execute_child_request(&adapter, request)?;
+    let output = serde_json::to_vec(&response)
+        .map_err(|error| format!("serialize benchmark child response: {error}"))?;
+    let mut stdout = std::io::stdout().lock();
+    stdout
+        .write_all(&output)
+        .and_then(|()| stdout.write_all(b"\n"))
+        .map_err(|error| format!("write benchmark child response: {error}"))
+}
+
+fn run_adapter_smoke() -> Result<(), String> {
+    let child_binary_sha256 = std::env::var("BENCH_CHILD_BINARY_SHA256")
+        .map_err(|_| "BENCH_CHILD_BINARY_SHA256 is required for adapter smoke".to_string())?;
+    if child_binary_sha256.len() != 64
+        || !child_binary_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err("BENCH_CHILD_BINARY_SHA256 must be 64 lowercase hexadecimal bytes".into());
+    }
+    let adapter = LinkedAdapter::load().map_err(|error| error.to_string())?;
+    let smoke = adapter.smoke_test().map_err(|error| error.to_string())?;
+    let output = AdapterSmokeOutput {
+        allocator_id: smoke.identity.allocator_id,
+        allocator_version: smoke.identity.allocator_version,
+        source_sha: smoke.identity.source_sha,
+        library_sha256: smoke.identity.library_sha256,
+        child_binary_sha256: &child_binary_sha256,
+        checksum: smoke.checksum,
+        usable_size: smoke.usable_size,
+    };
+    let encoded = serde_json::to_vec(&output)
+        .map_err(|error| format!("serialize adapter smoke response: {error}"))?;
+    let mut stdout = std::io::stdout().lock();
+    stdout
+        .write_all(&encoded)
+        .and_then(|()| stdout.write_all(b"\n"))
+        .map_err(|error| format!("write adapter smoke response: {error}"))
+}

--- a/rust/benchmark-suite/src/config.rs
+++ b/rust/benchmark-suite/src/config.rs
@@ -1,0 +1,177 @@
+use serde::Deserialize;
+
+/// Complete immutable identity for a directly-linked allocator child.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AllocatorLock {
+    pub schema_version: u32,
+    pub target: String,
+    pub allocators: Vec<AllocatorPin>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AllocatorPin {
+    pub id: String,
+    pub pin: String,
+    pub source: AllocatorSource,
+    pub build: AllocatorBuild,
+    #[serde(rename = "expected_static_library")]
+    pub static_library: String,
+    pub adapter_kind: String,
+    pub license: String,
+    pub patches: AllocatorPatches,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AllocatorSource {
+    pub kind: String,
+    #[serde(rename = "canonical_repository")]
+    pub repository: String,
+    pub commit: String,
+    pub archive_url: Option<String>,
+    pub archive_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AllocatorBuild {
+    pub system: String,
+    pub commands: Vec<Vec<String>>,
+    pub flags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AllocatorPatches {
+    pub source: Vec<SourcePatch>,
+    pub build: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct SourcePatch {
+    pub file: String,
+    pub sha256: String,
+}
+
+impl AllocatorLock {
+    pub fn parse_and_validate(input: &str) -> Result<Self, String> {
+        let lock: Self = serde_json::from_str(input).map_err(|error| error.to_string())?;
+        let expected = [
+            "tcmalloc",
+            "jemalloc",
+            "upstream-mimalloc",
+            "mimalloc-pprof",
+        ];
+        if lock.schema_version != 1
+            || lock.target != "x86_64-unknown-linux-gnu"
+            || lock
+                .allocators
+                .iter()
+                .map(|pin| pin.id.as_str())
+                .collect::<Vec<_>>()
+                != expected
+        {
+            return Err("lockfile must define the exact four Linux allocator IDs in order".into());
+        }
+        for pin in &lock.allocators {
+            if pin.repository_is_invalid()
+                || pin.build.commands.is_empty()
+                || pin.static_library.is_empty()
+                || !pin.patches.build.is_empty()
+                || pin
+                    .patches
+                    .source
+                    .iter()
+                    .any(|patch| !is_patch_filename(&patch.file) || !is_hex(&patch.sha256, 64))
+            {
+                return Err(format!("allocator {} has incomplete provenance", pin.id));
+            }
+            let pin_matches = match pin.id.as_str() {
+                "tcmalloc" => {
+                    pin.pin == "c316de3ee8ffb5aff6547aa10151bc8dda3a2942"
+                        && pin.source.commit == "c316de3ee8ffb5aff6547aa10151bc8dda3a2942"
+                }
+                "jemalloc" => {
+                    pin.pin == "5.3.1@81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+                        && pin.source.commit == "81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+                }
+                "upstream-mimalloc" => {
+                    pin.pin == "dev3@bcee5a88"
+                        && pin.source.commit == "bcee5a88e9311c08b8f93fbce3dcafe2f22a2d26"
+                }
+                "mimalloc-pprof" => {
+                    pin.pin == "workflow-source" && pin.source.commit == "workflow-source"
+                }
+                _ => false,
+            };
+            if !pin_matches {
+                return Err(format!(
+                    "allocator {} does not match its prescribed pin",
+                    pin.id
+                ));
+            }
+            if pin.id == "mimalloc-pprof" {
+                if pin.pin != "workflow-source"
+                    || pin.source.kind != "checkout"
+                    || pin.source.commit != "workflow-source"
+                {
+                    return Err("mimalloc-pprof must use the workflow source identity".into());
+                }
+                if !pin.patches.source.is_empty() {
+                    return Err("mimalloc-pprof may not patch the workflow source checkout".into());
+                }
+            } else if pin.source.kind != "archive"
+                || !is_hex(&pin.source.commit, 40)
+                || !is_hex(pin.source.archive_sha256.as_deref().unwrap_or_default(), 64)
+                || pin
+                    .source
+                    .archive_url
+                    .as_deref()
+                    .unwrap_or_default()
+                    .is_empty()
+            {
+                return Err(format!(
+                    "allocator {} has a floating or incomplete archive identity",
+                    pin.id
+                ));
+            }
+        }
+        Ok(lock)
+    }
+}
+
+impl AllocatorPin {
+    fn repository_is_invalid(&self) -> bool {
+        !self.source.repository.starts_with("https://")
+            || self.adapter_kind.is_empty()
+            || self.license.is_empty()
+    }
+}
+
+fn is_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn is_patch_filename(value: &str) -> bool {
+    !value.is_empty()
+        && value.ends_with(".patch")
+        && !value.contains(['/', '\\'])
+        && value != "."
+        && value != ".."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uppercase_source_identity_is_rejected() {
+        let lock = include_str!("../allocators/allocator-lock.json");
+        AllocatorLock::parse_and_validate(lock).unwrap();
+        let uppercase = lock.replace(
+            "c316de3ee8ffb5aff6547aa10151bc8dda3a2942",
+            "C316de3ee8ffb5aff6547aa10151bc8dda3a2942",
+        );
+        assert!(AllocatorLock::parse_and_validate(&uppercase).is_err());
+    }
+}

--- a/rust/benchmark-suite/src/execution.rs
+++ b/rust/benchmark-suite/src/execution.rs
@@ -1,0 +1,1122 @@
+//! Allocator-neutral execution of one `core-throughput-v1` child request.
+
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
+use std::time::Instant;
+
+use crate::adapter::LinkedAdapter;
+use crate::model::{
+    BenchmarkChildRequest, BenchmarkChildResponse, RawSample, CHILD_PROTOCOL_VERSION,
+};
+use crate::scenarios::{
+    card, CardId, ExpectedCounts, Request, RequestKind, ScenarioCell, ThreadPoint, Topology,
+    MAX_REQUESTS_PER_TRANSACTION, REQUEST_CYCLE_OPERATIONS,
+};
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+const PAGE_BYTES: usize = 4096;
+
+type MeasuredRegionHook = fn(bool);
+static MEASURED_REGION_HOOK: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+
+/// Install a process-global, allocation-free timing hook used by the contract
+/// test to audit system-allocator calls. Production leaves it unset.
+pub fn set_measured_region_hook(hook: Option<MeasuredRegionHook>) {
+    let pointer = hook
+        .map(|callback| callback as *const () as *mut ())
+        .unwrap_or(std::ptr::null_mut());
+    MEASURED_REGION_HOOK.store(pointer, Ordering::SeqCst);
+}
+
+fn notify_measured_region(active: bool) {
+    let pointer = MEASURED_REGION_HOOK.load(Ordering::SeqCst);
+    if !pointer.is_null() {
+        let callback: MeasuredRegionHook = unsafe { std::mem::transmute(pointer) };
+        callback(active);
+    }
+}
+
+/// Small Rust abstraction matching the native adapter ABI. Tests can provide
+/// an instrumented implementation without linking a competitor allocator.
+pub trait AllocatorAdapter: Sync {
+    fn allocator_id(&self) -> &str;
+    fn allocator_version(&self) -> &str;
+    fn source_sha(&self) -> &str;
+    fn library_sha256(&self) -> &str;
+    fn alloc(&self, size: usize) -> Result<NonNull<u8>, String>;
+    fn calloc(&self, count: usize, size: usize) -> Result<NonNull<u8>, String>;
+    unsafe fn realloc(&self, pointer: NonNull<u8>, size: usize) -> Result<NonNull<u8>, String>;
+    fn aligned_alloc(&self, alignment: usize, size: usize) -> Result<NonNull<u8>, String>;
+    unsafe fn free(&self, pointer: NonNull<u8>);
+}
+
+struct SerializedAdapter<'a, A> {
+    inner: &'a A,
+    gate: Mutex<()>,
+}
+
+impl<A: AllocatorAdapter> AllocatorAdapter for SerializedAdapter<'_, A> {
+    fn allocator_id(&self) -> &str {
+        self.inner.allocator_id()
+    }
+    fn allocator_version(&self) -> &str {
+        self.inner.allocator_version()
+    }
+    fn source_sha(&self) -> &str {
+        self.inner.source_sha()
+    }
+    fn library_sha256(&self) -> &str {
+        self.inner.library_sha256()
+    }
+    fn alloc(&self, size: usize) -> Result<NonNull<u8>, String> {
+        let _guard = self
+            .gate
+            .lock()
+            .map_err(|_| "serialized control lock poisoned")?;
+        self.inner.alloc(size)
+    }
+    fn calloc(&self, count: usize, size: usize) -> Result<NonNull<u8>, String> {
+        let _guard = self
+            .gate
+            .lock()
+            .map_err(|_| "serialized control lock poisoned")?;
+        self.inner.calloc(count, size)
+    }
+    unsafe fn realloc(&self, pointer: NonNull<u8>, size: usize) -> Result<NonNull<u8>, String> {
+        let _guard = self
+            .gate
+            .lock()
+            .map_err(|_| "serialized control lock poisoned")?;
+        unsafe { self.inner.realloc(pointer, size) }
+    }
+    fn aligned_alloc(&self, alignment: usize, size: usize) -> Result<NonNull<u8>, String> {
+        let _guard = self
+            .gate
+            .lock()
+            .map_err(|_| "serialized control lock poisoned")?;
+        self.inner.aligned_alloc(alignment, size)
+    }
+    unsafe fn free(&self, pointer: NonNull<u8>) {
+        let _guard = self.gate.lock().expect("serialized control lock poisoned");
+        unsafe { self.inner.free(pointer) }
+    }
+}
+
+impl AllocatorAdapter for LinkedAdapter {
+    fn allocator_id(&self) -> &str {
+        self.identity().allocator_id
+    }
+    fn allocator_version(&self) -> &str {
+        self.identity().allocator_version
+    }
+    fn source_sha(&self) -> &str {
+        self.identity().source_sha
+    }
+    fn library_sha256(&self) -> &str {
+        self.identity().library_sha256
+    }
+    fn alloc(&self, size: usize) -> Result<NonNull<u8>, String> {
+        self.alloc(size).map_err(|error| error.to_string())
+    }
+    fn calloc(&self, count: usize, size: usize) -> Result<NonNull<u8>, String> {
+        self.calloc(count, size).map_err(|error| error.to_string())
+    }
+    unsafe fn realloc(&self, pointer: NonNull<u8>, size: usize) -> Result<NonNull<u8>, String> {
+        unsafe { self.realloc(pointer, size) }.map_err(|error| error.to_string())
+    }
+    fn aligned_alloc(&self, alignment: usize, size: usize) -> Result<NonNull<u8>, String> {
+        self.aligned_alloc(alignment, size)
+            .map_err(|error| error.to_string())
+    }
+    unsafe fn free(&self, pointer: NonNull<u8>) {
+        unsafe { self.free(pointer) }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ExecutionResult {
+    pub counts: ExpectedCounts,
+    pub checksum: u64,
+    pub peak_live_requested_bytes: u64,
+    pub setup_ns: u64,
+    pub elapsed_ns: u64,
+    pub teardown_ns: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LiveAllocation {
+    pointer: NonNull<u8>,
+    size: usize,
+    pattern: Option<u64>,
+}
+
+type LiveSlots = Vec<(u64, LiveAllocation)>;
+type HandoffQueues = Arc<Vec<Mutex<Vec<(Request, LiveAllocation)>>>>;
+
+// The pointer is transferred only after its owner has stopped accessing it and
+// before the receiving worker starts its next barrier phase.
+unsafe impl Send for LiveAllocation {}
+
+#[derive(Debug)]
+struct WorkerOutcome {
+    counts: ExpectedCounts,
+    checksum: u64,
+}
+
+/// Execute one strict request and construct its raw response. This is the
+/// reusable entrypoint used by `benchmark-child` and native wrapper builds.
+pub fn execute_child_request<A: AllocatorAdapter>(
+    adapter: &A,
+    request: BenchmarkChildRequest,
+) -> Result<BenchmarkChildResponse, String> {
+    request.validate()?;
+    validate_linked_identity(adapter, &request)?;
+    let card_id = CardId::parse(&request.scenario_id)
+        .ok_or_else(|| format!("unknown scenario {}", request.scenario_id))?;
+    let thread_point = ThreadPoint::parse(&request.thread_point)
+        .ok_or_else(|| format!("unknown thread point {}", request.thread_point))?;
+    let topology = Topology {
+        physical_cores: request.physical_cores as usize,
+        logical_cores: request.logical_cores as usize,
+    };
+
+    let setup_started = Instant::now();
+    let measured_cell = ScenarioCell::new(
+        card_id,
+        thread_point,
+        topology,
+        request.transactions_per_worker,
+        request.workload_seed,
+    )
+    .map_err(|error| error.to_string())?;
+    let expected = measured_cell
+        .expected_counts()
+        .map_err(|error| error.to_string())?;
+    let request_setup_ns = nonzero_ns(setup_started);
+
+    let warmup_started = Instant::now();
+    if request.warmup_transactions_per_worker > 0 {
+        let warmup = ScenarioCell::new(
+            card_id,
+            thread_point,
+            topology,
+            request.warmup_transactions_per_worker,
+            request.workload_seed ^ 0xa076_1d64_78bd_642f,
+        )
+        .map_err(|error| error.to_string())?;
+        execute_for_mode(adapter, &warmup, &request.execution_mode)?;
+    }
+    let warmup_ns = if request.warmup_transactions_per_worker == 0 {
+        0
+    } else {
+        nonzero_ns(warmup_started)
+    };
+
+    let outcome = execute_for_mode(adapter, &measured_cell, &request.execution_mode)?;
+    let setup_ns = request_setup_ns.saturating_add(outcome.setup_ns);
+    let elapsed_ns = outcome.elapsed_ns;
+
+    let teardown_started = Instant::now();
+    if outcome.counts != expected {
+        return Err(format!(
+            "executed allocator counts differ from scenario contract: {:?} != {:?}",
+            outcome.counts, expected
+        ));
+    }
+    if outcome.checksum != expected_touch_checksum(&measured_cell)? {
+        return Err("observed touch checksum differs from deterministic workload".into());
+    }
+    let teardown_ns = outcome
+        .teardown_ns
+        .saturating_add(nonzero_ns(teardown_started));
+    let definition = card(card_id);
+    let operation_count = definition.operation_count(&expected);
+    let throughput = operation_count as f64 * 1_000_000_000.0 / elapsed_ns as f64;
+    if !throughput.is_finite() || throughput <= 0.0 {
+        return Err("derived throughput is non-finite or non-positive".into());
+    }
+
+    let sample = RawSample {
+        schema_version: request.schema_version.clone(),
+        suite_version: request.suite_version.clone(),
+        run_kind: request.run_kind.clone(),
+        execution_mode: request.execution_mode.clone(),
+        run_seed: request.run_seed,
+        block_id: request.block_id,
+        ordinal: request.ordinal,
+        workload_seed: request.workload_seed,
+        allocator_id: request.allocator.allocator_id.clone(),
+        allocator_version: request.allocator.allocator_version.clone(),
+        allocator_source_sha: request.allocator.source_sha.clone(),
+        allocator_library_sha256: request.allocator.library_sha256.clone(),
+        child_binary_sha256: request.allocator.child_binary_sha256.clone(),
+        scenario_id: request.scenario_id.clone(),
+        scenario_version: request.scenario_version.clone(),
+        thread_point: request.thread_point.clone(),
+        thread_count: measured_cell.threads as u32,
+        operation_unit: definition.operation_unit.name().into(),
+        operation_count,
+        requested_transactions: expected.requested_transactions,
+        completed_transactions: outcome.counts.completed_transactions,
+        allocation_calls: outcome.counts.alloc_calls,
+        calloc_calls: outcome.counts.calloc_calls,
+        aligned_allocation_calls: outcome.counts.aligned_alloc_calls,
+        free_calls: outcome.counts.free_calls,
+        realloc_calls: outcome.counts.realloc_calls,
+        setup_ns,
+        warmup_ns,
+        elapsed_ns,
+        teardown_ns,
+        throughput_operations_per_second: throughput,
+        checksum: outcome.checksum,
+        peak_live_requested_bytes: outcome.peak_live_requested_bytes,
+        timed_out: false,
+        crashed: false,
+        exit_code: 0,
+        signal: None,
+        runner: request.runner.clone(),
+        toolchain: request.toolchain.clone(),
+        reproduction_command: request.reproduction_command.clone(),
+    };
+    let response = BenchmarkChildResponse {
+        protocol_version: CHILD_PROTOCOL_VERSION.into(),
+        sample,
+    };
+    response.validate_against(&request)?;
+    Ok(response)
+}
+
+fn execute_for_mode<A: AllocatorAdapter>(
+    adapter: &A,
+    cell: &ScenarioCell,
+    mode: &str,
+) -> Result<ExecutionResult, String> {
+    match mode {
+        "normal" => execute_cell(adapter, cell),
+        "serialized-control" => execute_cell(
+            &SerializedAdapter {
+                inner: adapter,
+                gate: Mutex::new(()),
+            },
+            cell,
+        ),
+        _ => Err("unknown benchmark execution mode".into()),
+    }
+}
+
+fn validate_linked_identity<A: AllocatorAdapter>(
+    adapter: &A,
+    request: &BenchmarkChildRequest,
+) -> Result<(), String> {
+    let expected = &request.allocator;
+    if adapter.allocator_id() != expected.allocator_id
+        || adapter.allocator_version() != expected.allocator_version
+        || adapter.source_sha() != expected.source_sha
+        || adapter.library_sha256() != expected.library_sha256
+    {
+        return Err("requested allocator identity does not match the linked adapter".into());
+    }
+    Ok(())
+}
+
+pub fn execute_cell<A: AllocatorAdapter>(
+    adapter: &A,
+    cell: &ScenarioCell,
+) -> Result<ExecutionResult, String> {
+    if cell.card == CardId::ThreadChurn {
+        return execute_thread_churn(adapter, cell);
+    }
+    if matches!(
+        cell.card,
+        CardId::CrossThreadProducerConsumer | CardId::RandomOwnership
+    ) {
+        execute_cross_thread_cell(adapter, cell)
+    } else {
+        execute_ordered_cell(adapter, cell)
+    }
+}
+
+fn execute_ordered_cell<A: AllocatorAdapter>(
+    adapter: &A,
+    cell: &ScenarioCell,
+) -> Result<ExecutionResult, String> {
+    let setup_started = Instant::now();
+    let ready_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let start_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let end_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let live = Arc::new(AtomicU64::new(0));
+    let peak = Arc::new(AtomicU64::new(0));
+
+    let (outcomes, setup_ns, elapsed_ns) = std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(cell.threads);
+        for worker in 0..cell.threads {
+            let ready_barrier = Arc::clone(&ready_barrier);
+            let start_barrier = Arc::clone(&start_barrier);
+            let end_barrier = Arc::clone(&end_barrier);
+            let live = Arc::clone(&live);
+            let peak = Arc::clone(&peak);
+            let slot_capacity = card(cell.card).max_live_allocations_per_worker();
+            handles.push(scope.spawn(move || {
+                let mut allocations = Vec::with_capacity(slot_capacity);
+                let mut requests = Vec::with_capacity(MAX_REQUESTS_PER_TRANSACTION);
+                let mut counts = ExpectedCounts::default();
+                let mut observation_checksum = 0_u64;
+                let mut failure: Option<String> = None;
+                ready_barrier.wait();
+                start_barrier.wait();
+                for operation in 0..cell.transactions_per_worker {
+                    if let Err(error) =
+                        cell.fill_worker_transaction(worker, operation, &mut requests)
+                    {
+                        failure = Some(error.to_string());
+                        break;
+                    }
+                    for request in &requests {
+                        if let Err(error) = execute_one(
+                            adapter,
+                            cell.card,
+                            request,
+                            &mut allocations,
+                            &mut counts,
+                            &mut observation_checksum,
+                            &live,
+                            &peak,
+                        ) {
+                            failure = Some(error);
+                            break;
+                        }
+                    }
+                    if failure.is_some() {
+                        break;
+                    }
+                }
+                std::hint::black_box(observation_checksum);
+                end_barrier.wait();
+                for (_, allocation) in allocations {
+                    unsafe { adapter.free(allocation.pointer) };
+                    subtract_live(&live, allocation.size as u64);
+                }
+                match failure {
+                    Some(error) => Err(error),
+                    None => Ok(WorkerOutcome {
+                        counts,
+                        checksum: observation_checksum,
+                    }),
+                }
+            }));
+        }
+        // Separate ready/start gates ensure thread creation and per-worker
+        // state construction are setup, not measured work.
+        ready_barrier.wait();
+        let setup_ns = nonzero_ns(setup_started);
+        notify_measured_region(true);
+        let measured_started = Instant::now();
+        start_barrier.wait();
+        end_barrier.wait();
+        let elapsed_ns = nonzero_ns(measured_started);
+        notify_measured_region(false);
+        let outcomes = handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .map_err(|_| "benchmark worker panicked".to_string())?
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok::<_, String>((outcomes, setup_ns, elapsed_ns))
+    })?;
+    let teardown_started = Instant::now();
+    finish_execution(
+        cell,
+        outcomes,
+        &live,
+        &peak,
+        setup_ns,
+        elapsed_ns,
+        nonzero_ns(teardown_started),
+    )
+}
+
+fn execute_cross_thread_cell<A: AllocatorAdapter>(
+    adapter: &A,
+    cell: &ScenarioCell,
+) -> Result<ExecutionResult, String> {
+    let setup_started = Instant::now();
+    let ready_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let start_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let end_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let operation_barrier = Arc::new(Barrier::new(cell.threads));
+    let live = Arc::new(AtomicU64::new(0));
+    let peak = Arc::new(AtomicU64::new(0));
+    let handoffs: HandoffQueues = Arc::new(
+        (0..cell.threads)
+            .map(|_| Mutex::new(Vec::with_capacity(1)))
+            .collect::<Vec<_>>(),
+    );
+
+    let (outcomes, setup_ns, elapsed_ns) = std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(cell.threads);
+        for worker in 0..cell.threads {
+            let ready_barrier = Arc::clone(&ready_barrier);
+            let start_barrier = Arc::clone(&start_barrier);
+            let end_barrier = Arc::clone(&end_barrier);
+            let operation_barrier = Arc::clone(&operation_barrier);
+            let live = Arc::clone(&live);
+            let peak = Arc::clone(&peak);
+            let handoffs = Arc::clone(&handoffs);
+            let slot_capacity = card(cell.card).max_live_allocations_per_worker();
+            let transactions_per_worker = cell.transactions_per_worker;
+            handles.push(scope.spawn(move || {
+                let mut allocations = Vec::with_capacity(slot_capacity);
+                let mut requests = Vec::with_capacity(MAX_REQUESTS_PER_TRANSACTION);
+                let mut counts = ExpectedCounts::default();
+                let mut observation_checksum = 0_u64;
+                let mut failure: Option<String> = None;
+                ready_barrier.wait();
+                start_barrier.wait();
+                for operation in 0..transactions_per_worker {
+                    if failure.is_none() {
+                        if let Err(error) =
+                            cell.fill_worker_transaction(worker, operation, &mut requests)
+                        {
+                            failure = Some(error.to_string());
+                        }
+                    }
+
+                    let mut transfer = None;
+                    if failure.is_none() {
+                        for request in &requests {
+                            if request.kind == RequestKind::Free
+                                && request.owner_worker != request.executor_worker
+                            {
+                                if transfer.replace(*request).is_some() {
+                                    failure = Some("operation has multiple remote frees".into());
+                                    break;
+                                }
+                                continue;
+                            }
+                            if let Err(error) = execute_one(
+                                adapter,
+                                cell.card,
+                                request,
+                                &mut allocations,
+                                &mut counts,
+                                &mut observation_checksum,
+                                &live,
+                                &peak,
+                            ) {
+                                failure = Some(error);
+                                break;
+                            }
+                        }
+                    }
+                    if failure.is_none() {
+                        match transfer {
+                            Some(request) => {
+                                let destination = request.executor_worker;
+                                match remove_slot(&mut allocations, request.token) {
+                                    Some(allocation) => handoffs[destination]
+                                        .lock()
+                                        .expect("handoff queue lock poisoned")
+                                        .push((request, allocation)),
+                                    None => {
+                                        failure = Some(format!(
+                                            "remote transfer token {} was not live",
+                                            request.token
+                                        ))
+                                    }
+                                }
+                            }
+                            None => failure = Some("operation is missing its remote free".into()),
+                        }
+                    }
+                    operation_barrier.wait();
+                    {
+                        let mut inbox = handoffs[worker]
+                            .lock()
+                            .expect("handoff queue lock poisoned");
+                        for (request, allocation) in inbox.drain(..) {
+                            if failure.is_none() {
+                                if allocations.len() == allocations.capacity() {
+                                    failure =
+                                        Some("cross-thread live-slot capacity exhausted".into());
+                                    unsafe { adapter.free(allocation.pointer) };
+                                    subtract_live(&live, allocation.size as u64);
+                                } else {
+                                    allocations.push((request.token, allocation));
+                                    if let Err(error) = execute_one(
+                                        adapter,
+                                        cell.card,
+                                        &request,
+                                        &mut allocations,
+                                        &mut counts,
+                                        &mut observation_checksum,
+                                        &live,
+                                        &peak,
+                                    ) {
+                                        failure = Some(error);
+                                    }
+                                }
+                            } else {
+                                unsafe { adapter.free(allocation.pointer) };
+                                subtract_live(&live, allocation.size as u64);
+                            }
+                        }
+                    }
+                    operation_barrier.wait();
+                }
+                std::hint::black_box(observation_checksum);
+                end_barrier.wait();
+                for (_, allocation) in allocations {
+                    unsafe { adapter.free(allocation.pointer) };
+                    subtract_live(&live, allocation.size as u64);
+                }
+                match failure {
+                    Some(error) => Err(error),
+                    None => Ok(WorkerOutcome {
+                        counts,
+                        checksum: observation_checksum,
+                    }),
+                }
+            }));
+        }
+        ready_barrier.wait();
+        let setup_ns = nonzero_ns(setup_started);
+        notify_measured_region(true);
+        let measured_started = Instant::now();
+        start_barrier.wait();
+        end_barrier.wait();
+        let elapsed_ns = nonzero_ns(measured_started);
+        notify_measured_region(false);
+        let outcomes = handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .map_err(|_| "benchmark worker panicked".to_string())?
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok::<_, String>((outcomes, setup_ns, elapsed_ns))
+    })?;
+    let teardown_started = Instant::now();
+    finish_execution(
+        cell,
+        outcomes,
+        &live,
+        &peak,
+        setup_ns,
+        elapsed_ns,
+        nonzero_ns(teardown_started),
+    )
+}
+
+fn execute_thread_churn<A: AllocatorAdapter>(
+    adapter: &A,
+    cell: &ScenarioCell,
+) -> Result<ExecutionResult, String> {
+    let setup_started = Instant::now();
+    let mut request_buffers = (0..cell.threads)
+        .map(|_| Vec::with_capacity(MAX_REQUESTS_PER_TRANSACTION))
+        .collect::<Vec<_>>();
+    let live = Arc::new(AtomicU64::new(0));
+    let peak = Arc::new(AtomicU64::new(0));
+    let mut totals = (0..cell.threads)
+        .map(|_| WorkerOutcome {
+            counts: ExpectedCounts::default(),
+            checksum: 0,
+        })
+        .collect::<Vec<_>>();
+
+    let setup_ns = nonzero_ns(setup_started);
+    // Spawning each generation is part of this card's declared workload.
+    let measured_started = Instant::now();
+    for operation in 0..cell.transactions_per_worker {
+        for (worker, requests) in request_buffers.iter_mut().enumerate() {
+            cell.fill_worker_transaction(worker, operation, requests)
+                .map_err(|error| error.to_string())?;
+        }
+        for generation in 0..8_u32 {
+            let outcomes = std::thread::scope(|scope| {
+                let mut handles = Vec::with_capacity(cell.threads);
+                for requests in &request_buffers {
+                    let token_remainder = 1 + generation as u64;
+                    let live = Arc::clone(&live);
+                    let peak = Arc::clone(&peak);
+                    handles.push(scope.spawn(move || {
+                        let mut allocations = Vec::with_capacity(1);
+                        let mut counts = ExpectedCounts::default();
+                        let mut checksum = 0_u64;
+                        for request in requests.iter().filter(|request| {
+                            (request.kind == RequestKind::WorkerGeneration
+                                && request.phase == generation)
+                                || (request.kind != RequestKind::WorkerGeneration
+                                    && request.token % 64 == token_remainder)
+                        }) {
+                            execute_one(
+                                adapter,
+                                cell.card,
+                                request,
+                                &mut allocations,
+                                &mut counts,
+                                &mut checksum,
+                                &live,
+                                &peak,
+                            )?;
+                        }
+                        if !allocations.is_empty() {
+                            return Err("thread-churn generation leaked an allocation".into());
+                        }
+                        Ok(WorkerOutcome { counts, checksum })
+                    }));
+                }
+                handles
+                    .into_iter()
+                    .map(|handle| {
+                        handle
+                            .join()
+                            .map_err(|_| "thread-churn worker panicked".to_string())?
+                    })
+                    .collect::<Result<Vec<_>, String>>()
+            })?;
+            for (total, outcome) in totals.iter_mut().zip(outcomes) {
+                add_counts(&mut total.counts, outcome.counts);
+                total.checksum = total.checksum.wrapping_add(outcome.checksum);
+            }
+        }
+    }
+    for total in &totals {
+        std::hint::black_box(total.checksum);
+    }
+    let elapsed_ns = nonzero_ns(measured_started);
+    let teardown_started = Instant::now();
+    finish_execution(
+        cell,
+        totals,
+        &live,
+        &peak,
+        setup_ns,
+        elapsed_ns,
+        nonzero_ns(teardown_started),
+    )
+}
+
+fn finish_execution(
+    cell: &ScenarioCell,
+    outcomes: Vec<WorkerOutcome>,
+    live: &AtomicU64,
+    peak: &AtomicU64,
+    setup_ns: u64,
+    elapsed_ns: u64,
+    teardown_ns: u64,
+) -> Result<ExecutionResult, String> {
+    if live.load(Ordering::SeqCst) != 0 {
+        return Err("workload finished with live requested bytes".into());
+    }
+    let mut counts = ExpectedCounts {
+        requested_transactions: cell.requested_transactions(),
+        completed_transactions: cell.requested_transactions(),
+        ..ExpectedCounts::default()
+    };
+    let mut checksum = FNV_OFFSET;
+    for (worker, outcome) in outcomes.into_iter().enumerate() {
+        add_counts(&mut counts, outcome.counts);
+        checksum = fnv_u64(checksum, worker as u64);
+        checksum = fnv_u64(checksum, outcome.checksum);
+    }
+    Ok(ExecutionResult {
+        counts,
+        checksum,
+        peak_live_requested_bytes: peak.load(Ordering::SeqCst),
+        setup_ns,
+        elapsed_ns,
+        teardown_ns,
+    })
+}
+
+fn execute_one<A: AllocatorAdapter>(
+    adapter: &A,
+    card_id: CardId,
+    request: &Request,
+    allocations: &mut LiveSlots,
+    counts: &mut ExpectedCounts,
+    checksum: &mut u64,
+    live: &AtomicU64,
+    peak: &AtomicU64,
+) -> Result<(), String> {
+    match request.kind {
+        RequestKind::Alloc => {
+            let pointer = adapter.alloc(request.size)?;
+            insert_live(
+                allocations,
+                request.token,
+                pointer,
+                request.size,
+                live,
+                peak,
+            )?;
+        }
+        RequestKind::Calloc => {
+            let pointer = adapter.calloc(1, request.size)?;
+            insert_live(
+                allocations,
+                request.token,
+                pointer,
+                request.size,
+                live,
+                peak,
+            )?;
+        }
+        RequestKind::AlignedAlloc => {
+            let pointer = adapter.aligned_alloc(request.alignment, request.size)?;
+            if pointer.as_ptr() as usize % request.alignment != 0 {
+                unsafe { adapter.free(pointer) };
+                return Err("adapter returned a misaligned allocation".into());
+            }
+            insert_live(
+                allocations,
+                request.token,
+                pointer,
+                request.size,
+                live,
+                peak,
+            )?;
+        }
+        RequestKind::Realloc => {
+            let allocation = find_slot_mut(allocations, request.token)
+                .ok_or_else(|| format!("realloc token {} was not live", request.token))?;
+            let preserved_pattern = allocation.pattern;
+            let old_size = allocation.size;
+            let new_pointer = unsafe { adapter.realloc(allocation.pointer, request.size) }?;
+            allocation.pointer = new_pointer;
+            allocation.size = request.size;
+            if let Some(pattern) = preserved_pattern {
+                verify_pattern(*allocation, pattern, request.preserve_bytes)?;
+            }
+            if request.size >= old_size {
+                add_live(live, peak, (request.size - old_size) as u64);
+            } else {
+                subtract_live(live, (old_size - request.size) as u64);
+            }
+        }
+        RequestKind::Free => {
+            let allocation = remove_slot(allocations, request.token)
+                .ok_or_else(|| format!("free token {} was not live", request.token))?;
+            unsafe { adapter.free(allocation.pointer) };
+            subtract_live(live, allocation.size as u64);
+        }
+        RequestKind::VerifyZero => {
+            let allocation = find_slot(allocations, request.token)
+                .ok_or_else(|| format!("zero-check token {} was not live", request.token))?;
+            for offset in 0..request.size {
+                let value = unsafe { allocation.pointer.as_ptr().add(offset).read_volatile() };
+                if value != 0 {
+                    return Err(format!("calloc byte {offset} was nonzero"));
+                }
+                *checksum = checksum_byte(*checksum, request.token, offset, value);
+            }
+        }
+        RequestKind::Touch => {
+            let allocation = find_slot_mut(allocations, request.token)
+                .ok_or_else(|| format!("touch token {} was not live", request.token))?;
+            if request.size > allocation.size {
+                return Err("touch exceeds requested allocation size".into());
+            }
+            for offset in touched_offsets_for_card(card_id, request.size) {
+                let value = pattern_byte(request.touch, offset);
+                unsafe {
+                    allocation
+                        .pointer
+                        .as_ptr()
+                        .add(offset)
+                        .write_volatile(value);
+                    let observed = allocation.pointer.as_ptr().add(offset).read_volatile();
+                    if observed != value {
+                        return Err(format!("touch verification failed at byte {offset}"));
+                    }
+                    *checksum = checksum_byte(*checksum, request.token, offset, observed);
+                }
+            }
+            allocation.pattern = Some(request.touch);
+        }
+        RequestKind::WorkerGeneration => {}
+    }
+    counts.record(request);
+    Ok(())
+}
+
+fn insert_live(
+    allocations: &mut LiveSlots,
+    token: u64,
+    pointer: NonNull<u8>,
+    size: usize,
+    live: &AtomicU64,
+    peak: &AtomicU64,
+) -> Result<(), String> {
+    if find_slot(allocations, token).is_some() {
+        return Err(format!("allocation token {token} was reused while live"));
+    }
+    if allocations.len() == allocations.capacity() {
+        return Err("preallocated live-slot capacity was exhausted".into());
+    }
+    allocations.push((
+        token,
+        LiveAllocation {
+            pointer,
+            size,
+            pattern: None,
+        },
+    ));
+    add_live(live, peak, size as u64);
+    Ok(())
+}
+
+fn find_slot(allocations: &LiveSlots, token: u64) -> Option<&LiveAllocation> {
+    allocations
+        .iter()
+        .find(|(candidate, _)| *candidate == token)
+        .map(|(_, allocation)| allocation)
+}
+
+fn find_slot_mut(allocations: &mut LiveSlots, token: u64) -> Option<&mut LiveAllocation> {
+    allocations
+        .iter_mut()
+        .find(|(candidate, _)| *candidate == token)
+        .map(|(_, allocation)| allocation)
+}
+
+fn remove_slot(allocations: &mut LiveSlots, token: u64) -> Option<LiveAllocation> {
+    allocations
+        .iter()
+        .position(|(candidate, _)| *candidate == token)
+        .map(|position| allocations.swap_remove(position).1)
+}
+
+fn add_live(live: &AtomicU64, peak: &AtomicU64, bytes: u64) {
+    let current = live
+        .fetch_add(bytes, Ordering::SeqCst)
+        .saturating_add(bytes);
+    peak.fetch_max(current, Ordering::SeqCst);
+}
+
+fn subtract_live(live: &AtomicU64, bytes: u64) {
+    live.fetch_sub(bytes, Ordering::SeqCst);
+}
+
+fn verify_pattern(allocation: LiveAllocation, pattern: u64, preserve: usize) -> Result<(), String> {
+    for offset in touched_offsets(preserve.min(allocation.size)) {
+        let expected = pattern_byte(pattern, offset);
+        let observed = unsafe { allocation.pointer.as_ptr().add(offset).read_volatile() };
+        if observed != expected {
+            return Err(format!("realloc failed to preserve byte {offset}"));
+        }
+    }
+    Ok(())
+}
+
+pub fn expected_touch_checksum(cell: &ScenarioCell) -> Result<u64, String> {
+    let mut checksum = FNV_OFFSET;
+    for worker in 0..cell.threads {
+        checksum = fnv_u64(checksum, worker as u64);
+        checksum = fnv_u64(checksum, expected_worker_touch_checksum(cell, worker)?);
+    }
+    Ok(checksum)
+}
+
+fn expected_worker_touch_checksum(cell: &ScenarioCell, worker: usize) -> Result<u64, String> {
+    let full_cycles = cell.transactions_per_worker / REQUEST_CYCLE_OPERATIONS;
+    let remainder = cell.transactions_per_worker % REQUEST_CYCLE_OPERATIONS;
+    let generated_operations = if full_cycles == 0 {
+        remainder
+    } else {
+        REQUEST_CYCLE_OPERATIONS
+    };
+    let mut requests = Vec::with_capacity(MAX_REQUESTS_PER_TRANSACTION);
+    let mut cycle_checksum = 0_u64;
+    let mut remainder_checksum = 0_u64;
+    for operation in 0..generated_operations {
+        cell.fill_worker_transaction(worker, operation, &mut requests)
+            .map_err(|error| error.to_string())?;
+        let transaction_checksum = expected_requests_touch_checksum(cell.card, &requests);
+        cycle_checksum = cycle_checksum.wrapping_add(transaction_checksum);
+        if operation < remainder {
+            remainder_checksum = remainder_checksum.wrapping_add(transaction_checksum);
+        }
+    }
+    Ok(cycle_checksum
+        .wrapping_mul(full_cycles)
+        .wrapping_add(remainder_checksum))
+}
+
+fn expected_requests_touch_checksum(card_id: CardId, requests: &[Request]) -> u64 {
+    let mut checksum = 0_u64;
+    for request in requests {
+        match request.kind {
+            RequestKind::VerifyZero => {
+                for offset in 0..request.size {
+                    checksum = checksum_byte(checksum, request.token, offset, 0);
+                }
+            }
+            RequestKind::Touch => {
+                for offset in touched_offsets_for_card(card_id, request.size) {
+                    checksum = checksum_byte(
+                        checksum,
+                        request.token,
+                        offset,
+                        pattern_byte(request.touch, offset),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    checksum
+}
+
+fn touched_offsets(size: usize) -> TouchedOffsets {
+    let stride = if size < 1024 * 1024 { 1 } else { PAGE_BYTES };
+    touched_offsets_with_stride(size, stride)
+}
+
+fn touched_offsets_for_card(card_id: CardId, size: usize) -> TouchedOffsets {
+    if card_id == CardId::LargeObjects {
+        touched_offsets_with_stride(size, 64)
+    } else {
+        touched_offsets(size)
+    }
+}
+
+fn touched_offsets_with_stride(size: usize, stride: usize) -> TouchedOffsets {
+    TouchedOffsets {
+        size,
+        next: 0,
+        stride,
+        emitted_last: false,
+    }
+}
+
+struct TouchedOffsets {
+    size: usize,
+    next: usize,
+    stride: usize,
+    emitted_last: bool,
+}
+
+impl Iterator for TouchedOffsets {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.size == 0 {
+            return None;
+        }
+        if self.next < self.size {
+            let current = self.next;
+            self.next = self.next.saturating_add(self.stride);
+            if current == self.size - 1 {
+                self.emitted_last = true;
+            }
+            return Some(current);
+        }
+        if !self.emitted_last {
+            self.emitted_last = true;
+            return Some(self.size - 1);
+        }
+        None
+    }
+}
+
+fn pattern_byte(seed: u64, offset: usize) -> u8 {
+    let mixed = seed
+        .wrapping_add((offset as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15))
+        .rotate_left((offset & 63) as u32);
+    (mixed ^ (mixed >> 17) ^ (mixed >> 41)) as u8
+}
+
+fn checksum_byte(checksum: u64, token: u64, offset: usize, value: u8) -> u64 {
+    // Each event is hashed independently and then accumulated commutatively.
+    // The token's low six bits identify its transaction-local slot, allowing
+    // a full deterministic request cycle to be composed arithmetically while
+    // the `value` remains the byte actually read from allocator-owned memory.
+    let mut event = fnv_u64(FNV_OFFSET, token % 64);
+    event = fnv_u64(event, offset as u64);
+    event = fnv_u64(event, value as u64);
+    checksum.wrapping_add(event)
+}
+
+fn fnv_u64(mut state: u64, value: u64) -> u64 {
+    for byte in value.to_le_bytes() {
+        state ^= byte as u64;
+        state = state.wrapping_mul(FNV_PRIME);
+    }
+    state
+}
+
+fn add_counts(total: &mut ExpectedCounts, increment: ExpectedCounts) {
+    total.allocator_calls += increment.allocator_calls;
+    total.alloc_calls += increment.alloc_calls;
+    total.calloc_calls += increment.calloc_calls;
+    total.realloc_calls += increment.realloc_calls;
+    total.aligned_alloc_calls += increment.aligned_alloc_calls;
+    total.free_calls += increment.free_calls;
+    total.touches += increment.touches;
+    total.worker_generations += increment.worker_generations;
+}
+
+fn nonzero_ns(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_nanos())
+        .unwrap_or(u64::MAX)
+        .max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn large_objects_touch_every_cache_line_and_include_the_final_byte() {
+        let size = 1024 * 1024 + 17;
+        let large_offsets =
+            touched_offsets_for_card(CardId::LargeObjects, size).collect::<Vec<_>>();
+        assert_eq!(&large_offsets[..4], &[0, 64, 128, 192]);
+        assert_eq!(large_offsets.last(), Some(&(size - 1)));
+        assert!(large_offsets.windows(2).all(|pair| pair[1] - pair[0] <= 64));
+        for page in (0..size).step_by(PAGE_BYTES) {
+            assert!(large_offsets.contains(&page));
+        }
+
+        let legacy_offsets =
+            touched_offsets_for_card(CardId::MediumLogMixed, size).collect::<Vec<_>>();
+        assert_eq!(&legacy_offsets[..3], &[0, PAGE_BYTES, PAGE_BYTES * 2]);
+        assert!(legacy_offsets.len() < large_offsets.len());
+
+        let request = Request {
+            kind: RequestKind::Touch,
+            phase: 0,
+            transaction: 0,
+            token: 1,
+            owner_worker: 0,
+            executor_worker: 0,
+            size,
+            alignment: 0,
+            touch: 0x5eed,
+            preserve_bytes: 0,
+        };
+        let expected = large_offsets.into_iter().fold(0_u64, |checksum, offset| {
+            checksum_byte(
+                checksum,
+                request.token,
+                offset,
+                pattern_byte(request.touch, offset),
+            )
+        });
+        assert_eq!(
+            expected_requests_touch_checksum(CardId::LargeObjects, &[request]),
+            expected
+        );
+        assert_ne!(
+            expected_requests_touch_checksum(CardId::MediumLogMixed, &[request]),
+            expected
+        );
+    }
+}

--- a/rust/benchmark-suite/src/lib.rs
+++ b/rust/benchmark-suite/src/lib.rs
@@ -1,0 +1,17 @@
+//! Native, isolated four-allocator benchmark producer.
+//!
+//! Phase 2 writes raw, paired measurements only. Statistical publication is
+//! intentionally deferred to Phase 3.
+
+pub mod adapter;
+pub mod child;
+pub mod config;
+pub mod execution;
+pub mod model;
+pub mod orchestration;
+pub mod provenance;
+pub mod runner;
+pub mod scenarios;
+
+pub const RAW_SCHEMA_VERSION: &str = "benchmark-raw-v1";
+pub const CORE_SUITE_VERSION: &str = "core-throughput-v1";

--- a/rust/benchmark-suite/src/model.rs
+++ b/rust/benchmark-suite/src/model.rs
@@ -1,0 +1,303 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{CORE_SUITE_VERSION, RAW_SCHEMA_VERSION};
+
+pub const CHILD_PROTOCOL_VERSION: &str = "benchmark-child-v1";
+
+/// Immutable identity supplied by the producer after it hashes the directly
+/// linked artifacts. The child echoes these values into every raw record.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AllocatorIdentity {
+    pub allocator_id: String,
+    pub allocator_version: String,
+    pub source_sha: String,
+    pub library_sha256: String,
+    pub child_binary_sha256: String,
+}
+
+impl AllocatorIdentity {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.allocator_id.is_empty() || self.allocator_version.is_empty() {
+            return Err("allocator identity is incomplete".into());
+        }
+        if !is_lower_hex(&self.source_sha, 40)
+            || !is_lower_hex(&self.library_sha256, 64)
+            || !is_lower_hex(&self.child_binary_sha256, 64)
+        {
+            return Err("allocator identity contains an invalid digest".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerMetadata {
+    pub os: String,
+    pub architecture: String,
+    pub physical_cores: u32,
+    pub logical_cores: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ToolchainMetadata {
+    pub rustc: String,
+    pub target: String,
+    pub compiler: String,
+    pub linker: String,
+}
+
+/// Versioned, strict request consumed by one freshly spawned benchmark child.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchmarkChildRequest {
+    pub protocol_version: String,
+    pub schema_version: String,
+    pub suite_version: String,
+    /// `headline` for publishable paired cells, `reduced-smoke` only for the
+    /// explicit one-block Linux acceptance probe.
+    pub run_kind: String,
+    pub execution_mode: String,
+    pub run_seed: u64,
+    pub block_id: u32,
+    pub ordinal: u8,
+    pub workload_seed: u64,
+    pub allocator: AllocatorIdentity,
+    pub scenario_id: String,
+    pub scenario_version: String,
+    pub thread_point: String,
+    pub physical_cores: u32,
+    pub logical_cores: u32,
+    pub transactions_per_worker: u64,
+    pub warmup_transactions_per_worker: u64,
+    pub reproduction_command: String,
+    pub runner: RunnerMetadata,
+    pub toolchain: ToolchainMetadata,
+}
+
+impl BenchmarkChildRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.protocol_version != CHILD_PROTOCOL_VERSION
+            || self.schema_version != RAW_SCHEMA_VERSION
+            || self.suite_version != CORE_SUITE_VERSION
+            || self.scenario_version != CORE_SUITE_VERSION
+        {
+            return Err("unsupported benchmark child protocol or schema version".into());
+        }
+        if !matches!(self.run_kind.as_str(), "headline" | "reduced-smoke") {
+            return Err("unknown benchmark run kind".into());
+        }
+        if !matches!(
+            self.execution_mode.as_str(),
+            "normal" | "serialized-control"
+        ) {
+            return Err("unknown benchmark execution mode".into());
+        }
+        self.allocator.validate()?;
+        if self.ordinal >= 4
+            || self.physical_cores == 0
+            || self.logical_cores == 0
+            || self.physical_cores > self.logical_cores
+            || self.transactions_per_worker == 0
+            || self.reproduction_command.is_empty()
+        {
+            return Err("benchmark child request contains invalid counts or topology".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BenchmarkChildResponse {
+    pub protocol_version: String,
+    pub sample: RawSample,
+}
+
+impl BenchmarkChildResponse {
+    pub fn validate_against(&self, request: &BenchmarkChildRequest) -> Result<(), String> {
+        if self.protocol_version != CHILD_PROTOCOL_VERSION {
+            return Err("child response protocol version mismatch".into());
+        }
+        self.sample.validate()?;
+        if self.sample.schema_version != request.schema_version
+            || self.sample.suite_version != request.suite_version
+            || self.sample.run_kind != request.run_kind
+            || self.sample.execution_mode != request.execution_mode
+            || self.sample.run_seed != request.run_seed
+            || self.sample.block_id != request.block_id
+            || self.sample.ordinal != request.ordinal
+            || self.sample.workload_seed != request.workload_seed
+            || self.sample.allocator_id != request.allocator.allocator_id
+            || self.sample.allocator_version != request.allocator.allocator_version
+            || self.sample.allocator_source_sha != request.allocator.source_sha
+            || self.sample.allocator_library_sha256 != request.allocator.library_sha256
+            || self.sample.child_binary_sha256 != request.allocator.child_binary_sha256
+            || self.sample.scenario_id != request.scenario_id
+            || self.sample.scenario_version != request.scenario_version
+            || self.sample.thread_point != request.thread_point
+            || self.sample.reproduction_command != request.reproduction_command
+            || self.sample.runner != request.runner
+            || self.sample.toolchain != request.toolchain
+        {
+            return Err("child response does not exactly match its request".into());
+        }
+        let card_id = crate::scenarios::CardId::parse(&request.scenario_id)
+            .ok_or_else(|| "child response names an unknown scenario".to_string())?;
+        let thread_point = crate::scenarios::ThreadPoint::parse(&request.thread_point)
+            .ok_or_else(|| "child response names an unknown thread point".to_string())?;
+        let cell = crate::scenarios::ScenarioCell::new(
+            card_id,
+            thread_point,
+            crate::scenarios::Topology {
+                physical_cores: request.physical_cores as usize,
+                logical_cores: request.logical_cores as usize,
+            },
+            request.transactions_per_worker,
+            request.workload_seed,
+        )
+        .map_err(|error| error.to_string())?;
+        let expected = cell.expected_counts().map_err(|error| error.to_string())?;
+        let definition = crate::scenarios::card(card_id);
+        let expected_operation_count = definition.operation_count(&expected);
+        let expected_checksum = crate::execution::expected_touch_checksum(&cell)?;
+        let expected_throughput =
+            expected_operation_count as f64 * 1_000_000_000.0 / self.sample.elapsed_ns as f64;
+        let throughput_error =
+            (self.sample.throughput_operations_per_second - expected_throughput).abs();
+        let throughput_tolerance = (expected_throughput.abs() * 1e-12).max(f64::EPSILON);
+        if self.sample.thread_count != cell.threads as u32
+            || self.sample.operation_unit != definition.operation_unit.name()
+            || self.sample.operation_count != expected_operation_count
+            || self.sample.requested_transactions != expected.requested_transactions
+            || self.sample.completed_transactions != expected.completed_transactions
+            || self.sample.allocation_calls != expected.alloc_calls
+            || self.sample.calloc_calls != expected.calloc_calls
+            || self.sample.aligned_allocation_calls != expected.aligned_alloc_calls
+            || self.sample.free_calls != expected.free_calls
+            || self.sample.realloc_calls != expected.realloc_calls
+            || self.sample.checksum != expected_checksum
+            || throughput_error > throughput_tolerance
+            || (request.warmup_transactions_per_worker == 0 && self.sample.warmup_ns != 0)
+        {
+            return Err("child response contradicts the derived scenario contract".into());
+        }
+        Ok(())
+    }
+}
+
+/// One append-only child outcome. All raw quantities use integer units except
+/// the explicitly derived, finite throughput value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct RawSample {
+    pub schema_version: String,
+    pub suite_version: String,
+    pub run_kind: String,
+    pub execution_mode: String,
+    pub run_seed: u64,
+    pub block_id: u32,
+    pub ordinal: u8,
+    pub workload_seed: u64,
+    pub allocator_id: String,
+    pub allocator_version: String,
+    pub allocator_source_sha: String,
+    pub allocator_library_sha256: String,
+    pub child_binary_sha256: String,
+    pub scenario_id: String,
+    pub scenario_version: String,
+    pub thread_point: String,
+    pub thread_count: u32,
+    pub operation_unit: String,
+    pub operation_count: u64,
+    pub requested_transactions: u64,
+    pub completed_transactions: u64,
+    pub allocation_calls: u64,
+    pub calloc_calls: u64,
+    pub aligned_allocation_calls: u64,
+    pub free_calls: u64,
+    pub realloc_calls: u64,
+    pub setup_ns: u64,
+    pub warmup_ns: u64,
+    pub elapsed_ns: u64,
+    pub teardown_ns: u64,
+    pub throughput_operations_per_second: f64,
+    pub checksum: u64,
+    pub peak_live_requested_bytes: u64,
+    pub timed_out: bool,
+    pub crashed: bool,
+    pub exit_code: i32,
+    pub signal: Option<i32>,
+    pub runner: RunnerMetadata,
+    pub toolchain: ToolchainMetadata,
+    pub reproduction_command: String,
+}
+
+impl RawSample {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != RAW_SCHEMA_VERSION
+            || self.suite_version != CORE_SUITE_VERSION
+            || self.scenario_version != CORE_SUITE_VERSION
+            || !matches!(self.run_kind.as_str(), "headline" | "reduced-smoke")
+            || !matches!(
+                self.execution_mode.as_str(),
+                "normal" | "serialized-control"
+            )
+            || self.elapsed_ns == 0
+            || self.operation_count == 0
+            || self.requested_transactions == 0
+            || self.completed_transactions != self.requested_transactions
+            || self.ordinal >= 4
+            || self.thread_count == 0
+        {
+            return Err("raw sample has invalid identity, timing, or transaction counts".into());
+        }
+        if !self.throughput_operations_per_second.is_finite()
+            || self.throughput_operations_per_second <= 0.0
+        {
+            return Err("raw sample has non-finite or non-positive throughput".into());
+        }
+        if self
+            .allocation_calls
+            .saturating_add(self.calloc_calls)
+            .saturating_add(self.aligned_allocation_calls)
+            == 0
+            || self.free_calls == 0
+            || self.checksum == 0
+            || self.peak_live_requested_bytes == 0
+        {
+            return Err("raw sample has impossible allocator counts or checksum".into());
+        }
+        if self.timed_out || self.crashed || self.exit_code != 0 || self.signal.is_some() {
+            return Err("raw sample reports a failed child".into());
+        }
+        AllocatorIdentity {
+            allocator_id: self.allocator_id.clone(),
+            allocator_version: self.allocator_version.clone(),
+            source_sha: self.allocator_source_sha.clone(),
+            library_sha256: self.allocator_library_sha256.clone(),
+            child_binary_sha256: self.child_binary_sha256.clone(),
+        }
+        .validate()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct RawRun {
+    pub schema_version: String,
+    pub suite_version: String,
+    pub run_kind: String,
+    pub execution_mode: String,
+    pub run_seed: u64,
+    pub samples: Vec<RawSample>,
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}

--- a/rust/benchmark-suite/src/orchestration.rs
+++ b/rust/benchmark-suite/src/orchestration.rs
@@ -1,0 +1,559 @@
+use std::ffi::OsString;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::model::{
+    AllocatorIdentity, BenchmarkChildRequest, BenchmarkChildResponse, RawRun, RawSample,
+};
+
+pub const ALLOCATOR_IDS: [&str; 4] = [
+    "tcmalloc",
+    "jemalloc",
+    "upstream-mimalloc",
+    "mimalloc-pprof",
+];
+
+#[derive(Debug, Clone)]
+pub struct ChildProgram {
+    pub allocator: AllocatorIdentity,
+    pub program: PathBuf,
+    pub arguments: Vec<OsString>,
+    pub toolchain: crate::model::ToolchainMetadata,
+    /// Deliberate environment allowlist. The process starts from an empty
+    /// environment; allocator runtime features are forced off below.
+    pub environment: Vec<(OsString, OsString)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CellRunPlan {
+    pub request_template: BenchmarkChildRequest,
+    pub children: Vec<ChildProgram>,
+    pub blocks: u32,
+    pub timeout: Duration,
+    /// When present, persist every exact child request before launch so the
+    /// raw record's reproduction command can replay it byte-for-byte.
+    pub request_directory: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CalibrationResult {
+    pub transactions_per_worker: u64,
+    pub operation_count: u64,
+    pub elapsed_ns: u64,
+}
+
+/// Calibrate only against the pinned upstream-mimalloc child. The realized
+/// per-worker count returned here is then frozen into every paired request.
+pub fn calibrate_cell(
+    upstream: &ChildProgram,
+    request_template: &BenchmarkChildRequest,
+    timeout: Duration,
+) -> Result<CalibrationResult, String> {
+    calibrate_cell_with(
+        upstream,
+        request_template,
+        timeout,
+        |child, request, timeout| run_child_sample(child, request, timeout),
+    )
+}
+
+pub fn calibrate_cell_with<R>(
+    upstream: &ChildProgram,
+    request_template: &BenchmarkChildRequest,
+    timeout: Duration,
+    mut run_sample: R,
+) -> Result<CalibrationResult, String>
+where
+    R: FnMut(&ChildProgram, &BenchmarkChildRequest, Duration) -> Result<RawSample, String>,
+{
+    if upstream.allocator.allocator_id != "upstream-mimalloc" {
+        return Err("calibration must use the pinned upstream-mimalloc child".into());
+    }
+    if timeout < Duration::from_secs(2) {
+        return Err("calibration timeout must permit the two-second upper bound".into());
+    }
+    let mut transactions = request_template.transactions_per_worker.max(1);
+    let mut observations = Vec::new();
+    for attempt in 0..20_u32 {
+        let mut request = request_template.clone();
+        request.block_id = u32::MAX;
+        request.ordinal = 0;
+        request.workload_seed = splitmix64(request.run_seed ^ 0xca11_ba7e ^ attempt as u64);
+        request.transactions_per_worker = transactions;
+        request.allocator = upstream.allocator.clone();
+        request.toolchain = upstream.toolchain.clone();
+        request.reproduction_command = reproduction_command(upstream, &request);
+        let sample = run_sample(upstream, &request, timeout)?;
+        observations.push(format!(
+            "attempt={attempt},transactions={transactions},elapsed_ns={}",
+            sample.elapsed_ns
+        ));
+        if (500_000_000..=2_000_000_000).contains(&sample.elapsed_ns) {
+            return Ok(CalibrationResult {
+                transactions_per_worker: transactions,
+                operation_count: sample.operation_count,
+                elapsed_ns: sample.elapsed_ns,
+            });
+        }
+        let desired = (transactions as u128)
+            .saturating_mul(1_000_000_000)
+            .checked_div(sample.elapsed_ns.max(1) as u128)
+            .unwrap_or(u128::from(u64::MAX))
+            .clamp(1, u128::from(u64::MAX)) as u64;
+        // Avoid one noisy observation producing a pathological jump while
+        // still converging quickly from the one-transaction probe.
+        let lower = (transactions / 16).max(1);
+        let upper = transactions.saturating_mul(16).max(2);
+        let next = desired.clamp(lower, upper);
+        transactions = if next == transactions {
+            if sample.elapsed_ns < 500_000_000 {
+                transactions.saturating_add(1)
+            } else {
+                transactions.saturating_sub(1).max(1)
+            }
+        } else {
+            next
+        };
+    }
+    Err(format!(
+        "upstream calibration did not reach the 0.5-2.0 second interval: {}",
+        observations.join("; ")
+    ))
+}
+
+/// Run one complete paired cell. A sink sees each successful sample
+/// immediately (for append-only JSONL), but a `RawRun` is returned only after
+/// every allocator in every block succeeds and validates.
+pub fn run_balanced_cell<F>(plan: &CellRunPlan, mut append_sample: F) -> Result<RawRun, String>
+where
+    F: FnMut(&RawSample) -> Result<(), String>,
+{
+    run_balanced_cell_with(plan, &mut append_sample, |child, request, timeout| {
+        run_child_sample(child, request, timeout)
+    })
+}
+
+/// Injectable form used by contract tests and calibration harnesses. It keeps
+/// the same no-retry/all-or-nothing state machine as the process-backed path.
+pub fn run_balanced_cell_with<F, R>(
+    plan: &CellRunPlan,
+    mut append_sample: F,
+    mut run_sample: R,
+) -> Result<RawRun, String>
+where
+    F: FnMut(&RawSample) -> Result<(), String>,
+    R: FnMut(&ChildProgram, &BenchmarkChildRequest, Duration) -> Result<RawSample, String>,
+{
+    match plan.request_template.run_kind.as_str() {
+        "headline" if plan.blocks < 15 => {
+            return Err("headline core cells require at least 15 complete blocks".into())
+        }
+        "reduced-smoke" if plan.blocks != 1 => {
+            return Err("reduced smoke runs require exactly one non-headline block".into())
+        }
+        "headline" | "reduced-smoke" => {}
+        _ => return Err("unknown benchmark run kind".into()),
+    }
+    if plan.timeout.is_zero() {
+        return Err("child timeout must be nonzero".into());
+    }
+    if plan.children.len() != ALLOCATOR_IDS.len() {
+        return Err("exactly four directly linked child programs are required".into());
+    }
+    for allocator in ALLOCATOR_IDS {
+        let matches = plan
+            .children
+            .iter()
+            .filter(|child| child.allocator.allocator_id == allocator)
+            .count();
+        if matches != 1 {
+            return Err(format!("expected exactly one child for {allocator}"));
+        }
+    }
+    let orders = balanced_block_orders(plan.blocks, plan.request_template.run_seed)?;
+    validate_near_balanced(&orders)?;
+    let mut samples = Vec::with_capacity(plan.blocks as usize * ALLOCATOR_IDS.len());
+    for order in orders {
+        for (ordinal, allocator_id) in order.allocator_ids.iter().enumerate() {
+            let child = plan
+                .children
+                .iter()
+                .find(|child| child.allocator.allocator_id == *allocator_id)
+                .expect("child IDs validated above");
+            let mut request = plan.request_template.clone();
+            request.block_id = order.block_id;
+            request.ordinal = ordinal as u8;
+            request.workload_seed = order.workload_seed;
+            request.allocator = child.allocator.clone();
+            request.toolchain = child.toolchain.clone();
+            let request_path = plan.request_directory.as_ref().map(|directory| {
+                directory.join(format!(
+                    "{}-{}-block-{:04}-ordinal-{}-{}.json",
+                    request.scenario_id,
+                    request.thread_point,
+                    request.block_id,
+                    request.ordinal,
+                    request.allocator.allocator_id
+                ))
+            });
+            request.reproduction_command = match &request_path {
+                Some(path) => format!(
+                    "MIMALLOC_PROF=0 MIMALLOC_MEMORY_EVENTS=0 {} < {}",
+                    shell_quote(&child.program.display().to_string()),
+                    shell_quote(&path.display().to_string())
+                ),
+                None => reproduction_command(child, &request),
+            };
+            if let Some(path) = request_path {
+                let parent = path
+                    .parent()
+                    .ok_or_else(|| "request artifact has no parent directory".to_string())?;
+                std::fs::create_dir_all(parent)
+                    .map_err(|error| format!("create request artifact directory: {error}"))?;
+                let mut file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&path)
+                    .map_err(|error| {
+                        format!("create request artifact {}: {error}", path.display())
+                    })?;
+                serde_json::to_writer(&mut file, &request)
+                    .map_err(|error| format!("write request artifact: {error}"))?;
+                file.write_all(b"\n")
+                    .map_err(|error| format!("finish request artifact: {error}"))?;
+            }
+            let sample = run_sample(child, &request, plan.timeout).map_err(|error| {
+                format!(
+                    "cell aborted at block {} ordinal {} allocator {}: {error}",
+                    order.block_id, ordinal, allocator_id
+                )
+            })?;
+            append_sample(&sample)?;
+            samples.push(sample);
+        }
+    }
+    let run = RawRun {
+        schema_version: plan.request_template.schema_version.clone(),
+        suite_version: plan.request_template.suite_version.clone(),
+        run_kind: plan.request_template.run_kind.clone(),
+        execution_mode: plan.request_template.execution_mode.clone(),
+        run_seed: plan.request_template.run_seed,
+        samples,
+    };
+    validate_complete_raw_run(&run, plan.blocks)?;
+    Ok(run)
+}
+
+/// Spawn one fresh child with a strict watchdog and an empty ambient
+/// environment. Success means exactly one matching JSON response and no
+/// timeout/crash/nonzero exit; no failed outcome can become a raw sample.
+pub fn run_child_sample(
+    child: &ChildProgram,
+    request: &BenchmarkChildRequest,
+    timeout: Duration,
+) -> Result<RawSample, String> {
+    request.validate()?;
+    if child.allocator != request.allocator {
+        return Err("child program identity differs from request identity".into());
+    }
+    let encoded = serde_json::to_vec(request)
+        .map_err(|error| format!("serialize benchmark child request: {error}"))?;
+    let mut command = Command::new(&child.program);
+    command
+        .args(&child.arguments)
+        .env_clear()
+        .envs(child.environment.iter().map(|(key, value)| (key, value)))
+        .env("MIMALLOC_PROF", "0")
+        .env("MIMALLOC_MEMORY_EVENTS", "0")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut process = command
+        .spawn()
+        .map_err(|error| format!("spawn benchmark child: {error}"))?;
+    process
+        .stdin
+        .take()
+        .ok_or_else(|| "benchmark child stdin was not piped".to_string())?
+        .write_all(&encoded)
+        .map_err(|error| format!("write benchmark child request: {error}"))?;
+
+    let started = Instant::now();
+    loop {
+        match process
+            .try_wait()
+            .map_err(|error| format!("poll benchmark child: {error}"))?
+        {
+            Some(status) => {
+                let output = process
+                    .wait_with_output()
+                    .map_err(|error| format!("collect benchmark child output: {error}"))?;
+                if !status.success() {
+                    return Err(format!(
+                        "benchmark child exited unsuccessfully: status={status}, stderr={}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
+                if output.stdout.len() > 1024 * 1024 {
+                    return Err("benchmark child response exceeded 1 MiB".into());
+                }
+                if !output.stderr.is_empty() {
+                    return Err(format!(
+                        "successful benchmark child wrote stderr: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
+                let response: BenchmarkChildResponse = serde_json::from_slice(&output.stdout)
+                    .map_err(|error| {
+                        format!("expected exactly one benchmark child response: {error}")
+                    })?;
+                response.validate_against(request)?;
+                return Ok(response.sample);
+            }
+            None if started.elapsed() >= timeout => {
+                let _ = process.kill();
+                let _ = process.wait();
+                return Err(format!(
+                    "benchmark child timed out after {} ms",
+                    timeout.as_millis()
+                ));
+            }
+            None => std::thread::sleep(Duration::from_millis(5)),
+        }
+    }
+}
+
+fn reproduction_command(child: &ChildProgram, request: &BenchmarkChildRequest) -> String {
+    format!(
+        "MIMALLOC_PROF=0 MIMALLOC_MEMORY_EVENTS=0 {} # suite={} scenario={} threads={} transactions-per-worker={} seed={}",
+        child.program.display(),
+        request.suite_version,
+        request.scenario_id,
+        request.thread_point,
+        request.transactions_per_worker,
+        request.workload_seed
+    )
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+/// A replayable, block-local order. Every allocator occurs once per block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockOrder {
+    pub block_id: u32,
+    pub workload_seed: u64,
+    pub allocator_ids: [String; 4],
+}
+
+/// Deterministically balances every ordinal position without selective retries.
+pub fn balanced_block_orders(blocks: u32, run_seed: u64) -> Result<Vec<BlockOrder>, String> {
+    if blocks == 0 {
+        return Err("at least one complete block is required".into());
+    }
+    let mut base = ALLOCATOR_IDS.map(str::to_string);
+    deterministic_shuffle(&mut base, run_seed);
+    Ok((0..blocks)
+        .map(|block_id| {
+            let rotation = (block_id % 4) as usize;
+            let allocator_ids =
+                std::array::from_fn(|ordinal| base[(ordinal + rotation) % 4].clone());
+            BlockOrder {
+                block_id,
+                workload_seed: splitmix64(run_seed.wrapping_add(block_id as u64)),
+                allocator_ids,
+            }
+        })
+        .collect())
+}
+
+/// Check the `floor(blocks/4)`/`ceil(blocks/4)` ordinal requirement.
+pub fn validate_near_balanced(orders: &[BlockOrder]) -> Result<(), String> {
+    if orders.is_empty() {
+        return Err("no blocks supplied".into());
+    }
+    let floor = orders.len() / 4;
+    let ceiling = (orders.len() + 3) / 4;
+    for ordinal in 0..4 {
+        for allocator in ALLOCATOR_IDS {
+            let count = orders
+                .iter()
+                .filter(|order| order.allocator_ids[ordinal] == allocator)
+                .count();
+            if !(floor..=ceiling).contains(&count) {
+                return Err(format!("{allocator} appears {count} times at ordinal {ordinal}, expected {floor}..={ceiling}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A calibrated count belongs to one scenario/thread cell and is immutable for
+/// the complete four-allocator run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrozenCalibration {
+    pub scenario_id: String,
+    pub thread_count: u32,
+    pub operation_count: u64,
+}
+
+impl FrozenCalibration {
+    pub fn new(
+        scenario_id: impl Into<String>,
+        thread_count: u32,
+        operation_count: u64,
+    ) -> Result<Self, String> {
+        let calibration = Self {
+            scenario_id: scenario_id.into(),
+            thread_count,
+            operation_count,
+        };
+        if calibration.scenario_id.is_empty()
+            || calibration.thread_count == 0
+            || calibration.operation_count == 0
+        {
+            return Err(
+                "calibration requires a scenario, non-zero thread count, and non-zero operations"
+                    .into(),
+            );
+        }
+        Ok(calibration)
+    }
+
+    pub fn apply_to(&self, allocator_id: &str) -> Result<u64, String> {
+        if !ALLOCATOR_IDS.contains(&allocator_id) {
+            return Err(format!("unknown allocator {allocator_id}"));
+        }
+        Ok(self.operation_count)
+    }
+}
+
+/// Reject incomplete cells before any raw run can be handed to Phase 3.
+pub fn validate_complete_raw_run(run: &RawRun, expected_blocks: u32) -> Result<(), String> {
+    if run.run_kind == "headline" && expected_blocks < 15 {
+        return Err("core runs require at least 15 blocks".into());
+    }
+    if run.run_kind == "reduced-smoke" && expected_blocks != 1 {
+        return Err("reduced smoke raw runs require exactly one block".into());
+    }
+    if run.samples.len() != expected_blocks as usize * ALLOCATOR_IDS.len() {
+        return Err("raw run does not contain exactly four samples per block".into());
+    }
+    for block in 0..expected_blocks {
+        let samples: Vec<&RawSample> = run
+            .samples
+            .iter()
+            .filter(|sample| sample.block_id == block)
+            .collect();
+        if samples.len() != 4 {
+            return Err(format!("block {block} is incomplete"));
+        }
+        let mut seen_ordinals = [false; 4];
+        for sample in &samples {
+            let ordinal = sample.ordinal as usize;
+            if ordinal >= 4 || seen_ordinals[ordinal] {
+                return Err(format!("block {block} has duplicate or invalid ordinals"));
+            }
+            seen_ordinals[ordinal] = true;
+        }
+        for allocator in ALLOCATOR_IDS {
+            let sample = samples
+                .iter()
+                .find(|sample| sample.allocator_id == allocator)
+                .ok_or_else(|| format!("block {block} is missing {allocator}"))?;
+            sample.validate()?;
+        }
+        if samples
+            .iter()
+            .any(|sample| sample.workload_seed != samples[0].workload_seed)
+        {
+            return Err(format!("block {block} does not share one workload seed"));
+        }
+        if samples.iter().any(|sample| {
+            sample.run_seed != run.run_seed
+                || sample.schema_version != run.schema_version
+                || sample.suite_version != run.suite_version
+                || sample.run_kind != run.run_kind
+                || sample.execution_mode != run.execution_mode
+                || sample.scenario_id != samples[0].scenario_id
+                || sample.scenario_version != samples[0].scenario_version
+                || sample.thread_point != samples[0].thread_point
+                || sample.thread_count != samples[0].thread_count
+                || sample.operation_count != samples[0].operation_count
+                || sample.requested_transactions != samples[0].requested_transactions
+                || sample.checksum != samples[0].checksum
+        }) {
+            return Err(format!(
+                "block {block} does not share one frozen workload contract"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Contract check for the planted mutex-serialized control. It is kept out of
+/// headline output and exists only to prove the complete four-child/block path
+/// remains sensitive to an intentionally slower execution mode.
+pub fn detect_planted_serialized_control(
+    normal: &RawRun,
+    serialized: &RawRun,
+) -> Result<f64, String> {
+    if normal.execution_mode != "normal" || serialized.execution_mode != "serialized-control" {
+        return Err("control comparison requires normal and serialized-control runs".into());
+    }
+    if normal.samples.len() != serialized.samples.len() || normal.samples.is_empty() {
+        return Err("control comparison requires equally complete raw runs".into());
+    }
+    let mut normal_ns = 0_u128;
+    let mut serialized_ns = 0_u128;
+    let mut paired = 0_u64;
+    for sample in normal
+        .samples
+        .iter()
+        .filter(|sample| sample.thread_count > 1)
+    {
+        let control = serialized.samples.iter().find(|candidate| {
+            candidate.block_id == sample.block_id
+                && candidate.ordinal == sample.ordinal
+                && candidate.allocator_id == sample.allocator_id
+                && candidate.scenario_id == sample.scenario_id
+                && candidate.thread_point == sample.thread_point
+                && candidate.workload_seed == sample.workload_seed
+                && candidate.operation_count == sample.operation_count
+                && candidate.checksum == sample.checksum
+        });
+        let control =
+            control.ok_or_else(|| "serialized control is missing a paired sample".to_string())?;
+        normal_ns += u128::from(sample.elapsed_ns);
+        serialized_ns += u128::from(control.elapsed_ns);
+        paired += 1;
+    }
+    if paired == 0 {
+        return Err("serialized control needs at least one multi-thread paired sample".into());
+    }
+    let ratio = serialized_ns as f64 / normal_ns.max(1) as f64;
+    if !ratio.is_finite() || ratio < 1.05 {
+        return Err(format!(
+            "planted serialized control was not detected (elapsed ratio {ratio:.3})"
+        ));
+    }
+    Ok(ratio)
+}
+
+fn deterministic_shuffle(values: &mut [String; 4], mut state: u64) {
+    for index in (1..values.len()).rev() {
+        state = splitmix64(state);
+        values.swap(index, (state as usize) % (index + 1));
+    }
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    let mut z = value;
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}

--- a/rust/benchmark-suite/src/provenance.rs
+++ b/rust/benchmark-suite/src/provenance.rs
@@ -1,0 +1,342 @@
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::AllocatorLock;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolchainProvenance {
+    pub compiler: String,
+    pub linker: String,
+}
+
+/// The subset of one producer record required to launch and identify a child.
+/// Unknown producer fields remain allowed so the Python artifact can retain
+/// richer link/symbol/build evidence without duplicating that schema in Rust.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AllocatorProvenance {
+    #[serde(rename = "id")]
+    pub allocator_id: String,
+    #[serde(rename = "version")]
+    pub allocator_version: String,
+    pub source_sha: String,
+    #[serde(rename = "source_archive_sha256")]
+    pub source_archive_sha256: Option<String>,
+    #[serde(rename = "library_sha256")]
+    pub static_library_sha256: String,
+    #[serde(rename = "library")]
+    pub static_library: String,
+    #[serde(rename = "child_binary")]
+    pub child_binary: String,
+    pub child_binary_sha256: String,
+    #[serde(rename = "commands")]
+    pub build_commands: Vec<Vec<String>>,
+    pub toolchain: ToolchainProvenance,
+    pub build_flags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProducerProvenance {
+    pub schema_version: u32,
+    pub lockfile_sha256: String,
+    pub environment: BTreeMap<String, String>,
+    pub tool_versions: BTreeMap<String, String>,
+    pub build_elapsed_seconds: f64,
+    pub allocators: Vec<AllocatorProvenance>,
+}
+
+impl ProducerProvenance {
+    pub fn parse_and_validate(input: &str, lock: &AllocatorLock) -> Result<Self, String> {
+        let provenance: Self = serde_json::from_str(input).map_err(|error| error.to_string())?;
+        if provenance.schema_version != 1 || provenance.allocators.len() != 4 {
+            return Err("producer provenance must contain exactly four allocator builds".into());
+        }
+        if !provenance.build_elapsed_seconds.is_finite() || provenance.build_elapsed_seconds < 0.0 {
+            return Err("producer build elapsed time must be finite and nonnegative".into());
+        }
+        let embedded_lock_sha256 =
+            sha256_bytes(include_bytes!("../allocators/allocator-lock.json"));
+        if provenance.lockfile_sha256 != embedded_lock_sha256 {
+            return Err("producer provenance was built from a different allocator lockfile".into());
+        }
+        validate_distinct_child_hashes(&provenance.allocators)?;
+        for pin in &lock.allocators {
+            let built = provenance
+                .allocators
+                .iter()
+                .find(|item| item.allocator_id == pin.id)
+                .ok_or_else(|| format!("producer provenance is missing {}", pin.id))?;
+            let expected_source = if pin.id == "mimalloc-pprof" {
+                // The workflow source pin is resolved to the checked-out full
+                // commit by the deterministic producer.
+                None
+            } else {
+                Some(pin.source.commit.as_str())
+            };
+            if expected_source.is_some_and(|expected| built.source_sha != expected)
+                || (pin.id != "mimalloc-pprof"
+                    && built.source_archive_sha256.as_deref()
+                        != pin.source.archive_sha256.as_deref())
+                || !is_lower_hex(&built.source_sha, 40)
+                || (pin.id != "mimalloc-pprof"
+                    && !is_lower_hex(
+                        built.source_archive_sha256.as_deref().unwrap_or_default(),
+                        64,
+                    ))
+                || !is_lower_hex(&built.static_library_sha256, 64)
+                || !is_lower_hex(&built.child_binary_sha256, 64)
+                || built.allocator_version.is_empty()
+                || built.static_library.is_empty()
+                || built.child_binary.is_empty()
+                || built.build_commands.is_empty()
+                || built.toolchain.compiler.is_empty()
+                || built.toolchain.linker.is_empty()
+            {
+                return Err(format!("producer provenance for {} is invalid", pin.id));
+            }
+        }
+        Ok(provenance)
+    }
+
+    /// Hash the exact files immediately before launch. Provenance strings are
+    /// never accepted as proof that the artifacts on disk are unchanged.
+    pub fn validate_artifact_hashes(&self) -> Result<(), String> {
+        for allocator in &self.allocators {
+            validate_file_hash(
+                &allocator.static_library,
+                &allocator.static_library_sha256,
+                &format!("{} static library", allocator.allocator_id),
+            )?;
+            validate_file_hash(
+                &allocator.child_binary,
+                &allocator.child_binary_sha256,
+                &format!("{} child binary", allocator.allocator_id),
+            )?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_file_hash(path: &str, expected: &str, label: &str) -> Result<(), String> {
+    if !Path::new(path).is_file() {
+        return Err(format!("{label} does not exist: {path}"));
+    }
+    let actual = sha256_file(Path::new(path))?;
+    if actual != expected {
+        return Err(format!(
+            "{label} SHA-256 mismatch: expected {expected}, got {actual}"
+        ));
+    }
+    Ok(())
+}
+
+/// Reject accidental same-binary/multiple-allocator link reuse.
+pub fn validate_distinct_child_hashes(provenance: &[AllocatorProvenance]) -> Result<(), String> {
+    if provenance.len() != 4 {
+        return Err("expected four allocator child artifacts".into());
+    }
+    for (index, item) in provenance.iter().enumerate() {
+        if provenance
+            .iter()
+            .skip(index + 1)
+            .any(|other| other.child_binary_sha256 == item.child_binary_sha256)
+        {
+            return Err("allocator child hashes must be distinct".into());
+        }
+    }
+    Ok(())
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+pub fn sha256_file(path: &Path) -> Result<String, String> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|error| format!("open {} for SHA-256: {error}", path.display()))?;
+    let mut hash = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .map_err(|error| format!("read {} for SHA-256: {error}", path.display()))?;
+        if count == 0 {
+            break;
+        }
+        hash.update(&buffer[..count]);
+    }
+    Ok(hex_digest(hash.finish()))
+}
+
+pub fn sha256_bytes(bytes: &[u8]) -> String {
+    let mut hash = Sha256::new();
+    hash.update(bytes);
+    hex_digest(hash.finish())
+}
+
+fn hex_digest(digest: [u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+struct Sha256 {
+    state: [u32; 8],
+    buffer: [u8; 64],
+    buffered: usize,
+    bit_length: u64,
+}
+
+impl Sha256 {
+    fn new() -> Self {
+        Self {
+            state: [
+                0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+                0x5be0cd19,
+            ],
+            buffer: [0; 64],
+            buffered: 0,
+            bit_length: 0,
+        }
+    }
+
+    fn update(&mut self, mut input: &[u8]) {
+        self.bit_length = self
+            .bit_length
+            .wrapping_add((input.len() as u64).wrapping_mul(8));
+        if self.buffered > 0 {
+            let count = (64 - self.buffered).min(input.len());
+            self.buffer[self.buffered..self.buffered + count].copy_from_slice(&input[..count]);
+            self.buffered += count;
+            input = &input[count..];
+            if self.buffered == 64 {
+                let block = self.buffer;
+                self.transform(&block);
+                self.buffered = 0;
+            } else {
+                return;
+            }
+        }
+        while input.len() >= 64 {
+            let block: &[u8; 64] = input[..64].try_into().expect("64-byte SHA-256 block");
+            self.transform(block);
+            input = &input[64..];
+        }
+        self.buffer[..input.len()].copy_from_slice(input);
+        self.buffered = input.len();
+    }
+
+    fn finish(mut self) -> [u8; 32] {
+        self.buffer[self.buffered] = 0x80;
+        self.buffered += 1;
+        if self.buffered > 56 {
+            self.buffer[self.buffered..].fill(0);
+            let block = self.buffer;
+            self.transform(&block);
+            self.buffer = [0; 64];
+        } else {
+            self.buffer[self.buffered..56].fill(0);
+        }
+        self.buffer[56..64].copy_from_slice(&self.bit_length.to_be_bytes());
+        let block = self.buffer;
+        self.transform(&block);
+        let mut output = [0_u8; 32];
+        for (chunk, word) in output.chunks_exact_mut(4).zip(self.state) {
+            chunk.copy_from_slice(&word.to_be_bytes());
+        }
+        output
+    }
+
+    fn transform(&mut self, block: &[u8; 64]) {
+        const K: [u32; 64] = [
+            0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+            0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+            0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+            0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+            0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+            0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+            0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+            0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+            0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+            0xc67178f2,
+        ];
+        let mut schedule = [0_u32; 64];
+        for (index, chunk) in block.chunks_exact(4).enumerate() {
+            schedule[index] = u32::from_be_bytes(chunk.try_into().expect("four-byte word"));
+        }
+        for index in 16..64 {
+            let s0 = schedule[index - 15].rotate_right(7)
+                ^ schedule[index - 15].rotate_right(18)
+                ^ (schedule[index - 15] >> 3);
+            let s1 = schedule[index - 2].rotate_right(17)
+                ^ schedule[index - 2].rotate_right(19)
+                ^ (schedule[index - 2] >> 10);
+            schedule[index] = schedule[index - 16]
+                .wrapping_add(s0)
+                .wrapping_add(schedule[index - 7])
+                .wrapping_add(s1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = self.state;
+        for index in 0..64 {
+            let sum1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let choose = (e & f) ^ ((!e) & g);
+            let temporary1 = h
+                .wrapping_add(sum1)
+                .wrapping_add(choose)
+                .wrapping_add(K[index])
+                .wrapping_add(schedule[index]);
+            let sum0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let majority = (a & b) ^ (a & c) ^ (b & c);
+            let temporary2 = sum0.wrapping_add(majority);
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temporary1);
+            d = c;
+            c = b;
+            b = a;
+            a = temporary1.wrapping_add(temporary2);
+        }
+        for (state, value) in self.state.iter_mut().zip([a, b, c, d, e, f, g, h]) {
+            *state = state.wrapping_add(value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_matches_fips_vector() {
+        assert_eq!(
+            sha256_bytes(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_bytes(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        let mut fragmented = Sha256::new();
+        fragmented.update(b"a");
+        fragmented.update(b"b");
+        fragmented.update(b"c");
+        assert_eq!(
+            hex_digest(fragmented.finish()),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            sha256_bytes(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+        );
+    }
+}

--- a/rust/benchmark-suite/src/runner.rs
+++ b/rust/benchmark-suite/src/runner.rs
@@ -1,0 +1,466 @@
+//! Production all-card/all-allocator benchmark runner.
+
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use serde_json::json;
+
+use crate::config::AllocatorLock;
+use crate::model::{
+    AllocatorIdentity, BenchmarkChildRequest, RawRun, RunnerMetadata, ToolchainMetadata,
+    CHILD_PROTOCOL_VERSION,
+};
+use crate::orchestration::{calibrate_cell, run_balanced_cell, CellRunPlan, ChildProgram};
+use crate::provenance::{sha256_bytes, ProducerProvenance};
+use crate::scenarios::{cards, Topology};
+use crate::{CORE_SUITE_VERSION, RAW_SCHEMA_VERSION};
+
+const FULL_RUNTIME_LIMIT_SECONDS: f64 = 50.0 * 60.0;
+
+#[derive(Debug)]
+struct Options {
+    provenance: PathBuf,
+    output_dir: PathBuf,
+    blocks: u32,
+    run_seed: u64,
+    timeout: Duration,
+    warmup_transactions: u64,
+    initial_transactions: u64,
+    topology: Option<Topology>,
+    reduced_smoke: bool,
+}
+
+pub fn benchmark_run_main() -> Result<(), String> {
+    let options = parse_options(std::env::args_os().skip(1))?;
+    run(options)
+}
+
+fn run(options: Options) -> Result<(), String> {
+    if cfg!(not(target_os = "linux")) {
+        return Err("the four-allocator producer is Linux-only".into());
+    }
+    if options.output_dir.exists() {
+        return Err(format!(
+            "output directory already exists: {}",
+            options.output_dir.display()
+        ));
+    }
+    std::fs::create_dir_all(&options.output_dir)
+        .map_err(|error| format!("create output directory: {error}"))?;
+    let lock =
+        AllocatorLock::parse_and_validate(include_str!("../allocators/allocator-lock.json"))?;
+    let provenance_bytes = std::fs::read(&options.provenance)
+        .map_err(|error| format!("read allocator provenance: {error}"))?;
+    let provenance_text = std::str::from_utf8(&provenance_bytes)
+        .map_err(|error| format!("allocator provenance is not UTF-8: {error}"))?;
+    let provenance = ProducerProvenance::parse_and_validate(provenance_text, &lock)?;
+    provenance.validate_artifact_hashes()?;
+    let provenance_sha256 = sha256_bytes(&provenance_bytes);
+    write_new_bytes(
+        options.output_dir.join("allocator-provenance.json"),
+        &provenance_bytes,
+    )?;
+    let topology = options.topology.map_or_else(detect_topology, Ok)?;
+    topology.validate().map_err(|error| error.to_string())?;
+    let run_kind = if options.reduced_smoke {
+        "reduced-smoke"
+    } else {
+        "headline"
+    };
+    if options.reduced_smoke && options.blocks != 1 {
+        return Err("--reduced-smoke requires --blocks 1".into());
+    }
+    if !options.reduced_smoke && options.blocks < 15 {
+        return Err("headline runs require --blocks at least 15".into());
+    }
+
+    let children = children_from_provenance(&provenance)?;
+    let upstream = children
+        .iter()
+        .find(|child| child.allocator.allocator_id == "upstream-mimalloc")
+        .ok_or_else(|| "provenance is missing upstream-mimalloc".to_string())?;
+    let runner = RunnerMetadata {
+        os: std::env::consts::OS.into(),
+        architecture: std::env::consts::ARCH.into(),
+        physical_cores: topology.physical_cores as u32,
+        logical_cores: topology.logical_cores as u32,
+    };
+
+    let mut sample_output = create_new_writer(options.output_dir.join("raw-samples.jsonl"))?;
+    let mut diagnostic_output = create_new_writer(options.output_dir.join("diagnostics.jsonl"))?;
+    write_json_line(
+        &mut diagnostic_output,
+        &json!({
+            "event": "run-start",
+            "run_kind": run_kind,
+            "run_seed": options.run_seed,
+            "blocks": options.blocks,
+            "runtime_environment": {
+                "MIMALLOC_PROF": "0",
+                "MIMALLOC_MEMORY_EVENTS": "0"
+            }
+        }),
+    )?;
+    let mut all_samples = Vec::new();
+    let runner_started = Instant::now();
+    let mut calibration_wall = Duration::ZERO;
+    let mut block_wall = Duration::ZERO;
+
+    for definition in cards() {
+        for &thread_point in definition.thread_points {
+            let mut request = BenchmarkChildRequest {
+                protocol_version: CHILD_PROTOCOL_VERSION.into(),
+                schema_version: RAW_SCHEMA_VERSION.into(),
+                suite_version: CORE_SUITE_VERSION.into(),
+                run_kind: run_kind.into(),
+                execution_mode: "normal".into(),
+                run_seed: options.run_seed,
+                block_id: 0,
+                ordinal: 0,
+                workload_seed: 0,
+                allocator: upstream.allocator.clone(),
+                scenario_id: definition.id.as_str().into(),
+                scenario_version: CORE_SUITE_VERSION.into(),
+                thread_point: thread_point.name().into(),
+                physical_cores: topology.physical_cores as u32,
+                logical_cores: topology.logical_cores as u32,
+                transactions_per_worker: options.initial_transactions,
+                warmup_transactions_per_worker: options.warmup_transactions,
+                reproduction_command: "calibration placeholder".into(),
+                runner: runner.clone(),
+                toolchain: upstream.toolchain.clone(),
+            };
+            write_json_line(
+                &mut diagnostic_output,
+                &json!({
+                    "event": "cell-calibration-start",
+                    "scenario_id": request.scenario_id,
+                    "thread_point": request.thread_point,
+                }),
+            )?;
+            let calibration_started = Instant::now();
+            let calibration = calibrate_cell(upstream, &request, options.timeout)?;
+            calibration_wall = calibration_wall.saturating_add(calibration_started.elapsed());
+            request.transactions_per_worker = calibration.transactions_per_worker;
+            write_json_line(
+                &mut diagnostic_output,
+                &json!({
+                    "event": "cell-calibrated",
+                    "scenario_id": request.scenario_id,
+                    "thread_point": request.thread_point,
+                    "transactions_per_worker": calibration.transactions_per_worker,
+                    "operation_count": calibration.operation_count,
+                    "elapsed_ns": calibration.elapsed_ns,
+                }),
+            )?;
+            let request_directory = options.output_dir.join("requests");
+            let plan = CellRunPlan {
+                request_template: request,
+                children: children.clone(),
+                blocks: options.blocks,
+                timeout: options.timeout,
+                request_directory: Some(request_directory),
+            };
+            let block_started = Instant::now();
+            let raw_cell =
+                run_balanced_cell(&plan, |sample| write_json_line(&mut sample_output, sample))?;
+            block_wall = block_wall.saturating_add(block_started.elapsed());
+            write_json_line(
+                &mut diagnostic_output,
+                &json!({
+                    "event": "cell-complete",
+                    "scenario_id": definition.id.as_str(),
+                    "thread_point": thread_point.name(),
+                    "samples": raw_cell.samples.len(),
+                }),
+            )?;
+            all_samples.extend(raw_cell.samples);
+        }
+    }
+
+    let raw_run = RawRun {
+        schema_version: RAW_SCHEMA_VERSION.into(),
+        suite_version: CORE_SUITE_VERSION.into(),
+        run_kind: run_kind.into(),
+        execution_mode: "normal".into(),
+        run_seed: options.run_seed,
+        samples: all_samples,
+    };
+    let measured_seconds = raw_run
+        .samples
+        .iter()
+        .map(|sample| {
+            (sample.setup_ns + sample.warmup_ns + sample.elapsed_ns + sample.teardown_ns) as f64
+                / 1_000_000_000.0
+        })
+        .sum::<f64>();
+    write_new_json(options.output_dir.join("raw-run.json"), &raw_run)?;
+    write_new_json(
+        options.output_dir.join("run-provenance.json"),
+        &json!({
+            "run_kind": run_kind,
+            "headline_eligible": !options.reduced_smoke,
+            "runtime_environment": {
+                "MIMALLOC_PROF": "0",
+                "MIMALLOC_MEMORY_EVENTS": "0"
+            },
+            "allocator_provenance_file": "allocator-provenance.json",
+            "allocator_provenance_sha256": provenance_sha256,
+        }),
+    )?;
+    let observed_runner_wall = runner_started.elapsed();
+    let fixed_wall = observed_runner_wall.saturating_sub(calibration_wall + block_wall);
+    let native_build_seconds = provenance.build_elapsed_seconds;
+    // One second conservatively covers the final projection-file write and
+    // process shutdown, which occur after this observation is captured.
+    let fixed_projection_seconds = fixed_wall.as_secs_f64() + 1.0;
+    let projected_full_seconds = native_build_seconds
+        + calibration_wall.as_secs_f64()
+        + block_wall.as_secs_f64() * 15.0 / f64::from(options.blocks)
+        + fixed_projection_seconds;
+    if !projected_full_seconds.is_finite() {
+        return Err("runtime projection is non-finite".into());
+    }
+    write_new_json(
+        options.output_dir.join("runtime-projection.json"),
+        &json!({
+            "observed_blocks": options.blocks,
+            "child_reported_observed_seconds": measured_seconds,
+            "observed_runner_wall_seconds": observed_runner_wall.as_secs_f64(),
+            "observed_calibration_wall_seconds": calibration_wall.as_secs_f64(),
+            "observed_block_wall_seconds": block_wall.as_secs_f64(),
+            "observed_fixed_wall_seconds": fixed_wall.as_secs_f64(),
+            "native_build_elapsed_seconds": provenance.build_elapsed_seconds,
+            "projected_calibration_seconds": calibration_wall.as_secs_f64(),
+            "projected_block_seconds": block_wall.as_secs_f64() * 15.0 / f64::from(options.blocks),
+            "projected_fixed_seconds": fixed_projection_seconds,
+            "projected_headline_blocks": 15,
+            "projected_full_suite_seconds": projected_full_seconds,
+            "hard_limit_seconds": FULL_RUNTIME_LIMIT_SECONDS,
+            "fits_limit": projected_full_seconds <= FULL_RUNTIME_LIMIT_SECONDS,
+        }),
+    )?;
+    if projected_full_seconds > FULL_RUNTIME_LIMIT_SECONDS {
+        return Err(format!(
+            "projected full suite runtime {:.1}s exceeds the 3000s hard limit",
+            projected_full_seconds
+        ));
+    }
+    println!(
+        "PASS {} cells, {} samples; projected full runtime {:.1}s",
+        cards()
+            .iter()
+            .map(|card| card.thread_points.len())
+            .sum::<usize>(),
+        raw_run.samples.len(),
+        projected_full_seconds
+    );
+    Ok(())
+}
+
+fn children_from_provenance(provenance: &ProducerProvenance) -> Result<Vec<ChildProgram>, String> {
+    provenance
+        .allocators
+        .iter()
+        .map(|item| {
+            let path = PathBuf::from(&item.child_binary);
+            if !path.is_file() {
+                return Err(format!(
+                    "allocator child does not exist: {}",
+                    path.display()
+                ));
+            }
+            Ok(ChildProgram {
+                allocator: AllocatorIdentity {
+                    allocator_id: item.allocator_id.clone(),
+                    allocator_version: item.allocator_version.clone(),
+                    source_sha: item.source_sha.clone(),
+                    library_sha256: item.static_library_sha256.clone(),
+                    child_binary_sha256: item.child_binary_sha256.clone(),
+                },
+                program: path,
+                arguments: Vec::new(),
+                toolchain: ToolchainMetadata {
+                    rustc: rustc_version(),
+                    target: "x86_64-unknown-linux-gnu".into(),
+                    compiler: item.toolchain.compiler.clone(),
+                    linker: item.toolchain.linker.clone(),
+                },
+                environment: Vec::new(),
+            })
+        })
+        .collect()
+}
+
+fn detect_topology() -> Result<Topology, String> {
+    let logical = std::thread::available_parallelism()
+        .map_err(|error| format!("detect logical CPU count: {error}"))?
+        .get();
+    let cpu_root = Path::new("/sys/devices/system/cpu");
+    let mut physical = BTreeSet::new();
+    for entry in
+        std::fs::read_dir(cpu_root).map_err(|error| format!("read Linux CPU topology: {error}"))?
+    {
+        let entry = entry.map_err(|error| format!("read Linux CPU topology entry: {error}"))?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name
+            .strip_prefix("cpu")
+            .is_some_and(|suffix| !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit()))
+        {
+            continue;
+        }
+        let topology = entry.path().join("topology");
+        let package = std::fs::read_to_string(topology.join("physical_package_id"))
+            .map_err(|error| format!("read physical package ID: {error}"))?;
+        let core = std::fs::read_to_string(topology.join("core_id"))
+            .map_err(|error| format!("read physical core ID: {error}"))?;
+        physical.insert((package.trim().to_owned(), core.trim().to_owned()));
+    }
+    if physical.is_empty() {
+        return Err(
+            "Linux physical-core topology unavailable; pass --physical-cores and --logical-cores"
+                .into(),
+        );
+    }
+    Ok(Topology {
+        physical_cores: physical.len(),
+        logical_cores: logical,
+    })
+}
+
+fn rustc_version() -> String {
+    std::process::Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|value| value.trim().to_owned())
+        .unwrap_or_else(|| "rustc-version-unavailable".into())
+}
+
+fn create_new_writer(path: PathBuf) -> Result<BufWriter<File>, String> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map(BufWriter::new)
+        .map_err(|error| format!("create {}: {error}", path.display()))
+}
+
+fn write_json_line<T: Serialize>(writer: &mut BufWriter<File>, value: &T) -> Result<(), String> {
+    serde_json::to_writer(&mut *writer, value)
+        .map_err(|error| format!("serialize JSONL record: {error}"))?;
+    writer
+        .write_all(b"\n")
+        .and_then(|()| writer.flush())
+        .map_err(|error| format!("append JSONL record: {error}"))
+}
+
+fn write_new_json<T: Serialize>(path: PathBuf, value: &T) -> Result<(), String> {
+    let mut writer = create_new_writer(path)?;
+    serde_json::to_writer_pretty(&mut writer, value)
+        .map_err(|error| format!("serialize JSON artifact: {error}"))?;
+    writer
+        .write_all(b"\n")
+        .and_then(|()| writer.flush())
+        .map_err(|error| format!("finish JSON artifact: {error}"))
+}
+
+fn write_new_bytes(path: PathBuf, value: &[u8]) -> Result<(), String> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(|error| format!("create {}: {error}", path.display()))?;
+    file.write_all(value)
+        .and_then(|()| file.flush())
+        .map_err(|error| format!("write {}: {error}", path.display()))
+}
+
+fn parse_options(arguments: impl Iterator<Item = OsString>) -> Result<Options, String> {
+    let arguments = arguments
+        .map(|value| {
+            value
+                .into_string()
+                .map_err(|_| "runner arguments must be UTF-8".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut provenance = None;
+    let mut build_root = None;
+    let mut output_dir = None;
+    let mut blocks = 15;
+    let mut run_seed = 0x6d69_6d61_6c6c_6f63;
+    let mut timeout_secs = 60;
+    let mut warmup_transactions = 1;
+    let mut initial_transactions = 1;
+    let mut physical_cores = None;
+    let mut logical_cores = None;
+    let mut reduced_smoke = false;
+    let mut index = 0;
+    while index < arguments.len() {
+        let flag = &arguments[index];
+        if flag == "--reduced-smoke" {
+            reduced_smoke = true;
+            index += 1;
+            continue;
+        }
+        let value = arguments
+            .get(index + 1)
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--provenance" => provenance = Some(PathBuf::from(value)),
+            "--build-root" => build_root = Some(PathBuf::from(value)),
+            "--output-dir" => output_dir = Some(PathBuf::from(value)),
+            "--blocks" => blocks = parse_number(flag, value)?,
+            "--run-seed" => run_seed = parse_number(flag, value)?,
+            "--timeout-secs" => timeout_secs = parse_number(flag, value)?,
+            "--warmup-transactions" => warmup_transactions = parse_number(flag, value)?,
+            "--initial-transactions" => initial_transactions = parse_number(flag, value)?,
+            "--physical-cores" => physical_cores = Some(parse_number(flag, value)?),
+            "--logical-cores" => logical_cores = Some(parse_number(flag, value)?),
+            _ => return Err(format!("unknown argument {flag}")),
+        }
+        index += 2;
+    }
+    if blocks == 0 || timeout_secs == 0 || initial_transactions == 0 {
+        return Err("blocks, timeout, and initial transactions must be nonzero".into());
+    }
+    let topology = match (physical_cores, logical_cores) {
+        (None, None) => None,
+        (Some(physical_cores), Some(logical_cores)) => Some(Topology {
+            physical_cores,
+            logical_cores,
+        }),
+        _ => return Err("physical and logical core overrides must be supplied together".into()),
+    };
+    if provenance.is_some() && build_root.is_some() {
+        return Err("pass either --provenance or --build-root, not both".into());
+    }
+    let provenance = provenance
+        .or_else(|| build_root.map(|root| root.join("allocator-provenance.json")))
+        .ok_or("--provenance or --build-root is required")?;
+    Ok(Options {
+        provenance,
+        output_dir: output_dir.ok_or("--output-dir is required")?,
+        blocks,
+        run_seed,
+        timeout: Duration::from_secs(timeout_secs),
+        warmup_transactions,
+        initial_transactions,
+        topology,
+        reduced_smoke,
+    })
+}
+
+fn parse_number<T: std::str::FromStr>(flag: &str, value: &str) -> Result<T, String> {
+    value
+        .parse()
+        .map_err(|_| format!("invalid numeric value for {flag}: {value}"))
+}

--- a/rust/benchmark-suite/src/scenarios.rs
+++ b/rust/benchmark-suite/src/scenarios.rs
@@ -1,0 +1,1608 @@
+//! The fixed `core-throughput-v1` workload catalogue.
+//!
+//! This module deliberately contains no allocator calls.  It is the common,
+//! deterministic request producer used by every directly-linked child, so an
+//! allocator cannot influence the next requested operation, its touch value,
+//! or the checksum used to validate the sample.
+
+use std::fmt;
+
+/// The version is part of every raw record.  Changing a card's semantics,
+/// membership, or its declared thread points requires a new suite version.
+pub const CORE_THROUGHPUT_V1: &str = "core-throughput-v1";
+
+const BATCH_WIDTH: u32 = 16;
+const SAWTOOTH_WIDTH: u32 = 12;
+const REALLOC_STEPS: u32 = 6;
+const CHURN_GENERATIONS: u32 = 8;
+/// The largest declared transaction is a 16-item batch: alloc + touch + free.
+/// Executors allocate this buffer before the start gate and reuse it forever.
+pub const MAX_REQUESTS_PER_TRANSACTION: usize = 3 * BATCH_WIDTH as usize;
+/// Request entropy repeats on this checked-in cycle. Besides making long
+/// calibrations reproducible, this lets the controller derive data-dependent
+/// touch checksums without regenerating millions of transactions.
+pub const REQUEST_CYCLE_OPERATIONS: u64 = 20;
+
+/// A declared point, before it is expanded using runner topology.  Keeping
+/// these symbolic is important: a machine with 12 physical cores must not
+/// silently turn a "physical-core" card into a generic 12-thread Cartesian
+/// product.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum ThreadPoint {
+    One,
+    Two,
+    PhysicalCores,
+    TwiceLogicalCores,
+}
+
+impl ThreadPoint {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::One => "1",
+            Self::Two => "2",
+            Self::PhysicalCores => "physical-core",
+            Self::TwiceLogicalCores => "2x-logical",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "1" => Some(Self::One),
+            "2" => Some(Self::Two),
+            "physical-core" => Some(Self::PhysicalCores),
+            "2x-logical" => Some(Self::TwiceLogicalCores),
+            _ => None,
+        }
+    }
+}
+
+/// Runner topology needed to resolve symbolic thread points.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Topology {
+    pub physical_cores: usize,
+    pub logical_cores: usize,
+}
+
+impl Topology {
+    pub fn validate(self) -> Result<(), ScenarioError> {
+        if self.physical_cores == 0 || self.logical_cores == 0 {
+            return Err(ScenarioError::InvalidTopology(
+                "physical and logical core counts must both be non-zero",
+            ));
+        }
+        if self.physical_cores > self.logical_cores {
+            return Err(ScenarioError::InvalidTopology(
+                "physical core count cannot exceed logical core count",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn resolve(self, point: ThreadPoint) -> Result<usize, ScenarioError> {
+        self.validate()?;
+        match point {
+            ThreadPoint::One => Ok(1),
+            ThreadPoint::Two => {
+                if self.logical_cores < 2 {
+                    Err(ScenarioError::InvalidExpansion {
+                        point,
+                        threads: 2,
+                        logical_cores: self.logical_cores,
+                    })
+                } else {
+                    Ok(2)
+                }
+            }
+            ThreadPoint::PhysicalCores => Ok(self.physical_cores),
+            ThreadPoint::TwiceLogicalCores => self
+                .logical_cores
+                .checked_mul(2)
+                .ok_or(ScenarioError::ThreadCountOverflow),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ScenarioError {
+    UnknownCard,
+    UnsupportedThreadPoint {
+        card: &'static str,
+        point: ThreadPoint,
+    },
+    InvalidTopology(&'static str),
+    InvalidExpansion {
+        point: ThreadPoint,
+        threads: usize,
+        logical_cores: usize,
+    },
+    ThreadCountOverflow,
+    CountOverflow,
+    ZeroTransactions,
+    WorkerOutOfRange {
+        worker: usize,
+        threads: usize,
+    },
+    TransactionOutOfRange {
+        operation: u64,
+        transactions: u64,
+    },
+}
+
+impl fmt::Display for ScenarioError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownCard => write!(f, "unknown core-throughput-v1 scenario card"),
+            Self::UnsupportedThreadPoint { card, point } => {
+                write!(f, "thread point {} is not declared by {card}", point.name())
+            }
+            Self::InvalidTopology(reason) => write!(f, "invalid CPU topology: {reason}"),
+            Self::InvalidExpansion {
+                point,
+                threads,
+                logical_cores,
+            } => write!(
+                f,
+                "cannot expand {} to {threads} threads on {logical_cores} logical cores",
+                point.name()
+            ),
+            Self::ThreadCountOverflow => write!(f, "thread count expansion overflowed"),
+            Self::CountOverflow => write!(f, "scenario transaction or token count overflowed"),
+            Self::ZeroTransactions => write!(f, "a scenario cell needs at least one transaction"),
+            Self::WorkerOutOfRange { worker, threads } => {
+                write!(f, "worker {worker} is outside a {threads}-worker cell")
+            }
+            Self::TransactionOutOfRange {
+                operation,
+                transactions,
+            } => write!(
+                f,
+                "operation {operation} is outside a {transactions}-transaction worker stream"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ScenarioError {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OperationUnit {
+    Transaction,
+    Batch,
+    WorkerGeneration,
+    MixedTransaction,
+}
+
+impl OperationUnit {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Transaction => "transaction",
+            Self::Batch => "batch",
+            Self::WorkerGeneration => "worker-generation",
+            Self::MixedTransaction => "mixed-transaction",
+        }
+    }
+}
+
+/// Requested-byte distributions. These are independent of allocator usable
+/// size and make the workload contract inspectable without parsing its name.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SizeDistribution {
+    Fixed(usize),
+    LogParetoLike {
+        min: usize,
+        max: usize,
+    },
+    AlignedRange {
+        min_alignment: usize,
+        max_alignment: usize,
+    },
+    RepresentativeWeightedMix,
+    WorkerGenerationMix,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LifetimeRule {
+    ImmediateFree,
+    BatchLifo,
+    BatchFifo,
+    CrossThreadProducerConsumer,
+    OwnerPermutation,
+    GeometricRealloc,
+    RetainThenDrain,
+    NativeWorkerGenerations,
+    WeightedMix,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TouchRule {
+    DeterministicBytePattern,
+    PagePattern,
+    ZeroThenBytePattern,
+    AlignedAddressAndPattern,
+    PreserveThenBytePattern,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ScenarioInvariant {
+    AllocTouchFree,
+    FreeOrderIsLifo,
+    FreeOrderIsFifo,
+    FreeIsRemote,
+    OwnershipIsPermutation,
+    ReallocPreservesPrefix,
+    CallocIsZero,
+    AddressHonorsAlignment,
+    RetainedSubsetDrains,
+    GenerationCompletionExact,
+    WeightedActionMix,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CardId {
+    TinyFixed16,
+    TinyFixed64,
+    SmallLogMixed,
+    MediumLogMixed,
+    LargeObjects,
+    BatchLifo,
+    BatchFifo,
+    CrossThreadProducerConsumer,
+    RandomOwnership,
+    ReallocGeometric,
+    CallocZero,
+    AlignedRange,
+    SawtoothRetainDrain,
+    ThreadChurn,
+    RepresentativeMix,
+}
+
+impl CardId {
+    pub const ALL: [Self; 15] = [
+        Self::TinyFixed16,
+        Self::TinyFixed64,
+        Self::SmallLogMixed,
+        Self::MediumLogMixed,
+        Self::LargeObjects,
+        Self::BatchLifo,
+        Self::BatchFifo,
+        Self::CrossThreadProducerConsumer,
+        Self::RandomOwnership,
+        Self::ReallocGeometric,
+        Self::CallocZero,
+        Self::AlignedRange,
+        Self::SawtoothRetainDrain,
+        Self::ThreadChurn,
+        Self::RepresentativeMix,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TinyFixed16 => "tiny-fixed-16",
+            Self::TinyFixed64 => "tiny-fixed-64",
+            Self::SmallLogMixed => "small-log-mixed",
+            Self::MediumLogMixed => "medium-log-mixed",
+            Self::LargeObjects => "large-objects",
+            Self::BatchLifo => "batch-lifo",
+            Self::BatchFifo => "batch-fifo",
+            Self::CrossThreadProducerConsumer => "cross-thread-producer-consumer",
+            Self::RandomOwnership => "random-ownership",
+            Self::ReallocGeometric => "realloc-geometric",
+            Self::CallocZero => "calloc-zero",
+            Self::AlignedRange => "aligned-range",
+            Self::SawtoothRetainDrain => "sawtooth-retain-drain",
+            Self::ThreadChurn => "thread-churn",
+            Self::RepresentativeMix => "representative-mix",
+        }
+    }
+
+    pub fn parse(id: &str) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|candidate| candidate.as_str() == id)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ScenarioCard {
+    pub id: CardId,
+    pub operation_unit: OperationUnit,
+    pub thread_points: &'static [ThreadPoint],
+    pub description: &'static str,
+}
+
+impl ScenarioCard {
+    pub fn operation_count(self, counts: &ExpectedCounts) -> u64 {
+        match self.operation_unit {
+            OperationUnit::WorkerGeneration => counts.worker_generations,
+            OperationUnit::Transaction | OperationUnit::Batch | OperationUnit::MixedTransaction => {
+                counts.requested_transactions
+            }
+        }
+    }
+
+    pub const fn max_live_allocations_per_worker(self) -> usize {
+        match self.id {
+            CardId::BatchLifo | CardId::BatchFifo | CardId::RepresentativeMix => {
+                BATCH_WIDTH as usize
+            }
+            CardId::SawtoothRetainDrain => SAWTOOTH_WIDTH as usize,
+            _ => 1,
+        }
+    }
+
+    pub const fn size_distribution(self) -> SizeDistribution {
+        match self.id {
+            CardId::TinyFixed16 => SizeDistribution::Fixed(16),
+            CardId::TinyFixed64 => SizeDistribution::Fixed(64),
+            CardId::SmallLogMixed => SizeDistribution::LogParetoLike { min: 8, max: 1024 },
+            CardId::MediumLogMixed | CardId::SawtoothRetainDrain => {
+                SizeDistribution::LogParetoLike {
+                    min: 4 * 1024,
+                    max: 64 * 1024,
+                }
+            }
+            CardId::LargeObjects => SizeDistribution::LogParetoLike {
+                min: 1024 * 1024,
+                max: 16 * 1024 * 1024,
+            },
+            CardId::BatchLifo
+            | CardId::BatchFifo
+            | CardId::CrossThreadProducerConsumer
+            | CardId::RandomOwnership
+            | CardId::CallocZero => SizeDistribution::LogParetoLike { min: 8, max: 1024 },
+            CardId::ReallocGeometric => SizeDistribution::LogParetoLike { min: 16, max: 8192 },
+            CardId::AlignedRange => SizeDistribution::AlignedRange {
+                min_alignment: 16,
+                max_alignment: 4096,
+            },
+            CardId::ThreadChurn => SizeDistribution::WorkerGenerationMix,
+            CardId::RepresentativeMix => SizeDistribution::RepresentativeWeightedMix,
+        }
+    }
+
+    pub const fn lifetime(self) -> LifetimeRule {
+        match self.id {
+            CardId::TinyFixed16
+            | CardId::TinyFixed64
+            | CardId::SmallLogMixed
+            | CardId::MediumLogMixed
+            | CardId::LargeObjects
+            | CardId::CallocZero
+            | CardId::AlignedRange => LifetimeRule::ImmediateFree,
+            CardId::BatchLifo => LifetimeRule::BatchLifo,
+            CardId::BatchFifo => LifetimeRule::BatchFifo,
+            CardId::CrossThreadProducerConsumer => LifetimeRule::CrossThreadProducerConsumer,
+            CardId::RandomOwnership => LifetimeRule::OwnerPermutation,
+            CardId::ReallocGeometric => LifetimeRule::GeometricRealloc,
+            CardId::SawtoothRetainDrain => LifetimeRule::RetainThenDrain,
+            CardId::ThreadChurn => LifetimeRule::NativeWorkerGenerations,
+            CardId::RepresentativeMix => LifetimeRule::WeightedMix,
+        }
+    }
+
+    pub const fn touch_rule(self) -> TouchRule {
+        match self.id {
+            CardId::LargeObjects => TouchRule::PagePattern,
+            CardId::CallocZero => TouchRule::ZeroThenBytePattern,
+            CardId::AlignedRange => TouchRule::AlignedAddressAndPattern,
+            CardId::ReallocGeometric => TouchRule::PreserveThenBytePattern,
+            _ => TouchRule::DeterministicBytePattern,
+        }
+    }
+
+    pub const fn invariant(self) -> ScenarioInvariant {
+        match self.id {
+            CardId::TinyFixed16
+            | CardId::TinyFixed64
+            | CardId::SmallLogMixed
+            | CardId::MediumLogMixed
+            | CardId::LargeObjects => ScenarioInvariant::AllocTouchFree,
+            CardId::BatchLifo => ScenarioInvariant::FreeOrderIsLifo,
+            CardId::BatchFifo => ScenarioInvariant::FreeOrderIsFifo,
+            CardId::CrossThreadProducerConsumer => ScenarioInvariant::FreeIsRemote,
+            CardId::RandomOwnership => ScenarioInvariant::OwnershipIsPermutation,
+            CardId::ReallocGeometric => ScenarioInvariant::ReallocPreservesPrefix,
+            CardId::CallocZero => ScenarioInvariant::CallocIsZero,
+            CardId::AlignedRange => ScenarioInvariant::AddressHonorsAlignment,
+            CardId::SawtoothRetainDrain => ScenarioInvariant::RetainedSubsetDrains,
+            CardId::ThreadChurn => ScenarioInvariant::GenerationCompletionExact,
+            CardId::RepresentativeMix => ScenarioInvariant::WeightedActionMix,
+        }
+    }
+}
+
+const ONE_AND_PHYSICAL: &[ThreadPoint] = &[ThreadPoint::One, ThreadPoint::PhysicalCores];
+const ONE_PHYSICAL_TWICE_LOGICAL: &[ThreadPoint] = &[
+    ThreadPoint::One,
+    ThreadPoint::PhysicalCores,
+    ThreadPoint::TwiceLogicalCores,
+];
+const ONE_AND_TWO: &[ThreadPoint] = &[ThreadPoint::One, ThreadPoint::Two];
+const TWO_AND_PHYSICAL: &[ThreadPoint] = &[ThreadPoint::Two, ThreadPoint::PhysicalCores];
+const PHYSICAL_ONLY: &[ThreadPoint] = &[ThreadPoint::PhysicalCores];
+
+const CARDS: [ScenarioCard; 15] = [
+    ScenarioCard {
+        id: CardId::TinyFixed16,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "fixed 16 B alloc, touch, and free",
+    },
+    ScenarioCard {
+        id: CardId::TinyFixed64,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "fixed 64 B alloc, touch, and free",
+    },
+    ScenarioCard {
+        id: CardId::SmallLogMixed,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: ONE_PHYSICAL_TWICE_LOGICAL,
+        description: "deterministic log/Pareto-like 8-1024 B requests",
+    },
+    ScenarioCard {
+        id: CardId::MediumLogMixed,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "deterministic 4-64 KiB requests",
+    },
+    ScenarioCard {
+        id: CardId::LargeObjects,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: ONE_AND_TWO,
+        description: "deterministic 1-16 MiB requests with page touching",
+    },
+    ScenarioCard {
+        id: CardId::BatchLifo,
+        operation_unit: OperationUnit::Batch,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "allocate a batch then free it in reverse order",
+    },
+    ScenarioCard {
+        id: CardId::BatchFifo,
+        operation_unit: OperationUnit::Batch,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "allocate a batch then free it in insertion order",
+    },
+    ScenarioCard {
+        id: CardId::CrossThreadProducerConsumer,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: TWO_AND_PHYSICAL,
+        description: "distinct producer and consumer ownership",
+    },
+    ScenarioCard {
+        id: CardId::RandomOwnership,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: PHYSICAL_ONLY,
+        description: "deterministic ownership permutation",
+    },
+    ScenarioCard {
+        id: CardId::ReallocGeometric,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "geometric grow and shrink with preservation checks",
+    },
+    ScenarioCard {
+        id: CardId::CallocZero,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "calloc zero verification followed by touch",
+    },
+    ScenarioCard {
+        id: CardId::AlignedRange,
+        operation_unit: OperationUnit::Transaction,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "16-4096 B alignment with address and content checks",
+    },
+    ScenarioCard {
+        id: CardId::SawtoothRetainDrain,
+        operation_unit: OperationUnit::Batch,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "burst, deterministic retention, and drain",
+    },
+    ScenarioCard {
+        id: CardId::ThreadChurn,
+        operation_unit: OperationUnit::WorkerGeneration,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "repeated native worker generations",
+    },
+    ScenarioCard {
+        id: CardId::RepresentativeMix,
+        operation_unit: OperationUnit::MixedTransaction,
+        thread_points: ONE_AND_PHYSICAL,
+        description: "checked-in weighted small/medium/realloc/batch mix",
+    },
+];
+
+pub const fn cards() -> &'static [ScenarioCard; 15] {
+    &CARDS
+}
+
+/// Compatibility name used by the phase runner; the catalogue is intentionally
+/// the fixed core suite rather than a parameter-generated scenario matrix.
+pub const fn core_scenarios() -> &'static [ScenarioCard; 15] {
+    cards()
+}
+
+pub fn card(id: CardId) -> &'static ScenarioCard {
+    // `CardId::ALL` and CARDS intentionally have matching stable order.
+    &CARDS[id as usize]
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RequestKind {
+    Alloc,
+    Calloc,
+    Realloc,
+    AlignedAlloc,
+    Free,
+    /// Checks that a calloc result is all zero before it is touched.
+    VerifyZero,
+    /// Writes and reads a deterministic byte pattern, contributing to checksum.
+    Touch,
+    /// Separates native worker generations in the churn scenario.
+    WorkerGeneration,
+}
+
+/// A single executor request. `phase` is a deterministic barrier number: all
+/// phase N allocation actions must finish before their phase N+1 frees are
+/// attempted.  This is what makes cross-thread ownership executable rather
+/// than merely a label in a result row.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Request {
+    pub kind: RequestKind,
+    pub phase: u32,
+    pub transaction: u64,
+    pub token: u64,
+    pub owner_worker: usize,
+    pub executor_worker: usize,
+    pub size: usize,
+    pub alignment: usize,
+    pub touch: u64,
+    pub preserve_bytes: usize,
+}
+
+impl Request {
+    const fn alloc(
+        phase: u32,
+        transaction: u64,
+        token: u64,
+        owner_worker: usize,
+        executor_worker: usize,
+        size: usize,
+        touch: u64,
+    ) -> Self {
+        Self {
+            kind: RequestKind::Alloc,
+            phase,
+            transaction,
+            token,
+            owner_worker,
+            executor_worker,
+            size,
+            alignment: 0,
+            touch,
+            preserve_bytes: 0,
+        }
+    }
+
+    const fn calloc(transaction: u64, token: u64, worker: usize, size: usize, touch: u64) -> Self {
+        Self {
+            kind: RequestKind::Calloc,
+            phase: 0,
+            transaction,
+            token,
+            owner_worker: worker,
+            executor_worker: worker,
+            size,
+            alignment: 0,
+            touch,
+            preserve_bytes: 0,
+        }
+    }
+
+    const fn free(
+        phase: u32,
+        transaction: u64,
+        token: u64,
+        owner_worker: usize,
+        executor_worker: usize,
+    ) -> Self {
+        Self {
+            kind: RequestKind::Free,
+            phase,
+            transaction,
+            token,
+            owner_worker,
+            executor_worker,
+            size: 0,
+            alignment: 0,
+            touch: 0,
+            preserve_bytes: 0,
+        }
+    }
+
+    const fn touch(
+        phase: u32,
+        transaction: u64,
+        token: u64,
+        worker: usize,
+        size: usize,
+        touch: u64,
+    ) -> Self {
+        Self {
+            kind: RequestKind::Touch,
+            phase,
+            transaction,
+            token,
+            owner_worker: worker,
+            executor_worker: worker,
+            size,
+            alignment: 0,
+            touch,
+            preserve_bytes: 0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkerStream {
+    pub worker: usize,
+    pub requests: Vec<Request>,
+    pub checksum: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ExpectedCounts {
+    pub requested_transactions: u64,
+    /// Completion count required for a valid sample. A partial execution must
+    /// not be representable as a valid cell result.
+    pub completed_transactions: u64,
+    pub allocator_calls: u64,
+    pub alloc_calls: u64,
+    pub calloc_calls: u64,
+    pub realloc_calls: u64,
+    pub aligned_alloc_calls: u64,
+    pub free_calls: u64,
+    pub touches: u64,
+    pub worker_generations: u64,
+}
+
+impl ExpectedCounts {
+    pub fn record(&mut self, request: &Request) {
+        match request.kind {
+            RequestKind::Alloc => {
+                self.allocator_calls += 1;
+                self.alloc_calls += 1;
+            }
+            RequestKind::Calloc => {
+                self.allocator_calls += 1;
+                self.calloc_calls += 1;
+            }
+            RequestKind::Realloc => {
+                self.allocator_calls += 1;
+                self.realloc_calls += 1;
+            }
+            RequestKind::AlignedAlloc => {
+                self.allocator_calls += 1;
+                self.aligned_alloc_calls += 1;
+            }
+            RequestKind::Free => {
+                self.allocator_calls += 1;
+                self.free_calls += 1;
+            }
+            RequestKind::Touch => self.touches += 1,
+            RequestKind::WorkerGeneration => self.worker_generations += 1,
+            RequestKind::VerifyZero => {}
+        }
+    }
+}
+
+/// A resolved cell. `transactions_per_worker` is deliberately explicit so the
+/// runner can freeze a calibrated count and replay it unchanged for all four
+/// allocators in a paired block.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScenarioCell {
+    pub suite_version: &'static str,
+    pub card: CardId,
+    pub thread_point: ThreadPoint,
+    pub threads: usize,
+    pub seed: u64,
+    pub transactions_per_worker: u64,
+}
+
+impl ScenarioCell {
+    pub fn new(
+        card_id: CardId,
+        thread_point: ThreadPoint,
+        topology: Topology,
+        transactions_per_worker: u64,
+        seed: u64,
+    ) -> Result<Self, ScenarioError> {
+        if transactions_per_worker == 0 {
+            return Err(ScenarioError::ZeroTransactions);
+        }
+        let definition = card(card_id);
+        if !definition.thread_points.contains(&thread_point) {
+            return Err(ScenarioError::UnsupportedThreadPoint {
+                card: card_id.as_str(),
+                point: thread_point,
+            });
+        }
+        let threads = topology.resolve(thread_point)?;
+        let total_transactions = transactions_per_worker
+            .checked_mul(threads as u64)
+            .ok_or(ScenarioError::CountOverflow)?;
+        total_transactions
+            .checked_mul(64)
+            .and_then(|value| value.checked_add(64))
+            .ok_or(ScenarioError::CountOverflow)?;
+        // The two cross-worker cards would otherwise be falsely labelled on a
+        // one-core machine whose physical point resolves to one worker.
+        if matches!(
+            card_id,
+            CardId::CrossThreadProducerConsumer | CardId::RandomOwnership
+        ) && threads < 2
+        {
+            return Err(ScenarioError::InvalidExpansion {
+                point: thread_point,
+                threads,
+                logical_cores: topology.logical_cores,
+            });
+        }
+        Ok(Self {
+            suite_version: CORE_THROUGHPUT_V1,
+            card: card_id,
+            thread_point,
+            threads,
+            seed,
+            transactions_per_worker,
+        })
+    }
+
+    pub fn requested_transactions(&self) -> u64 {
+        self.transactions_per_worker * self.threads as u64
+    }
+
+    /// Generate one transaction into a caller-owned fixed-capacity buffer.
+    /// This is the production execution path; `worker_stream` remains a small
+    /// test/inspection convenience and is never used by the benchmark child.
+    pub fn fill_worker_transaction(
+        &self,
+        worker: usize,
+        operation: u64,
+        requests: &mut Vec<Request>,
+    ) -> Result<(), ScenarioError> {
+        if worker >= self.threads {
+            return Err(ScenarioError::WorkerOutOfRange {
+                worker,
+                threads: self.threads,
+            });
+        }
+        if operation >= self.transactions_per_worker {
+            return Err(ScenarioError::TransactionOutOfRange {
+                operation,
+                transactions: self.transactions_per_worker,
+            });
+        }
+        requests.clear();
+        let mut checksum = None;
+        let transaction = worker as u64 * self.transactions_per_worker + operation;
+        let cycle_operation = operation % REQUEST_CYCLE_OPERATIONS;
+        self.append_transaction(
+            worker,
+            cycle_operation,
+            transaction,
+            requests,
+            &mut checksum,
+        );
+        debug_assert!(requests.len() <= MAX_REQUESTS_PER_TRANSACTION);
+        Ok(())
+    }
+
+    pub fn worker_stream(&self, worker: usize) -> Result<WorkerStream, ScenarioError> {
+        if worker >= self.threads {
+            return Err(ScenarioError::WorkerOutOfRange {
+                worker,
+                threads: self.threads,
+            });
+        }
+        let mut requests = Vec::new();
+        let mut checksum = FNV_OFFSET;
+        let mut checksum_sink = Some(&mut checksum);
+        for operation in 0..self.transactions_per_worker {
+            let transaction = (worker as u64) * self.transactions_per_worker + operation;
+            self.append_transaction(
+                worker,
+                operation % REQUEST_CYCLE_OPERATIONS,
+                transaction,
+                &mut requests,
+                &mut checksum_sink,
+            );
+        }
+        Ok(WorkerStream {
+            worker,
+            requests,
+            checksum,
+        })
+    }
+
+    pub fn streams(&self) -> Result<Vec<WorkerStream>, ScenarioError> {
+        (0..self.threads)
+            .map(|worker| self.worker_stream(worker))
+            .collect()
+    }
+
+    /// Requests actually performed by one native worker, ordered first by the
+    /// per-worker operation ordinal and then by barrier phase. For ordinary
+    /// cards the executor uses the owner stream directly; cross-thread cards
+    /// use this view to interleave one local allocation and one remote free per
+    /// operation without stretching lifetimes across the full sample.
+    pub fn executor_stream(&self, worker: usize) -> Result<WorkerStream, ScenarioError> {
+        if worker >= self.threads {
+            return Err(ScenarioError::WorkerOutOfRange {
+                worker,
+                threads: self.threads,
+            });
+        }
+        let mut requests: Vec<Request> = self
+            .streams()?
+            .into_iter()
+            .flat_map(|stream| stream.requests)
+            .filter(|request| request.executor_worker == worker)
+            .collect();
+        requests.sort_by_key(|request| {
+            (
+                request.transaction % self.transactions_per_worker,
+                request.phase,
+                request.transaction,
+                request.token,
+            )
+        });
+        let checksum = requests.iter().fold(FNV_OFFSET, |state, request| {
+            checksum_request(state, request)
+        });
+        Ok(WorkerStream {
+            worker,
+            requests,
+            checksum,
+        })
+    }
+
+    pub fn expected_counts(&self) -> Result<ExpectedCounts, ScenarioError> {
+        let requested_transactions = self.requested_transactions();
+        let mut counts = ExpectedCounts {
+            requested_transactions,
+            completed_transactions: requested_transactions,
+            ..ExpectedCounts::default()
+        };
+        let per_worker = counts_for_operations(self.card, self.transactions_per_worker);
+        let workers = self.threads as u64;
+        counts.alloc_calls = per_worker.alloc_calls * workers;
+        counts.calloc_calls = per_worker.calloc_calls * workers;
+        counts.realloc_calls = per_worker.realloc_calls * workers;
+        counts.aligned_alloc_calls = per_worker.aligned_alloc_calls * workers;
+        counts.free_calls = per_worker.free_calls * workers;
+        counts.touches = per_worker.touches * workers;
+        counts.worker_generations = per_worker.worker_generations * workers;
+        counts.allocator_calls = counts.alloc_calls
+            + counts.calloc_calls
+            + counts.realloc_calls
+            + counts.aligned_alloc_calls
+            + counts.free_calls;
+        Ok(counts)
+    }
+
+    pub fn worker_contract_checksum(&self, worker: usize) -> Result<u64, ScenarioError> {
+        if worker >= self.threads {
+            return Err(ScenarioError::WorkerOutOfRange {
+                worker,
+                threads: self.threads,
+            });
+        }
+        let mut state = FNV_OFFSET;
+        state = fnv_u64(state, self.card as u64);
+        state = fnv_u64(state, self.thread_point as u64);
+        state = fnv_u64(state, self.threads as u64);
+        state = fnv_u64(state, self.seed);
+        state = fnv_u64(state, self.transactions_per_worker);
+        Ok(fnv_u64(state, worker as u64))
+    }
+
+    /// A stable bounded-size contract checksum for the cell identity. The raw
+    /// sample's separately-derived touch checksum remains data-dependent on
+    /// values observed through the native adapter.
+    pub fn expected_checksum(&self) -> Result<u64, ScenarioError> {
+        let mut state = FNV_OFFSET;
+        for worker in 0..self.threads {
+            state = fnv_u64(state, worker as u64);
+            state = fnv_u64(state, self.worker_contract_checksum(worker)?);
+        }
+        Ok(state)
+    }
+
+    pub fn topology_oracle(&self) -> Result<TopologyOracle, ScenarioError> {
+        let streams = self.streams()?;
+        let mut cross_thread_frees = 0_u64;
+        let mut allocation_tokens = 0_u64;
+        for stream in &streams {
+            for request in &stream.requests {
+                if matches!(
+                    request.kind,
+                    RequestKind::Alloc | RequestKind::Calloc | RequestKind::AlignedAlloc
+                ) {
+                    allocation_tokens += 1;
+                }
+                if request.kind == RequestKind::Free
+                    && request.owner_worker != request.executor_worker
+                {
+                    cross_thread_frees += 1;
+                }
+            }
+        }
+        let claims_cross_thread = matches!(
+            self.card,
+            CardId::CrossThreadProducerConsumer | CardId::RandomOwnership
+        );
+        Ok(TopologyOracle {
+            claims_cross_thread,
+            allocation_tokens,
+            cross_thread_frees,
+        })
+    }
+
+    /// Checks the card's asserted ownership topology directly from generated
+    /// requests. For random ownership every operation must map owners to a
+    /// one-to-one remote consumer permutation.
+    pub fn ownership_oracle(&self) -> Result<bool, ScenarioError> {
+        if self.card != CardId::RandomOwnership {
+            return Ok(true);
+        }
+        let streams = self.streams()?;
+        for operation in 0..self.transactions_per_worker {
+            let mut consumers = vec![false; self.threads];
+            for (owner, stream) in streams.iter().enumerate() {
+                let transaction = (owner as u64) * self.transactions_per_worker + operation;
+                let free = stream.requests.iter().find(|request| {
+                    request.kind == RequestKind::Free && request.transaction == transaction
+                });
+                let Some(free) = free else { return Ok(false) };
+                if free.executor_worker == owner || consumers[free.executor_worker] {
+                    return Ok(false);
+                }
+                consumers[free.executor_worker] = true;
+            }
+            if consumers.iter().any(|seen| !seen) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn append_transaction(
+        &self,
+        worker: usize,
+        operation: u64,
+        transaction: u64,
+        out: &mut Vec<Request>,
+        checksum: &mut Option<&mut u64>,
+    ) {
+        let entropy = mix(self.seed ^ ((worker as u64) << 32) ^ operation);
+        let base_token = transaction * 64 + 1;
+        match self.card {
+            CardId::TinyFixed16 => {
+                self.simple_alloc_free(worker, transaction, base_token, 16, entropy, out, checksum)
+            }
+            CardId::TinyFixed64 => {
+                self.simple_alloc_free(worker, transaction, base_token, 64, entropy, out, checksum)
+            }
+            CardId::SmallLogMixed => self.simple_alloc_free(
+                worker,
+                transaction,
+                base_token,
+                small_size(entropy),
+                entropy,
+                out,
+                checksum,
+            ),
+            CardId::MediumLogMixed => self.simple_alloc_free(
+                worker,
+                transaction,
+                base_token,
+                medium_size(entropy),
+                entropy,
+                out,
+                checksum,
+            ),
+            CardId::LargeObjects => self.simple_alloc_free(
+                worker,
+                transaction,
+                base_token,
+                large_size(entropy),
+                entropy,
+                out,
+                checksum,
+            ),
+            CardId::BatchLifo => self.batch(
+                worker,
+                transaction,
+                base_token,
+                entropy,
+                true,
+                out,
+                checksum,
+            ),
+            CardId::BatchFifo => self.batch(
+                worker,
+                transaction,
+                base_token,
+                entropy,
+                false,
+                out,
+                checksum,
+            ),
+            CardId::CrossThreadProducerConsumer => self.cross_thread(
+                worker,
+                operation,
+                transaction,
+                base_token,
+                entropy,
+                false,
+                out,
+                checksum,
+            ),
+            CardId::RandomOwnership => self.cross_thread(
+                worker,
+                operation,
+                transaction,
+                base_token,
+                entropy,
+                true,
+                out,
+                checksum,
+            ),
+            CardId::ReallocGeometric => {
+                self.realloc_geometric(worker, transaction, base_token, entropy, out, checksum)
+            }
+            CardId::CallocZero => {
+                self.calloc_zero(worker, transaction, base_token, entropy, out, checksum)
+            }
+            CardId::AlignedRange => {
+                self.aligned(worker, transaction, base_token, entropy, out, checksum)
+            }
+            CardId::SawtoothRetainDrain => {
+                self.sawtooth(worker, transaction, base_token, entropy, out, checksum)
+            }
+            CardId::ThreadChurn => {
+                self.thread_churn(worker, transaction, base_token, entropy, out, checksum)
+            }
+            CardId::RepresentativeMix => self.representative_mix(
+                worker,
+                operation,
+                transaction,
+                base_token,
+                entropy,
+                out,
+                checksum,
+            ),
+        }
+    }
+
+    fn push(&self, out: &mut Vec<Request>, checksum: &mut Option<&mut u64>, request: Request) {
+        if let Some(state) = checksum.as_deref_mut() {
+            *state = checksum_request(*state, &request);
+        }
+        out.push(request);
+    }
+
+    fn simple_alloc_free(
+        &self,
+        worker: usize,
+        tx: u64,
+        token: u64,
+        size: usize,
+        touch: u64,
+        out: &mut Vec<Request>,
+        sum: &mut Option<&mut u64>,
+    ) {
+        self.push(
+            out,
+            sum,
+            Request::alloc(0, tx, token, worker, worker, size, touch),
+        );
+        self.push(out, sum, Request::touch(0, tx, token, worker, size, touch));
+        self.push(out, sum, Request::free(1, tx, token, worker, worker));
+    }
+
+    fn batch(
+        &self,
+        worker: usize,
+        tx: u64,
+        token: u64,
+        entropy: u64,
+        lifo: bool,
+        out: &mut Vec<Request>,
+        sum: &mut Option<&mut u64>,
+    ) {
+        for slot in 0..BATCH_WIDTH {
+            let slot_token = token + slot as u64;
+            let size = 8usize << ((entropy.wrapping_add(slot as u64) % 8) as usize);
+            self.push(
+                out,
+                sum,
+                Request::alloc(
+                    0,
+                    tx,
+                    slot_token,
+                    worker,
+                    worker,
+                    size,
+                    mix(entropy ^ slot as u64),
+                ),
+            );
+            self.push(
+                out,
+                sum,
+                Request::touch(0, tx, slot_token, worker, size, mix(entropy ^ slot as u64)),
+            );
+        }
+        for order in 0..BATCH_WIDTH {
+            let slot = if lifo { BATCH_WIDTH - 1 - order } else { order };
+            self.push(
+                out,
+                sum,
+                Request::free(1, tx, token + slot as u64, worker, worker),
+            );
+        }
+    }
+
+    fn cross_thread(
+        &self,
+        worker: usize,
+        operation: u64,
+        tx: u64,
+        token: u64,
+        entropy: u64,
+        random: bool,
+        out: &mut Vec<Request>,
+        sum: &mut Option<&mut u64>,
+    ) {
+        let consumer = if random {
+            // Every operation gets a seed-derived cyclic derangement. Using
+            // one offset for all owners makes this a true permutation.
+            let offset = 1 + (mix(self.seed ^ operation) as usize % (self.threads - 1));
+            (worker + offset) % self.threads
+        } else {
+            (worker + 1) % self.threads
+        };
+        let size = small_size(entropy);
+        self.push(
+            out,
+            sum,
+            Request::alloc(0, tx, token, worker, worker, size, entropy),
+        );
+        self.push(
+            out,
+            sum,
+            Request::touch(0, tx, token, worker, size, entropy),
+        );
+        // The owner stream records the expected remote consumer; the executor
+        // dispatches phase-1 frees to the stream whose worker equals consumer.
+        self.push(out, sum, Request::free(1, tx, token, worker, consumer));
+    }
+
+    fn realloc_geometric(
+        &self,
+        worker: usize,
+        tx: u64,
+        token: u64,
+        entropy: u64,
+        out: &mut Vec<Request>,
+        sum: &mut Option<&mut u64>,
+    ) {
+        let mut size = 16usize << ((entropy % 5) as usize);
+        self.push(
+            out,
+            sum,
+            Request::alloc(0, tx, token, worker, worker, size, entropy),
+        );
+        self.push(
+            out,
+            sum,
+            Request::touch(0, tx, token, worker, size, entropy),
+        );
+        for step in 0..REALLOC_STEPS {
+            let grow = step < REALLOC_STEPS / 2;
+            let next = if grow {
+                size.saturating_mul(2)
+            } else {
+                (size / 2).max(16)
+            };
+            let request = Request {
+                kind: RequestKind::Realloc,
+                phase: 0,
+                transaction: tx,
+                token,
+                owner_worker: worker,
+                executor_worker: worker,
+                size: next,
+                alignment: 0,
+                touch: mix(entropy ^ step as u64),
+                preserve_bytes: size.min(next),
+            };
+            self.push(out, sum, request);
+            size = next;
+            self.push(
+                out,
+                sum,
+                Request::touch(0, tx, token, worker, size, mix(entropy ^ step as u64)),
+            );
+        }
+        self.push(out, sum, Request::free(1, tx, token, worker, worker));
+    }
+
+    fn calloc_zero(
+        &self,
+        worker: usize,
+        tx: u64,
+        token: u64,
+        entropy: u64,
+        out: &mut Vec<Request>,
+        sum: &mut Option<&mut u64>,
+    ) {
+        let size = 8usize << ((entropy % 8) as usize);
+        self.push(out, sum, Request::calloc(tx, token, worker, size, entropy));
+        self.push(
+            out,
+            sum,
+            Request {
+                kind: RequestKind::VerifyZero,
+                phase: 0,
+                transaction: tx,
+                token,
+                owner_worker: worker,
+                executor_worker: worker,
+                size,
+                alignment: 0,
+                touch: 0,
+                preserve_bytes: 0,
+            },
+        );
+        self.push(
+            out,
+            sum,
+            Request::touch(0, tx, token, worker, size, entropy),
+        );
+        self.push(out, sum, Request::free(1, tx, token, worker, worker));
+    }
+
+    fn aligned(
+        &self,
+        worker: usize,
+        tx: u64,
+        token: u64,
+        entropy: u64,
+        out: &mut Vec<Request>,
+        sum: &mut Option<&mut u64>,
+    ) {
+        let alignment = 16usize << ((entropy % 9) as usize); // 16 through 4096
+        let size = alignment + ((entropy >> 12) as usize & (alignment - 1));
+        self.push(
+            out,
+            sum,
+            Request {
+                kind: RequestKind::AlignedAlloc,
+                phase: 0,
+                transaction: tx,
+                token,
+                owner_worker: worker,
+                executor_worker: worker,
+                size,
+                alignment,
+                touch: entropy,
+                preserve_bytes: 0,
+            },
+        );
+        self.push(
+            out,
+            sum,
+            Request::touch(0, tx, token, worker, size, entropy),
+        );
+        self.push(out, sum, Request::free(1, tx, token, worker, worker));
+    }
+
+    fn sawtooth(
+        &self,
+        worker: usize,
+        tx: u64,
+        token: u64,
+        entropy: u64,
+        out: &mut Vec<Request>,
+        sum: &mut Option<&mut u64>,
+    ) {
+        for slot in 0..SAWTOOTH_WIDTH {
+            let size = medium_size(mix(entropy ^ slot as u64));
+            self.push(
+                out,
+                sum,
+                Request::alloc(
+                    0,
+                    tx,
+                    token + slot as u64,
+                    worker,
+                    worker,
+                    size,
+                    mix(entropy ^ slot as u64),
+                ),
+            );
+            self.push(
+                out,
+                sum,
+                Request::touch(
+                    0,
+                    tx,
+                    token + slot as u64,
+                    worker,
+                    size,
+                    mix(entropy ^ slot as u64),
+                ),
+            );
+        }
+        // Drain unretained blocks first, then retained blocks in a later phase.
+        for slot in 0..SAWTOOTH_WIDTH {
+            if !retained(entropy, slot) {
+                self.push(
+                    out,
+                    sum,
+                    Request::free(1, tx, token + slot as u64, worker, worker),
+                );
+            }
+        }
+        for slot in 0..SAWTOOTH_WIDTH {
+            if retained(entropy, slot) {
+                self.push(
+                    out,
+                    sum,
+                    Request::free(2, tx, token + slot as u64, worker, worker),
+                );
+            }
+        }
+    }
+
+    fn thread_churn(
+        &self,
+        worker: usize,
+        tx: u64,
+        token: u64,
+        entropy: u64,
+        out: &mut Vec<Request>,
+        sum: &mut Option<&mut u64>,
+    ) {
+        for generation in 0..CHURN_GENERATIONS {
+            self.push(
+                out,
+                sum,
+                Request {
+                    kind: RequestKind::WorkerGeneration,
+                    phase: generation,
+                    transaction: tx,
+                    token: token + generation as u64,
+                    owner_worker: worker,
+                    executor_worker: worker,
+                    size: 0,
+                    alignment: 0,
+                    touch: generation as u64,
+                    preserve_bytes: 0,
+                },
+            );
+            let local_token = token + generation as u64;
+            let size = small_size(mix(entropy ^ generation as u64));
+            self.push(
+                out,
+                sum,
+                Request::alloc(
+                    generation,
+                    tx,
+                    local_token,
+                    worker,
+                    worker,
+                    size,
+                    mix(entropy ^ generation as u64),
+                ),
+            );
+            self.push(
+                out,
+                sum,
+                Request::touch(
+                    generation,
+                    tx,
+                    local_token,
+                    worker,
+                    size,
+                    mix(entropy ^ generation as u64),
+                ),
+            );
+            self.push(
+                out,
+                sum,
+                Request::free(generation + 1, tx, local_token, worker, worker),
+            );
+        }
+    }
+
+    fn representative_mix(
+        &self,
+        worker: usize,
+        operation: u64,
+        tx: u64,
+        token: u64,
+        entropy: u64,
+        out: &mut Vec<Request>,
+        sum: &mut Option<&mut u64>,
+    ) {
+        // Checked-in weights: 50% small, 20% medium, 15% realloc, 15% batch.
+        match operation % 20 {
+            0..=9 => {
+                self.simple_alloc_free(worker, tx, token, small_size(entropy), entropy, out, sum)
+            }
+            10..=13 => {
+                self.simple_alloc_free(worker, tx, token, medium_size(entropy), entropy, out, sum)
+            }
+            14..=16 => self.realloc_geometric(worker, tx, token, entropy, out, sum),
+            _ => self.batch(worker, tx, token, entropy, true, out, sum),
+        }
+    }
+}
+
+fn counts_for_operations(card: CardId, operations: u64) -> ExpectedCounts {
+    let mut counts = ExpectedCounts::default();
+    match card {
+        CardId::TinyFixed16
+        | CardId::TinyFixed64
+        | CardId::SmallLogMixed
+        | CardId::MediumLogMixed
+        | CardId::LargeObjects
+        | CardId::CrossThreadProducerConsumer
+        | CardId::RandomOwnership => {
+            counts.alloc_calls = operations;
+            counts.free_calls = operations;
+            counts.touches = operations;
+        }
+        CardId::BatchLifo | CardId::BatchFifo => {
+            counts.alloc_calls = operations * u64::from(BATCH_WIDTH);
+            counts.free_calls = counts.alloc_calls;
+            counts.touches = counts.alloc_calls;
+        }
+        CardId::ReallocGeometric => {
+            counts.alloc_calls = operations;
+            counts.realloc_calls = operations * u64::from(REALLOC_STEPS);
+            counts.free_calls = operations;
+            counts.touches = operations * (u64::from(REALLOC_STEPS) + 1);
+        }
+        CardId::CallocZero => {
+            counts.calloc_calls = operations;
+            counts.free_calls = operations;
+            counts.touches = operations;
+        }
+        CardId::AlignedRange => {
+            counts.aligned_alloc_calls = operations;
+            counts.free_calls = operations;
+            counts.touches = operations;
+        }
+        CardId::SawtoothRetainDrain => {
+            counts.alloc_calls = operations * u64::from(SAWTOOTH_WIDTH);
+            counts.free_calls = counts.alloc_calls;
+            counts.touches = counts.alloc_calls;
+        }
+        CardId::ThreadChurn => {
+            counts.alloc_calls = operations * u64::from(CHURN_GENERATIONS);
+            counts.free_calls = counts.alloc_calls;
+            counts.touches = counts.alloc_calls;
+            counts.worker_generations = counts.alloc_calls;
+        }
+        CardId::RepresentativeMix => {
+            let cycles = operations / 20;
+            counts.alloc_calls = cycles * 65;
+            counts.free_calls = cycles * 65;
+            counts.realloc_calls = cycles * 18;
+            counts.touches = cycles * 83;
+            for operation in 0..operations % 20 {
+                match operation {
+                    0..=13 => {
+                        counts.alloc_calls += 1;
+                        counts.free_calls += 1;
+                        counts.touches += 1;
+                    }
+                    14..=16 => {
+                        counts.alloc_calls += 1;
+                        counts.free_calls += 1;
+                        counts.realloc_calls += u64::from(REALLOC_STEPS);
+                        counts.touches += u64::from(REALLOC_STEPS) + 1;
+                    }
+                    _ => {
+                        counts.alloc_calls += u64::from(BATCH_WIDTH);
+                        counts.free_calls += u64::from(BATCH_WIDTH);
+                        counts.touches += u64::from(BATCH_WIDTH);
+                    }
+                }
+            }
+        }
+    }
+    counts
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TopologyOracle {
+    pub claims_cross_thread: bool,
+    pub allocation_tokens: u64,
+    pub cross_thread_frees: u64,
+}
+
+impl TopologyOracle {
+    pub fn validates(self) -> bool {
+        !self.claims_cross_thread
+            || (self.allocation_tokens > 0 && self.cross_thread_frees == self.allocation_tokens)
+    }
+}
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+fn fnv_u64(mut state: u64, value: u64) -> u64 {
+    for byte in value.to_le_bytes() {
+        state ^= byte as u64;
+        state = state.wrapping_mul(FNV_PRIME);
+    }
+    state
+}
+
+fn checksum_request(mut state: u64, request: &Request) -> u64 {
+    state = fnv_u64(state, request.kind as u64);
+    state = fnv_u64(state, request.phase as u64);
+    state = fnv_u64(state, request.transaction);
+    state = fnv_u64(state, request.token);
+    state = fnv_u64(state, request.owner_worker as u64);
+    state = fnv_u64(state, request.executor_worker as u64);
+    state = fnv_u64(state, request.size as u64);
+    state = fnv_u64(state, request.alignment as u64);
+    state = fnv_u64(state, request.touch);
+    fnv_u64(state, request.preserve_bytes as u64)
+}
+
+fn mix(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+// The high-half-biased exponent produces a deterministic log/Pareto-like
+// mixture while retaining the advertised inclusive size range.
+fn small_size(entropy: u64) -> usize {
+    let exponent = ((entropy.trailing_zeros().min(7)) as usize).min(7);
+    let base = 8usize << exponent;
+    (base + (((entropy >> 16) as usize) & (base - 1)))
+        .min(1024)
+        .max(8)
+}
+
+fn medium_size(entropy: u64) -> usize {
+    let exponent = ((entropy.trailing_zeros().min(4)) as usize).min(4);
+    let base = 4usize << (10 + exponent);
+    (base + (((entropy >> 20) as usize) & (base - 1)))
+        .min(64 * 1024)
+        .max(4 * 1024)
+}
+
+fn large_size(entropy: u64) -> usize {
+    let exponent = ((entropy.trailing_zeros().min(4)) as usize).min(4);
+    let base = 1usize << (20 + exponent);
+    (base + (((entropy >> 24) as usize) & (base - 1)))
+        .min(16 * 1024 * 1024)
+        .max(1024 * 1024)
+}
+
+fn retained(entropy: u64, slot: u32) -> bool {
+    // Exactly one third of each burst is retained, independent of allocator.
+    (mix(entropy ^ slot as u64) % 3) == 0
+}

--- a/rust/benchmark-suite/tests/adapter_contract.rs
+++ b/rust/benchmark-suite/tests/adapter_contract.rs
@@ -1,0 +1,13 @@
+use benchmark_suite::adapter::{
+    AdapterError, LinkedAdapter, BUILD_ALLOCATOR_ID, BUILD_ALLOCATOR_VERSION, BUILD_LIBRARY_SHA256,
+    BUILD_SOURCE_SHA,
+};
+
+#[test]
+fn ordinary_workspace_test_build_cannot_masquerade_as_a_linked_child() {
+    assert_eq!(LinkedAdapter::load(), Err(AdapterError::Unlinked));
+    assert_eq!(BUILD_ALLOCATOR_ID, "unlinked-test-adapter");
+    assert_eq!(BUILD_ALLOCATOR_VERSION, "unlinked");
+    assert_eq!(BUILD_SOURCE_SHA, "unlinked");
+    assert_eq!(BUILD_LIBRARY_SHA256, "unlinked");
+}

--- a/rust/benchmark-suite/tests/execution_contract.rs
+++ b/rust/benchmark-suite/tests/execution_contract.rs
@@ -1,0 +1,366 @@
+use std::alloc::{alloc, alloc_zeroed, dealloc, realloc, Layout};
+use std::collections::HashMap;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use benchmark_suite::execution::{
+    execute_cell, execute_child_request, expected_touch_checksum, AllocatorAdapter,
+};
+use benchmark_suite::model::{
+    AllocatorIdentity, BenchmarkChildRequest, RunnerMetadata, ToolchainMetadata,
+    CHILD_PROTOCOL_VERSION,
+};
+use benchmark_suite::scenarios::{cards, CardId, ScenarioCell, Topology};
+use benchmark_suite::{CORE_SUITE_VERSION, RAW_SCHEMA_VERSION};
+
+struct TestAdapter {
+    layouts: Mutex<HashMap<usize, Layout>>,
+    owners: Mutex<HashMap<usize, std::thread::ThreadId>>,
+    remote_frees: AtomicU64,
+    corrupt_realloc: bool,
+}
+
+impl TestAdapter {
+    fn new() -> Self {
+        Self {
+            layouts: Mutex::new(HashMap::new()),
+            owners: Mutex::new(HashMap::new()),
+            remote_frees: AtomicU64::new(0),
+            corrupt_realloc: false,
+        }
+    }
+
+    fn corrupting_realloc() -> Self {
+        Self {
+            layouts: Mutex::new(HashMap::new()),
+            owners: Mutex::new(HashMap::new()),
+            remote_frees: AtomicU64::new(0),
+            corrupt_realloc: true,
+        }
+    }
+
+    fn allocate(&self, layout: Layout, zeroed: bool) -> Result<NonNull<u8>, String> {
+        let pointer = unsafe {
+            if zeroed {
+                alloc_zeroed(layout)
+            } else {
+                alloc(layout)
+            }
+        };
+        let pointer = NonNull::new(pointer).ok_or_else(|| "test allocation failed".to_string())?;
+        self.layouts
+            .lock()
+            .unwrap()
+            .insert(pointer.as_ptr() as usize, layout);
+        self.owners
+            .lock()
+            .unwrap()
+            .insert(pointer.as_ptr() as usize, std::thread::current().id());
+        Ok(pointer)
+    }
+}
+
+impl Drop for TestAdapter {
+    fn drop(&mut self) {
+        assert!(self.layouts.get_mut().unwrap().is_empty());
+    }
+}
+
+impl AllocatorAdapter for TestAdapter {
+    fn allocator_id(&self) -> &str {
+        "tcmalloc"
+    }
+    fn allocator_version(&self) -> &str {
+        "test"
+    }
+    fn source_sha(&self) -> &str {
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+    fn library_sha256(&self) -> &str {
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+    fn alloc(&self, size: usize) -> Result<NonNull<u8>, String> {
+        self.allocate(Layout::from_size_align(size, 16).unwrap(), false)
+    }
+    fn calloc(&self, count: usize, size: usize) -> Result<NonNull<u8>, String> {
+        let bytes = count.checked_mul(size).ok_or("calloc overflow")?;
+        self.allocate(Layout::from_size_align(bytes, 16).unwrap(), true)
+    }
+    unsafe fn realloc(&self, pointer: NonNull<u8>, size: usize) -> Result<NonNull<u8>, String> {
+        let address = pointer.as_ptr() as usize;
+        let old_layout = self
+            .layouts
+            .lock()
+            .unwrap()
+            .remove(&address)
+            .ok_or("unknown realloc pointer")?;
+        let owner = self.owners.lock().unwrap().remove(&address).unwrap();
+        let updated = unsafe { realloc(pointer.as_ptr(), old_layout, size) };
+        let updated = NonNull::new(updated).ok_or("test realloc failed")?;
+        let new_layout = Layout::from_size_align(size, old_layout.align()).unwrap();
+        self.layouts
+            .lock()
+            .unwrap()
+            .insert(updated.as_ptr() as usize, new_layout);
+        self.owners
+            .lock()
+            .unwrap()
+            .insert(updated.as_ptr() as usize, owner);
+        if self.corrupt_realloc {
+            unsafe {
+                updated
+                    .as_ptr()
+                    .write(updated.as_ptr().read().wrapping_add(1))
+            };
+        }
+        Ok(updated)
+    }
+    fn aligned_alloc(&self, alignment: usize, size: usize) -> Result<NonNull<u8>, String> {
+        self.allocate(Layout::from_size_align(size, alignment).unwrap(), false)
+    }
+    unsafe fn free(&self, pointer: NonNull<u8>) {
+        let address = pointer.as_ptr() as usize;
+        let layout = self.layouts.lock().unwrap().remove(&address).unwrap();
+        let owner = self.owners.lock().unwrap().remove(&address).unwrap();
+        if owner != std::thread::current().id() {
+            self.remote_frees.fetch_add(1, Ordering::SeqCst);
+        }
+        unsafe { dealloc(pointer.as_ptr(), layout) };
+    }
+}
+
+const TOPOLOGY: Topology = Topology {
+    physical_cores: 2,
+    logical_cores: 2,
+};
+
+#[test]
+fn every_card_executes_exact_allocator_calls_and_touch_checksum() {
+    let adapter = TestAdapter::new();
+    for definition in cards() {
+        let cell =
+            ScenarioCell::new(definition.id, definition.thread_points[0], TOPOLOGY, 1, 77).unwrap();
+        let result = execute_cell(&adapter, &cell)
+            .unwrap_or_else(|error| panic!("{} failed: {error}", definition.id.as_str()));
+        assert_eq!(result.counts, cell.expected_counts().unwrap());
+        assert_eq!(result.checksum, expected_touch_checksum(&cell).unwrap());
+        assert!(result.peak_live_requested_bytes > 0);
+        assert!(result.elapsed_ns > 0);
+        if definition.id == CardId::ThreadChurn {
+            assert_eq!(definition.operation_count(&result.counts), 8);
+            assert_eq!(result.counts.requested_transactions, 1);
+        }
+    }
+}
+
+#[test]
+fn observed_checksum_composes_across_complete_and_partial_request_cycles() {
+    let adapter = TestAdapter::new();
+    let cell = ScenarioCell::new(
+        CardId::TinyFixed16,
+        benchmark_suite::scenarios::ThreadPoint::One,
+        TOPOLOGY,
+        41,
+        0x5eed,
+    )
+    .unwrap();
+    let result = execute_cell(&adapter, &cell).unwrap();
+    assert_eq!(result.checksum, expected_touch_checksum(&cell).unwrap());
+}
+
+#[test]
+fn cross_thread_card_really_frees_on_a_different_native_worker() {
+    let adapter = TestAdapter::new();
+    let cell = ScenarioCell::new(
+        CardId::CrossThreadProducerConsumer,
+        benchmark_suite::scenarios::ThreadPoint::Two,
+        TOPOLOGY,
+        4,
+        91,
+    )
+    .unwrap();
+    execute_cell(&adapter, &cell).unwrap();
+    assert_eq!(adapter.remote_frees.load(Ordering::SeqCst), 8);
+}
+
+#[test]
+fn immediate_and_batch_lifetimes_do_not_scale_with_transaction_count() {
+    let adapter = TestAdapter::new();
+    for point in [
+        benchmark_suite::scenarios::ThreadPoint::One,
+        benchmark_suite::scenarios::ThreadPoint::PhysicalCores,
+    ] {
+        let cell = ScenarioCell::new(CardId::TinyFixed16, point, TOPOLOGY, 100, 44).unwrap();
+        let result = execute_cell(&adapter, &cell).unwrap();
+        assert!(result.peak_live_requested_bytes >= 16);
+        assert!(
+            result.peak_live_requested_bytes <= cell.threads as u64 * 16,
+            "tiny fixed allocations leaked across transactions"
+        );
+    }
+
+    for card in [CardId::BatchLifo, CardId::BatchFifo] {
+        let cell = ScenarioCell::new(
+            card,
+            benchmark_suite::scenarios::ThreadPoint::One,
+            TOPOLOGY,
+            100,
+            55,
+        )
+        .unwrap();
+        let expected_peak = requested_peak(&cell.worker_stream(0).unwrap().requests);
+        let result = execute_cell(&adapter, &cell).unwrap();
+        assert_eq!(result.peak_live_requested_bytes, expected_peak);
+        assert!(
+            result.peak_live_requested_bytes <= 16 * 1024,
+            "batch allocations leaked across transaction boundaries"
+        );
+    }
+}
+
+fn requested_peak(requests: &[benchmark_suite::scenarios::Request]) -> u64 {
+    use benchmark_suite::scenarios::RequestKind;
+    let mut live = HashMap::new();
+    let mut bytes = 0_u64;
+    let mut peak = 0_u64;
+    for request in requests {
+        match request.kind {
+            RequestKind::Alloc | RequestKind::Calloc | RequestKind::AlignedAlloc => {
+                live.insert(request.token, request.size as u64);
+                bytes += request.size as u64;
+                peak = peak.max(bytes);
+            }
+            RequestKind::Realloc => {
+                let old = live.insert(request.token, request.size as u64).unwrap();
+                bytes = bytes - old + request.size as u64;
+                peak = peak.max(bytes);
+            }
+            RequestKind::Free => bytes -= live.remove(&request.token).unwrap(),
+            RequestKind::VerifyZero | RequestKind::Touch | RequestKind::WorkerGeneration => {}
+        }
+    }
+    assert_eq!(bytes, 0);
+    peak
+}
+
+#[test]
+fn strict_child_response_is_derived_from_work_not_supplied_by_caller() {
+    let adapter = TestAdapter::new();
+    let request = BenchmarkChildRequest {
+        protocol_version: CHILD_PROTOCOL_VERSION.into(),
+        schema_version: RAW_SCHEMA_VERSION.into(),
+        suite_version: CORE_SUITE_VERSION.into(),
+        run_kind: "headline".into(),
+        execution_mode: "normal".into(),
+        run_seed: 5,
+        block_id: 2,
+        ordinal: 0,
+        workload_seed: 19,
+        allocator: AllocatorIdentity {
+            allocator_id: "tcmalloc".into(),
+            allocator_version: "test".into(),
+            source_sha: "a".repeat(40),
+            library_sha256: "b".repeat(64),
+            child_binary_sha256: "c".repeat(64),
+        },
+        scenario_id: "realloc-geometric".into(),
+        scenario_version: CORE_SUITE_VERSION.into(),
+        thread_point: "1".into(),
+        physical_cores: 2,
+        logical_cores: 2,
+        transactions_per_worker: 2,
+        warmup_transactions_per_worker: 1,
+        reproduction_command: "MIMALLOC_PROF=0 MIMALLOC_MEMORY_EVENTS=0 benchmark-child".into(),
+        runner: RunnerMetadata {
+            os: "linux".into(),
+            architecture: "x86_64".into(),
+            physical_cores: 2,
+            logical_cores: 2,
+        },
+        toolchain: ToolchainMetadata {
+            rustc: "rustc test".into(),
+            target: "x86_64-unknown-linux-gnu".into(),
+            compiler: "cc".into(),
+            linker: "cc".into(),
+        },
+    };
+    let response = execute_child_request(&adapter, request.clone()).unwrap();
+    response.validate_against(&request).unwrap();
+    assert_eq!(response.sample.requested_transactions, 2);
+    assert_eq!(response.sample.realloc_calls, 12);
+    assert!(response.sample.throughput_operations_per_second.is_finite());
+
+    let mut false_count = response.clone();
+    false_count.sample.allocation_calls += 1;
+    assert!(false_count.validate_against(&request).is_err());
+    let mut false_checksum = response.clone();
+    false_checksum.sample.checksum ^= 1;
+    assert!(false_checksum.validate_against(&request).is_err());
+    for invalid in [0.0, f64::INFINITY, f64::NAN] {
+        let mut false_throughput = response.clone();
+        false_throughput.sample.throughput_operations_per_second = invalid;
+        assert!(false_throughput.validate_against(&request).is_err());
+    }
+    let mut inconsistent_throughput = response.clone();
+    inconsistent_throughput
+        .sample
+        .throughput_operations_per_second *= 1.01;
+    assert!(inconsistent_throughput.validate_against(&request).is_err());
+
+    let encoded = serde_json::to_vec(&response).unwrap();
+    let mut extra_response = encoded.clone();
+    extra_response.extend_from_slice(b"{}");
+    assert!(
+        serde_json::from_slice::<benchmark_suite::model::BenchmarkChildResponse>(&extra_response)
+            .is_err()
+    );
+    assert!(
+        serde_json::from_slice::<benchmark_suite::model::BenchmarkChildResponse>(b"{").is_err()
+    );
+    let mut value = serde_json::to_value(&response).unwrap();
+    value
+        .as_object_mut()
+        .unwrap()
+        .insert("unexpected".into(), serde_json::Value::Bool(true));
+    assert!(
+        serde_json::from_value::<benchmark_suite::model::BenchmarkChildResponse>(value).is_err()
+    );
+
+    for (scenario_id, specialized_calls) in
+        [("calloc-zero", "calloc"), ("aligned-range", "aligned")]
+    {
+        let mut specialized_request = request.clone();
+        specialized_request.scenario_id = scenario_id.into();
+        let specialized = execute_child_request(&adapter, specialized_request.clone()).unwrap();
+        assert_eq!(specialized.sample.allocation_calls, 0);
+        match specialized_calls {
+            "calloc" => assert!(specialized.sample.calloc_calls > 0),
+            "aligned" => assert!(specialized.sample.aligned_allocation_calls > 0),
+            _ => unreachable!(),
+        }
+        specialized.validate_against(&specialized_request).unwrap();
+    }
+
+    let mut churn_request = request;
+    churn_request.scenario_id = "thread-churn".into();
+    let churn = execute_child_request(&adapter, churn_request.clone()).unwrap();
+    assert_eq!(churn.sample.requested_transactions, 2);
+    assert_eq!(churn.sample.operation_count, 16);
+    churn.validate_against(&churn_request).unwrap();
+}
+
+#[test]
+fn realloc_preservation_is_checked_after_the_allocator_returns() {
+    let adapter = TestAdapter::corrupting_realloc();
+    let cell = ScenarioCell::new(
+        CardId::ReallocGeometric,
+        benchmark_suite::scenarios::ThreadPoint::One,
+        TOPOLOGY,
+        1,
+        7,
+    )
+    .unwrap();
+    let error = execute_cell(&adapter, &cell).unwrap_err();
+    assert!(error.contains("preserve"), "unexpected error: {error}");
+}

--- a/rust/benchmark-suite/tests/orchestration.rs
+++ b/rust/benchmark-suite/tests/orchestration.rs
@@ -1,0 +1,343 @@
+use benchmark_suite::{
+    model::{
+        AllocatorIdentity, BenchmarkChildRequest, RawRun, RawSample, RunnerMetadata,
+        ToolchainMetadata, CHILD_PROTOCOL_VERSION,
+    },
+    orchestration::{
+        balanced_block_orders, calibrate_cell_with, detect_planted_serialized_control,
+        run_balanced_cell_with, validate_complete_raw_run, validate_near_balanced, CellRunPlan,
+        ChildProgram, FrozenCalibration, ALLOCATOR_IDS,
+    },
+    CORE_SUITE_VERSION, RAW_SCHEMA_VERSION,
+};
+use std::time::Duration;
+
+#[test]
+fn fifteen_and_sixteen_block_orders_are_balanced_and_replayable() {
+    for blocks in [15, 16] {
+        let first = balanced_block_orders(blocks, 0xfeed).expect("orders");
+        assert_eq!(
+            first,
+            balanced_block_orders(blocks, 0xfeed).expect("replay")
+        );
+        validate_near_balanced(&first).expect("near balanced ordinals");
+    }
+}
+
+#[test]
+fn calibration_count_is_identical_for_every_allocator() {
+    let calibration =
+        FrozenCalibration::new("tiny-fixed-16", 1, 1_000_000).expect("valid calibration");
+    for allocator in ALLOCATOR_IDS {
+        assert_eq!(calibration.apply_to(allocator).unwrap(), 1_000_000);
+    }
+}
+
+#[test]
+fn raw_run_requires_every_allocator_in_every_block() {
+    let samples = (0..15)
+        .flat_map(|block_id| {
+            ALLOCATOR_IDS
+                .into_iter()
+                .enumerate()
+                .map(move |(ordinal, allocator_id)| RawSample {
+                    schema_version: RAW_SCHEMA_VERSION.into(),
+                    suite_version: CORE_SUITE_VERSION.into(),
+                    run_kind: "headline".into(),
+                    execution_mode: "normal".into(),
+                    run_seed: 1,
+                    block_id,
+                    ordinal: ordinal as u8,
+                    workload_seed: block_id as u64,
+                    allocator_id: allocator_id.into(),
+                    allocator_version: "test".into(),
+                    allocator_source_sha: "a".repeat(40),
+                    allocator_library_sha256: "b".repeat(64),
+                    child_binary_sha256: format!("{:0<64}", &"c".repeat(ordinal + 1)),
+                    scenario_id: "tiny-fixed-16".into(),
+                    scenario_version: CORE_SUITE_VERSION.into(),
+                    thread_point: "1".into(),
+                    thread_count: 1,
+                    operation_unit: "transaction".into(),
+                    operation_count: 10,
+                    requested_transactions: 10,
+                    completed_transactions: 10,
+                    allocation_calls: 10,
+                    calloc_calls: 0,
+                    aligned_allocation_calls: 0,
+                    free_calls: 10,
+                    realloc_calls: 0,
+                    setup_ns: 1,
+                    warmup_ns: 1,
+                    elapsed_ns: 1,
+                    teardown_ns: 1,
+                    throughput_operations_per_second: 10.0,
+                    checksum: 1,
+                    peak_live_requested_bytes: 16,
+                    timed_out: false,
+                    crashed: false,
+                    exit_code: 0,
+                    signal: None,
+                    runner: RunnerMetadata {
+                        os: "linux".into(),
+                        architecture: "x86_64".into(),
+                        physical_cores: 1,
+                        logical_cores: 1,
+                    },
+                    toolchain: ToolchainMetadata {
+                        rustc: "rustc test".into(),
+                        target: "x86_64-unknown-linux-gnu".into(),
+                        compiler: "cc".into(),
+                        linker: "cc".into(),
+                    },
+                    reproduction_command: "benchmark-child".into(),
+                })
+        })
+        .collect();
+    let run = RawRun {
+        schema_version: RAW_SCHEMA_VERSION.into(),
+        suite_version: CORE_SUITE_VERSION.into(),
+        run_kind: "headline".into(),
+        execution_mode: "normal".into(),
+        run_seed: 1,
+        samples,
+    };
+    validate_complete_raw_run(&run, 15).expect("complete blocks");
+    let mut incomplete = run.clone();
+    incomplete.samples.pop();
+    assert!(validate_complete_raw_run(&incomplete, 15).is_err());
+}
+
+#[test]
+fn a_failed_child_aborts_without_retry_or_complete_raw_run() {
+    let plan = plan();
+    let mut calls = 0;
+    let mut appended = 0;
+    let result = run_balanced_cell_with(
+        &plan,
+        |_| {
+            appended += 1;
+            Ok(())
+        },
+        |_, request, _| {
+            calls += 1;
+            if calls == 8 {
+                Err("planted child failure".into())
+            } else {
+                Ok(sample_for(request, 1_000_000_000))
+            }
+        },
+    );
+    assert!(result.unwrap_err().contains("planted child failure"));
+    assert_eq!(calls, 8, "a failed allocator is never selectively retried");
+    assert_eq!(
+        appended, 7,
+        "only successful samples reach append-only JSONL"
+    );
+}
+
+#[test]
+fn complete_controller_path_retains_all_four_raw_samples_per_block() {
+    let plan = plan();
+    let mut appended = 0;
+    let run = run_balanced_cell_with(
+        &plan,
+        |_| {
+            appended += 1;
+            Ok(())
+        },
+        |_, request, _| Ok(sample_for(request, 750_000_000)),
+    )
+    .unwrap();
+    assert_eq!(appended, 60);
+    assert_eq!(run.samples.len(), 60);
+    validate_complete_raw_run(&run, 15).unwrap();
+}
+
+#[test]
+fn upstream_calibration_freezes_a_realized_count_in_target_interval() {
+    let plan = plan();
+    let upstream = plan
+        .children
+        .iter()
+        .find(|child| child.allocator.allocator_id == "upstream-mimalloc")
+        .unwrap();
+    let calibration = calibrate_cell_with(
+        upstream,
+        &plan.request_template,
+        Duration::from_secs(5),
+        |_, request, _| {
+            Ok(sample_for(
+                request,
+                request.transactions_per_worker * 100_000_000,
+            ))
+        },
+    )
+    .unwrap();
+    assert_eq!(calibration.transactions_per_worker, 10);
+    assert_eq!(calibration.operation_count, 10);
+    assert_eq!(calibration.elapsed_ns, 1_000_000_000);
+}
+
+#[test]
+fn planted_serialized_control_is_detected_through_four_child_blocks() {
+    let mut normal_plan = plan();
+    normal_plan.request_template.thread_point = "physical-core".into();
+    normal_plan.request_template.physical_cores = 2;
+    normal_plan.request_template.logical_cores = 2;
+    normal_plan.request_template.runner.physical_cores = 2;
+    normal_plan.request_template.runner.logical_cores = 2;
+    let normal = run_balanced_cell_with(
+        &normal_plan,
+        |_| Ok(()),
+        |_, request, _| Ok(sample_for(request, 1_000_000_000)),
+    )
+    .unwrap();
+    let mut control_plan = normal_plan.clone();
+    control_plan.request_template.execution_mode = "serialized-control".into();
+    let control = run_balanced_cell_with(
+        &control_plan,
+        |_| Ok(()),
+        |_, request, _| Ok(sample_for(request, 2_000_000_000)),
+    )
+    .unwrap();
+    assert_eq!(
+        detect_planted_serialized_control(&normal, &control).unwrap(),
+        2.0
+    );
+}
+
+#[test]
+fn one_block_is_allowed_only_when_explicitly_marked_reduced_smoke() {
+    let mut headline = plan();
+    headline.blocks = 1;
+    assert!(run_balanced_cell_with(
+        &headline,
+        |_| Ok(()),
+        |_, request, _| Ok(sample_for(request, 1))
+    )
+    .is_err());
+    headline.request_template.run_kind = "reduced-smoke".into();
+    let smoke = run_balanced_cell_with(
+        &headline,
+        |_| Ok(()),
+        |_, request, _| Ok(sample_for(request, 1)),
+    )
+    .unwrap();
+    assert_eq!(smoke.run_kind, "reduced-smoke");
+    assert_eq!(smoke.samples.len(), 4);
+}
+
+fn plan() -> CellRunPlan {
+    let children = ALLOCATOR_IDS
+        .into_iter()
+        .enumerate()
+        .map(|(index, allocator_id)| ChildProgram {
+            allocator: AllocatorIdentity {
+                allocator_id: allocator_id.into(),
+                allocator_version: "test".into(),
+                source_sha: ["a", "b", "c", "d"][index].repeat(40),
+                library_sha256: ["1", "2", "3", "4"][index].repeat(64),
+                child_binary_sha256: ["5", "6", "7", "8"][index].repeat(64),
+            },
+            program: format!("benchmark-child-{allocator_id}").into(),
+            arguments: Vec::new(),
+            toolchain: ToolchainMetadata {
+                rustc: "rustc test".into(),
+                target: "x86_64-unknown-linux-gnu".into(),
+                compiler: "cc".into(),
+                linker: "cc".into(),
+            },
+            environment: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+    CellRunPlan {
+        request_template: BenchmarkChildRequest {
+            protocol_version: CHILD_PROTOCOL_VERSION.into(),
+            schema_version: RAW_SCHEMA_VERSION.into(),
+            suite_version: CORE_SUITE_VERSION.into(),
+            run_kind: "headline".into(),
+            execution_mode: "normal".into(),
+            run_seed: 0x1234,
+            block_id: 0,
+            ordinal: 0,
+            workload_seed: 0,
+            allocator: children[0].allocator.clone(),
+            scenario_id: "tiny-fixed-16".into(),
+            scenario_version: CORE_SUITE_VERSION.into(),
+            thread_point: "1".into(),
+            physical_cores: 1,
+            logical_cores: 1,
+            transactions_per_worker: 1,
+            warmup_transactions_per_worker: 0,
+            reproduction_command: "replaced by controller".into(),
+            runner: RunnerMetadata {
+                os: "linux".into(),
+                architecture: "x86_64".into(),
+                physical_cores: 1,
+                logical_cores: 1,
+            },
+            toolchain: ToolchainMetadata {
+                rustc: "rustc test".into(),
+                target: "x86_64-unknown-linux-gnu".into(),
+                compiler: "cc".into(),
+                linker: "cc".into(),
+            },
+        },
+        children,
+        blocks: 15,
+        timeout: Duration::from_secs(5),
+        request_directory: None,
+    }
+}
+
+fn sample_for(request: &BenchmarkChildRequest, elapsed_ns: u64) -> RawSample {
+    let threads = if request.thread_point == "physical-core" {
+        request.physical_cores as u64
+    } else {
+        1
+    };
+    let transactions = request.transactions_per_worker * threads;
+    RawSample {
+        schema_version: request.schema_version.clone(),
+        suite_version: request.suite_version.clone(),
+        run_kind: request.run_kind.clone(),
+        execution_mode: request.execution_mode.clone(),
+        run_seed: request.run_seed,
+        block_id: request.block_id,
+        ordinal: request.ordinal,
+        workload_seed: request.workload_seed,
+        allocator_id: request.allocator.allocator_id.clone(),
+        allocator_version: request.allocator.allocator_version.clone(),
+        allocator_source_sha: request.allocator.source_sha.clone(),
+        allocator_library_sha256: request.allocator.library_sha256.clone(),
+        child_binary_sha256: request.allocator.child_binary_sha256.clone(),
+        scenario_id: request.scenario_id.clone(),
+        scenario_version: request.scenario_version.clone(),
+        thread_point: request.thread_point.clone(),
+        thread_count: threads as u32,
+        operation_unit: "transaction".into(),
+        operation_count: transactions,
+        requested_transactions: transactions,
+        completed_transactions: transactions,
+        allocation_calls: transactions,
+        calloc_calls: 0,
+        aligned_allocation_calls: 0,
+        free_calls: transactions,
+        realloc_calls: 0,
+        setup_ns: 1,
+        warmup_ns: 0,
+        elapsed_ns,
+        teardown_ns: 1,
+        throughput_operations_per_second: transactions as f64 * 1_000_000_000.0 / elapsed_ns as f64,
+        checksum: 99,
+        peak_live_requested_bytes: 16,
+        timed_out: false,
+        crashed: false,
+        exit_code: 0,
+        signal: None,
+        runner: request.runner.clone(),
+        toolchain: request.toolchain.clone(),
+        reproduction_command: request.reproduction_command.clone(),
+    }
+}

--- a/rust/benchmark-suite/tests/scenario_contract.rs
+++ b/rust/benchmark-suite/tests/scenario_contract.rs
@@ -1,0 +1,227 @@
+use benchmark_suite::scenarios::{
+    card, cards, CardId, ExpectedCounts, RequestKind, ScenarioCell, ScenarioError, ThreadPoint,
+    Topology, CORE_THROUGHPUT_V1, MAX_REQUESTS_PER_TRANSACTION,
+};
+
+const TOPOLOGY: Topology = Topology {
+    physical_cores: 4,
+    logical_cores: 8,
+};
+
+#[test]
+fn core_throughput_v1_has_all_and_only_the_declared_cards_and_points() {
+    let observed: Vec<(&str, Vec<&str>)> = cards()
+        .iter()
+        .map(|definition| {
+            (
+                definition.id.as_str(),
+                definition
+                    .thread_points
+                    .iter()
+                    .map(|point| point.name())
+                    .collect(),
+            )
+        })
+        .collect();
+    assert_eq!(CORE_THROUGHPUT_V1, "core-throughput-v1");
+    assert_eq!(
+        observed,
+        vec![
+            ("tiny-fixed-16", vec!["1", "physical-core"]),
+            ("tiny-fixed-64", vec!["1", "physical-core"]),
+            ("small-log-mixed", vec!["1", "physical-core", "2x-logical"]),
+            ("medium-log-mixed", vec!["1", "physical-core"]),
+            ("large-objects", vec!["1", "2"]),
+            ("batch-lifo", vec!["1", "physical-core"]),
+            ("batch-fifo", vec!["1", "physical-core"]),
+            ("cross-thread-producer-consumer", vec!["2", "physical-core"]),
+            ("random-ownership", vec!["physical-core"]),
+            ("realloc-geometric", vec!["1", "physical-core"]),
+            ("calloc-zero", vec!["1", "physical-core"]),
+            ("aligned-range", vec!["1", "physical-core"]),
+            ("sawtooth-retain-drain", vec!["1", "physical-core"]),
+            ("thread-churn", vec!["1", "physical-core"]),
+            ("representative-mix", vec!["1", "physical-core"]),
+        ]
+    );
+    assert_eq!(CardId::ALL.len(), 15);
+}
+
+#[test]
+fn matching_seed_means_matching_worker_requests_and_checksum() {
+    for definition in cards() {
+        for &point in definition.thread_points {
+            let a = ScenarioCell::new(definition.id, point, TOPOLOGY, 5, 0x5eed).unwrap();
+            let b = ScenarioCell::new(definition.id, point, TOPOLOGY, 5, 0x5eed).unwrap();
+            assert_eq!(
+                a.streams().unwrap(),
+                b.streams().unwrap(),
+                "{} {}",
+                definition.id.as_str(),
+                point.name()
+            );
+            assert_eq!(
+                a.expected_checksum().unwrap(),
+                b.expected_checksum().unwrap()
+            );
+        }
+    }
+}
+
+#[test]
+fn allocator_identity_cannot_change_a_request_stream() {
+    // A child gets this stream before it invokes the adapter.  Replaying the
+    // same cell for every ID proves the producer has no allocator input.
+    let cell = ScenarioCell::new(
+        CardId::RepresentativeMix,
+        ThreadPoint::PhysicalCores,
+        TOPOLOGY,
+        20,
+        91,
+    )
+    .unwrap();
+    let baseline = cell.streams().unwrap();
+    for _allocator in [
+        "tcmalloc",
+        "jemalloc",
+        "upstream-mimalloc",
+        "mimalloc-pprof",
+    ] {
+        assert_eq!(cell.streams().unwrap(), baseline);
+        assert_eq!(
+            cell.expected_checksum().unwrap(),
+            cell.expected_checksum().unwrap()
+        );
+    }
+}
+
+#[test]
+fn exact_counts_are_derived_from_the_same_requests_an_executor_receives() {
+    for definition in cards() {
+        let point = definition.thread_points[0];
+        let cell = ScenarioCell::new(definition.id, point, TOPOLOGY, 3, 42).unwrap();
+        let counts = cell.expected_counts().unwrap();
+        assert_eq!(counts.requested_transactions, cell.requested_transactions());
+        assert_eq!(counts.completed_transactions, counts.requested_transactions);
+        assert!(counts.allocator_calls > 0, "{}", definition.id.as_str());
+        assert!(counts.touches > 0, "{}", definition.id.as_str());
+        assert_eq!(
+            counts.allocator_calls,
+            counts.alloc_calls
+                + counts.calloc_calls
+                + counts.realloc_calls
+                + counts.aligned_alloc_calls
+                + counts.free_calls
+        );
+        let mut oracle = ExpectedCounts {
+            requested_transactions: cell.requested_transactions(),
+            completed_transactions: cell.requested_transactions(),
+            ..ExpectedCounts::default()
+        };
+        for stream in cell.streams().unwrap() {
+            for request in &stream.requests {
+                oracle.record(request);
+            }
+        }
+        assert_eq!(counts, oracle, "{}", definition.id.as_str());
+    }
+}
+
+#[test]
+fn very_large_cells_have_bounded_request_storage_and_constant_time_contracts() {
+    let transactions = 50_000_000_u64;
+    let cell = ScenarioCell::new(
+        CardId::TinyFixed16,
+        ThreadPoint::One,
+        TOPOLOGY,
+        transactions,
+        0x5eed,
+    )
+    .unwrap();
+    let counts = cell.expected_counts().unwrap();
+    assert_eq!(counts.alloc_calls, transactions);
+    assert_eq!(counts.free_calls, transactions);
+    assert_eq!(counts.allocator_calls, transactions * 2);
+
+    let mut requests = Vec::with_capacity(MAX_REQUESTS_PER_TRANSACTION);
+    let fixed_capacity = requests.capacity();
+    cell.fill_worker_transaction(0, 0, &mut requests).unwrap();
+    assert_eq!(requests.len(), 3);
+    cell.fill_worker_transaction(0, transactions - 1, &mut requests)
+        .unwrap();
+    assert_eq!(requests.len(), 3);
+    assert_eq!(requests.capacity(), fixed_capacity);
+    assert_eq!(card(cell.card).max_live_allocations_per_worker(), 1);
+
+    // This derives at most one fixed request cycle, not `transactions` rows.
+    assert_ne!(
+        benchmark_suite::execution::expected_touch_checksum(&cell).unwrap(),
+        0
+    );
+}
+
+#[test]
+fn cross_thread_cards_have_a_real_ownership_oracle() {
+    for id in [CardId::CrossThreadProducerConsumer, CardId::RandomOwnership] {
+        let cell = ScenarioCell::new(id, card(id).thread_points[0], TOPOLOGY, 4, 123).unwrap();
+        let oracle = cell.topology_oracle().unwrap();
+        assert!(oracle.claims_cross_thread);
+        assert!(oracle.validates());
+        assert!(cell.ownership_oracle().unwrap());
+        for stream in cell.streams().unwrap() {
+            assert!(stream
+                .requests
+                .iter()
+                .any(|request| request.kind == RequestKind::Free
+                    && request.owner_worker != request.executor_worker));
+        }
+    }
+}
+
+#[test]
+fn declared_points_expand_and_invalid_expansions_are_rejected() {
+    assert_eq!(TOPOLOGY.resolve(ThreadPoint::PhysicalCores).unwrap(), 4);
+    assert_eq!(
+        TOPOLOGY.resolve(ThreadPoint::TwiceLogicalCores).unwrap(),
+        16
+    );
+    assert!(matches!(
+        Topology {
+            physical_cores: 0,
+            logical_cores: 8
+        }
+        .resolve(ThreadPoint::PhysicalCores),
+        Err(ScenarioError::InvalidTopology(_))
+    ));
+    assert!(matches!(
+        Topology {
+            physical_cores: 4,
+            logical_cores: 1
+        }
+        .resolve(ThreadPoint::One),
+        Err(ScenarioError::InvalidTopology(_))
+    ));
+    assert!(matches!(
+        ScenarioCell::new(
+            CardId::TinyFixed16,
+            ThreadPoint::TwiceLogicalCores,
+            TOPOLOGY,
+            1,
+            1
+        ),
+        Err(ScenarioError::UnsupportedThreadPoint { .. })
+    ));
+    assert!(matches!(
+        ScenarioCell::new(
+            CardId::CrossThreadProducerConsumer,
+            ThreadPoint::PhysicalCores,
+            Topology {
+                physical_cores: 1,
+                logical_cores: 1
+            },
+            1,
+            1
+        ),
+        Err(ScenarioError::InvalidExpansion { .. })
+    ));
+}

--- a/rust/benchmark-suite/tests/timed_allocation_audit.rs
+++ b/rust/benchmark-suite/tests/timed_allocation_audit.rs
@@ -1,0 +1,183 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use benchmark_suite::execution::{execute_cell, set_measured_region_hook, AllocatorAdapter};
+use benchmark_suite::scenarios::{cards, CardId, ScenarioCell, Topology};
+
+static MEASURED: AtomicBool = AtomicBool::new(false);
+static HARNESS_ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+
+thread_local! {
+    static INSIDE_ADAPTER: Cell<bool> = const { Cell::new(false) };
+}
+
+struct AuditedSystem;
+
+unsafe impl GlobalAlloc for AuditedSystem {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if MEASURED.load(Ordering::SeqCst) && !INSIDE_ADAPTER.with(Cell::get) {
+            HARNESS_ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        if MEASURED.load(Ordering::SeqCst) && !INSIDE_ADAPTER.with(Cell::get) {
+            HARNESS_ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
+        }
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        if MEASURED.load(Ordering::SeqCst) && !INSIDE_ADAPTER.with(Cell::get) {
+            HARNESS_ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
+        }
+        unsafe { System.realloc(pointer, layout, size) }
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(pointer, layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: AuditedSystem = AuditedSystem;
+
+fn timing_hook(active: bool) {
+    MEASURED.store(active, Ordering::SeqCst);
+}
+
+struct InstrumentedAdapter {
+    layouts: Mutex<HashMap<usize, Layout>>,
+}
+
+impl InstrumentedAdapter {
+    fn allocate(&self, layout: Layout, zeroed: bool) -> Result<NonNull<u8>, String> {
+        INSIDE_ADAPTER.set(true);
+        let pointer = unsafe {
+            if zeroed {
+                std::alloc::alloc_zeroed(layout)
+            } else {
+                std::alloc::alloc(layout)
+            }
+        };
+        let pointer = NonNull::new(pointer).ok_or_else(|| "audit allocation failed".to_string())?;
+        self.layouts
+            .lock()
+            .unwrap()
+            .insert(pointer.as_ptr() as usize, layout);
+        INSIDE_ADAPTER.set(false);
+        Ok(pointer)
+    }
+}
+
+impl AllocatorAdapter for InstrumentedAdapter {
+    fn allocator_id(&self) -> &str {
+        "audit"
+    }
+    fn allocator_version(&self) -> &str {
+        "audit"
+    }
+    fn source_sha(&self) -> &str {
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+    fn library_sha256(&self) -> &str {
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+    fn alloc(&self, size: usize) -> Result<NonNull<u8>, String> {
+        self.allocate(Layout::from_size_align(size, 16).unwrap(), false)
+    }
+    fn calloc(&self, count: usize, size: usize) -> Result<NonNull<u8>, String> {
+        self.allocate(
+            Layout::from_size_align(count.checked_mul(size).ok_or("overflow")?, 16).unwrap(),
+            true,
+        )
+    }
+    unsafe fn realloc(&self, pointer: NonNull<u8>, size: usize) -> Result<NonNull<u8>, String> {
+        INSIDE_ADAPTER.set(true);
+        let old = self
+            .layouts
+            .lock()
+            .unwrap()
+            .remove(&(pointer.as_ptr() as usize))
+            .ok_or("unknown pointer")?;
+        let updated = NonNull::new(unsafe { std::alloc::realloc(pointer.as_ptr(), old, size) })
+            .ok_or("audit realloc failed")?;
+        self.layouts.lock().unwrap().insert(
+            updated.as_ptr() as usize,
+            Layout::from_size_align(size, old.align()).unwrap(),
+        );
+        INSIDE_ADAPTER.set(false);
+        Ok(updated)
+    }
+    fn aligned_alloc(&self, alignment: usize, size: usize) -> Result<NonNull<u8>, String> {
+        self.allocate(Layout::from_size_align(size, alignment).unwrap(), false)
+    }
+    unsafe fn free(&self, pointer: NonNull<u8>) {
+        INSIDE_ADAPTER.set(true);
+        let layout = self
+            .layouts
+            .lock()
+            .unwrap()
+            .remove(&(pointer.as_ptr() as usize))
+            .unwrap();
+        unsafe { std::alloc::dealloc(pointer.as_ptr(), layout) };
+        INSIDE_ADAPTER.set(false);
+    }
+}
+
+#[test]
+fn ordinary_measured_region_performs_zero_harness_allocations() {
+    let adapter = InstrumentedAdapter {
+        layouts: Mutex::new(HashMap::new()),
+    };
+    let topology = Topology {
+        physical_cores: 2,
+        logical_cores: 2,
+    };
+    let mut audited_cards = 0;
+    for definition in cards()
+        .iter()
+        .filter(|definition| definition.id != CardId::ThreadChurn)
+    {
+        audited_cards += 1;
+        for &thread_point in definition.thread_points {
+            let transactions = if definition.id == CardId::RepresentativeMix {
+                20
+            } else {
+                2
+            };
+            let cell =
+                ScenarioCell::new(definition.id, thread_point, topology, transactions, 0x5eed)
+                    .unwrap();
+            audit_cell(&adapter, &cell);
+        }
+    }
+    assert_eq!(audited_cards, 14);
+    assert_eq!(
+        cards()
+            .iter()
+            .filter(|definition| definition.id == CardId::ThreadChurn)
+            .count(),
+        1,
+        "native thread creation is the sole explicit timed-allocation exemption"
+    );
+}
+
+fn audit_cell(adapter: &InstrumentedAdapter, cell: &ScenarioCell) {
+    HARNESS_ALLOCATIONS.store(0, Ordering::SeqCst);
+    set_measured_region_hook(Some(timing_hook));
+    let result = execute_cell(adapter, cell);
+    set_measured_region_hook(None);
+    result.unwrap();
+    assert_eq!(
+        HARNESS_ALLOCATIONS.load(Ordering::SeqCst),
+        0,
+        "Rust control-plane allocation entered the measured interval for {:?}",
+        cell.card
+    );
+}


### PR DESCRIPTION
## What changed

- adds the deterministic four-allocator producer for TCMalloc, jemalloc, upstream mimalloc, and mimalloc-pprof
- adds the strict `core-throughput-v1` 15-card workload suite and isolated native benchmark children
- adds checksum-locked source/build provenance, strict child orchestration, raw sample retention, and runtime projection
- includes the narrowly checksum-locked TCMalloc dev-dependency repair approved on #179

## Validation

- all required Rust workspace/package, formatting, xtask, Python selftest, Ruff, and Pyright gates pass
- real Linux native producer built and audited four distinct directly linked children
- reduced smoke completed all 30 cells / 120 samples
- projected full runtime: 2,209.04 seconds (under 50 minutes)
- raw run SHA-256: `352066ecbd5d9a258b6c1f19e5f949bda1ada1c3c91a55bc50ec3c6c53449c0a`
- allocator provenance SHA-256: `7982e0df5d847b73bd191bd2164d61e95cb291d1f061b852de15777ee207b53c`

## Scope

This is the Phase 2 measurement producer only. It does not publish public benchmark statistics or a dashboard.

Fixes #179