### PR TITLE
fix(ci): resolve soldr PATH in filtered subprocess environment + Phase 5B README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,47 @@ A fork of [microsoft/mimalloc](https://github.com/microsoft/mimalloc) that adds
 **pprof-compatible sampled heap profiling**, with native Windows as a first-class
 target alongside Linux and macOS.
 
-## Allocator benchmark preview
+## Performance
+
+mimalloc-pprof is continuously benchmarked against **upstream mimalloc**,
+**TCMalloc**, and **jemalloc** on a dedicated Linux x86-64 runner.  Every result
+is **GitHub-hosted and informational** — no self-hosted hardware, no hand-picked
+runs, no unpublished baselines.
+
+| Resource | Description |
+|---|---|
+| [**Benchmark dashboard**](https://zackees.github.io/mimalloc-pprof/) | Live per-scenario throughput, paired statistical effects, and full allocator provenance |
+| [`benchmark-stats` branch](https://github.com/zackees/mimalloc-pprof/tree/benchmark-stats) | Raw sealed site artifacts (history, manifests, digests) |
+| [`latest.json`](https://zackees.github.io/mimalloc-pprof/latest.json) | Machine-readable publication envelope for the most recent headline run |
+
+### Methodology summary
+
+- **4 allocators** — mimalloc-pprof, upstream mimalloc (same `dev3` base),
+  TCMalloc, and jemalloc — pinned to immutable commits with SHA-256-verified
+  source archives.
+- **Paired balanced blocks** — every block runs all four allocators in
+  randomized order under one workload seed; ≥15 complete blocks per headline
+  cell.
+- **Type-7 quantile bootstrap** — 10,000 resamples, splitmix64-rejection PRNG,
+  percentile-block confidence intervals at 95%.  Paired effects are expressed
+  relative to upstream mimalloc.
+- **No profiling during measurement** — `MIMALLOC_PROF=0` and
+  `MIMALLOC_MEMORY_EVENTS=0` are set on every child process; the allocator runs
+  in its natural configuration.
+- **Deterministic reproducibility** — every raw sample carries its exact command
+  line and workload seed; the published site manifest carries a detached SHA-256
+  digest of every file.
+
+Full protocol details, JSON schemas, and reproduction commands are in
+[`rust/benchmark-suite/`](rust/benchmark-suite/).
+
+### Development smoke preview
 
 ![Development smoke preview comparing mimalloc-pprof, upstream mimalloc, TCMalloc, and jemalloc](doc/benchmark-smoke-preview.svg)
 
-**Development smoke preview only.** This is one Linux x86-64 reduced-smoke block
-for the 1-thread `tiny-fixed-64` cell, with profiling and memory-events collection
-disabled. One block is not statistically valid and this is not a headline
-benchmark result; it is shown only as an early end-to-end preview while the full
-benchmark suite is completed.
+*This is one reduced-smoke block for the 1-thread `tiny-fixed-64` cell — not a
+headline result.  For live statistically-valid results, see the dashboard
+above.*
 
 ```
    __  __ ___ __  __    _    _     _     ___   ____

--- a/ci/build_benchmark_allocators.py
+++ b/ci/build_benchmark_allocators.py
@@ -460,6 +460,7 @@ def command_environment() -> dict[str, str]:
     # into its persistent soldr volume rather than the base image. Make those
     # exact binaries visible to the native recipes and retain the resulting PATH
     # in provenance.
+    inherited = environment.get("PATH", "")
     soldr_syslib = Path("/root/.soldr/bin/syslib")
     try:
         is_syslib = soldr_syslib.is_dir()
@@ -471,8 +472,21 @@ def command_environment() -> dict[str, str]:
             reverse=True,
         )
         if syslib_bins:
-            inherited = environment.get("PATH", "")
-            environment["PATH"] = os.pathsep.join([*(str(path) for path in syslib_bins), inherited])
+            inherited = os.pathsep.join([*(str(path) for path in syslib_bins), inherited])
+    # Ensure the soldr binary itself is discoverable. The setup-soldr action adds
+    # it to PATH in the shell environment, but our allowlist-based filtering may
+    # drop its directory. Resolve it from the unfiltered environment and prepend
+    # its parent directory so subprocess.run can find it.
+    soldr_path = shutil.which("soldr", path=os.environ.get("PATH", os.defpath))
+    if soldr_path is None:
+        # Fall back to the canonical Docker harness install location.
+        candidate = Path("/root/.soldr/bin/soldr")
+        if candidate.is_file():
+            soldr_path = str(candidate)
+    if soldr_path is not None:
+        soldr_dir = str(Path(soldr_path).resolve().parent)
+        inherited = os.pathsep.join([soldr_dir, inherited])
+    environment["PATH"] = inherited
     return environment
 
 
@@ -893,8 +907,7 @@ def build_child(
         allocator_id, source_dir, build_dir, library, build_root, logs
     )
     target_dir = (build_root / "cargo-target" / allocator_id).resolve()
-    command = [
-        "soldr",
+    cargo_args = [
         "cargo",
         "build",
         "--manifest-path",
@@ -922,8 +935,20 @@ def build_child(
             "BENCH_ALLOCATOR_LINK_MANIFEST": str(link_manifest),
         }
     )
+    # soldr may be installed as a binary on PATH (detected by command_environment
+    # above) or as a shell function (common in the setup-soldr Docker harness).
+    # Resolve it once and prefer the absolute path for subprocess safety.
+    resolved_soldr = shutil.which("soldr", path=environment.get("PATH", os.defpath))
+    if resolved_soldr is not None:
+        command = [resolved_soldr, *cargo_args]
+        display = " ".join(command)
+    else:
+        # soldr may be a shell function; invoke through bash to resolve it.
+        quoted = " ".join(shlex.quote(arg) for arg in cargo_args)
+        command = ["bash", "-c", f"soldr {quoted}"]
+        display = "$ " + " ".join(command)
     with (logs / f"{allocator_id}-child.log").open("w", encoding="utf-8") as log:
-        log.write("$ " + " ".join(command) + "\n")
+        log.write(display + "\n")
         log.flush()
         subprocess.run(
             command,

--- a/ci/build_benchmark_allocators.py
+++ b/ci/build_benchmark_allocators.py
@@ -1087,7 +1087,10 @@ def build_records(
         required_tool = build.get("required_tool_version")
         if required_tool is not None:
             actual_tool = checked_tool_version([resolved[0][0]])
-            if not _tool_version_satisfies(actual_tool, required_tool):
+            required_tool_str = require_string(
+                required_tool, f"{allocator_id}.build.required_tool_version"
+            )
+            if not _tool_version_satisfies(actual_tool, required_tool_str):
                 raise ArchiveError(f"{allocator_id} requires {required_tool}, got {actual_tool}")
         with (logs / f"{allocator_id}.log").open("w", encoding="utf-8") as log:
             for command in resolved:


### PR DESCRIPTION
## Summary

Fixes the CI benchmark publication pipeline (Phase 5A fix) and adds live benchmark dashboard links to README (Phase 5B).

Addresses remaining items in #194.

## Changes

### Phase 5A fix: soldr PATH resolution
- `ci/build_benchmark_allocators.py`: `command_environment()` now locates the `soldr` binary from the unfiltered environment via `shutil.which()` and prepends its directory to the filtered PATH.
- Falls back to `/root/.soldr/bin/soldr` (canonical Docker harness location) if not found on PATH.
- `build_child()` uses `shutil.which()` to resolve the absolute path to `soldr`; falls back to `bash -c` invocation if `soldr` is a shell function rather than a binary.
- **Root cause**: The allowlist-based environment filtering in `command_environment()` dropped the `soldr` binary directory from PATH, causing `FileNotFoundError: [Errno 2] No such file or directory: soldr` in the `build-and-measure` job.

### Phase 5B: README benchmark surfacing
- Replaced the "Development smoke preview only" placeholder with a **Performance** section.
- Links to: live GitHub Pages dashboard, benchmark-stats branch, and latest.json.
- Methodological summary (4-allocator paired blocks, Type-7 bootstrap, deterministic reproducibility, profiler-off measurement).
- Retains the smoke preview SVG as a development artifact.

## Remaining (tracked in sub-issues)

Phase 6 advanced metrics (#183) with child issues #184-187 remain open and are tracked independently.

## Validation

- [x] `python ci/build_benchmark_allocators.py --selftest` — PASS
- [x] `python ci/build_benchmark_allocators.py` — PASS (validated 4 allocator records)
- [x] `python ci/check_benchmark_workflow.py --selftest` — PASS
- [x] `python -m unittest discover -s ci/tests -p "test_*.py"` — 22 tests PASS
- [x] `python ci/benchmark_report.py --selftest` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)