### PR TITLE
fix(validate): remove peak_live_requested_bytes from block-identity check

### DIFF
--- a/rust/benchmark-suite/src/validate.rs
+++ b/rust/benchmark-suite/src/validate.rs
@@ -665,7 +665,11 @@ fn validate_block(
             || sample.free_calls != first.free_calls
             || sample.realloc_calls != first.realloc_calls
             || sample.checksum != first.checksum
-            || sample.peak_live_requested_bytes != first.peak_live_requested_bytes
+            // peak_live_requested_bytes is excluded from the block-identity
+            // check: it is measured via AtomicU64::fetch_max across threads,
+            // and different allocator speeds cause different thread-scheduling
+            // order, so the observed peak is inherently non-deterministic
+            // across allocators in multi-threaded workloads.
         {
             return Err(ValidationError::new(format!(
                 "cell {}/{} block {block_id} has mismatched seed/count/request identity",


### PR DESCRIPTION
## Summary

Fixes a validator false-positive where `peak_live_requested_bytes` was required to match across all 4 allocators in a block. This field is measured via `AtomicU64::fetch_max` across threads — different allocator speeds cause different thread-scheduling order, so the observed peak is inherently non-deterministic across allocators in multi-threaded workloads like `sawtooth-retain-drain`.

## Root cause

The block-identity check at `validate.rs:656-668` compared every field including `peak_live_requested_bytes`. In multi-threaded workloads, the atomic `fetch_max` of the live-byte counter depends on thread interleaving, which varies by allocator speed. This is not a correctness bug — it is an inherent property of concurrent measurement.

## Fix

Remove `peak_live_requested_bytes` from the block-identity comparison. All other fields (checksum, call counts, seed, transaction counts) remain checked.

## Prior fixes in this pipeline

- PR #195: soldr PATH resolution
- PR #196: provenance commands field stores templates
- PR #197: this PR — remove nondeterministic peak_live from identity check

## Validation

- [x] `soldr cargo test -p benchmark-suite --locked` — 14 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)