### PR TITLE
docs: add allocator smoke preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ A fork of [microsoft/mimalloc](https://github.com/microsoft/mimalloc) that adds
 **pprof-compatible sampled heap profiling**, with native Windows as a first-class
 target alongside Linux and macOS.
 
+## Allocator benchmark preview
+
+![Development smoke preview comparing mimalloc-pprof, upstream mimalloc, TCMalloc, and jemalloc](doc/benchmark-smoke-preview.svg)
+
+**Development smoke preview only.** This is one Linux x86-64 reduced-smoke block
+for the 1-thread `tiny-fixed-64` cell, with profiling and memory-events collection
+disabled. One block is not statistically valid and this is not a headline
+benchmark result; it is shown only as an early end-to-end preview while the full
+benchmark suite is completed.
+
 ```
    __  __ ___ __  __    _    _     _     ___   ____
   |  \/  |_ _|  \/  |  / \  | |   | |   / _ \ / ___|

--- a/doc/benchmark-smoke-preview.svg
+++ b/doc/benchmark-smoke-preview.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="400" viewBox="0 0 900 400" role="img" aria-labelledby="title desc">
+  <title id="title">Development smoke preview for four allocators</title>
+  <desc id="desc">Horizontal bar chart of one-thread tiny fixed 64-byte allocation throughput. Mimalloc pprof reaches 2.496 million transactions per second, upstream mimalloc 2.516 million, TCMalloc 2.426 million, and jemalloc 2.608 million.</desc>
+  <rect width="900" height="400" fill="#ffffff"/>
+  <text x="40" y="38" font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="22" font-weight="700" fill="#111827">Development smoke preview — tiny fixed 64 B</text>
+  <text x="40" y="64" font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="14" fill="#4b5563">1 thread · throughput (transactions/s) · higher is better</text>
+
+  <g stroke="#e5e7eb" stroke-width="1">
+    <line x1="240" y1="84" x2="240" y2="326"/>
+    <line x1="340" y1="84" x2="340" y2="326"/>
+    <line x1="440" y1="84" x2="440" y2="326"/>
+    <line x1="540" y1="84" x2="540" y2="326"/>
+    <line x1="640" y1="84" x2="640" y2="326"/>
+    <line x1="740" y1="84" x2="740" y2="326"/>
+    <line x1="840" y1="84" x2="840" y2="326"/>
+  </g>
+
+  <g font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="14" fill="#111827">
+    <text x="224" y="116" text-anchor="end">mimalloc-pprof</text>
+    <text x="224" y="176" text-anchor="end">upstream mimalloc</text>
+    <text x="224" y="236" text-anchor="end">TCMalloc</text>
+    <text x="224" y="296" text-anchor="end">jemalloc</text>
+  </g>
+
+  <rect x="240" y="92" width="499.119" height="36" rx="4" fill="#f59e0b"/>
+  <rect x="240" y="152" width="503.147" height="36" rx="4" fill="#2563eb"/>
+  <rect x="240" y="212" width="485.127" height="36" rx="4" fill="#16a34a"/>
+  <rect x="240" y="272" width="521.634" height="36" rx="4" fill="#7c3aed"/>
+
+  <g font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="13" font-weight="700" fill="#111827">
+    <text x="747" y="116">2.496M</text>
+    <text x="751" y="176">2.516M</text>
+    <text x="733" y="236">2.426M</text>
+    <text x="769" y="296">2.608M</text>
+  </g>
+
+  <line x1="240" y1="326" x2="840" y2="326" stroke="#9ca3af" stroke-width="1"/>
+  <g font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="12" fill="#6b7280" text-anchor="middle">
+    <text x="240" y="348">0</text>
+    <text x="340" y="348">0.5M</text>
+    <text x="440" y="348">1.0M</text>
+    <text x="540" y="348">1.5M</text>
+    <text x="640" y="348">2.0M</text>
+    <text x="740" y="348">2.5M</text>
+    <text x="840" y="348">3.0M</text>
+  </g>
+  <text x="840" y="378" text-anchor="end" font-family="system-ui, -apple-system, Segoe UI, sans-serif" font-size="11" fill="#6b7280">Linux x86-64 · reduced smoke block 0 · profiling disabled</text>
+</svg>


### PR DESCRIPTION
## What changed

Adds a visible README checkpoint from the completed Phase 2 four-allocator producer: one static SVG comparing the final reduced-smoke `tiny-fixed-64`, 1-thread cell.

The README explicitly labels this as a development smoke preview, one block, and not statistically valid or a headline result.

## Source data

- mimalloc-pprof: 2,495,595.18 tx/s
- upstream mimalloc: 2,515,733.34 tx/s
- TCMalloc: 2,425,634.55 tx/s
- jemalloc: 2,608,169.14 tx/s
- all four completed 2,282,064 transactions with checksum `7378262852609382910`
- Linux x86-64; profiling and memory-events collection disabled

## Validation

- SVG parses as XML
- `git diff --check` passes