### PR TITLE
fix(benchmarks): seal stats publication and surface headline graphics

### DIFF
--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -208,7 +208,9 @@ jobs:
         with:
           name: benchmark-site-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/site/
+          include-hidden-files: true
           retention-days: 30
+          if-no-files-found: error
       - name: upload diagnostics artifact
         if: failure()
         uses: actions/upload-artifact@v4.6.2
@@ -230,10 +232,22 @@ jobs:
       - uses: actions/checkout@v4.4.0
         with:
           persist-credentials: false
+      - name: download site artifact
+        uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit/site/
+      - name: download validation artifact
+        uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit/validation/
       - name: audit site artifact
         run: |
           set -euxo pipefail
-          echo "Independent audit: re-validating raw/latest/site, recomputing digests, verifying allowlist."
+          python ci/benchmark_report.py validate-site \
+            --site-dir audit/site/ \
+            --detached-digest audit/validation/manifest.sha256
           echo "Run ${{ github.run_id }} attempt ${{ github.run_attempt }}: audit complete."
 
   publish-branch:
@@ -257,9 +271,9 @@ jobs:
       - name: validate site before push
         run: |
           python ci/benchmark_report.py validate-site \
-            --site-dir site-temp/ \
-            --detached-digest "$RUNNER_TEMP/manifest.sha256" || true
+            --site-dir site-temp/
       - name: push benchmark-stats branch
+        id: publish
         run: |
           set -euxo pipefail
           MANIFEST_DIGEST=$(sha256sum site-temp/manifest.json | awk '{print $1}')
@@ -267,11 +281,15 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           WORKTREE=$(mktemp -d)
           git worktree add --detach "$WORKTREE" HEAD
+          python ci/benchmark_report.py prepare-branch \
+            --worktree "$WORKTREE" \
+            --site-dir "$GITHUB_WORKSPACE/site-temp"
           cd "$WORKTREE"
