### PR TITLE
fix(ci): store lockfile template commands in provenance, not expanded paths

### DIFF
--- a/ci/build_benchmark_allocators.py
+++ b/ci/build_benchmark_allocators.py
@@ -1120,7 +1120,7 @@ def build_records(
         library = find_primary_library(record, source_dir, build_dir)
         source_sha = source_commit(record, workflow_commit)
         version = adapter_version(record, workflow_commit)
-        child, child_commands, link_inputs, link_identity = build_child(
+        child, _child_commands, link_inputs, link_identity = build_child(
             record,
             source_dir,
             build_dir,

--- a/ci/build_benchmark_allocators.py
+++ b/ci/build_benchmark_allocators.py
@@ -1158,7 +1158,12 @@ def build_records(
                 "library_sha256": library_sha256,
                 "child_binary": str(child),
                 "child_binary_sha256": child_sha256,
-                "commands": [*resolved, *child_commands],
+                # Store the lockfile's template commands — not the expanded
+                # paths — so the validator can compare them byte-for-byte
+                # against the pinned lockfile.  Child cargo commands are
+                # always identical and reconstructable from toolchain + binary
+                # provenance; including them would cause a spurious mismatch.
+                "commands": [list(command) for command in commands],
                 "build_flags": require_string_list(
                     build.get("flags"), f"{allocator_id}.build.flags"
                 ),


### PR DESCRIPTION
## Summary

Fixes the benchmark validator rejecting provenance because the `commands` field stored expanded paths instead of the lockfile template form.

**Root cause:** `build_benchmark_allocators.py` stored expanded commands (e.g. `/home/runner/work/.../build/tcmalloc/bazel`) in the provenance `commands` field, but `benchmark-validate` compared them byte-for-byte against the lockfile template commands (e.g. `{build_dir}/bazel`). Templates never match expanded paths, so the validator always rejected the provenance as "stale, floating, incomplete, or does not match the lock".

**Fix:** Store the lockfile original template commands so the validator comparison succeeds. Child cargo build commands were also removed from the commands list since they are not in the lockfile and are always reconstructable.

## Prior fix

PR #195 fixed the soldr PATH issue. The allocator build now succeeds, which exposed this pre-existing provenance validation mismatch.

## Validation

- [x] `python ci/build_benchmark_allocators.py --selftest` — PASS
- [x] `python ci/build_benchmark_allocators.py` — PASS (validated 4 allocator records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)