### PR TITLE
fix(ci): authenticate git push in publish-branch job

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -272,6 +272,7 @@ jobs:
           cp -r "$GITHUB_WORKSPACE/site-temp/"* .
           git add -A
           git commit -m "benchmark-stats run=${{ github.run_id }}/${{ github.run_attempt }} src=${{ github.sha }} manifest=$MANIFEST_DIGEST"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
           PRIOR_SHA="${{ needs.build-and-measure.outputs.prior_branch_sha }}"
           if [ "$PRIOR_SHA" = "first-publication" ]; then
             git push origin "HEAD:$PUBLISH_REF"


### PR DESCRIPTION
## Summary

The publish-branch job uses `persist-credentials: false` for security (required by workflow policy), but its git push to the benchmark-stats branch needs authentication. This adds `git remote set-url origin` with the GITHUB_TOKEN before the push.

## Context

PRs #195, #196, and #197 fixed the benchmark pipeline through build-and-measure. Run #31455357839 showed all build, measure, validate, and render steps passing. The only remaining failure was the publish-branch push failing with `could not read Username for 'https://github.com'`.

## Validation

- [x] `python ci/check_benchmark_workflow.py --workflow .github/workflows/benchmark-stats.yml` — PASS
- [x] `python -m unittest discover -s ci/tests -p test_benchmark_workflow.py` — 13 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)