-          rm -rf ./*
-          cp -r "$GITHUB_WORKSPACE/site-temp/"* .
-          git add -A
           git commit -m "benchmark-stats run=${{ github.run_id }}/${{ github.run_attempt }} src=${{ github.sha }} manifest=$MANIFEST_DIGEST"
+          python "$GITHUB_WORKSPACE/ci/benchmark_report.py" validate-revision \
+            --repository "$WORKTREE" \
+            --revision HEAD \
+            --site-dir "$GITHUB_WORKSPACE/site-temp"
           git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
           PRIOR_SHA="${{ needs.build-and-measure.outputs.prior_branch_sha }}"
           if [ "$PRIOR_SHA" = "first-publication" ]; then
@@ -279,10 +297,13 @@ jobs:
           else
             git push origin "HEAD:$PUBLISH_REF" --force-with-lease="refs/heads/benchmark-stats:$PRIOR_SHA"
           fi
-          echo "published_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          PUBLISHED_SHA=$(git rev-parse HEAD)
+          REMOTE_SHA=$(git ls-remote origin "$PUBLISH_REF" | awk '{print $1}')
+          test "$REMOTE_SHA" = "$PUBLISHED_SHA"
+          echo "published_sha=$PUBLISHED_SHA" >> "$GITHUB_OUTPUT"
           echo "manifest_digest=$MANIFEST_DIGEST" >> "$GITHUB_OUTPUT"
           cd "$GITHUB_WORKSPACE"
-          rm -rf "$WORKTREE"
+          git worktree remove --force "$WORKTREE"
         env:
           PUBLISH_REF: ${{ env.PUBLISH_REF }}
 
@@ -303,6 +324,7 @@ jobs:
         uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: _site/
+          include-hidden-files: true
 
   deploy-pages:
     runs-on: ubuntu-24.04
@@ -315,6 +337,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/deploy-pages@v4.0.5
         id: deployment
@@ -330,10 +354,23 @@ jobs:
       - uses: actions/checkout@v4.4.0
         with:
           persist-credentials: false
+      - name: download sealed site artifact
+        uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit/site/
       - name: audit publication
         run: |
           set -euxo pipefail
-          PAGES_URL="${{ steps.deployment.outputs.page_url }}"
+          git fetch origin refs/heads/benchmark-stats --depth=1
+          python ci/benchmark_report.py validate-revision \
+            --repository . \
+            --revision FETCH_HEAD \
+            --site-dir audit/site/
+          PAGES_URL="${{ needs.deploy-pages.outputs.page_url }}"
+          python ci/benchmark_report.py audit-pages \
+            --site-dir audit/site/ \
+            --page-url "$PAGES_URL"
           echo "## Publication Audit" >> "$GITHUB_STEP_SUMMARY"
           echo "- Pages URL: $PAGES_URL" >> "$GITHUB_STEP_SUMMARY"
           echo "- Run: ${{ github.run_id }}" >> "$GITHUB_STEP_SUMMARY"
@@ -346,7 +383,7 @@ jobs:
           ELIGIBLE="${{ needs.build-and-measure.outputs.publish_eligible }}"
           if [ "$ELIGIBLE" = "true" ]; then
             echo "- Published to branch and Pages" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Pages: ${{ steps.deployment.outputs.page_url || 'pending' }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Pages: ${{ needs.deploy-pages.outputs.page_url || 'pending' }}" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- Non-publishing run" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ![Development smoke preview comparing mimalloc-pprof, upstream mimalloc, TCMalloc, and jemalloc](doc/benchmark-smoke-preview.svg)
 
+*Development-only smoke preview from one reduced block; the statistically
+validated headline results are published below.*
+
 > **The one mimalloc heap profiler that runs natively on Windows.** Upstream mimalloc
 > has no profiler at all, and the only other known implementation
 > ([Bun's](https://github.com/oven-sh/mimalloc), surveyed in
@@ -48,6 +51,28 @@ runs, no unpublished baselines.
 Full protocol details, JSON schemas, and reproduction commands are in
 [`rust/benchmark-suite/`](rust/benchmark-suite/).
 
+### Headline results
+
+[![Per-scenario throughput: mimalloc-pprof, upstream mimalloc, TCMalloc, and jemalloc](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-throughput.png)](https://zackees.github.io/mimalloc-pprof/#throughput)
+
+[![Compatible history for the current comparison key](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-history.png)](https://zackees.github.io/mimalloc-pprof/#history)
+
+*Headline throughput and history charts from the latest daily publication run.
+Click either chart for the live interactive dashboard with full per-scenario
+tables and paired effects. The raw sealed artifacts remain available on the
+[`benchmark-stats` branch](https://github.com/zackees/mimalloc-pprof/tree/benchmark-stats).*
+
+#### Pending Phase 6 panels
+
+The following metrics are tracked in the dashboard as explicitly pending
+placeholder panels until their measurement protocols land:
+
+| Metric | Phase issue |
+|---|---|
+| Memory (Linux RSS, fragmentation proxy) | [#184](https://github.com/zackees/mimalloc-pprof/issues/184) |
+| Honest transaction latency | [#185](https://github.com/zackees/mimalloc-pprof/issues/185) |
+| Thread/affinity scaling curves | [#186](https://github.com/zackees/mimalloc-pprof/issues/186) |
+| Pprof compilation and runtime tax | [#187](https://github.com/zackees/mimalloc-pprof/issues/187) |
 
 ```
    __  __ ___ __  __    _    _     _     ___   ____

--- a/ci/benchmark_report.py
+++ b/ci/benchmark_report.py
@@ -13,10 +13,17 @@ import hashlib
 import html
 import json
 import math
+import os
 import re
+import shutil
 import struct
+import subprocess
 import sys
 import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
 import zlib
 from collections.abc import Mapping, Sequence
 from datetime import datetime
@@ -981,9 +988,9 @@ def render_html(latest: Mapping[str, object]) -> bytes:
 <style>body{{font:15px system-ui,sans-serif;max-width:1200px;margin:auto;padding:24px;color:#182334}}table{{border-collapse:collapse;width:100%;margin:16px 0}}th,td{{border:1px solid #ccd4dd;padding:7px;text-align:left}}img{{max-width:100%;height:auto}}.pending{{border:1px solid #ccd4dd;padding:12px;margin:12px 0}}code,pre{{overflow-wrap:anywhere;white-space:pre-wrap}}small{{color:#596575}}</style></head><body>
 <h1>Allocator benchmark report</h1><p>Suite <code>{escaped(latest["suite_version"])}</code>; source <code>{escaped(run["source_sha"])}</code>; runner {escaped(runner["runner_class"])}. Intervals are informational.</p>
 <nav><a href="latest.json">validated latest data</a> · <a href="history.jsonl">compact history</a></nav>
-<h2>Throughput</h2><img src="benchmark-throughput.png" alt="Per-scenario absolute throughput bars for all four allocators"><table><thead><tr><th>Scenario</th><th>Threads</th><th>Allocator</th><th>Median</th><th>Noisy</th></tr></thead><tbody>{absolute_rows}</tbody></table>
+<h2 id="throughput">Throughput</h2><img src="benchmark-throughput.png" alt="Per-scenario absolute throughput bars for all four allocators"><table><thead><tr><th>Scenario</th><th>Threads</th><th>Allocator</th><th>Median</th><th>Noisy</th></tr></thead><tbody>{absolute_rows}</tbody></table>
 <h2>Paired effects</h2><table><thead><tr><th>Scenario</th><th>Candidate</th><th>Effect</th><th>95% interval</th><th>Interpretation</th></tr></thead><tbody>{paired_rows}</tbody></table>
-<h2>Compatible history</h2><img src="benchmark-history.png" alt="History connected only across the selected identical comparison key">
+<h2 id="history">Compatible history</h2><img src="benchmark-history.png" alt="History connected only across the selected identical comparison key">
 <h2>Pending Phase 6 panels</h2>{pending_html}<section id="phase-6"><p>Pending panels contain no measured values.</p></section>
 <h2>Provenance</h2><p>Run {escaped(run["run_id"])}, attempt {escaped(run["run_attempt"])}; target {escaped(runner["target"])}; fingerprint <code>{escaped(runner["fingerprint_sha256"])}</code>.</p><table><thead><tr><th>Allocator</th><th>Source</th><th>Binary</th></tr></thead><tbody>{allocator_rows}</tbody></table><p><a href="{escaped(latest["actions_run_url"])}">Actions run</a></p>
 <h2>Methodology</h2><pre>{escaped(json.dumps(latest["methodology"], sort_keys=True, ensure_ascii=False))}</pre><h2>Reproduce</h2><pre><code>{escaped(latest["reproduction_command"])}</code></pre>
@@ -1097,13 +1104,21 @@ def validate_site(site: Path, detached: Path | None = None) -> None:
     if site.is_symlink() or not site.is_dir():
         fail(f"{site}: site must be a real directory")
     actual: set[str] = set()
-    for path in site.rglob("*"):
-        relative = path.relative_to(site).as_posix()
-        if path.is_symlink():
-            fail(f"{path}: symlinks are forbidden")
-        if not path.is_file():
-            fail(f"{path}: nested directories and special entries are forbidden")
-        actual.add(relative)
+    # os.walk includes dotfiles unconditionally; rglob("*") may not on every Python.
+    for dirpath_str, dirnames, filenames in os.walk(site):
+        dirpath = Path(dirpath_str)
+        for name in dirnames:
+            path = dirpath / name
+            if path.is_symlink():
+                fail(f"{path}: symlinks are forbidden")
+            fail(f"{path}: nested directories are forbidden")
+        for name in filenames:
+            path = dirpath / name
+            if path.is_symlink():
+                fail(f"{path}: symlinks are forbidden")
+            if not path.is_file():
+                fail(f"{path}: special entries are forbidden")
+            actual.add(path.relative_to(site).as_posix())
     if actual != SITE_FILES:
         fail(
             f"{site}: site allowlist mismatch; missing={sorted(SITE_FILES - actual)} unexpected={sorted(actual - SITE_FILES)}"
@@ -1175,6 +1190,131 @@ def validate_site(site: Path, detached: Path | None = None) -> None:
             fail(f"{detached}: detached manifest digest mismatch")
 
 
+def git_command(repository: Path, *arguments: str) -> bytes:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repository), *arguments],
+            check=False,
+            capture_output=True,
+        )
+    except OSError as error:
+        fail(f"git {' '.join(arguments)}: cannot execute: {error}")
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        fail(f"git {' '.join(arguments)} failed in {repository}: {detail}")
+    return completed.stdout
+
+
+def decode_git_paths(data: bytes, label: str) -> set[str]:
+    paths: set[str] = set()
+    for raw in data.split(b"\0"):
+        if not raw:
+            continue
+        try:
+            path = raw.decode("utf-8")
+        except UnicodeDecodeError as error:
+            fail(f"{label}: non-UTF-8 path: {error}")
+        if path in paths:
+            fail(f"{label}: duplicate path {path!r}")
+        paths.add(path)
+    return paths
+
+
+def git_index_files(repository: Path) -> set[str]:
+    return decode_git_paths(git_command(repository, "ls-files", "-z"), "git index")
+
+
+def git_revision_files(repository: Path, revision: str) -> set[str]:
+    return decode_git_paths(
+        git_command(repository, "ls-tree", "-r", "--name-only", "-z", revision),
+        f"git revision {revision}",
+    )
+
+
+def require_exact_files(actual: set[str], label: str) -> None:
+    if actual != SITE_FILES:
+        fail(
+            f"{label} allowlist mismatch; missing={sorted(SITE_FILES - actual)} "
+            f"unexpected={sorted(actual - SITE_FILES)}"
+        )
+
+
+def prepare_branch(worktree: Path, site: Path) -> None:
+    """Replace a linked worktree's index with exactly the sealed site."""
+
+    validate_site(site)
+    worktree = worktree.resolve()
+    site = site.resolve()
+    if worktree == site:
+        fail("publication worktree and site directory must be distinct")
+    administrative_file = worktree / ".git"
+    if not administrative_file.is_file() or administrative_file.is_symlink():
+        fail(f"{administrative_file}: expected linked-worktree administrative file")
+    top_level = Path(
+        git_command(worktree, "rev-parse", "--show-toplevel").decode("utf-8").strip()
+    ).resolve()
+    if top_level != worktree:
+        fail(f"{worktree}: not the Git worktree root ({top_level})")
+    if git_command(worktree, "status", "--porcelain=v1", "-z"):
+        fail(f"{worktree}: publication worktree must start clean")
+
+    git_command(worktree, "rm", "-r", "-f", "--ignore-unmatch", "--", ".")
+    leftovers = sorted(path.name for path in worktree.iterdir() if path.name != ".git")
+    if leftovers:
+        fail(f"{worktree}: unexpected untracked files after git rm: {leftovers}")
+    for name in sorted(SITE_FILES):
+        shutil.copy2(site / name, worktree / name)
+    git_command(worktree, "add", "-A")
+
+    if not administrative_file.is_file():
+        fail(f"{administrative_file}: worktree administration was removed")
+    require_exact_files(git_index_files(worktree), "staged publication index")
+    for name in SITE_FILES:
+        if (worktree / name).read_bytes() != (site / name).read_bytes():
+            fail(f"{worktree / name}: copied bytes differ from sealed site")
+
+
+def validate_git_revision(repository: Path, revision: str, site: Path) -> None:
+    """Prove a revision contains exactly the sealed site and identical bytes."""
+
+    validate_site(site)
+    require_exact_files(git_revision_files(repository, revision), "revision")
+    for name in SITE_FILES:
+        published = git_command(repository, "show", f"{revision}:{name}")
+        if published != (site / name).read_bytes():
+            fail(f"{revision}:{name}: bytes differ from sealed site")
+
+
+def audit_pages(site: Path, page_url: str, attempts: int, delay_seconds: float) -> None:
+    """Wait for the deployed public payload to become byte-identical to the sealed site."""
+
+    validate_site(site)
+    parsed = urllib.parse.urlparse(page_url)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
+        fail(f"{page_url!r}: expected a plain HTTPS Pages base URL")
+    if attempts < 1 or delay_seconds < 0:
+        fail("Pages audit attempts must be positive and delay non-negative")
+    base = page_url.rstrip("/") + "/"
+    version = sha256(site / "manifest.json")
+    public_files = SITE_FILES - {".nojekyll"}
+    last_error = "Pages payload did not match"
+    for attempt in range(1, attempts + 1):
+        try:
+            for name in sorted(public_files):
+                url = urllib.parse.urljoin(base, name) + f"?manifest={version}"
+                request = urllib.request.Request(url, headers={"Cache-Control": "no-cache"})
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    data = response.read(FILE_CAPS[name] + 1)
+                if data != (site / name).read_bytes():
+                    raise ReportError(f"{url}: deployed bytes differ from sealed site")
+            return
+        except (OSError, urllib.error.URLError, ReportError) as error:
+            last_error = str(error)
+            if attempt < attempts:
+                time.sleep(delay_seconds)
+    fail(f"Pages audit failed after {attempts} attempts: {last_error}")
+
+
 def assert_fixture_determinism(
     input_path: Path,
     history_path: Path,
@@ -1244,6 +1384,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     validate_parser = subparsers.add_parser("validate-site")
     validate_parser.add_argument("--site-dir", type=Path, required=True)
     validate_parser.add_argument("--detached-digest", type=Path)
+    prepare_parser = subparsers.add_parser("prepare-branch")
+    prepare_parser.add_argument("--worktree", type=Path, required=True)
+    prepare_parser.add_argument("--site-dir", type=Path, required=True)
+    revision_parser = subparsers.add_parser("validate-revision")
+    revision_parser.add_argument("--repository", type=Path, required=True)
+    revision_parser.add_argument("--revision", required=True)
+    revision_parser.add_argument("--site-dir", type=Path, required=True)
+    pages_parser = subparsers.add_parser("audit-pages")
+    pages_parser.add_argument("--site-dir", type=Path, required=True)
+    pages_parser.add_argument("--page-url", required=True)
+    pages_parser.add_argument("--attempts", type=int, default=12)
+    pages_parser.add_argument("--delay-seconds", type=float, default=10.0)
     args = parser.parse_args(argv)
     if args.selftest:
         if args.command is not None:
@@ -1271,7 +1423,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         validate_site(args.site_dir, args.detached_digest)
         print(f"PASS validated sealed benchmark site {args.site_dir}")
         return 0
-    parser.error("choose --selftest, render, or validate-site")
+    if args.command == "prepare-branch":
+        prepare_branch(args.worktree, args.site_dir)
+        print(f"PASS prepared exact benchmark branch index in {args.worktree}")
+        return 0
+    if args.command == "validate-revision":
+        validate_git_revision(args.repository, args.revision, args.site_dir)
+        print(f"PASS validated {args.revision} against sealed benchmark site")
+        return 0
+    if args.command == "audit-pages":
+        audit_pages(args.site_dir, args.page_url, args.attempts, args.delay_seconds)
+        print(f"PASS Pages payload matches sealed benchmark site at {args.page_url}")
+        return 0
+    parser.error(
+        "choose --selftest, render, validate-site, prepare-branch, validate-revision, or audit-pages"
+    )
     return 2
 
 

--- a/ci/check_benchmark_workflow.py
+++ b/ci/check_benchmark_workflow.py
@@ -238,6 +238,20 @@ def check_jobs(workflow: Mapping[str, object]) -> None:
             env = job.get("environment")
             if not isinstance(env, dict) or env.get("name") != "github-pages":
                 fail("workflow.jobs.deploy-pages.environment: must target github-pages")
+            outputs = object_value(job.get("outputs", {}), "workflow.jobs.deploy-pages.outputs")
+            if outputs.get("page_url") != "${{ steps.deployment.outputs.page_url }}":
+                fail("workflow.jobs.deploy-pages.outputs.page_url: must expose deployment URL")
+        if name == "publication-audit":
+            needs = job.get("needs", [])
+            needs_list = (
+                [needs]
+                if isinstance(needs, str)
+                else list_value(needs, f"workflow.jobs.{name}.needs")
+            )
+            if not {"publish-branch", "deploy-pages"}.issubset(set(needs_list)):
+                fail(
+                    "workflow.jobs.publication-audit.needs: must include publish-branch and deploy-pages"
+                )
         _check_steps(name, job.get("steps", []), f"workflow.jobs.{name}")
 
 
@@ -246,13 +260,20 @@ def _check_steps(job_name: str, steps: object, label: str) -> None:
         fail(f"{label}.steps: expected array")
     steps_list = cast(list[object], steps)
     seen_validate = False
+    seen_site_validate = False
     seen_eligible = job_name != "build-and-measure"
+    seen_site_upload = job_name != "build-and-measure"
+    seen_prepare_branch = job_name != "publish-branch"
+    seen_pages_upload = job_name != "package-pages"
+    seen_revision_audit = job_name != "publication-audit"
+    seen_pages_audit = job_name != "publication-audit"
     for index, step in enumerate(steps_list):
         prefix = f"{label}.steps[{index}]"
         step_obj = object_value(step, prefix)
         uses = step_obj.get("uses")
         if uses and isinstance(uses, str):
             parts = uses.split("@", 1)
+            action = parts[0]
             if len(parts) == 2:
                 action = parts[0]
                 if action in FORBIDDEN_ACTIONS:
@@ -266,14 +287,89 @@ def _check_steps(job_name: str, steps: object, label: str) -> None:
                     fail(f"{prefix}.with.persist-credentials: must be false")
                 continue
             check_action_ref(uses, prefix)
+            if step_obj.get("name") == "upload site artifact":
+                if action != "actions/upload-artifact":
+                    fail(f"{prefix}: site artifact must use actions/upload-artifact")
+                if not seen_site_validate:
+                    fail(f"{prefix}: site upload before sealed-site validation step")
+                with_obj = object_value(step_obj.get("with", {}), f"{prefix}.with")
+                if with_obj.get("include-hidden-files") is not True:
+                    fail(f"{prefix}.with.include-hidden-files: must be true for .nojekyll")
+                if with_obj.get("if-no-files-found") != "error":
+                    fail(f"{prefix}.with.if-no-files-found: must be error")
+                if with_obj.get("path") != "${{ runner.temp }}/site/":
+                    fail(f"{prefix}.with.path: must upload exactly the sealed site directory")
+                seen_site_upload = True
+            if action == "actions/upload-pages-artifact":
+                if job_name != "package-pages":
+                    fail(f"{prefix}: upload-pages-artifact is only allowed in package-pages")
+                with_obj = object_value(step_obj.get("with", {}), f"{prefix}.with")
+                if with_obj.get("include-hidden-files") is not True:
+                    fail(f"{prefix}.with.include-hidden-files: must be true for .nojekyll")
+                seen_pages_upload = True
         run = step_obj.get("run")
         if run and isinstance(run, str):
             if step_obj.get("name") == "validate raw run":
                 seen_validate = True
+            if step_obj.get("name") == "validate site":
+                if (
+                    "benchmark_report.py validate-site" not in run
+                    or '--site-dir "$RUNNER_TEMP/site"' not in run
+                ):
+                    fail(f"{prefix}: validate site must validate the rendered site directory")
+                seen_site_validate = True
             if step_obj.get("name") == "compute publication eligibility":
                 seen_eligible = True
-            if step_obj.get("name") == "upload site artifact" and not seen_validate:
-                fail(f"{prefix}: site upload before validation step")
+            if job_name == "publish-branch":
+                if "shopt -s dotglob" in run or re.search(r"rm\s+-rf\s+\.?/?\*", run):
+                    fail(f"{prefix}: shell-glob worktree deletion can remove .git")
+                if step_obj.get("name") == "push benchmark-stats branch":
+                    required = (
+                        "benchmark_report.py prepare-branch",
+                        '--worktree "$WORKTREE"',
+                        '--site-dir "$GITHUB_WORKSPACE/site-temp"',
+                        "git commit",
+                        'benchmark_report.py" validate-revision',
+                        "--revision HEAD",
+                        "git push origin",
+                    )
+                    if any(value not in run for value in required):
+                        fail(
+                            f"{prefix}: publish command is missing exact preparation/audit arguments"
+                        )
+                    positions = [
+                        run.index("benchmark_report.py prepare-branch"),
+                        run.index("git commit"),
+                        run.index('benchmark_report.py" validate-revision'),
+                        run.index("git push origin"),
+                    ]
+                    if positions != sorted(positions) or len(set(positions)) != len(positions):
+                        fail(f"{prefix}: prepare, commit, revision audit, and push must be ordered")
+                    seen_prepare_branch = True
+            if job_name == "publication-audit" and step_obj.get("name") == "audit publication":
+                required = (
+                    "git fetch origin refs/heads/benchmark-stats --depth=1",
+                    "benchmark_report.py validate-revision",
+                    "--revision FETCH_HEAD",
+                    "--site-dir audit/site/",
+                    'PAGES_URL="${{ needs.deploy-pages.outputs.page_url }}"',
+                    "benchmark_report.py audit-pages",
+                    '--page-url "$PAGES_URL"',
+                )
+                if any(value not in run for value in required):
+                    fail(f"{prefix}: publication audit is missing exact branch/Pages arguments")
+                positions = [
+                    run.index("git fetch origin refs/heads/benchmark-stats --depth=1"),
+                    run.index("benchmark_report.py validate-revision"),
+                    run.index('PAGES_URL="${{ needs.deploy-pages.outputs.page_url }}"'),
+                    run.index("benchmark_report.py audit-pages"),
+                ]
+                if positions != sorted(positions) or len(set(positions)) != len(positions):
+                    fail(
+                        f"{prefix}: fetch, revision audit, URL wiring, and Pages audit must be ordered"
+                    )
+                seen_revision_audit = True
+                seen_pages_audit = True
             # force-with-lease is required in publish-branch push
             if job_name == "publish-branch" and "git push" in run:
                 if "--force-with-lease" not in run:
@@ -291,6 +387,16 @@ def _check_steps(job_name: str, steps: object, label: str) -> None:
             fail(f"{label}: missing validation step in build-and-measure job")
         if not seen_eligible:
             fail(f"{label}: missing publication eligibility step in build-and-measure job")
+        if not seen_site_validate:
+            fail(f"{label}: missing sealed-site validation step")
+        if not seen_site_upload:
+            fail(f"{label}: missing fail-closed hidden-file site upload")
+    if not seen_prepare_branch:
+        fail(f"{label}: missing exact prepare-branch step")
+    if not seen_pages_upload:
+        fail(f"{label}: missing hidden-file Pages artifact upload")
+    if not seen_revision_audit or not seen_pages_audit:
+        fail(f"{label}: publication audit must validate branch revision and Pages bytes")
 
 
 def check_artifact_retention(workflow: Mapping[str, object]) -> None:
@@ -359,10 +465,20 @@ def selftest() -> int:
                         "with": {"persist-credentials": False},
                     },
                     {"name": "validate raw run", "run": "echo validated"},
+                    {
+                        "name": "validate site",
+                        "run": 'python ci/benchmark_report.py validate-site --site-dir "$RUNNER_TEMP/site"',
+                    },
                     {"name": "compute publication eligibility", "run": "echo eligible"},
                     {
+                        "name": "upload site artifact",
                         "uses": "actions/upload-artifact@ea165f8d65b6e75b540449e92b4880f43607fa02",
-                        "with": {"name": "x", "path": "."},
+                        "with": {
+                            "name": "x",
+                            "path": "${{ runner.temp }}/site/",
+                            "include-hidden-files": True,
+                            "if-no-files-found": "error",
+                        },
                         "retention-days": 30,
                     },
                 ],
@@ -384,8 +500,8 @@ def selftest() -> int:
                 "permissions": {"contents": "write"},
                 "steps": [
                     {
-                        "name": "push",
-                        "run": "git push origin HEAD:ref --force-with-lease=ref:abc123",
+                        "name": "push benchmark-stats branch",
+                        "run": 'python ci/benchmark_report.py prepare-branch --worktree "$WORKTREE" --site-dir "$GITHUB_WORKSPACE/site-temp"\ngit commit -m generated\npython "$GITHUB_WORKSPACE/ci/benchmark_report.py" validate-revision --repository "$WORKTREE" --revision HEAD --site-dir "$GITHUB_WORKSPACE/site-temp"\ngit push origin HEAD:ref --force-with-lease=ref:abc123',
                     }
                 ],
             },
@@ -393,13 +509,19 @@ def selftest() -> int:
                 "runs-on": "ubuntu-24.04",
                 "timeout-minutes": 10,
                 "permissions": {"contents": "read"},
-                "steps": [],
+                "steps": [
+                    {
+                        "uses": "actions/upload-pages-artifact@v4.0.0",
+                        "with": {"path": "_site/", "include-hidden-files": True},
+                    }
+                ],
             },
             "deploy-pages": {
                 "runs-on": "ubuntu-24.04",
                 "timeout-minutes": 10,
                 "permissions": {"pages": "write", "id-token": "write"},
                 "environment": {"name": "github-pages"},
+                "outputs": {"page_url": "${{ steps.deployment.outputs.page_url }}"},
                 "steps": [
                     {"uses": "actions/deploy-pages@c9ba3c5b5fca82fcf21936bd1efba49f2b8f40a0"}
                 ],
@@ -408,11 +530,16 @@ def selftest() -> int:
                 "runs-on": "ubuntu-24.04",
                 "timeout-minutes": 10,
                 "permissions": {"contents": "read"},
+                "needs": ["publish-branch", "deploy-pages"],
                 "steps": [
                     {
                         "uses": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
                         "with": {"persist-credentials": False},
-                    }
+                    },
+                    {
+                        "name": "audit publication",
+                        "run": 'git fetch origin refs/heads/benchmark-stats --depth=1\npython ci/benchmark_report.py validate-revision --repository . --revision FETCH_HEAD --site-dir audit/site/\nPAGES_URL="${{ needs.deploy-pages.outputs.page_url }}"\npython ci/benchmark_report.py audit-pages --site-dir audit/site/ --page-url "$PAGES_URL"',
+                    },
                 ],
             },
         },

--- a/ci/tests/test_benchmark_report.py
+++ b/ci/tests/test_benchmark_report.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
+import urllib.request
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -19,6 +22,14 @@ FIXTURE = Path(__file__).parent / "fixtures" / "benchmark"
 
 
 class BenchmarkReportTests(unittest.TestCase):
+    def git(self, repository: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(repository), *arguments],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
     def load_latest(self) -> dict[str, object]:
         return json.loads((FIXTURE / "latest.json").read_text(encoding="utf-8"))
 
@@ -52,6 +63,44 @@ class BenchmarkReportTests(unittest.TestCase):
                 },
             )
             report.validate_site(site, digest)
+
+    def test_prepare_branch_preserves_git_and_replaces_the_index_exactly(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository = root / "repository"
+            repository.mkdir()
+            self.git(repository, "init")
+            self.git(repository, "config", "user.name", "Fixture")
+            self.git(repository, "config", "user.email", "fixture@example.invalid")
+            (repository / ".github").mkdir()
+            (repository / ".github" / "workflow.yml").write_text("fixture\n")
+            (repository / ".clud").mkdir()
+            (repository / ".clud" / "state").write_text("fixture\n")
+            (repository / "README.md").write_text("fixture\n")
+            self.git(repository, "add", "-A")
+            self.git(repository, "commit", "-m", "fixture")
+
+            worktree = root / "worktree"
+            self.git(repository, "worktree", "add", "--detach", str(worktree), "HEAD")
+            site, _digest = self.render_fixture(root / "rendered")
+
+            report.prepare_branch(worktree, site)
+
+            self.assertTrue((worktree / ".git").is_file())
+            self.assertFalse((worktree / ".github").exists())
+            self.assertFalse((worktree / ".clud").exists())
+            self.assertEqual(report.SITE_FILES, report.git_index_files(worktree))
+            self.assertEqual(b"", (worktree / ".nojekyll").read_bytes())
+            for name in report.SITE_FILES:
+                self.assertEqual((site / name).read_bytes(), (worktree / name).read_bytes())
+
+            self.git(worktree, "commit", "-m", "published fixture")
+            report.validate_git_revision(worktree, "HEAD", site)
+            (worktree / "unexpected.txt").write_text("not sealed\n")
+            self.git(worktree, "add", "unexpected.txt")
+            self.git(worktree, "commit", "-m", "polluted fixture")
+            with self.assertRaisesRegex(report.ReportError, "revision allowlist mismatch"):
+                report.validate_git_revision(worktree, "HEAD", site)
 
     def test_two_fixture_renders_are_byte_identical(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -102,6 +151,74 @@ class BenchmarkReportTests(unittest.TestCase):
             self.assertNotIn("<script>alert(1)</script>", page)
             self.assertNotIn("<img src=x onerror=alert(1)>", page)
             self.assertIn("&lt;img src=x onerror=alert(1)&gt;", page)
+
+    def test_html_has_stable_headline_chart_anchors(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            site, _digest = self.render_fixture(Path(temporary))
+            page = (site / "index.html").read_text(encoding="utf-8")
+            self.assertIn('<h2 id="throughput">Throughput</h2>', page)
+            self.assertIn('<h2 id="history">Compatible history</h2>', page)
+
+    def test_readme_embeds_only_real_charts_and_clicks_through_to_pages(self) -> None:
+        readme = Path(__file__).resolve().parents[2] / "README.md"
+        source = readme.read_text(encoding="utf-8")
+        expected = {
+            "benchmark-throughput.png": "https://zackees.github.io/mimalloc-pprof/#throughput",
+            "benchmark-history.png": "https://zackees.github.io/mimalloc-pprof/#history",
+        }
+        for image, destination in expected.items():
+            raw = (
+                f"https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/{image}"
+            )
+            self.assertIn(f"]({raw})]({destination})", source)
+        for pending in (
+            "benchmark-memory.png",
+            "benchmark-latency.png",
+            "benchmark-scaling.png",
+            "benchmark-pprof-tax.png",
+        ):
+            self.assertNotIn(pending, source)
+        self.assertIn("https://github.com/zackees/mimalloc-pprof/tree/benchmark-stats", source)
+        self.assertIn("https://zackees.github.io/mimalloc-pprof/latest.json", source)
+
+    def test_pages_audit_compares_every_public_payload_byte(self) -> None:
+        class Response:
+            def __init__(self, data: bytes) -> None:
+                self.data = data
+
+            def __enter__(self) -> Response:
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self, limit: int) -> bytes:
+                return self.data[:limit]
+
+        with tempfile.TemporaryDirectory() as temporary:
+            site, _digest = self.render_fixture(Path(temporary))
+            requested: set[str] = set()
+
+            def open_fixture(request: urllib.request.Request, timeout: int) -> Response:
+                self.assertEqual(30, timeout)
+                url = request.full_url
+                name = url.split("/")[-1].split("?", 1)[0]
+                requested.add(name)
+                return Response((site / name).read_bytes())
+
+            with mock.patch.object(report.urllib.request, "urlopen", side_effect=open_fixture):
+                report.audit_pages(site, "https://example.invalid/benchmarks/", 1, 0)
+            self.assertEqual(report.SITE_FILES - {".nojekyll"}, requested)
+
+            def open_corrupt(request: urllib.request.Request, timeout: int) -> Response:
+                response = open_fixture(request, timeout)
+                return Response(response.data + b"corrupt")
+
+            with (
+                mock.patch.object(report.urllib.request, "urlopen", side_effect=open_corrupt),
+                self.assertRaisesRegex(report.ReportError, "deployed bytes differ"),
+            ):
+                report.audit_pages(site, "https://example.invalid/benchmarks/", 1, 0)
 
     def test_site_rejects_corruption_unexpected_files_and_broken_links(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/ci/tests/test_benchmark_workflow.py
+++ b/ci/tests/test_benchmark_workflow.py
@@ -39,10 +39,20 @@ def _phase5_workflow() -> dict[str, object]:
                         "with": {"persist-credentials": False},
                     },
                     {"name": "validate raw run", "run": "echo validated"},
+                    {
+                        "name": "validate site",
+                        "run": 'python ci/benchmark_report.py validate-site --site-dir "$RUNNER_TEMP/site"',
+                    },
                     {"name": "compute publication eligibility", "run": "echo eligible"},
                     {
                         "uses": "actions/upload-artifact@ea165f8d65b6e75b540449e92b4880f43607fa02",
-                        "with": {"name": "x", "path": "."},
+                        "name": "upload site artifact",
+                        "with": {
+                            "name": "x",
+                            "path": "${{ runner.temp }}/site/",
+                            "include-hidden-files": True,
+                            "if-no-files-found": "error",
+                        },
                         "retention-days": 30,
                     },
                 ],
@@ -64,8 +74,8 @@ def _phase5_workflow() -> dict[str, object]:
                 "permissions": {"contents": "write"},
                 "steps": [
                     {
-                        "name": "push",
-                        "run": "git push origin HEAD:ref --force-with-lease=ref:sha123",
+                        "name": "push benchmark-stats branch",
+                        "run": 'python ci/benchmark_report.py prepare-branch --worktree "$WORKTREE" --site-dir "$GITHUB_WORKSPACE/site-temp"\ngit commit -m generated\npython "$GITHUB_WORKSPACE/ci/benchmark_report.py" validate-revision --repository "$WORKTREE" --revision HEAD --site-dir "$GITHUB_WORKSPACE/site-temp"\ngit push origin HEAD:ref --force-with-lease=ref:sha123',
                     }
                 ],
             },
@@ -73,13 +83,19 @@ def _phase5_workflow() -> dict[str, object]:
                 "runs-on": "ubuntu-24.04",
                 "timeout-minutes": 10,
                 "permissions": {"contents": "read"},
-                "steps": [],
+                "steps": [
+                    {
+                        "uses": "actions/upload-pages-artifact@v4.0.0",
+                        "with": {"path": "_site/", "include-hidden-files": True},
+                    }
+                ],
             },
             "deploy-pages": {
                 "runs-on": "ubuntu-24.04",
                 "timeout-minutes": 10,
                 "permissions": {"pages": "write", "id-token": "write"},
                 "environment": {"name": "github-pages"},
+                "outputs": {"page_url": "${{ steps.deployment.outputs.page_url }}"},
                 "steps": [
                     {"uses": "actions/deploy-pages@c9ba3c5b5fca82fcf21936bd1efba49f2b8f40a0"}
                 ],
@@ -88,11 +104,16 @@ def _phase5_workflow() -> dict[str, object]:
                 "runs-on": "ubuntu-24.04",
                 "timeout-minutes": 10,
                 "permissions": {"contents": "read"},
+                "needs": ["publish-branch", "deploy-pages"],
                 "steps": [
                     {
                         "uses": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
                         "with": {"persist-credentials": False},
-                    }
+                    },
+                    {
+                        "name": "audit publication",
+                        "run": 'git fetch origin refs/heads/benchmark-stats --depth=1\npython ci/benchmark_report.py validate-revision --repository . --revision FETCH_HEAD --site-dir audit/site/\nPAGES_URL="${{ needs.deploy-pages.outputs.page_url }}"\npython ci/benchmark_report.py audit-pages --site-dir audit/site/ --page-url "$PAGES_URL"',
+                    },
                 ],
             },
         },
@@ -153,6 +174,87 @@ class TestPhase5Policy(unittest.TestCase):
         with self.assertRaises(PolicyError):
             check(bad)
 
+    def test_site_artifact_requires_hidden_files_and_fail_closed_upload(self) -> None:
+        bad = _phase5_workflow()
+        upload = bad["jobs"]["build-and-measure"]["steps"][4]["with"]
+        del upload["include-hidden-files"]
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+        bad = _phase5_workflow()
+        steps = bad["jobs"]["build-and-measure"]["steps"]
+        upload = steps.pop(4)
+        steps.insert(2, upload)
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+        bad = _phase5_workflow()
+        upload = bad["jobs"]["build-and-measure"]["steps"][4]["with"]
+        upload["if-no-files-found"] = "warn"
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+        bad = _phase5_workflow()
+        upload = bad["jobs"]["build-and-measure"]["steps"][4]["with"]
+        upload["path"] = "${{ runner.temp }}/"
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+    def test_pages_artifact_requires_hidden_files(self) -> None:
+        bad = _phase5_workflow()
+        upload = bad["jobs"]["package-pages"]["steps"][0]["with"]
+        del upload["include-hidden-files"]
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+    def test_unsafe_dotglob_cleanup_is_rejected(self) -> None:
+        bad = _phase5_workflow()
+        bad["jobs"]["publish-branch"]["steps"][0]["run"] += "\nshopt -s dotglob\nrm -rf ./*"
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+    def test_publish_requires_exact_prepare_and_revision_audit_order(self) -> None:
+        bad = _phase5_workflow()
+        run = bad["jobs"]["publish-branch"]["steps"][0]["run"]
+        bad["jobs"]["publish-branch"]["steps"][0]["run"] = run.replace(
+            '--worktree "$WORKTREE"', "--worktree wrong"
+        )
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+        bad = _phase5_workflow()
+        run = bad["jobs"]["publish-branch"]["steps"][0]["run"]
+        lines = run.splitlines()
+        lines[1], lines[2] = lines[2], lines[1]
+        bad["jobs"]["publish-branch"]["steps"][0]["run"] = "\n".join(lines)
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+    def test_publication_audit_must_validate_the_remote_revision(self) -> None:
+        bad = _phase5_workflow()
+        bad["jobs"]["publication-audit"]["steps"][1]["run"] = "echo not-an-audit"
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+        bad = _phase5_workflow()
+        run = bad["jobs"]["publication-audit"]["steps"][1]["run"]
+        bad["jobs"]["publication-audit"]["steps"][1]["run"] = run.replace(
+            "--revision FETCH_HEAD", "--revision HEAD"
+        )
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+    def test_publication_audit_requires_deployment_output_and_needs(self) -> None:
+        bad = _phase5_workflow()
+        del bad["jobs"]["deploy-pages"]["outputs"]
+        with self.assertRaises(PolicyError):
+            check(bad)
+
+        bad = _phase5_workflow()
+        bad["jobs"]["publication-audit"]["needs"] = ["publish-branch"]
+        with self.assertRaises(PolicyError):
+            check(bad)
+
     def test_deploy_pages_outside_deploy_job_rejected(self) -> None:
         bad = _phase5_workflow()
         bad["jobs"]["publish-branch"]["steps"].append({"uses": "actions/deploy-pages@v4.0.5"})
@@ -168,7 +270,7 @@ class TestPhase5Policy(unittest.TestCase):
     def test_missing_eligibility_step_rejected(self) -> None:
         bad = _phase5_workflow()
         steps = bad["jobs"]["build-and-measure"]["steps"]
-        del steps[2]  # remove eligibility step
+        del steps[3]  # remove eligibility step
         with self.assertRaises(PolicyError):
             check(bad)
 


### PR DESCRIPTION
## What

Completes the Phase 5B recovery in #200 and makes `benchmark-stats` an exact, fail-closed generated branch.

- publishes exactly `ci/benchmark_report.py::SITE_FILES` and preserves the linked worktree `.git` file;
- includes `.nojekyll` explicitly in both the cross-job and Pages artifacts;
- validates the staged index, committed revision, remote SHA, and deployed Pages bytes;
- replaces the previous no-op artifact/publication audits with real validation;
- adds stable `#throughput` and `#history` dashboard anchors;
- embeds only the two real headline charts in README, using raw branch bytes with Pages click-through;
- leaves memory, latency, scaling, and pprof-tax panels explicitly pending behind #184-#187.

## RED -> GREEN

RED before implementation:

- branch preparation API absent and `.git` preservation/exact-index test errored;
- stable dashboard anchor assertions failed;
- workflow policy accepted missing hidden-file opt-in, unsafe `dotglob` cleanup, and a no-op publication audit.

GREEN after implementation:

- `python -m unittest discover -s ci/tests -p "test_*.py"` — 32 passed;
- `python ci/benchmark_report.py --selftest` — passed;
- `python ci/check_benchmark_workflow.py --selftest` — passed;
- real workflow policy check — passed;
- Ruff format/lint — passed;
- Pyright strict — 0 errors;
- `actionlint .github/workflows/benchmark-stats.yml` — passed;
- `git diff --check` — passed;
- `clud-review` — clean after one follow-up, no remaining CRITICAL/HIGH/MEDIUM findings.

The first post-merge eligible publication will provide the remote branch/Pages evidence after the ordered feature merges, as requested.

Refs #200
