### PR TITLE
feat: add Linux process memory benchmarks

### DIFF
--- a/.github/workflows/benchmark-memory.yml
+++ b/.github/workflows/benchmark-memory.yml
@@ -1,0 +1,302 @@
+name: benchmark-memory
+
+# Linux-only weekly/manual process-memory collection. It serializes with the
+# daily producer and publishes through the same sealed branch/Pages pipeline.
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "full (publishable, >=15 blocks) or smoke (1 block, artifact only)"
+        type: choice
+        options: [full, smoke]
+        default: full
+      run_seed:
+        description: "Explicit seed (empty derives and records one)"
+        required: false
+        type: string
+      blocks:
+        description: "Blocks per cell (minimum 15 for full; smoke must use 1)"
+        type: number
+        default: 15
+        required: false
+  schedule:
+    - cron: "41 8 * * 0"
+
+concurrency:
+  group: benchmark-stats-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PUBLISH_REF: refs/heads/benchmark-stats
+
+jobs:
+  build-and-measure:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    outputs:
+      publish_eligible: ${{ steps.eligibility.outputs.publish_eligible }}
+      mode: ${{ inputs.mode || 'full' }}
+      prior_branch_sha: ${{ steps.prior.outputs.prior_sha }}
+    steps:
+      - uses: actions/checkout@v4.4.0
+        with:
+          persist-credentials: false
+      - uses: zackees/setup-soldr@62d1596b70168e422156f12273a2ed476d3a16dc
+      - name: build native allocator libraries
+        run: |
+          set -euxo pipefail
+          python3 ci/build_benchmark_allocators.py --build-root rust/target/release --jobs "$(nproc)"
+      - name: resolve prior public site
+        id: prior
+        run: |
+          set -euxo pipefail
+          git ls-remote --exit-code origin "$PUBLISH_REF" >/dev/null
+          PRIOR_SHA=$(git ls-remote origin "$PUBLISH_REF" | awk '{print $1}')
+          test -n "$PRIOR_SHA"
+          echo "prior_sha=$PRIOR_SHA" >> "$GITHUB_OUTPUT"
+          git fetch origin "$PUBLISH_REF" --depth=1
+          git checkout FETCH_HEAD -- history.jsonl latest.json
+          test -s history.jsonl
+          test -s latest.json
+          cp history.jsonl "$RUNNER_TEMP/history-input.jsonl"
+          cp latest.json "$RUNNER_TEMP/base-latest.json"
+      - name: build benchmark suite
+        run: |
+          set -euxo pipefail
+          cd rust
+          soldr cargo build -p benchmark-suite --release --locked
+      - name: determine run seed
+        id: seed
+        env:
+          INPUT_RUN_SEED: ${{ inputs.run_seed }}
+        run: |
+          set -euo pipefail
+          SEED="$INPUT_RUN_SEED"
+          if [ -z "$SEED" ]; then
+            SEED=$(( RANDOM << 17 | RANDOM << 1 | RANDOM >> 14 ))
+          fi
+          case "$SEED" in
+            *[!0-9]*) echo "::error::run_seed must be a positive decimal integer"; exit 1 ;;
+          esac
+          test "$SEED" -gt 0
+          echo "seed=$SEED" >> "$GITHUB_OUTPUT"
+      - name: run external memory suite
+        env:
+          MEMORY_MODE: ${{ inputs.mode || 'full' }}
+          MEMORY_BLOCKS: ${{ inputs.blocks || 15 }}
+          MEMORY_RUN_SEED: ${{ steps.seed.outputs.seed }}
+        run: |
+          set -euxo pipefail
+          cd rust
+          MODE="$MEMORY_MODE"
+          BLOCKS="$MEMORY_BLOCKS"
+          SMOKE_FLAG=""
+          if [ "$MODE" = "smoke" ]; then
+            test "$BLOCKS" = "1"
+            SMOKE_FLAG="--reduced-smoke"
+          fi
+          soldr cargo run -p benchmark-suite --bin benchmark-memory-run --release -- \
+            $SMOKE_FLAG \
+            --blocks "$BLOCKS" \
+            --run-seed "$MEMORY_RUN_SEED" \
+            --output-dir "$RUNNER_TEMP/memory-output-${{ github.run_id }}" \
+            --build-root target/release
+      - name: validate and overlay complete memory report
+        if: (inputs.mode || 'full') == 'full'
+        run: |
+          set -euxo pipefail
+          cd rust
+          soldr cargo run -p benchmark-suite --bin benchmark-memory-validate --release -- \
+            --input "$RUNNER_TEMP/memory-output-${{ github.run_id }}/memory-raw-run.json" \
+            --base-latest "$RUNNER_TEMP/base-latest.json" \
+            --report-out "$RUNNER_TEMP/memory-report.json" \
+            --latest-out "$RUNNER_TEMP/latest.json"
+      - name: render sealed site
+        if: (inputs.mode || 'full') == 'full'
+        run: |
+          set -euxo pipefail
+          mkdir -p "$RUNNER_TEMP/site"
+          python ci/benchmark_report.py render \
+            --input "$RUNNER_TEMP/latest.json" \
+            --history-in "$RUNNER_TEMP/history-input.jsonl" \
+            --output-dir "$RUNNER_TEMP/site" \
+            --detached-digest-out "$RUNNER_TEMP/manifest.sha256"
+          python ci/benchmark_report.py validate-site \
+            --site-dir "$RUNNER_TEMP/site" \
+            --detached-digest "$RUNNER_TEMP/manifest.sha256"
+      - name: compute publication eligibility
+        id: eligibility
+        if: success()
+        env:
+          MEMORY_REPOSITORY: ${{ github.repository }}
+          MEMORY_REF: ${{ github.ref }}
+          MEMORY_MODE: ${{ inputs.mode || 'full' }}
+          MEMORY_BLOCKS: ${{ inputs.blocks || 15 }}
+        run: |
+          set -euo pipefail
+          ELIGIBLE=false
+          if [ "$MEMORY_REPOSITORY" = "zackees/mimalloc-pprof" ] && \
+             [ "$MEMORY_REF" = "refs/heads/main" ] && \
+             [ "$MEMORY_MODE" = "full" ] && \
+             [ "$MEMORY_BLOCKS" -ge 15 ]; then
+            ELIGIBLE=true
+          fi
+          echo "publish_eligible=$ELIGIBLE" >> "$GITHUB_OUTPUT"
+      - name: upload raw proc artifact
+        if: always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: benchmark-memory-raw-${{ github.run_id }}-${{ github.run_attempt }}
+          path: "${{ runner.temp }}/memory-output-${{ github.run_id }}/"
+          include-hidden-files: true
+          retention-days: 30
+          if-no-files-found: error
+      - name: upload validation artifact
+        if: (inputs.mode || 'full') == 'full' && always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: benchmark-memory-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/memory-report.json
+            ${{ runner.temp }}/manifest.sha256
+          retention-days: 30
+          if-no-files-found: error
+      - name: upload site artifact
+        if: (inputs.mode || 'full') == 'full' && success()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/site/
+          include-hidden-files: true
+          retention-days: 30
+          if-no-files-found: error
+
+  artifact-audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: build-and-measure
+    if: needs.build-and-measure.outputs.mode == 'full'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit/site/
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-memory-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit/validation/
+      - name: audit sealed memory site
+        run: |
+          python ci/benchmark_report.py validate-site \
+            --site-dir audit/site/ \
+            --detached-digest audit/validation/manifest.sha256
+
+  publish-branch:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [build-and-measure, artifact-audit]
+    if: needs.build-and-measure.outputs.publish_eligible == 'true'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: site-temp/
+      - name: publish exact memory site revision
+        run: |
+          set -euxo pipefail
+          MANIFEST_DIGEST=$(sha256sum site-temp/manifest.json | awk '{print $1}')
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          WORKTREE=$(mktemp -d)
+          git worktree add --detach "$WORKTREE" HEAD
+          python ci/benchmark_report.py prepare-branch \
+            --worktree "$WORKTREE" \
+            --site-dir "$GITHUB_WORKSPACE/site-temp"
+          cd "$WORKTREE"
+          git commit -m "benchmark-memory run=${{ github.run_id }}/${{ github.run_attempt }} src=${{ github.sha }} manifest=$MANIFEST_DIGEST"
+          python "$GITHUB_WORKSPACE/ci/benchmark_report.py" validate-revision \
+            --repository "$WORKTREE" \
+            --revision HEAD \
+            --site-dir "$GITHUB_WORKSPACE/site-temp"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git push origin "HEAD:$PUBLISH_REF" --force-with-lease="refs/heads/benchmark-stats:${{ needs.build-and-measure.outputs.prior_branch_sha }}"
+          test "$(git ls-remote origin "$PUBLISH_REF" | awk '{print $1}')" = "$(git rev-parse HEAD)"
+          cd "$GITHUB_WORKSPACE"
+          git worktree remove --force "$WORKTREE"
+
+  package-pages:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [build-and-measure, artifact-audit, publish-branch]
+    if: needs.build-and-measure.outputs.publish_eligible == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: _site/
+      - uses: actions/upload-pages-artifact@v4.0.0
+        with:
+          path: _site/
+          include-hidden-files: true
+
+  deploy-pages:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [build-and-measure, artifact-audit, publish-branch, package-pages]
+    if: needs.build-and-measure.outputs.publish_eligible == 'true'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4.0.5
+        id: deployment
+
+  publication-audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [build-and-measure, publish-branch, deploy-pages]
+    if: needs.build-and-measure.outputs.publish_eligible == 'true' && always()
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit/site/
+      - name: audit memory publication
+        run: |
+          set -euxo pipefail
+          git fetch origin refs/heads/benchmark-stats --depth=1
+          python ci/benchmark_report.py validate-revision \
+            --repository . \
+            --revision FETCH_HEAD \
+            --site-dir audit/site/
+          python ci/benchmark_report.py audit-pages \
+            --site-dir audit/site/ \
+            --page-url "${{ needs.deploy-pages.outputs.page_url }}"
+          echo "Memory publication branch and Pages bytes match." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -66,11 +66,12 @@ jobs:
             PRIOR_SHA=$(git ls-remote origin "$PUBLISH_REF" | awk '{print $1}')
             echo "prior_sha=$PRIOR_SHA" >> "$GITHUB_OUTPUT"
             git fetch origin "$PUBLISH_REF" --depth=1
-            git checkout FETCH_HEAD -- history.jsonl 2>/dev/null || true
-            if [ -f history.jsonl ]; then
+            git checkout FETCH_HEAD -- history.jsonl latest.json 2>/dev/null || true
+            if [ -f history.jsonl ] && [ -f latest.json ]; then
               cp history.jsonl "$RUNNER_TEMP/history-input.jsonl"
+              cp latest.json "$RUNNER_TEMP/prior-latest.json"
             else
-              echo "::error::benchmark-stats branch exists but history.jsonl is absent"
+              echo "::error::benchmark-stats branch exists but history.jsonl/latest.json is absent"
               exit 1
             fi
           else
@@ -148,15 +149,19 @@ jobs:
           set -euxo pipefail
           mkdir -p "$RUNNER_TEMP/site"
           INIT_FLAG=""
+          PRIOR_FLAG=""
           if [ ! -s "$RUNNER_TEMP/history-input.jsonl" ]; then
             INIT_FLAG="--initialize-history"
+          fi
+          if [ -f "$RUNNER_TEMP/prior-latest.json" ]; then
+            PRIOR_FLAG="--prior-latest $RUNNER_TEMP/prior-latest.json"
           fi
           python ci/benchmark_report.py render \
             --input "$RUNNER_TEMP/latest.json" \
             --history-in "$RUNNER_TEMP/history-input.jsonl" \
             --output-dir "$RUNNER_TEMP/site" \
             --detached-digest-out "$RUNNER_TEMP/manifest.sha256" \
-            $INIT_FLAG
+            $INIT_FLAG $PRIOR_FLAG
       - name: validate site
         run: |
           python ci/benchmark_report.py validate-site \
@@ -179,7 +184,7 @@ jobs:
         uses: actions/upload-artifact@v4.6.2
         with:
           name: benchmark-raw-${{ github.run_id }}-${{ github.run_attempt }}
-          path: "${{ runner.temp }}/raw-run.json"
+          path: "${{ runner.temp }}/benchmark-output-${{ github.run_id }}/raw-run.json"
           retention-days: 30
           if-no-files-found: ignore
       - name: upload provenance artifact

--- a/ci/benchmark_report.py
+++ b/ci/benchmark_report.py
@@ -9,6 +9,7 @@ validator and rejects raw or aggregate-only inputs.
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import html
 import json
@@ -69,6 +70,7 @@ TOP_LEVEL_FIELDS = {
     "reproduction_command",
     "actions_run_url",
 }
+OPTIONAL_TOP_LEVEL_FIELDS = {"memory"}
 HISTORY_FIELDS = {
     "history_schema_version",
     "statistics_version",
@@ -80,6 +82,7 @@ HISTORY_FIELDS = {
     "absolute_summaries",
     "paired_summaries",
 }
+OPTIONAL_HISTORY_FIELDS = {"memory"}
 RUN_FIELDS = {
     "source_repository",
     "source_sha",
@@ -149,10 +152,160 @@ ROLES = {
     "history.jsonl": "bounded-compatible-history",
     "benchmark-throughput.png": "throughput-chart",
     "benchmark-history.png": "history-chart",
-    "benchmark-memory.png": "pending-memory-panel",
+    "benchmark-memory.png": "memory-panel",
     "benchmark-latency.png": "pending-latency-panel",
     "benchmark-scaling.png": "pending-scaling-panel",
     "benchmark-pprof-tax.png": "pending-pprof-tax-panel",
+}
+
+MEMORY_SCHEMA = "linux-process-memory-v1"
+MEMORY_METRICS = (
+    "sampled-peak-rss-bytes",
+    "post-drain-rss-100ms-bytes",
+    "post-drain-rss-1s-bytes",
+    "post-drain-rss-5s-bytes",
+    "fragmentation-proxy",
+)
+MEMORY_CELLS = (
+    ("large-objects", "1"),
+    ("large-objects", "2"),
+    ("sawtooth-retain-drain", "1"),
+    ("sawtooth-retain-drain", "physical-core"),
+    ("small-log-mixed", "physical-core"),
+    ("cross-thread-producer-consumer", "physical-core"),
+    ("thread-churn", "physical-core"),
+)
+MEMORY_REPORT_FIELDS = {
+    "metric_schema_version",
+    "status",
+    "invalid_reason",
+    "metric_comparison_key",
+    "run",
+    "runner",
+    "sampling_target_interval_ns",
+    "purge_policy",
+    "units",
+    "direction",
+    "informational",
+    "methodology",
+    "absolute_summaries",
+    "paired_summaries",
+    "raw_samples",
+}
+MEMORY_METHODOLOGY = {
+    "rss_source": "/proc/<pid>/smaps_rollup Rss, parsed as integer kB * 1024",
+    "hwm_source": "/proc/<pid>/status VmHWM, parsed as integer kB * 1024; cross-check only",
+    "baseline_definition": "external RSS/HWM after child warmup and baseline-ready, before begin",
+    "sampled_peak_definition": "maximum external smaps_rollup RSS timestamped inside workload-active..workload-drained",
+    "post_drain_definition": "external smaps_rollup RSS at >=100ms, >=1s, and >=5s after workload-drained",
+    "fragmentation_formula": "(sampled_peak_rss_bytes - baseline_rss_bytes) / peak_live_requested_bytes; both operands must be positive",
+    "hwm_discrepancy_tolerance": "flag when abs(sampled RSS delta - VmHWM delta) > max(8 MiB, 20% of the larger positive delta)",
+    "page_touch_contract": "every allocation touches deterministic boundary bytes and at least one byte per OS page",
+    "purge_policy": "natural allocator behavior only; no allocator-specific purge call",
+}
+MEMORY_HISTORY_FIELDS = MEMORY_REPORT_FIELDS - {"invalid_reason", "runner", "raw_samples"} | {
+    "runner_fingerprint_sha256"
+}
+MEMORY_SAMPLE_FIELDS = {
+    "metric_schema_version",
+    "block_id",
+    "ordinal",
+    "workload_seed",
+    "allocator_id",
+    "allocator_source_sha",
+    "child_binary_sha256",
+    "scenario_id",
+    "thread_point",
+    "thread_count",
+    "baseline_ready_ns",
+    "workload_active_ns",
+    "workload_drained_ns",
+    "post_drain_sample_100ms_ns",
+    "post_drain_sample_1s_ns",
+    "post_drain_sample_5s_ns",
+    "sampler_pid",
+    "sampled_pid",
+    "baseline_rss_bytes",
+    "baseline_hwm_bytes",
+    "sampled_peak_rss_bytes",
+    "kernel_peak_hwm_bytes",
+    "peak_live_requested_bytes",
+    "post_drain_rss_100ms_bytes",
+    "post_drain_rss_1s_bytes",
+    "post_drain_rss_5s_bytes",
+    "sampled_peak_rss_delta_bytes",
+    "post_drain_rss_delta_100ms_bytes",
+    "post_drain_rss_delta_1s_bytes",
+    "post_drain_rss_delta_5s_bytes",
+    "fragmentation_proxy",
+    "hwm_discrepancy",
+    "hwm_tolerance_bytes",
+    "sampling",
+    "timeline",
+    "environment",
+    "child_sample",
+}
+CHILD_SAMPLE_FIELDS = {
+    "schema_version",
+    "suite_version",
+    "run_kind",
+    "execution_mode",
+    "run_seed",
+    "block_id",
+    "ordinal",
+    "workload_seed",
+    "allocator_id",
+    "allocator_version",
+    "allocator_source_sha",
+    "allocator_library_sha256",
+    "child_binary_sha256",
+    "scenario_id",
+    "scenario_version",
+    "thread_point",
+    "thread_count",
+    "operation_unit",
+    "operation_count",
+    "requested_transactions",
+    "completed_transactions",
+    "allocation_calls",
+    "calloc_calls",
+    "aligned_allocation_calls",
+    "free_calls",
+    "realloc_calls",
+    "setup_ns",
+    "warmup_ns",
+    "elapsed_ns",
+    "teardown_ns",
+    "throughput_operations_per_second",
+    "checksum",
+    "peak_live_requested_bytes",
+    "timed_out",
+    "crashed",
+    "exit_code",
+    "signal",
+    "runner",
+    "toolchain",
+    "reproduction_command",
+}
+CHILD_RUNNER_FIELDS = {"os", "architecture", "physical_cores", "logical_cores"}
+CHILD_TOOLCHAIN_FIELDS = {"rustc", "target", "compiler", "linker"}
+CHILD_BLOCK_IDENTITY_FIELDS = {
+    "run_seed",
+    "workload_seed",
+    "scenario_id",
+    "scenario_version",
+    "thread_point",
+    "thread_count",
+    "operation_unit",
+    "operation_count",
+    "requested_transactions",
+    "completed_transactions",
+    "allocation_calls",
+    "calloc_calls",
+    "aligned_allocation_calls",
+    "free_calls",
+    "realloc_calls",
+    "checksum",
 }
 
 
@@ -210,6 +363,16 @@ def exact_fields(value: Mapping[str, object], fields: set[str], label: str) -> N
         fail(
             f"{label}: fields mismatch; missing={sorted(fields - actual)} unexpected={sorted(actual - fields)}"
         )
+
+
+def exact_fields_with_optional(
+    value: Mapping[str, object], required: set[str], optional: set[str], label: str
+) -> None:
+    actual = set(value)
+    missing = required - actual
+    unexpected = actual - required - optional
+    if missing or unexpected:
+        fail(f"{label}: fields mismatch; missing={sorted(missing)} unexpected={sorted(unexpected)}")
 
 
 def reject_nonfinite(value: object, label: str) -> None:
@@ -491,8 +654,449 @@ def validate_paired(record: object, label: str) -> dict[str, object]:
     return item
 
 
+def signed_int_value(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        fail(f"{label}: expected signed integer")
+    return value
+
+
+def validate_memory_environment(value: object, label: str) -> dict[str, object]:
+    environment = object_value(value, label)
+    exact_fields(
+        environment,
+        {
+            "page_size_bytes",
+            "kernel",
+            "transparent_hugepage",
+            "cgroup_memory_max",
+            "cgroup_memory_high",
+            "hosted_runner",
+            "purge_policy",
+            "allocator_runtime_options",
+        },
+        label,
+    )
+    page_size = int_value(environment.get("page_size_bytes"), f"{label}.page_size_bytes", 1)
+    if page_size & (page_size - 1):
+        fail(f"{label}.page_size_bytes: expected a power of two")
+    for field in ("kernel", "transparent_hugepage", "cgroup_memory_max", "cgroup_memory_high"):
+        string_value(environment.get(field), f"{label}.{field}")
+    if not isinstance(environment.get("hosted_runner"), bool):
+        fail(f"{label}.hosted_runner: expected boolean")
+    if environment.get("purge_policy") != "natural-only":
+        fail(f"{label}.purge_policy: allocator-specific purge is forbidden")
+    options = object_value(
+        environment.get("allocator_runtime_options"), f"{label}.allocator_runtime_options"
+    )
+    exact_fields(
+        options, {"MIMALLOC_MEMORY_EVENTS", "MIMALLOC_PROF"}, f"{label}.allocator_runtime_options"
+    )
+    if options != {"MIMALLOC_MEMORY_EVENTS": "0", "MIMALLOC_PROF": "0"}:
+        fail(f"{label}.allocator_runtime_options: profiler and memory events must be disabled")
+    return environment
+
+
+def validate_memory_sample(value: object, label: str) -> dict[str, object]:
+    sample = object_value(value, label)
+    exact_fields(sample, MEMORY_SAMPLE_FIELDS, label)
+    if sample.get("metric_schema_version") != MEMORY_SCHEMA:
+        fail(f"{label}.metric_schema_version: unsupported memory metric")
+    allocator = string_value(sample.get("allocator_id"), f"{label}.allocator_id")
+    if allocator not in ALLOCATOR_IDS:
+        fail(f"{label}.allocator_id: unknown allocator")
+    if not HEX_40.fullmatch(
+        string_value(sample.get("allocator_source_sha"), f"{label}.allocator_source_sha")
+    ):
+        fail(f"{label}.allocator_source_sha: invalid digest")
+    comparison_digest(sample.get("child_binary_sha256"), f"{label}.child_binary_sha256")
+    cell = (
+        string_value(sample.get("scenario_id"), f"{label}.scenario_id"),
+        string_value(sample.get("thread_point"), f"{label}.thread_point"),
+    )
+    if cell not in MEMORY_CELLS:
+        fail(f"{label}: undeclared memory scenario/thread cell")
+    for field in (
+        "block_id",
+        "workload_seed",
+        "thread_count",
+        "baseline_ready_ns",
+        "workload_active_ns",
+        "workload_drained_ns",
+        "post_drain_sample_100ms_ns",
+        "post_drain_sample_1s_ns",
+        "post_drain_sample_5s_ns",
+        "sampler_pid",
+        "sampled_pid",
+        "baseline_rss_bytes",
+        "baseline_hwm_bytes",
+        "sampled_peak_rss_bytes",
+        "kernel_peak_hwm_bytes",
+        "peak_live_requested_bytes",
+        "post_drain_rss_100ms_bytes",
+        "post_drain_rss_1s_bytes",
+        "post_drain_rss_5s_bytes",
+        "hwm_tolerance_bytes",
+    ):
+        int_value(
+            sample.get(field),
+            f"{label}.{field}",
+            0 if field in ("block_id", "workload_seed") else 1,
+        )
+    ordinal = int_value(sample.get("ordinal"), f"{label}.ordinal")
+    if ordinal > 3:
+        fail(f"{label}.ordinal: expected 0..3")
+    if sample["sampler_pid"] == sample["sampled_pid"]:
+        fail(f"{label}: sampler must target a distinct child PID")
+    baseline_ready = cast(int, sample["baseline_ready_ns"])
+    active = cast(int, sample["workload_active_ns"])
+    drained = cast(int, sample["workload_drained_ns"])
+    if not baseline_ready < active < drained:
+        fail(f"{label}: control timestamps are out of order")
+    for field, target in (
+        ("post_drain_sample_100ms_ns", 100_000_000),
+        ("post_drain_sample_1s_ns", 1_000_000_000),
+        ("post_drain_sample_5s_ns", 5_000_000_000),
+    ):
+        observed = cast(int, sample[field]) - drained
+        if observed < target or observed > target + 100_000_000:
+            fail(f"{label}.{field}: outside declared post-drain window")
+    baseline_rss = cast(int, sample["baseline_rss_bytes"])
+    derived = {
+        "sampled_peak_rss_delta_bytes": cast(int, sample["sampled_peak_rss_bytes"]) - baseline_rss,
+        "post_drain_rss_delta_100ms_bytes": cast(int, sample["post_drain_rss_100ms_bytes"])
+        - baseline_rss,
+        "post_drain_rss_delta_1s_bytes": cast(int, sample["post_drain_rss_1s_bytes"])
+        - baseline_rss,
+        "post_drain_rss_delta_5s_bytes": cast(int, sample["post_drain_rss_5s_bytes"])
+        - baseline_rss,
+    }
+    for field, expected in derived.items():
+        if signed_int_value(sample.get(field), f"{label}.{field}") != expected:
+            fail(f"{label}.{field}: inconsistent signed delta")
+    if derived["sampled_peak_rss_delta_bytes"] <= 0:
+        fail(
+            f"{label}.sampled_peak_rss_delta_bytes: fragmentation denominator delta must be positive"
+        )
+    expected_ratio = derived["sampled_peak_rss_delta_bytes"] / cast(
+        int, sample["peak_live_requested_bytes"]
+    )
+    ratio = float_value(sample.get("fragmentation_proxy"), f"{label}.fragmentation_proxy", True)
+    if not math.isclose(ratio, expected_ratio, rel_tol=1e-12):
+        fail(f"{label}.fragmentation_proxy: inconsistent ratio")
+    if not isinstance(sample.get("hwm_discrepancy"), bool):
+        fail(f"{label}.hwm_discrepancy: expected boolean")
+    hwm_delta = cast(int, sample["kernel_peak_hwm_bytes"]) - cast(int, sample["baseline_hwm_bytes"])
+    tolerance = max(
+        8 * 1024 * 1024,
+        max(derived["sampled_peak_rss_delta_bytes"], hwm_delta, 0) // 5,
+    )
+    discrepancy = abs(derived["sampled_peak_rss_delta_bytes"] - hwm_delta) > tolerance
+    if sample["hwm_tolerance_bytes"] != tolerance or sample["hwm_discrepancy"] != discrepancy:
+        fail(f"{label}: inconsistent VmHWM discrepancy flag or tolerance")
+    sampling = object_value(sample.get("sampling"), f"{label}.sampling")
+    exact_fields(
+        sampling,
+        {
+            "target_interval_ns",
+            "sample_count",
+            "minimum_interval_ns",
+            "median_interval_ns",
+            "p95_interval_ns",
+            "maximum_interval_ns",
+        },
+        f"{label}.sampling",
+    )
+    if (
+        int_value(sampling.get("target_interval_ns"), f"{label}.sampling.target_interval_ns")
+        != 5_000_000
+    ):
+        fail(f"{label}.sampling.target_interval_ns: expected 5 ms")
+    timeline = list_value(sample.get("timeline"), f"{label}.timeline")
+    if int_value(sampling.get("sample_count"), f"{label}.sampling.sample_count", 2) != len(
+        timeline
+    ):
+        fail(f"{label}.sampling.sample_count: does not match timeline")
+    timestamps: list[int] = []
+    rss_values: list[int] = []
+    for index, point_value in enumerate(timeline):
+        point = object_value(point_value, f"{label}.timeline[{index}]")
+        exact_fields(point, {"elapsed_ns", "rss_bytes"}, f"{label}.timeline[{index}]")
+        timestamps.append(
+            int_value(point.get("elapsed_ns"), f"{label}.timeline[{index}].elapsed_ns", 1)
+        )
+        rss_values.append(
+            int_value(point.get("rss_bytes"), f"{label}.timeline[{index}].rss_bytes", 1)
+        )
+    intervals = [right - left for left, right in zip(timestamps, timestamps[1:])]
+    if timestamps[0] < active or timestamps[-1] > drained or any(value <= 0 for value in intervals):
+        fail(f"{label}.timeline: timestamps must be strictly inside the workload window")
+    if timestamps[0] - active > 100_000_000 or drained - timestamps[-1] > 100_000_000:
+        fail(f"{label}.timeline: sampler missed a workload edge")
+    if max(intervals) > 100_000_000 or sampling.get("maximum_interval_ns") != max(intervals):
+        fail(f"{label}.timeline: sampler interval bound/summary mismatch")
+    ordered_intervals = sorted(intervals)
+
+    def interval_quantile(numerator: int, denominator: int) -> int:
+        return ordered_intervals[(len(ordered_intervals) - 1) * numerator // denominator]
+
+    expected_sampling = {
+        "target_interval_ns": 5_000_000,
+        "sample_count": len(timeline),
+        "minimum_interval_ns": ordered_intervals[0],
+        "median_interval_ns": interval_quantile(1, 2),
+        "p95_interval_ns": interval_quantile(95, 100),
+        "maximum_interval_ns": ordered_intervals[-1],
+    }
+    if sampling != expected_sampling:
+        fail(f"{label}.sampling: interval distribution does not match timeline")
+    if max(rss_values) != sample["sampled_peak_rss_bytes"]:
+        fail(f"{label}.sampled_peak_rss_bytes: does not match timeline")
+    validate_memory_environment(sample.get("environment"), f"{label}.environment")
+    child = object_value(sample.get("child_sample"), f"{label}.child_sample")
+    exact_fields(child, CHILD_SAMPLE_FIELDS, f"{label}.child_sample")
+    if (
+        child.get("schema_version") != RAW_SCHEMA
+        or child.get("suite_version") != SUITE_VERSION
+        or child.get("scenario_version") != SUITE_VERSION
+        or child.get("run_kind") != "headline"
+        or child.get("execution_mode") != "normal"
+        or int_value(child.get("run_seed"), f"{label}.child_sample.run_seed", 1) == 0
+        or child.get("timed_out") is not False
+        or child.get("crashed") is not False
+        or child.get("exit_code") != 0
+        or child.get("signal") is not None
+    ):
+        fail(f"{label}.child_sample: invalid protocol, run mode, or process result")
+    for field in (
+        "operation_count",
+        "requested_transactions",
+        "completed_transactions",
+        "free_calls",
+        "warmup_ns",
+        "elapsed_ns",
+        "checksum",
+        "peak_live_requested_bytes",
+    ):
+        int_value(child.get(field), f"{label}.child_sample.{field}", 1)
+    for field in (
+        "allocation_calls",
+        "calloc_calls",
+        "aligned_allocation_calls",
+        "realloc_calls",
+        "setup_ns",
+        "teardown_ns",
+    ):
+        int_value(child.get(field), f"{label}.child_sample.{field}")
+    if child["completed_transactions"] != child["requested_transactions"]:
+        fail(f"{label}.child_sample: incomplete transactions")
+    float_value(
+        child.get("throughput_operations_per_second"),
+        f"{label}.child_sample.throughput_operations_per_second",
+        True,
+    )
+    for field in (
+        "allocator_version",
+        "operation_unit",
+        "reproduction_command",
+    ):
+        string_value(child.get(field), f"{label}.child_sample.{field}")
+    for field, pattern in (
+        ("allocator_source_sha", HEX_40),
+        ("allocator_library_sha256", HEX_64),
+        ("child_binary_sha256", HEX_64),
+    ):
+        if not pattern.fullmatch(string_value(child.get(field), f"{label}.child_sample.{field}")):
+            fail(f"{label}.child_sample.{field}: invalid digest")
+    child_runner = object_value(child.get("runner"), f"{label}.child_sample.runner")
+    exact_fields(child_runner, CHILD_RUNNER_FIELDS, f"{label}.child_sample.runner")
+    for field in ("os", "architecture"):
+        string_value(child_runner.get(field), f"{label}.child_sample.runner.{field}")
+    for field in ("physical_cores", "logical_cores"):
+        int_value(child_runner.get(field), f"{label}.child_sample.runner.{field}", 1)
+    child_toolchain = object_value(child.get("toolchain"), f"{label}.child_sample.toolchain")
+    exact_fields(child_toolchain, CHILD_TOOLCHAIN_FIELDS, f"{label}.child_sample.toolchain")
+    for field in CHILD_TOOLCHAIN_FIELDS:
+        string_value(child_toolchain.get(field), f"{label}.child_sample.toolchain.{field}")
+    if (
+        child.get("allocator_id") != allocator
+        or child.get("allocator_source_sha") != sample["allocator_source_sha"]
+        or child.get("child_binary_sha256") != sample["child_binary_sha256"]
+        or child.get("scenario_id") != cell[0]
+        or child.get("thread_point") != cell[1]
+        or child.get("thread_count") != sample["thread_count"]
+        or child.get("block_id") != sample["block_id"]
+        or child.get("ordinal") != sample["ordinal"]
+        or child.get("workload_seed") != sample["workload_seed"]
+        or child.get("peak_live_requested_bytes") != sample["peak_live_requested_bytes"]
+    ):
+        fail(f"{label}.child_sample: child workload oracle mismatch")
+    return sample
+
+
+def validate_memory_report(
+    value: object, label: str, *, compact: bool = False
+) -> dict[str, object]:
+    report = object_value(value, label)
+    exact_fields(report, MEMORY_HISTORY_FIELDS if compact else MEMORY_REPORT_FIELDS, label)
+    if report.get("metric_schema_version") != MEMORY_SCHEMA or report.get("status") != "complete":
+        fail(f"{label}: memory report must be complete {MEMORY_SCHEMA}")
+    if not compact and report.get("invalid_reason") is not None:
+        fail(f"{label}.invalid_reason: complete report requires null")
+    comparison_digest(report.get("metric_comparison_key"), f"{label}.metric_comparison_key")
+    validate_run(report.get("run"), f"{label}.run")
+    runner: dict[str, object] | None = None
+    runner_class = None
+    if compact:
+        comparison_digest(
+            report.get("runner_fingerprint_sha256"), f"{label}.runner_fingerprint_sha256"
+        )
+    else:
+        runner = validate_runner(report.get("runner"), f"{label}.runner")
+        runner_class = runner["runner_class"]
+    if report.get("sampling_target_interval_ns") != 5_000_000:
+        fail(f"{label}.sampling_target_interval_ns: expected 5 ms")
+    if report.get("purge_policy") != "natural-only":
+        fail(f"{label}.purge_policy: explicit purge is forbidden")
+    units = object_value(report.get("units"), f"{label}.units")
+    exact_fields(units, set(MEMORY_METRICS), f"{label}.units")
+    expected_units = {
+        metric: "ratio" if metric == "fragmentation-proxy" else "bytes" for metric in MEMORY_METRICS
+    }
+    if (
+        units != expected_units
+        or report.get("direction") != "lower-is-better"
+        or report.get("informational") is not True
+    ):
+        fail(f"{label}: invalid units, direction, or hosted-runner interpretation")
+    methodology = object_value(report.get("methodology"), f"{label}.methodology")
+    exact_fields(methodology, set(MEMORY_METHODOLOGY), f"{label}.methodology")
+    if methodology != MEMORY_METHODOLOGY:
+        fail(f"{label}.methodology: unsupported Linux process-memory contract")
+    absolute = [
+        validate_absolute(item, f"{label}.absolute_summaries[{index}]")
+        for index, item in enumerate(
+            list_value(report.get("absolute_summaries"), f"{label}.absolute_summaries")
+        )
+    ]
+    paired = [
+        validate_paired(item, f"{label}.paired_summaries[{index}]")
+        for index, item in enumerate(
+            list_value(report.get("paired_summaries"), f"{label}.paired_summaries")
+        )
+    ]
+    expected_absolute = {
+        (scenario, point, metric, allocator)
+        for scenario, point in MEMORY_CELLS
+        for metric in MEMORY_METRICS
+        for allocator in ALLOCATOR_IDS
+    }
+    actual_absolute = {
+        (item["scenario_id"], item["thread_point"], item["metric_id"], item["allocator_id"])
+        for item in absolute
+        if item.get("direction") == "lower-is-better"
+    }
+    expected_paired = {
+        (scenario, point, metric, allocator)
+        for scenario, point in MEMORY_CELLS
+        for metric in MEMORY_METRICS
+        for allocator in ALLOCATOR_IDS
+        if allocator != "upstream-mimalloc"
+    }
+    actual_paired = {
+        (
+            item["scenario_id"],
+            item["thread_point"],
+            item["metric_id"],
+            object_value(item["summary"], "memory paired summary")["candidate_id"],
+        )
+        for item in paired
+        if object_value(item["summary"], "memory paired summary").get("direction")
+        == "lower-is-better"
+    }
+    if (
+        len(absolute) != len(expected_absolute)
+        or len(paired) != len(expected_paired)
+        or actual_absolute != expected_absolute
+        or actual_paired != expected_paired
+        or any(item.get("direction") != "lower-is-better" for item in absolute)
+        or any(
+            object_value(item["summary"], "memory paired summary").get("direction")
+            != "lower-is-better"
+            for item in paired
+        )
+    ):
+        fail(f"{label}: incomplete or duplicate memory summary matrix")
+    if compact:
+        return report
+    raw = [
+        validate_memory_sample(item, f"{label}.raw_samples[{index}]")
+        for index, item in enumerate(list_value(report.get("raw_samples"), f"{label}.raw_samples"))
+    ]
+    groups: dict[tuple[object, object, object], list[dict[str, object]]] = {}
+    first_environment: dict[str, object] | None = None
+    run_seeds: set[object] = set()
+    allocator_identities: dict[object, tuple[object, ...]] = {}
+    for sample in raw:
+        groups.setdefault(
+            (sample["scenario_id"], sample["thread_point"], sample["block_id"]), []
+        ).append(sample)
+        environment = object_value(sample["environment"], "memory environment")
+        if first_environment is None:
+            first_environment = environment
+        elif environment != first_environment:
+            fail(f"{label}: mixed memory environments are not comparable")
+        if runner_class is not None and environment["hosted_runner"] != (
+            runner_class == "github-hosted"
+        ):
+            fail(f"{label}: hosted-runner label disagrees with runner metadata")
+        child = object_value(sample["child_sample"], "memory child sample")
+        run_seeds.add(child["run_seed"])
+        child_runner = object_value(child["runner"], "memory child runner")
+        if runner is not None and child_runner != {
+            "os": runner["os"],
+            "architecture": runner["architecture"],
+            "physical_cores": runner["physical_cores"],
+            "logical_cores": runner["logical_cores"],
+        }:
+            fail(f"{label}: child runner contradicts memory runner metadata")
+        identity = (
+            child["allocator_version"],
+            child["allocator_source_sha"],
+            child["allocator_library_sha256"],
+            child["child_binary_sha256"],
+        )
+        prior_identity = allocator_identities.setdefault(sample["allocator_id"], identity)
+        if prior_identity != identity:
+            fail(f"{label}: allocator identity changed within the memory run")
+    if len(run_seeds) != 1 or set(allocator_identities) != set(ALLOCATOR_IDS):
+        fail(f"{label}: memory run seed or allocator provenance is incomplete")
+    blocks_by_cell: dict[tuple[object, object], set[object]] = {}
+    for (scenario, point, block), samples in groups.items():
+        ids = {sample["allocator_id"] for sample in samples}
+        ordinals = {sample["ordinal"] for sample in samples}
+        seeds = {sample["workload_seed"] for sample in samples}
+        if (
+            len(samples) != 4
+            or ids != set(ALLOCATOR_IDS)
+            or ordinals != {0, 1, 2, 3}
+            or len(seeds) != 1
+        ):
+            fail(f"{label}: incomplete memory pair for {scenario}/{point}/block-{block}")
+        first_child = object_value(samples[0]["child_sample"], "memory paired child")
+        for sample in samples[1:]:
+            child = object_value(sample["child_sample"], "memory paired child")
+            if any(child[field] != first_child[field] for field in CHILD_BLOCK_IDENTITY_FIELDS):
+                fail(f"{label}: mismatched workload identity within a complete memory pair")
+        blocks_by_cell.setdefault((scenario, point), set()).add(block)
+    if set(blocks_by_cell) != set(MEMORY_CELLS) or any(
+        len(blocks) < 15 for blocks in blocks_by_cell.values()
+    ):
+        fail(f"{label}: every memory cell requires at least 15 complete paired blocks")
+    return report
+
+
 def validate_latest(latest: dict[str, object], label: str) -> None:
-    exact_fields(latest, TOP_LEVEL_FIELDS, label)
+    exact_fields_with_optional(latest, TOP_LEVEL_FIELDS, OPTIONAL_TOP_LEVEL_FIELDS, label)
     versions = {
         "latest_schema_version": LATEST_SCHEMA,
         "raw_schema_version": RAW_SCHEMA,
@@ -631,9 +1235,31 @@ def validate_latest(latest: dict[str, object], label: str) -> None:
         or methodology.get("informational") is not True
     ):
         fail(f"{label}.methodology: unsupported methodology contract")
+    memory = latest.get("memory")
+    if memory is not None:
+        memory_report = validate_memory_report(memory, f"{label}.memory")
+        expected_sources = {
+            object_value(value, f"{label}.allocators")["allocator_id"]: object_value(
+                value, f"{label}.allocators"
+            )["source_sha"]
+            for value in allocators
+        }
+        observed_sources = {
+            object_value(value, f"{label}.memory.raw_samples")["allocator_id"]: object_value(
+                value, f"{label}.memory.raw_samples"
+            )["allocator_source_sha"]
+            for value in list_value(memory_report["raw_samples"], f"{label}.memory.raw_samples")
+        }
+        if observed_sources != expected_sources:
+            fail(f"{label}.memory: allocator source pins differ from the core run")
     pending = list_value(latest.get("pending_metrics"), f"{label}.pending_metrics")
-    if len(pending) != 4:
-        fail(f"{label}.pending_metrics: expected four explicit pending metrics")
+    expected_pending = (
+        ("latency", "scaling", "pprof-tax")
+        if memory is not None
+        else ("memory", "latency", "scaling", "pprof-tax")
+    )
+    if len(pending) != len(expected_pending):
+        fail(f"{label}.pending_metrics: does not match collected optional metrics")
     for index, value in enumerate(pending):
         item = object_value(value, f"{label}.pending_metrics[{index}]")
         exact_fields(
@@ -650,12 +1276,7 @@ def validate_latest(latest: dict[str, object], label: str) -> None:
         )
         if any(isinstance(item.get(field), (int, float)) for field in item):
             fail(f"{label}.pending_metrics[{index}]: pending metrics cannot contain numbers")
-    if tuple(object_value(item, "pending")["metric_id"] for item in pending) != (
-        "memory",
-        "latency",
-        "scaling",
-        "pprof-tax",
-    ):
+    if tuple(object_value(item, "pending")["metric_id"] for item in pending) != expected_pending:
         fail(f"{label}.pending_metrics: unexpected metric IDs or order")
     urls = object_value(latest.get("canonical_urls"), f"{label}.canonical_urls")
     exact_fields(
@@ -686,12 +1307,14 @@ def compact_json(value: object) -> bytes:
     ).encode("utf-8")
 
 
-def history_row(latest: dict[str, object]) -> dict[str, object]:
+def history_row(
+    latest: dict[str, object], *, include_optional_metrics: bool = True
+) -> dict[str, object]:
     allocators = [
         object_value(value, "latest.allocators")
         for value in list_value(latest["allocators"], "latest.allocators")
     ]
-    return {
+    row: dict[str, object] = {
         "history_schema_version": HISTORY_SCHEMA,
         "statistics_version": STATISTICS_VERSION,
         "suite_version": SUITE_VERSION,
@@ -711,11 +1334,20 @@ def history_row(latest: dict[str, object]) -> dict[str, object]:
         "absolute_summaries": latest["absolute_summaries"],
         "paired_summaries": latest["paired_summaries"],
     }
+    if include_optional_metrics and "memory" in latest:
+        memory = validate_memory_report(latest["memory"], "latest.memory")
+        runner = object_value(memory["runner"], "latest.memory.runner")
+        row["memory"] = {
+            key: value
+            for key, value in memory.items()
+            if key not in {"invalid_reason", "runner", "raw_samples"}
+        } | {"runner_fingerprint_sha256": runner["fingerprint_sha256"]}
+    return row
 
 
 def validate_history_row(value: object, label: str) -> dict[str, object]:
     row = object_value(value, label)
-    exact_fields(row, HISTORY_FIELDS, label)
+    exact_fields_with_optional(row, HISTORY_FIELDS, OPTIONAL_HISTORY_FIELDS, label)
     if row.get("history_schema_version") != HISTORY_SCHEMA:
         fail(f"{label}.history_schema_version: incompatible schema")
     if (
@@ -767,6 +1399,8 @@ def validate_history_row(value: object, label: str) -> dict[str, object]:
         validate_absolute(item, f"{label}.absolute_summaries[{index}]")
     for index, item in enumerate(paired):
         validate_paired(item, f"{label}.paired_summaries[{index}]")
+    if "memory" in row:
+        validate_memory_report(row["memory"], f"{label}.memory", compact=True)
     return row
 
 
@@ -814,7 +1448,21 @@ def history_sort_key(row: Mapping[str, object]) -> tuple[datetime, str, int, str
 def merge_history(
     rows: list[dict[str, object]], current: dict[str, object]
 ) -> list[dict[str, object]]:
-    combined = [*rows, current]
+    current_run = object_value(current["run"], "current history run")
+    current_identity = (current_run["run_id"], current_run["run_attempt"])
+    combined = list(rows)
+    for index, row in enumerate(combined):
+        run = object_value(row["run"], "history run")
+        if (run["run_id"], run["run_attempt"]) != current_identity:
+            continue
+        previous_base = {key: value for key, value in row.items() if key != "memory"}
+        current_base = {key: value for key, value in current.items() if key != "memory"}
+        if previous_base != current_base or "memory" not in current:
+            fail("history append: duplicate run may only gain a validated optional metric")
+        combined[index] = current
+        break
+    else:
+        combined.append(current)
     reject_duplicate_history(combined, "history append")
     combined.sort(key=history_sort_key)
     return combined[-1000:]
@@ -945,6 +1593,53 @@ def pending_png(metric: str, reason: str) -> bytes:
     return encode_png(960, 540, canvas.pixels, f"PENDING {metric}: {reason}")
 
 
+def memory_png(memory: Mapping[str, object]) -> bytes:
+    canvas = Canvas(960, 540, (248, 250, 252))
+    canvas.rectangle(0, 0, 960, 62, (24, 35, 52))
+    records = [
+        validate_absolute(value, "memory absolute summary")
+        for value in list_value(memory["absolute_summaries"], "memory absolute summaries")
+        if object_value(value, "memory absolute summary").get("metric_id")
+        == "sampled-peak-rss-bytes"
+    ]
+    cells: dict[tuple[str, str], list[dict[str, object]]] = {}
+    for record in records:
+        key = (cast(str, record["scenario_id"]), cast(str, record["thread_point"]))
+        cells.setdefault(key, []).append(record)
+    for ordinal, (_key, values) in enumerate(sorted(cells.items())):
+        column, row = ordinal % 2, ordinal // 2
+        left, top = 45 + column * 460, 85 + row * 112
+        canvas.rectangle(left, top, 420, 92, (235, 240, 246))
+        medians = [
+            float_value(object_value(value["summary"], "summary")["median"], "median", True)
+            for value in values
+        ]
+        maximum = max(medians)
+        for index, median in enumerate(medians):
+            canvas.rectangle(
+                left + 14,
+                top + 10 + index * 19,
+                max(1, int(380 * median / maximum)),
+                11,
+                COLORS[index],
+            )
+    return encode_png(960, 540, canvas.pixels, "Linux process RSS; lower is better")
+
+
+def carry_forward_optional_metrics(latest: dict[str, object], prior: dict[str, object]) -> bool:
+    validate_latest(prior, "prior latest")
+    if "memory" not in latest and "memory" in prior:
+        latest["memory"] = copy.deepcopy(prior["memory"])
+        pending = list_value(latest["pending_metrics"], "latest.pending_metrics")
+        latest["pending_metrics"] = [
+            value
+            for value in pending
+            if object_value(value, "latest pending metric").get("metric_id") != "memory"
+        ]
+        return True
+    return False
+
+
 def escaped(value: object) -> str:
     return html.escape(str(value), quote=True)
 
@@ -973,16 +1668,35 @@ def render_html(latest: Mapping[str, object]) -> bytes:
         for value in paired
     )
     pending = cast(list[dict[str, object]], latest["pending_metrics"])
-    pending_names = [
-        "benchmark-memory.png",
-        "benchmark-latency.png",
-        "benchmark-scaling.png",
-        "benchmark-pprof-tax.png",
-    ]
+    pending_names = {
+        "memory": "benchmark-memory.png",
+        "latency": "benchmark-latency.png",
+        "scaling": "benchmark-scaling.png",
+        "pprof-tax": "benchmark-pprof-tax.png",
+    }
     pending_html = "".join(
-        f"<article class='pending'><img src='{name}' alt='{escaped(item['metric_id'])} pending: {escaped(item['reason'])}'><h3>{escaped(item['metric_id'])}: pending</h3><p>{escaped(item['reason'])}</p><a href='{escaped(item['phase_issue_url'])}'>Phase issue</a></article>"
-        for name, item in zip(pending_names, pending)
+        f"<article class='pending'><img src='{pending_names[cast(str, item['metric_id'])]}' alt='{escaped(item['metric_id'])} pending: {escaped(item['reason'])}'><h3>{escaped(item['metric_id'])}: pending</h3><p>{escaped(item['reason'])}</p><a href='{escaped(item['phase_issue_url'])}'>Phase issue</a></article>"
+        for item in pending
     )
+    memory_html = ""
+    if "memory" in latest:
+        memory = validate_memory_report(latest["memory"], "latest.memory")
+        memory_run = object_value(memory["run"], "latest.memory.run")
+        memory_runner = object_value(memory["runner"], "latest.memory.runner")
+        memory_absolute = [
+            validate_absolute(value, "memory absolute")
+            for value in list_value(memory["absolute_summaries"], "memory absolute summaries")
+        ]
+        memory_rows = "".join(
+            f"<tr><td>{escaped(value['scenario_id'])}</td><td>{escaped(value['thread_point'])}</td><td>{escaped(value['metric_id'])}</td><td>{escaped(value['allocator_id'])}</td><td>{escaped(round(float_value(object_value(value['summary'], 'memory summary')['median'], 'memory median') / (1024 * 1024), 3) if value['metric_id'] != 'fragmentation-proxy' else object_value(value['summary'], 'memory summary')['median'])}</td></tr>"
+            for value in memory_absolute
+        )
+        memory_actions = (
+            f"https://github.com/zackees/mimalloc-pprof/actions/runs/{escaped(memory_run['run_id'])}"
+            if memory_run["run_origin"] == "github-actions"
+            else "https://github.com/zackees/mimalloc-pprof/actions"
+        )
+        memory_html = f"""<section><h2 id="memory">Linux process memory</h2><img src="benchmark-memory.png" alt="Absolute Linux process RSS for all four allocators; lower is better"><p>Externally sampled from <code>/proc/&lt;pid&gt;/smaps_rollup</code> every {escaped(memory["sampling_target_interval_ns"])} ns with VmHWM cross-checks and natural purge only. Runner: {escaped(memory_runner["runner_class"])}; results are informational. Memory run <a href="{memory_actions}">{escaped(memory_run["run_id"])}/{escaped(memory_run["run_attempt"])}</a>; metric key <code>{escaped(memory["metric_comparison_key"])}</code>.</p><table><thead><tr><th>Scenario</th><th>Threads</th><th>Metric</th><th>Allocator</th><th>Median (MiB or ratio)</th></tr></thead><tbody>{memory_rows}</tbody></table></section>"""
     document = f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>mimalloc allocator benchmarks</title>
 <style>body{{font:15px system-ui,sans-serif;max-width:1200px;margin:auto;padding:24px;color:#182334}}table{{border-collapse:collapse;width:100%;margin:16px 0}}th,td{{border:1px solid #ccd4dd;padding:7px;text-align:left}}img{{max-width:100%;height:auto}}.pending{{border:1px solid #ccd4dd;padding:12px;margin:12px 0}}code,pre{{overflow-wrap:anywhere;white-space:pre-wrap}}small{{color:#596575}}</style></head><body>
@@ -991,7 +1705,7 @@ def render_html(latest: Mapping[str, object]) -> bytes:
 <h2 id="throughput">Throughput</h2><img src="benchmark-throughput.png" alt="Per-scenario absolute throughput bars for all four allocators"><table><thead><tr><th>Scenario</th><th>Threads</th><th>Allocator</th><th>Median</th><th>Noisy</th></tr></thead><tbody>{absolute_rows}</tbody></table>
 <h2>Paired effects</h2><table><thead><tr><th>Scenario</th><th>Candidate</th><th>Effect</th><th>95% interval</th><th>Interpretation</th></tr></thead><tbody>{paired_rows}</tbody></table>
 <h2 id="history">Compatible history</h2><img src="benchmark-history.png" alt="History connected only across the selected identical comparison key">
-<h2>Pending Phase 6 panels</h2>{pending_html}<section id="phase-6"><p>Pending panels contain no measured values.</p></section>
+{memory_html}<h2>Pending Phase 6 panels</h2>{pending_html}<section id="phase-6"><p>Pending panels contain no measured values.</p></section>
 <h2>Provenance</h2><p>Run {escaped(run["run_id"])}, attempt {escaped(run["run_attempt"])}; target {escaped(runner["target"])}; fingerprint <code>{escaped(runner["fingerprint_sha256"])}</code>.</p><table><thead><tr><th>Allocator</th><th>Source</th><th>Binary</th></tr></thead><tbody>{allocator_rows}</tbody></table><p><a href="{escaped(latest["actions_run_url"])}">Actions run</a></p>
 <h2>Methodology</h2><pre>{escaped(json.dumps(latest["methodology"], sort_keys=True, ensure_ascii=False))}</pre><h2>Reproduce</h2><pre><code>{escaped(latest["reproduction_command"])}</code></pre>
 </body></html>"""
@@ -1025,12 +1739,25 @@ def ensure_empty_output(path: Path) -> None:
 
 
 def render(
-    input_path: Path, history_path: Path, output: Path, digest_out: Path, initialize: bool
+    input_path: Path,
+    history_path: Path,
+    output: Path,
+    digest_out: Path,
+    initialize: bool,
+    prior_latest_path: Path | None = None,
 ) -> str:
     latest = read_json(input_path)
     validate_latest(latest, str(input_path))
+    carried_optional_metrics = False
+    if prior_latest_path is not None:
+        prior = read_json(prior_latest_path)
+        carried_optional_metrics = carry_forward_optional_metrics(latest, prior)
+        validate_latest(latest, str(input_path))
     rows = read_history(history_path, initialize)
-    rows = merge_history(rows, history_row(latest))
+    rows = merge_history(
+        rows,
+        history_row(latest, include_optional_metrics=not carried_optional_metrics),
+    )
     output_resolved = output.resolve()
     digest_resolved = digest_out.resolve()
     try:
@@ -1047,19 +1774,27 @@ def render(
     (output / "benchmark-throughput.png").write_bytes(throughput_png(latest))
     key = comparison_digest(latest["comparison_key"], "comparison_key")
     (output / "benchmark-history.png").write_bytes(history_png(rows, key))
-    pending = cast(list[dict[str, object]], latest["pending_metrics"])
-    for name, item in zip(
-        (
-            "benchmark-memory.png",
-            "benchmark-latency.png",
-            "benchmark-scaling.png",
-            "benchmark-pprof-tax.png",
-        ),
-        pending,
-    ):
-        (output / name).write_bytes(
-            pending_png(cast(str, item["metric_id"]), cast(str, item["reason"]))
+    pending = {
+        cast(str, item["metric_id"]): item
+        for item in cast(list[dict[str, object]], latest["pending_metrics"])
+    }
+    image_names = {
+        "memory": "benchmark-memory.png",
+        "latency": "benchmark-latency.png",
+        "scaling": "benchmark-scaling.png",
+        "pprof-tax": "benchmark-pprof-tax.png",
+    }
+    if "memory" in latest:
+        memory = validate_memory_report(latest["memory"], "latest.memory")
+        (output / image_names["memory"]).write_bytes(memory_png(memory))
+    else:
+        item = pending["memory"]
+        (output / image_names["memory"]).write_bytes(
+            pending_png("memory", cast(str, item["reason"]))
         )
+    for metric in ("latency", "scaling", "pprof-tax"):
+        item = pending[metric]
+        (output / image_names[metric]).write_bytes(pending_png(metric, cast(str, item["reason"])))
     (output / "manifest.json").write_bytes(compact_json(manifest_for(output)))
     digest = sha256(output / "manifest.json")
     digest_out.parent.mkdir(parents=True, exist_ok=True)
@@ -1321,6 +2056,7 @@ def assert_fixture_determinism(
     rendered_site: Path,
     rendered_digest: Path,
     initialize: bool,
+    prior_latest_path: Path | None = None,
 ) -> None:
     with tempfile.TemporaryDirectory(prefix="benchmark-report-fixture-repeat-") as temporary:
         root = Path(temporary)
@@ -1332,6 +2068,7 @@ def assert_fixture_determinism(
             repeated_site,
             repeated_digest,
             initialize,
+            prior_latest_path,
         )
         for name in SITE_FILES:
             if (rendered_site / name).read_bytes() != (repeated_site / name).read_bytes():
@@ -1377,6 +2114,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     render_parser.add_argument("--detached-digest-out", type=Path, required=True)
     render_parser.add_argument("--initialize-history", action="store_true")
     render_parser.add_argument(
+        "--prior-latest",
+        type=Path,
+        help="carry forward validated optional metrics from the prior public latest.json",
+    )
+    render_parser.add_argument(
         "--fixture-mode",
         action="store_true",
         help="assert deterministic fixture workflow (rendering is always deterministic)",
@@ -1408,6 +2150,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.output_dir,
             args.detached_digest_out,
             args.initialize_history,
+            args.prior_latest,
         )
         if args.fixture_mode:
             assert_fixture_determinism(
@@ -1416,6 +2159,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 args.output_dir,
                 args.detached_digest_out,
                 args.initialize_history,
+                args.prior_latest,
             )
         print(f"PASS rendered and sealed {args.output_dir}; manifest sha256={digest}")
         return 0

--- a/ci/check_benchmark_memory_workflow.py
+++ b/ci/check_benchmark_memory_workflow.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Fail-closed policy checker for the Linux process-memory workflow."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import NoReturn, cast
+
+import yaml
+
+from check_benchmark_workflow import check_action_ref
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "benchmark-memory.yml"
+JOBS = {
+    "build-and-measure",
+    "artifact-audit",
+    "publish-branch",
+    "package-pages",
+    "deploy-pages",
+    "publication-audit",
+}
+
+
+class MemoryWorkflowError(RuntimeError):
+    """A process-memory workflow policy assertion failed."""
+
+
+def fail(message: str) -> NoReturn:
+    raise MemoryWorkflowError(message)
+
+
+def mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        fail(f"{label}: expected object")
+    return cast(dict[str, object], value)
+
+
+def steps_by_name(job: Mapping[str, object]) -> dict[str, dict[str, object]]:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        fail("job.steps: expected array")
+    result: dict[str, dict[str, object]] = {}
+    for value in cast(list[object], steps):
+        step = mapping(value, "job step")
+        name = step.get("name")
+        if isinstance(name, str):
+            result[name] = step
+        action = step.get("uses")
+        if isinstance(action, str):
+            try:
+                check_action_ref(action, "memory workflow action")
+            except Exception as error:
+                fail(str(error))
+    return result
+
+
+def validate(workflow: Mapping[str, object]) -> None:
+    raw_workflow = cast(Mapping[object, object], workflow)
+    on = workflow.get("on", raw_workflow.get(True))  # PyYAML 1.1 treats `on` as true.
+    triggers = mapping(on, "workflow.on")
+    if set(triggers) != {"workflow_dispatch", "schedule"}:
+        fail("workflow.on: only weekly schedule and manual dispatch are allowed")
+    schedule = triggers.get("schedule")
+    if not isinstance(schedule, list) or len(cast(list[object], schedule)) != 1:
+        fail("workflow.on.schedule: expected one weekly schedule")
+    dispatch = mapping(triggers.get("workflow_dispatch"), "workflow.on.workflow_dispatch")
+    inputs = mapping(dispatch.get("inputs"), "workflow.on.workflow_dispatch.inputs")
+    if set(inputs) != {"mode", "run_seed", "blocks"}:
+        fail("workflow dispatch inputs must be exactly mode/run_seed/blocks")
+    mode = mapping(inputs["mode"], "workflow input mode")
+    if mode.get("options") != ["full", "smoke"] or mode.get("default") != "full":
+        fail("workflow input mode must default to full with full/smoke choices")
+
+    concurrency = mapping(workflow.get("concurrency"), "workflow.concurrency")
+    if concurrency != {"group": "benchmark-stats-production", "cancel-in-progress": False}:
+        fail("memory workflow must serialize with the production publication group")
+    if mapping(workflow.get("permissions"), "workflow.permissions") != {"contents": "read"}:
+        fail("workflow permissions must be contents: read")
+
+    jobs = mapping(workflow.get("jobs"), "workflow.jobs")
+    if set(jobs) != JOBS:
+        fail(f"workflow jobs mismatch: expected {sorted(JOBS)}")
+    for name, value in jobs.items():
+        job = mapping(value, f"workflow.jobs.{name}")
+        if job.get("runs-on") != "ubuntu-24.04":
+            fail(f"workflow.jobs.{name}.runs-on: expected ubuntu-24.04")
+        timeout = job.get("timeout-minutes")
+        if not isinstance(timeout, int) or timeout > 60:
+            fail(f"workflow.jobs.{name}.timeout-minutes: expected <=60")
+        if "strategy" in job:
+            fail(f"workflow.jobs.{name}: parallel matrices are forbidden")
+        steps_by_name(job)
+
+    build = mapping(jobs["build-and-measure"], "build-and-measure")
+    if build.get("timeout-minutes") != 60:
+        fail("build-and-measure must enforce the 60-minute hard limit")
+    steps = steps_by_name(build)
+    run_step = mapping(steps.get("run external memory suite"), "run external memory suite")
+    run = run_step.get("run")
+    if not isinstance(run, str) or "benchmark-memory-run" not in run or "--blocks" not in run:
+        fail("memory measurement step must execute benchmark-memory-run with explicit blocks")
+    if " &" in run or "parallel" in run or "xargs" in run:
+        fail("memory allocators must execute sequentially")
+    for step_name in (
+        "determine run seed",
+        "run external memory suite",
+        "compute publication eligibility",
+    ):
+        step = mapping(steps.get(step_name), step_name)
+        if "${{ inputs." in str(step.get("run", "")):
+            fail(f"{step_name}: workflow inputs must enter shell through env, not source text")
+    seed_step = mapping(steps.get("determine run seed"), "determine run seed")
+    seed_env = mapping(seed_step.get("env"), "determine run seed.env")
+    if "INPUT_RUN_SEED" not in seed_env or "*[!0-9]*" not in str(seed_step.get("run", "")):
+        fail("run seed must use an env boundary and strict decimal validation")
+    raw = mapping(steps.get("upload raw proc artifact"), "upload raw proc artifact")
+    if raw.get("if") != "always()":
+        fail("raw proc artifact must upload with if: always()")
+    raw_with = mapping(raw.get("with"), "upload raw proc artifact.with")
+    if raw_with.get("retention-days") != 30 or raw_with.get("include-hidden-files") is not True:
+        fail("raw proc artifact must retain all bytes for 30 days")
+    eligibility = mapping(steps.get("compute publication eligibility"), "eligibility")
+    eligibility_run = eligibility.get("run")
+    if not isinstance(eligibility_run, str):
+        fail("eligibility step needs a shell policy")
+    for required in ("refs/heads/main", "full", "-ge 15"):
+        if required not in eligibility_run:
+            fail(f"eligibility step is missing {required!r}")
+
+    publish = mapping(jobs["publish-branch"], "publish-branch")
+    if mapping(publish.get("permissions"), "publish permissions") != {"contents": "write"}:
+        fail("only publish-branch may use contents: write")
+    deploy = mapping(jobs["deploy-pages"], "deploy-pages")
+    if mapping(deploy.get("permissions"), "deploy permissions") != {
+        "pages": "write",
+        "id-token": "write",
+    }:
+        fail("deploy-pages requires only pages/id-token write")
+    if mapping(deploy.get("environment"), "deploy environment").get("name") != "github-pages":
+        fail("deploy-pages must target the github-pages environment")
+    publish_text = str(publish)
+    if "--force-with-lease" not in publish_text or "prepare-branch" not in publish_text:
+        fail("branch publication must use exact replacement and a lease")
+    package_text = str(jobs["package-pages"])
+    if "benchmark-memory-site-" not in publish_text or "benchmark-memory-site-" not in package_text:
+        fail("branch and Pages must consume the same sealed memory site artifact")
+    audit_text = str(jobs["publication-audit"])
+    for required in ("validate-revision", "audit-pages"):
+        if required not in audit_text:
+            fail(f"publication audit is missing {required}")
+
+
+def load(path: Path) -> dict[str, object]:
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return mapping(value, str(path))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow", type=Path, default=WORKFLOW)
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+    validate(load(args.workflow))
+    if args.selftest:
+        print("PASS benchmark memory workflow policy selftest")
+    else:
+        print(f"PASS benchmark memory workflow policy: {args.workflow}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except MemoryWorkflowError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/ci/tests/test_benchmark_memory_workflow.py
+++ b/ci/tests/test_benchmark_memory_workflow.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+# pyright: reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false
+# ruff: noqa: I001
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_benchmark_memory_workflow as policy
+
+
+class BenchmarkMemoryWorkflowTests(unittest.TestCase):
+    def workflow(self) -> dict[str, object]:
+        return policy.load(policy.WORKFLOW)
+
+    def test_production_workflow_passes(self) -> None:
+        policy.validate(self.workflow())
+
+    def test_parallel_matrix_is_rejected(self) -> None:
+        value = self.workflow()
+        jobs = value["jobs"]
+        assert isinstance(jobs, dict)
+        build = jobs["build-and-measure"]
+        assert isinstance(build, dict)
+        build["strategy"] = {"matrix": {"allocator": ["a", "b"]}}
+        with self.assertRaisesRegex(policy.MemoryWorkflowError, "parallel matrices"):
+            policy.validate(value)
+
+    def test_nondefault_publication_and_missing_raw_retention_are_rejected(self) -> None:
+        value = self.workflow()
+        jobs = value["jobs"]
+        assert isinstance(jobs, dict)
+        build = jobs["build-and-measure"]
+        assert isinstance(build, dict)
+        steps = build["steps"]
+        assert isinstance(steps, list)
+        eligibility = next(
+            item
+            for item in steps
+            if isinstance(item, dict) and item.get("name") == "compute publication eligibility"
+        )
+        eligibility["run"] = str(eligibility["run"]).replace(
+            "refs/heads/main", "refs/heads/feature"
+        )
+        with self.assertRaisesRegex(policy.MemoryWorkflowError, "refs/heads/main"):
+            policy.validate(value)
+
+        value = self.workflow()
+        jobs = value["jobs"]
+        assert isinstance(jobs, dict)
+        build = jobs["build-and-measure"]
+        assert isinstance(build, dict)
+        raw = policy.steps_by_name(build)["upload raw proc artifact"]
+        raw_with = raw["with"]
+        assert isinstance(raw_with, dict)
+        raw_with["retention-days"] = 1
+        with self.assertRaisesRegex(policy.MemoryWorkflowError, "30 days"):
+            policy.validate(value)
+
+    def test_separate_concurrency_group_is_rejected(self) -> None:
+        value = copy.deepcopy(self.workflow())
+        value["concurrency"] = {"group": "memory-only", "cancel-in-progress": False}
+        with self.assertRaisesRegex(policy.MemoryWorkflowError, "serialize"):
+            policy.validate(value)
+
+    def test_shell_interpolated_seed_is_rejected(self) -> None:
+        value = self.workflow()
+        jobs = value["jobs"]
+        assert isinstance(jobs, dict)
+        build = jobs["build-and-measure"]
+        assert isinstance(build, dict)
+        seed = policy.steps_by_name(build)["determine run seed"]
+        seed["run"] = 'SEED="${{ inputs.run_seed }}"'
+        with self.assertRaisesRegex(policy.MemoryWorkflowError, "through env"):
+            policy.validate(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_benchmark_report.py
+++ b/ci/tests/test_benchmark_report.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+# pyright: reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportIndexIssue=false
+
 # The production script is intentionally standalone, not an installed package.
 # ruff: noqa: I001
 
@@ -38,6 +40,188 @@ class BenchmarkReportTests(unittest.TestCase):
 
     def write_json(self, path: Path, value: object) -> None:
         path.write_text(json.dumps(value) + "\n", encoding="utf-8", newline="\n")
+
+    def with_complete_memory(self, latest: dict[str, object]) -> dict[str, object]:
+        value = copy.deepcopy(latest)
+        raw_samples = value["raw_samples"]
+        assert isinstance(raw_samples, list)
+        memory_samples: list[dict[str, object]] = []
+        templates = [
+            item
+            for item in raw_samples
+            if isinstance(item, dict)
+            and item.get("scenario_id") == "scenario-00"
+            and item.get("thread_point") == "1"
+        ]
+        self.assertEqual(15 * 4, len(templates))
+        for scenario, point in report.MEMORY_CELLS:
+            for template in templates:
+                child_value = copy.deepcopy(template)
+                child_value["scenario_id"] = scenario
+                child_value["thread_point"] = point
+                child_value["thread_count"] = (
+                    1 if point == "1" else 2 if point == "2" else value["runner"]["physical_cores"]
+                )
+                assert isinstance(child_value, dict)
+                allocator = str(child_value["allocator_id"])
+                delta_mib = {
+                    "tcmalloc": 120,
+                    "jemalloc": 110,
+                    "upstream-mimalloc": 100,
+                    "mimalloc-pprof": 90,
+                }[allocator] + int(child_value["block_id"])
+                baseline = 100 * 1024 * 1024
+                delta = delta_mib * 1024 * 1024
+                peak = baseline + delta
+                post = baseline + delta // 2
+                memory_samples.append(
+                    {
+                        "metric_schema_version": report.MEMORY_SCHEMA,
+                        "block_id": child_value["block_id"],
+                        "ordinal": child_value["ordinal"],
+                        "workload_seed": child_value["workload_seed"],
+                        "allocator_id": allocator,
+                        "allocator_source_sha": child_value["allocator_source_sha"],
+                        "child_binary_sha256": child_value["child_binary_sha256"],
+                        "scenario_id": child_value["scenario_id"],
+                        "thread_point": child_value["thread_point"],
+                        "thread_count": child_value["thread_count"],
+                        "baseline_ready_ns": 1_000_000,
+                        "workload_active_ns": 9_000_000,
+                        "workload_drained_ns": 21_000_000,
+                        "post_drain_sample_100ms_ns": 121_000_000,
+                        "post_drain_sample_1s_ns": 1_021_000_000,
+                        "post_drain_sample_5s_ns": 5_021_000_000,
+                        "sampler_pid": 100,
+                        "sampled_pid": 101 + int(child_value["ordinal"]),
+                        "baseline_rss_bytes": baseline,
+                        "baseline_hwm_bytes": baseline,
+                        "sampled_peak_rss_bytes": peak,
+                        "kernel_peak_hwm_bytes": peak,
+                        "peak_live_requested_bytes": child_value["peak_live_requested_bytes"],
+                        "post_drain_rss_100ms_bytes": post,
+                        "post_drain_rss_1s_bytes": post,
+                        "post_drain_rss_5s_bytes": post,
+                        "sampled_peak_rss_delta_bytes": delta,
+                        "post_drain_rss_delta_100ms_bytes": delta // 2,
+                        "post_drain_rss_delta_1s_bytes": delta // 2,
+                        "post_drain_rss_delta_5s_bytes": delta // 2,
+                        "fragmentation_proxy": delta
+                        / int(child_value["peak_live_requested_bytes"]),
+                        "hwm_discrepancy": False,
+                        "hwm_tolerance_bytes": max(8 * 1024 * 1024, delta // 5),
+                        "sampling": {
+                            "target_interval_ns": 5_000_000,
+                            "sample_count": 3,
+                            "minimum_interval_ns": 5_000_000,
+                            "median_interval_ns": 5_000_000,
+                            "p95_interval_ns": 5_000_000,
+                            "maximum_interval_ns": 5_000_000,
+                        },
+                        "timeline": [
+                            {"elapsed_ns": 10_000_000, "rss_bytes": baseline + delta // 2},
+                            {"elapsed_ns": 15_000_000, "rss_bytes": peak},
+                            {"elapsed_ns": 20_000_000, "rss_bytes": baseline + delta * 3 // 4},
+                        ],
+                        "environment": {
+                            "page_size_bytes": 4096,
+                            "kernel": value["runner"]["kernel"],
+                            "transparent_hugepage": "always [madvise] never",
+                            "cgroup_memory_max": "2147483648",
+                            "cgroup_memory_high": "max",
+                            "hosted_runner": value["runner"]["runner_class"] == "github-hosted",
+                            "purge_policy": "natural-only",
+                            "allocator_runtime_options": {
+                                "MIMALLOC_MEMORY_EVENTS": "0",
+                                "MIMALLOC_PROF": "0",
+                            },
+                        },
+                        "child_sample": child_value,
+                    }
+                )
+
+        absolute: list[dict[str, object]] = []
+        paired: list[dict[str, object]] = []
+        stats = {
+            "count": 15,
+            "median": float(128 * 1024 * 1024),
+            "min": float(120 * 1024 * 1024),
+            "max": float(136 * 1024 * 1024),
+            "q1": float(124 * 1024 * 1024),
+            "q3": float(132 * 1024 * 1024),
+            "iqr": float(8 * 1024 * 1024),
+            "relative_iqr": 0.0625,
+            "noisy": False,
+        }
+        for scenario, point in report.MEMORY_CELLS:
+            for metric in report.MEMORY_METRICS:
+                metric_stats = copy.deepcopy(stats)
+                if metric == "fragmentation-proxy":
+                    metric_stats.update(median=1.1, min=1.0, max=1.2, q1=1.05, q3=1.15, iqr=0.1)
+                for allocator in report.ALLOCATOR_IDS:
+                    absolute.append(
+                        {
+                            "scenario_id": scenario,
+                            "thread_point": point,
+                            "metric_id": metric,
+                            "direction": "lower-is-better",
+                            "allocator_id": allocator,
+                            "summary": copy.deepcopy(metric_stats),
+                        }
+                    )
+                    if allocator != "upstream-mimalloc":
+                        paired.append(
+                            {
+                                "scenario_id": scenario,
+                                "thread_point": point,
+                                "metric_id": metric,
+                                "summary": {
+                                    "candidate_id": allocator,
+                                    "reference_id": "upstream-mimalloc",
+                                    "direction": "lower-is-better",
+                                    "block_count": 15,
+                                    "effect": 1.05,
+                                    "confidence_interval": {
+                                        "lower": 1.01,
+                                        "upper": 1.09,
+                                        "confidence_level": 0.95,
+                                    },
+                                    "bootstrap": {
+                                        "seed": 1,
+                                        "resample_count": 10_000,
+                                        "method": "percentile-block-bootstrap-type7-v1",
+                                        "prng": "splitmix64-rejection-v1",
+                                    },
+                                    "informational": True,
+                                },
+                            }
+                        )
+        value["memory"] = {
+            "metric_schema_version": report.MEMORY_SCHEMA,
+            "status": "complete",
+            "invalid_reason": None,
+            "metric_comparison_key": "a" * 64,
+            "run": copy.deepcopy(value["run"]),
+            "runner": copy.deepcopy(value["runner"]),
+            "sampling_target_interval_ns": 5_000_000,
+            "purge_policy": "natural-only",
+            "units": {
+                metric: "ratio" if metric == "fragmentation-proxy" else "bytes"
+                for metric in report.MEMORY_METRICS
+            },
+            "direction": "lower-is-better",
+            "informational": True,
+            "methodology": copy.deepcopy(report.MEMORY_METHODOLOGY),
+            "absolute_summaries": absolute,
+            "paired_summaries": paired,
+            "raw_samples": memory_samples,
+        }
+        pending = value["pending_metrics"]
+        assert isinstance(pending, list)
+        value["pending_metrics"] = [
+            item for item in pending if isinstance(item, dict) and item.get("metric_id") != "memory"
+        ]
+        return value
 
     def render_fixture(self, root: Path) -> tuple[Path, Path]:
         site = root / "site"
@@ -158,6 +342,110 @@ class BenchmarkReportTests(unittest.TestCase):
             page = (site / "index.html").read_text(encoding="utf-8")
             self.assertIn('<h2 id="throughput">Throughput</h2>', page)
             self.assertIn('<h2 id="history">Compatible history</h2>', page)
+
+    def test_complete_memory_replaces_pending_panel_and_history_stays_compact(self) -> None:
+        latest = self.with_complete_memory(self.load_latest())
+        report.validate_latest(latest, "memory fixture")
+        history = report.history_row(latest)
+        self.assertIn("memory", history)
+        memory_history = history["memory"]
+        assert isinstance(memory_history, dict)
+        self.assertNotIn("raw_samples", memory_history)
+        report.validate_history_row(history, "memory history")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "latest.json"
+            self.write_json(source, latest)
+            site = root / "site"
+            report.render(source, FIXTURE / "history.jsonl", site, root / "digest", False)
+            page = (site / "index.html").read_text(encoding="utf-8")
+            self.assertIn('<h2 id="memory">Linux process memory</h2>', page)
+            self.assertNotIn("memory: pending", page)
+            self.assertIn(b"Linux process RSS", (site / "benchmark-memory.png").read_bytes())
+
+    def test_incomplete_memory_never_replaces_pending_and_prior_complete_is_carried(self) -> None:
+        prior = self.with_complete_memory(self.load_latest())
+        incomplete = copy.deepcopy(prior)
+        memory = incomplete["memory"]
+        assert isinstance(memory, dict)
+        samples = memory["raw_samples"]
+        assert isinstance(samples, list)
+        samples.pop()
+        with self.assertRaisesRegex(report.ReportError, "complete memory pair"):
+            report.validate_latest(incomplete, "incomplete")
+
+        bad_hwm = copy.deepcopy(prior)
+        memory = bad_hwm["memory"]
+        assert isinstance(memory, dict)
+        samples = memory["raw_samples"]
+        assert isinstance(samples, list) and isinstance(samples[0], dict)
+        samples[0]["hwm_discrepancy"] = True
+        with self.assertRaisesRegex(report.ReportError, "VmHWM discrepancy"):
+            report.validate_latest(bad_hwm, "bad hwm")
+
+        bad_intervals = copy.deepcopy(prior)
+        memory = bad_intervals["memory"]
+        assert isinstance(memory, dict)
+        samples = memory["raw_samples"]
+        assert isinstance(samples, list) and isinstance(samples[0], dict)
+        sampling = samples[0]["sampling"]
+        assert isinstance(sampling, dict)
+        sampling["median_interval_ns"] = 1
+        with self.assertRaisesRegex(report.ReportError, "interval distribution"):
+            report.validate_latest(bad_intervals, "bad intervals")
+
+        mixed_environment = copy.deepcopy(prior)
+        memory = mixed_environment["memory"]
+        assert isinstance(memory, dict)
+        samples = memory["raw_samples"]
+        assert isinstance(samples, list) and isinstance(samples[0], dict)
+        environment = samples[0]["environment"]
+        assert isinstance(environment, dict)
+        environment["kernel"] = "other"
+        with self.assertRaisesRegex(report.ReportError, "mixed memory environments"):
+            report.validate_latest(mixed_environment, "mixed environment")
+
+        bad_child = copy.deepcopy(prior)
+        memory = bad_child["memory"]
+        assert isinstance(memory, dict)
+        samples = memory["raw_samples"]
+        assert isinstance(samples, list) and isinstance(samples[0], dict)
+        child = samples[0]["child_sample"]
+        assert isinstance(child, dict)
+        child["run_seed"] = 0
+        with self.assertRaisesRegex(report.ReportError, "run_seed"):
+            report.validate_latest(bad_child, "bad child")
+
+        mismatched_pair = copy.deepcopy(prior)
+        memory = mismatched_pair["memory"]
+        assert isinstance(memory, dict)
+        samples = memory["raw_samples"]
+        assert isinstance(samples, list) and isinstance(samples[0], dict)
+        child = samples[0]["child_sample"]
+        assert isinstance(child, dict)
+        child["checksum"] = int(child["checksum"]) + 1
+        with self.assertRaisesRegex(report.ReportError, "mismatched workload identity"):
+            report.validate_latest(mismatched_pair, "mismatched pair")
+
+        duplicate_summary = copy.deepcopy(prior)
+        memory = duplicate_summary["memory"]
+        assert isinstance(memory, dict)
+        absolute = memory["absolute_summaries"]
+        assert isinstance(absolute, list)
+        absolute.append(copy.deepcopy(absolute[0]))
+        with self.assertRaisesRegex(report.ReportError, "duplicate memory summary"):
+            report.validate_latest(duplicate_summary, "duplicate summary")
+
+        fresh = self.load_latest()
+        self.assertTrue(report.carry_forward_optional_metrics(fresh, prior))
+        report.validate_latest(fresh, "carried")
+        self.assertIn("memory", fresh)
+        self.assertNotIn("memory", report.history_row(fresh, include_optional_metrics=False))
+        pending = fresh["pending_metrics"]
+        assert isinstance(pending, list)
+        self.assertNotIn(
+            "memory", [item["metric_id"] for item in pending if isinstance(item, dict)]
+        )
 
     def test_readme_embeds_only_real_charts_and_clicks_through_to_pages(self) -> None:
         readme = Path(__file__).resolve().parents[2] / "README.md"

--- a/rust/benchmark-suite/Cargo.toml
+++ b/rust/benchmark-suite/Cargo.toml
@@ -22,6 +22,14 @@ path = "src/bin/benchmark-run.rs"
 name = "benchmark-validate"
 path = "src/bin/benchmark-validate.rs"
 
+[[bin]]
+name = "benchmark-memory-run"
+path = "src/bin/benchmark-memory-run.rs"
+
+[[bin]]
+name = "benchmark-memory-validate"
+path = "src/bin/benchmark-memory-validate.rs"
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/benchmark-suite/schema/history-v1.schema.json
+++ b/rust/benchmark-suite/schema/history-v1.schema.json
@@ -14,7 +14,8 @@
     "runner": { "$ref": "raw-run-v1.schema.json#/$defs/runner" },
     "allocator_identities": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "$ref": "#/$defs/allocatorIdentity" } },
     "absolute_summaries": { "type": "array", "minItems": 120, "items": { "$ref": "latest-v1.schema.json#/$defs/absoluteCell" } },
-    "paired_summaries": { "type": "array", "minItems": 90, "items": { "$ref": "latest-v1.schema.json#/$defs/pairedCell" } }
+    "paired_summaries": { "type": "array", "minItems": 90, "items": { "$ref": "latest-v1.schema.json#/$defs/pairedCell" } },
+    "memory": { "$ref": "memory-v1.schema.json#/$defs/history" }
   },
   "$defs": {
     "allocatorIdentity": {

--- a/rust/benchmark-suite/schema/latest-v1.schema.json
+++ b/rust/benchmark-suite/schema/latest-v1.schema.json
@@ -20,7 +20,8 @@
     "paired_summaries": { "type": "array", "minItems": 90, "items": { "$ref": "#/$defs/pairedCell" } },
     "comparison_key": { "$ref": "#/$defs/sha256" },
     "methodology": { "$ref": "#/$defs/methodology" },
-    "pending_metrics": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "$ref": "#/$defs/pending" } },
+    "pending_metrics": { "type": "array", "minItems": 3, "maxItems": 4, "items": { "$ref": "#/$defs/pending" } },
+    "memory": { "$ref": "memory-v1.schema.json#/$defs/report" },
     "canonical_urls": { "$ref": "#/$defs/urls" },
     "reproduction_command": { "$ref": "#/$defs/nonempty" },
     "actions_run_url": { "type": "string" }

--- a/rust/benchmark-suite/schema/memory-v1.schema.json
+++ b/rust/benchmark-suite/schema/memory-v1.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/zackees/mimalloc-pprof/schema/memory-v1.schema.json",
+  "title": "mimalloc-pprof Linux process-memory raw run v1",
+  "type": "object",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "complete" } }, "required": ["status"] },
+      "then": { "properties": { "samples": { "minItems": 420 } } }
+    }
+  ],
+  "required": ["metric_schema_version", "status", "run_seed", "run", "runner", "allocator_lock_sha256", "allocators", "calibrations", "samples"],
+  "properties": {
+    "metric_schema_version": { "const": "linux-process-memory-v1" },
+    "status": { "enum": ["complete", "incomplete"] },
+    "run_seed": { "type": "integer", "minimum": 1 },
+    "run": { "$ref": "raw-run-v1.schema.json#/$defs/run" },
+    "runner": { "$ref": "raw-run-v1.schema.json#/$defs/runner" },
+    "allocator_lock_sha256": { "$ref": "raw-run-v1.schema.json#/$defs/sha256" },
+    "allocators": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "$ref": "raw-run-v1.schema.json#/$defs/allocator" } },
+    "calibrations": { "type": "array", "minItems": 7, "maxItems": 7, "items": { "$ref": "raw-run-v1.schema.json#/$defs/calibration" } },
+    "samples": { "type": "array", "minItems": 28, "items": { "$ref": "#/$defs/sample" } }
+  },
+  "$defs": {
+    "nonempty": { "type": "string", "minLength": 1 },
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "timeline": {
+      "type": "object", "additionalProperties": false,
+      "required": ["elapsed_ns", "rss_bytes"],
+      "properties": { "elapsed_ns": { "type": "integer", "minimum": 1 }, "rss_bytes": { "type": "integer", "minimum": 1 } }
+    },
+    "sampling": {
+      "type": "object", "additionalProperties": false,
+      "required": ["target_interval_ns", "sample_count", "minimum_interval_ns", "median_interval_ns", "p95_interval_ns", "maximum_interval_ns"],
+      "properties": {
+        "target_interval_ns": { "const": 5000000 },
+        "sample_count": { "type": "integer", "minimum": 2 },
+        "minimum_interval_ns": { "type": "integer", "minimum": 1, "maximum": 100000000 },
+        "median_interval_ns": { "type": "integer", "minimum": 1, "maximum": 100000000 },
+        "p95_interval_ns": { "type": "integer", "minimum": 1, "maximum": 100000000 },
+        "maximum_interval_ns": { "type": "integer", "minimum": 1, "maximum": 100000000 }
+      }
+    },
+    "environment": {
+      "type": "object", "additionalProperties": false,
+      "required": ["page_size_bytes", "kernel", "transparent_hugepage", "cgroup_memory_max", "cgroup_memory_high", "hosted_runner", "purge_policy", "allocator_runtime_options"],
+      "properties": {
+        "page_size_bytes": { "type": "integer", "minimum": 1 },
+        "kernel": { "$ref": "#/$defs/nonempty" },
+        "transparent_hugepage": { "$ref": "#/$defs/nonempty" },
+        "cgroup_memory_max": { "$ref": "#/$defs/nonempty" },
+        "cgroup_memory_high": { "$ref": "#/$defs/nonempty" },
+        "hosted_runner": { "type": "boolean" },
+        "purge_policy": { "const": "natural-only" },
+        "allocator_runtime_options": {
+          "type": "object", "additionalProperties": false,
+          "required": ["MIMALLOC_MEMORY_EVENTS", "MIMALLOC_PROF"],
+          "properties": { "MIMALLOC_MEMORY_EVENTS": { "const": "0" }, "MIMALLOC_PROF": { "const": "0" } }
+        }
+      }
+    },
+    "sample": {
+      "type": "object", "additionalProperties": false,
+      "required": ["metric_schema_version", "block_id", "ordinal", "workload_seed", "allocator_id", "allocator_source_sha", "child_binary_sha256", "scenario_id", "thread_point", "thread_count", "baseline_ready_ns", "workload_active_ns", "workload_drained_ns", "post_drain_sample_100ms_ns", "post_drain_sample_1s_ns", "post_drain_sample_5s_ns", "sampler_pid", "sampled_pid", "baseline_rss_bytes", "baseline_hwm_bytes", "sampled_peak_rss_bytes", "kernel_peak_hwm_bytes", "peak_live_requested_bytes", "post_drain_rss_100ms_bytes", "post_drain_rss_1s_bytes", "post_drain_rss_5s_bytes", "sampled_peak_rss_delta_bytes", "post_drain_rss_delta_100ms_bytes", "post_drain_rss_delta_1s_bytes", "post_drain_rss_delta_5s_bytes", "fragmentation_proxy", "hwm_discrepancy", "hwm_tolerance_bytes", "sampling", "timeline", "environment", "child_sample"],
+      "properties": {
+        "metric_schema_version": { "const": "linux-process-memory-v1" },
+        "block_id": { "type": "integer", "minimum": 0 }, "ordinal": { "type": "integer", "minimum": 0, "maximum": 3 }, "workload_seed": { "type": "integer", "minimum": 0 },
+        "allocator_id": { "enum": ["tcmalloc", "jemalloc", "upstream-mimalloc", "mimalloc-pprof"] },
+        "allocator_source_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }, "child_binary_sha256": { "$ref": "#/$defs/sha256" },
+        "scenario_id": { "enum": ["large-objects", "sawtooth-retain-drain", "small-log-mixed", "cross-thread-producer-consumer", "thread-churn"] },
+        "thread_point": { "enum": ["1", "2", "physical-core"] }, "thread_count": { "type": "integer", "minimum": 1 },
+        "baseline_ready_ns": { "type": "integer", "minimum": 1 }, "workload_active_ns": { "type": "integer", "minimum": 1 }, "workload_drained_ns": { "type": "integer", "minimum": 1 },
+        "post_drain_sample_100ms_ns": { "type": "integer", "minimum": 1 }, "post_drain_sample_1s_ns": { "type": "integer", "minimum": 1 }, "post_drain_sample_5s_ns": { "type": "integer", "minimum": 1 },
+        "sampler_pid": { "type": "integer", "minimum": 1 }, "sampled_pid": { "type": "integer", "minimum": 1 },
+        "baseline_rss_bytes": { "type": "integer", "minimum": 1 }, "baseline_hwm_bytes": { "type": "integer", "minimum": 1 }, "sampled_peak_rss_bytes": { "type": "integer", "minimum": 1 }, "kernel_peak_hwm_bytes": { "type": "integer", "minimum": 1 }, "peak_live_requested_bytes": { "type": "integer", "minimum": 1 },
+        "post_drain_rss_100ms_bytes": { "type": "integer", "minimum": 1 }, "post_drain_rss_1s_bytes": { "type": "integer", "minimum": 1 }, "post_drain_rss_5s_bytes": { "type": "integer", "minimum": 1 },
+        "sampled_peak_rss_delta_bytes": { "type": "integer" }, "post_drain_rss_delta_100ms_bytes": { "type": "integer" }, "post_drain_rss_delta_1s_bytes": { "type": "integer" }, "post_drain_rss_delta_5s_bytes": { "type": "integer" },
+        "fragmentation_proxy": { "type": "number", "exclusiveMinimum": 0 }, "hwm_discrepancy": { "type": "boolean" }, "hwm_tolerance_bytes": { "type": "integer", "minimum": 1 },
+        "sampling": { "$ref": "#/$defs/sampling" }, "timeline": { "type": "array", "minItems": 2, "items": { "$ref": "#/$defs/timeline" } }, "environment": { "$ref": "#/$defs/environment" },
+        "child_sample": { "$ref": "raw-run-v1.schema.json#/$defs/sample" }
+      }
+    },
+    "units": {
+      "type": "object", "additionalProperties": false,
+      "required": ["sampled-peak-rss-bytes", "post-drain-rss-100ms-bytes", "post-drain-rss-1s-bytes", "post-drain-rss-5s-bytes", "fragmentation-proxy"],
+      "properties": {
+        "sampled-peak-rss-bytes": { "const": "bytes" }, "post-drain-rss-100ms-bytes": { "const": "bytes" }, "post-drain-rss-1s-bytes": { "const": "bytes" }, "post-drain-rss-5s-bytes": { "const": "bytes" }, "fragmentation-proxy": { "const": "ratio" }
+      }
+    },
+    "methodology": {
+      "type": "object", "additionalProperties": false,
+      "required": ["rss_source", "hwm_source", "baseline_definition", "sampled_peak_definition", "post_drain_definition", "fragmentation_formula", "hwm_discrepancy_tolerance", "page_touch_contract", "purge_policy"],
+      "properties": {
+        "rss_source": { "const": "/proc/<pid>/smaps_rollup Rss, parsed as integer kB * 1024" },
+        "hwm_source": { "const": "/proc/<pid>/status VmHWM, parsed as integer kB * 1024; cross-check only" },
+        "baseline_definition": { "const": "external RSS/HWM after child warmup and baseline-ready, before begin" },
+        "sampled_peak_definition": { "const": "maximum external smaps_rollup RSS timestamped inside workload-active..workload-drained" },
+        "post_drain_definition": { "const": "external smaps_rollup RSS at >=100ms, >=1s, and >=5s after workload-drained" },
+        "fragmentation_formula": { "const": "(sampled_peak_rss_bytes - baseline_rss_bytes) / peak_live_requested_bytes; both operands must be positive" },
+        "hwm_discrepancy_tolerance": { "const": "flag when abs(sampled RSS delta - VmHWM delta) > max(8 MiB, 20% of the larger positive delta)" },
+        "page_touch_contract": { "const": "every allocation touches deterministic boundary bytes and at least one byte per OS page" },
+        "purge_policy": { "const": "natural allocator behavior only; no allocator-specific purge call" }
+      }
+    },
+    "report": {
+      "type": "object", "additionalProperties": false,
+      "required": ["metric_schema_version", "status", "invalid_reason", "metric_comparison_key", "run", "runner", "sampling_target_interval_ns", "purge_policy", "units", "direction", "informational", "methodology", "absolute_summaries", "paired_summaries", "raw_samples"],
+      "properties": {
+        "metric_schema_version": { "const": "linux-process-memory-v1" }, "status": { "const": "complete" }, "invalid_reason": { "type": "null" }, "metric_comparison_key": { "$ref": "#/$defs/sha256" },
+        "run": { "$ref": "raw-run-v1.schema.json#/$defs/run" }, "runner": { "$ref": "raw-run-v1.schema.json#/$defs/runner" }, "sampling_target_interval_ns": { "const": 5000000 }, "purge_policy": { "const": "natural-only" }, "units": { "$ref": "#/$defs/units" }, "direction": { "const": "lower-is-better" }, "informational": { "const": true }, "methodology": { "$ref": "#/$defs/methodology" },
+        "absolute_summaries": { "type": "array", "minItems": 140, "items": { "$ref": "latest-v1.schema.json#/$defs/absoluteCell" } }, "paired_summaries": { "type": "array", "minItems": 105, "items": { "$ref": "latest-v1.schema.json#/$defs/pairedCell" } }, "raw_samples": { "type": "array", "minItems": 420, "items": { "$ref": "#/$defs/sample" } }
+      }
+    },
+    "history": {
+      "type": "object", "additionalProperties": false,
+      "required": ["metric_schema_version", "status", "metric_comparison_key", "run", "runner_fingerprint_sha256", "sampling_target_interval_ns", "purge_policy", "units", "direction", "informational", "methodology", "absolute_summaries", "paired_summaries"],
+      "properties": {
+        "metric_schema_version": { "const": "linux-process-memory-v1" }, "status": { "const": "complete" }, "metric_comparison_key": { "$ref": "#/$defs/sha256" }, "run": { "$ref": "raw-run-v1.schema.json#/$defs/run" }, "runner_fingerprint_sha256": { "$ref": "#/$defs/sha256" }, "sampling_target_interval_ns": { "const": 5000000 }, "purge_policy": { "const": "natural-only" }, "units": { "$ref": "#/$defs/units" }, "direction": { "const": "lower-is-better" }, "informational": { "const": true }, "methodology": { "$ref": "#/$defs/methodology" },
+        "absolute_summaries": { "type": "array", "minItems": 140, "items": { "$ref": "latest-v1.schema.json#/$defs/absoluteCell" } }, "paired_summaries": { "type": "array", "minItems": 105, "items": { "$ref": "latest-v1.schema.json#/$defs/pairedCell" } }
+      }
+    }
+  }
+}

--- a/rust/benchmark-suite/src/bin/benchmark-memory-run.rs
+++ b/rust/benchmark-suite/src/bin/benchmark-memory-run.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if let Err(error) = benchmark_suite::memory_runner::benchmark_memory_run_main() {
+        eprintln!("benchmark-memory-run: {error}");
+        std::process::exit(1);
+    }
+}

--- a/rust/benchmark-suite/src/bin/benchmark-memory-validate.rs
+++ b/rust/benchmark-suite/src/bin/benchmark-memory-validate.rs
@@ -1,0 +1,77 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use benchmark_suite::memory::{attach_memory_report, build_memory_report, MemoryRawRun};
+use benchmark_suite::model::LatestReport;
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("benchmark-memory-validate: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut arguments = std::env::args().skip(1);
+    let mut input = None;
+    let mut base_latest = None;
+    let mut report_out = None;
+    let mut latest_out = None;
+    while let Some(argument) = arguments.next() {
+        let target = match argument.as_str() {
+            "--input" => &mut input,
+            "--base-latest" => &mut base_latest,
+            "--report-out" => &mut report_out,
+            "--latest-out" => &mut latest_out,
+            "--help" | "-h" => {
+                println!("usage: benchmark-memory-validate --input <memory-raw-run.json> --base-latest <latest.json> --report-out <memory-report.json> --latest-out <latest.json>");
+                return Ok(());
+            }
+            _ => return Err(format!("unknown argument: {argument}")),
+        };
+        *target = Some(PathBuf::from(
+            arguments
+                .next()
+                .ok_or_else(|| format!("{argument} requires a path"))?,
+        ));
+    }
+    let input = input.ok_or("--input is required")?;
+    let base_latest = base_latest.ok_or("--base-latest is required")?;
+    let report_out = report_out.ok_or("--report-out is required")?;
+    let latest_out = latest_out.ok_or("--latest-out is required")?;
+    let raw: MemoryRawRun = read_json(&input)?;
+    let report = build_memory_report(&raw)?;
+    let mut latest: LatestReport = read_json(&base_latest)?;
+    if latest.validation_report.status != "valid"
+        || !latest.validation_report.headline_eligible
+        || !latest.validation_report.errors.is_empty()
+    {
+        return Err("base latest report is not validated/headline-eligible".into());
+    }
+    attach_memory_report(&mut latest, report.clone())?;
+    write_new_json(&report_out, &report)?;
+    write_new_json(&latest_out, &latest)?;
+    println!(
+        "PASS validated {} memory samples; key={}",
+        report.raw_samples.len(),
+        report.metric_comparison_key
+    );
+    Ok(())
+}
+
+fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, String> {
+    let bytes = std::fs::read(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    serde_json::from_slice(&bytes).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+fn write_new_json<T: serde::Serialize>(path: &Path, value: &T) -> Result<(), String> {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    serde_json::to_writer_pretty(&mut file, value)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    file.write_all(b"\n")
+        .map_err(|error| format!("{}: {error}", path.display()))
+}

--- a/rust/benchmark-suite/src/child.rs
+++ b/rust/benchmark-suite/src/child.rs
@@ -1,11 +1,15 @@
 //! Reusable benchmark-child protocol entrypoint.
 
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 
 use serde::Serialize;
 
 use crate::adapter::LinkedAdapter;
-use crate::execution::execute_child_request;
+use crate::execution::{
+    execute_child_request, execute_child_request_with_observer, ExecutionResult,
+    MeasurementObserver,
+};
+use crate::memory::{read_control_record, write_control_record, ControlKind, ControlRecord};
 use crate::model::BenchmarkChildRequest;
 
 #[derive(Serialize)]
@@ -28,8 +32,95 @@ pub fn benchmark_child_main() -> Result<(), String> {
         Some(argument) if argument == "--adapter-smoke" && arguments.next().is_none() => {
             run_adapter_smoke()
         }
-        Some(_) => Err("usage: benchmark-child [--adapter-smoke]".into()),
+        Some(argument) if argument == "--memory" && arguments.next().is_none() => {
+            run_memory_measurement()
+        }
+        Some(_) => Err("usage: benchmark-child [--adapter-smoke|--memory]".into()),
     }
+}
+
+struct MemoryChildObserver<'a, R: Read, W: Write> {
+    reader: &'a mut R,
+    writer: &'a mut W,
+}
+
+impl<R: Read, W: Write> MeasurementObserver for MemoryChildObserver<'_, R, W> {
+    fn baseline_ready_and_wait_for_begin(&mut self) -> Result<(), String> {
+        write_control_record(
+            self.writer,
+            ControlRecord::empty(ControlKind::BaselineReady),
+        )?;
+        let begin = read_control_record(self.reader)?;
+        if begin != ControlRecord::empty(ControlKind::Begin) {
+            return Err("memory child expected an empty begin message".into());
+        }
+        Ok(())
+    }
+
+    fn workload_active(&mut self) -> Result<(), String> {
+        write_control_record(
+            self.writer,
+            ControlRecord::empty(ControlKind::WorkloadActive),
+        )
+    }
+
+    fn workload_drained(&mut self, outcome: &ExecutionResult) -> Result<(), String> {
+        write_control_record(
+            self.writer,
+            ControlRecord {
+                kind: ControlKind::WorkloadDrained,
+                current_live_requested_bytes: 0,
+                peak_live_requested_bytes: outcome.peak_live_requested_bytes,
+                checksum: outcome.checksum,
+            },
+        )
+    }
+}
+
+fn run_memory_measurement() -> Result<(), String> {
+    let adapter = LinkedAdapter::load().map_err(|error| error.to_string())?;
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut reader = BufReader::new(stdin.lock());
+    let mut writer = stdout.lock();
+    let mut input = Vec::with_capacity(16 * 1024);
+    (&mut reader)
+        .take(1024 * 1024 + 1)
+        .read_until(b'\n', &mut input)
+        .map_err(|error| format!("read memory child request: {error}"))?;
+    if input.len() > 1024 * 1024 || !input.ends_with(b"\n") {
+        return Err("memory child request must be one newline-terminated value below 1 MiB".into());
+    }
+    let request: BenchmarkChildRequest = serde_json::from_slice(&input)
+        .map_err(|error| format!("expected exactly one memory child request: {error}"))?;
+    let mut observer = MemoryChildObserver {
+        reader: &mut reader,
+        writer: &mut writer,
+    };
+    let response = execute_child_request_with_observer(&adapter, request, &mut observer)?;
+    let exit = read_control_record(observer.reader)?;
+    if exit != ControlRecord::empty(ControlKind::ExitResult) {
+        return Err("memory child expected an empty exit-result request".into());
+    }
+    // Serialize only after the parent completed the five-second post-drain
+    // window, so response allocation cannot perturb any reported RSS value.
+    let output = serde_json::to_vec(&response)
+        .map_err(|error| format!("serialize memory child response: {error}"))?;
+    let length = u32::try_from(output.len())
+        .map_err(|_| "memory child response exceeds the framing limit".to_string())?;
+    if output.len() > 1024 * 1024 {
+        return Err("memory child response exceeded 1 MiB".into());
+    }
+    write_control_record(
+        observer.writer,
+        ControlRecord::empty(ControlKind::ExitResult),
+    )?;
+    observer
+        .writer
+        .write_all(&length.to_le_bytes())
+        .and_then(|()| observer.writer.write_all(&output))
+        .and_then(|()| observer.writer.flush())
+        .map_err(|error| format!("write memory child result: {error}"))
 }
 
 fn run_measurement() -> Result<(), String> {

--- a/rust/benchmark-suite/src/execution.rs
+++ b/rust/benchmark-suite/src/execution.rs
@@ -1,7 +1,7 @@
 //! Allocator-neutral execution of one `core-throughput-v1` child request.
 
 use std::ptr::NonNull;
-use std::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::time::Instant;
 
@@ -165,11 +165,43 @@ struct WorkerOutcome {
     checksum: u64,
 }
 
+/// Fixed control hooks used by the Linux external-memory sampler. The normal
+/// throughput child uses the zero-cost no-op implementation below.
+pub trait MeasurementObserver {
+    fn baseline_ready_and_wait_for_begin(&mut self) -> Result<(), String>;
+    fn workload_active(&mut self) -> Result<(), String>;
+    fn workload_drained(&mut self, outcome: &ExecutionResult) -> Result<(), String>;
+}
+
+struct NoopObserver;
+
+impl MeasurementObserver for NoopObserver {
+    fn baseline_ready_and_wait_for_begin(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn workload_active(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn workload_drained(&mut self, _outcome: &ExecutionResult) -> Result<(), String> {
+        Ok(())
+    }
+}
+
 /// Execute one strict request and construct its raw response. This is the
 /// reusable entrypoint used by `benchmark-child` and native wrapper builds.
 pub fn execute_child_request<A: AllocatorAdapter>(
     adapter: &A,
     request: BenchmarkChildRequest,
+) -> Result<BenchmarkChildResponse, String> {
+    execute_child_request_with_observer(adapter, request, &mut NoopObserver)
+}
+
+pub fn execute_child_request_with_observer<A: AllocatorAdapter, O: MeasurementObserver>(
+    adapter: &A,
+    request: BenchmarkChildRequest,
+    observer: &mut O,
 ) -> Result<BenchmarkChildResponse, String> {
     request.validate()?;
     validate_linked_identity(adapter, &request)?;
@@ -206,7 +238,7 @@ pub fn execute_child_request<A: AllocatorAdapter>(
             request.workload_seed ^ 0xa076_1d64_78bd_642f,
         )
         .map_err(|error| error.to_string())?;
-        execute_for_mode(adapter, &warmup, &request.execution_mode)?;
+        execute_for_mode(adapter, &warmup, &request.execution_mode, &mut NoopObserver)?;
     }
     let warmup_ns = if request.warmup_transactions_per_worker == 0 {
         0
@@ -214,7 +246,7 @@ pub fn execute_child_request<A: AllocatorAdapter>(
         nonzero_ns(warmup_started)
     };
 
-    let outcome = execute_for_mode(adapter, &measured_cell, &request.execution_mode)?;
+    let outcome = execute_for_mode(adapter, &measured_cell, &request.execution_mode, observer)?;
     let setup_ns = request_setup_ns.saturating_add(outcome.setup_ns);
     let elapsed_ns = outcome.elapsed_ns;
 
@@ -288,19 +320,21 @@ pub fn execute_child_request<A: AllocatorAdapter>(
     Ok(response)
 }
 
-fn execute_for_mode<A: AllocatorAdapter>(
+fn execute_for_mode<A: AllocatorAdapter, O: MeasurementObserver>(
     adapter: &A,
     cell: &ScenarioCell,
     mode: &str,
+    observer: &mut O,
 ) -> Result<ExecutionResult, String> {
     match mode {
-        "normal" => execute_cell(adapter, cell),
-        "serialized-control" => execute_cell(
+        "normal" => execute_cell_with_observer(adapter, cell, observer),
+        "serialized-control" => execute_cell_with_observer(
             &SerializedAdapter {
                 inner: adapter,
                 gate: Mutex::new(()),
             },
             cell,
+            observer,
         ),
         _ => Err("unknown benchmark execution mode".into()),
     }
@@ -325,27 +359,37 @@ pub fn execute_cell<A: AllocatorAdapter>(
     adapter: &A,
     cell: &ScenarioCell,
 ) -> Result<ExecutionResult, String> {
+    execute_cell_with_observer(adapter, cell, &mut NoopObserver)
+}
+
+fn execute_cell_with_observer<A: AllocatorAdapter, O: MeasurementObserver>(
+    adapter: &A,
+    cell: &ScenarioCell,
+    observer: &mut O,
+) -> Result<ExecutionResult, String> {
     if cell.card == CardId::ThreadChurn {
-        return execute_thread_churn(adapter, cell);
+        return execute_thread_churn(adapter, cell, observer);
     }
     if matches!(
         cell.card,
         CardId::CrossThreadProducerConsumer | CardId::RandomOwnership
     ) {
-        execute_cross_thread_cell(adapter, cell)
+        execute_cross_thread_cell(adapter, cell, observer)
     } else {
-        execute_ordered_cell(adapter, cell)
+        execute_ordered_cell(adapter, cell, observer)
     }
 }
 
-fn execute_ordered_cell<A: AllocatorAdapter>(
+fn execute_ordered_cell<A: AllocatorAdapter, O: MeasurementObserver>(
     adapter: &A,
     cell: &ScenarioCell,
+    observer: &mut O,
 ) -> Result<ExecutionResult, String> {
     let setup_started = Instant::now();
     let ready_barrier = Arc::new(Barrier::new(cell.threads + 1));
     let start_barrier = Arc::new(Barrier::new(cell.threads + 1));
     let end_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let cancelled = Arc::new(AtomicBool::new(false));
     let live = Arc::new(AtomicU64::new(0));
     let peak = Arc::new(AtomicU64::new(0));
 
@@ -355,6 +399,7 @@ fn execute_ordered_cell<A: AllocatorAdapter>(
             let ready_barrier = Arc::clone(&ready_barrier);
             let start_barrier = Arc::clone(&start_barrier);
             let end_barrier = Arc::clone(&end_barrier);
+            let cancelled = Arc::clone(&cancelled);
             let live = Arc::clone(&live);
             let peak = Arc::clone(&peak);
             let slot_capacity = card(cell.card).max_live_allocations_per_worker();
@@ -366,6 +411,13 @@ fn execute_ordered_cell<A: AllocatorAdapter>(
                 let mut failure: Option<String> = None;
                 ready_barrier.wait();
                 start_barrier.wait();
+                if cancelled.load(Ordering::SeqCst) {
+                    end_barrier.wait();
+                    return Ok(WorkerOutcome {
+                        counts,
+                        checksum: observation_checksum,
+                    });
+                }
                 for operation in 0..cell.transactions_per_worker {
                     if let Err(error) =
                         cell.fill_worker_transaction(worker, operation, &mut requests)
@@ -411,6 +463,15 @@ fn execute_ordered_cell<A: AllocatorAdapter>(
         // state construction are setup, not measured work.
         ready_barrier.wait();
         let setup_ns = nonzero_ns(setup_started);
+        if let Err(error) = observer
+            .baseline_ready_and_wait_for_begin()
+            .and_then(|()| observer.workload_active())
+        {
+            cancelled.store(true, Ordering::SeqCst);
+            start_barrier.wait();
+            end_barrier.wait();
+            return Err(error);
+        }
         notify_measured_region(true);
         let measured_started = Instant::now();
         start_barrier.wait();
@@ -428,7 +489,7 @@ fn execute_ordered_cell<A: AllocatorAdapter>(
         Ok::<_, String>((outcomes, setup_ns, elapsed_ns))
     })?;
     let teardown_started = Instant::now();
-    finish_execution(
+    let outcome = finish_execution(
         cell,
         outcomes,
         &live,
@@ -436,17 +497,21 @@ fn execute_ordered_cell<A: AllocatorAdapter>(
         setup_ns,
         elapsed_ns,
         nonzero_ns(teardown_started),
-    )
+    )?;
+    observer.workload_drained(&outcome)?;
+    Ok(outcome)
 }
 
-fn execute_cross_thread_cell<A: AllocatorAdapter>(
+fn execute_cross_thread_cell<A: AllocatorAdapter, O: MeasurementObserver>(
     adapter: &A,
     cell: &ScenarioCell,
+    observer: &mut O,
 ) -> Result<ExecutionResult, String> {
     let setup_started = Instant::now();
     let ready_barrier = Arc::new(Barrier::new(cell.threads + 1));
     let start_barrier = Arc::new(Barrier::new(cell.threads + 1));
     let end_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let cancelled = Arc::new(AtomicBool::new(false));
     let operation_barrier = Arc::new(Barrier::new(cell.threads));
     let live = Arc::new(AtomicU64::new(0));
     let peak = Arc::new(AtomicU64::new(0));
@@ -462,6 +527,7 @@ fn execute_cross_thread_cell<A: AllocatorAdapter>(
             let ready_barrier = Arc::clone(&ready_barrier);
             let start_barrier = Arc::clone(&start_barrier);
             let end_barrier = Arc::clone(&end_barrier);
+            let cancelled = Arc::clone(&cancelled);
             let operation_barrier = Arc::clone(&operation_barrier);
             let live = Arc::clone(&live);
             let peak = Arc::clone(&peak);
@@ -476,6 +542,13 @@ fn execute_cross_thread_cell<A: AllocatorAdapter>(
                 let mut failure: Option<String> = None;
                 ready_barrier.wait();
                 start_barrier.wait();
+                if cancelled.load(Ordering::SeqCst) {
+                    end_barrier.wait();
+                    return Ok(WorkerOutcome {
+                        counts,
+                        checksum: observation_checksum,
+                    });
+                }
                 for operation in 0..transactions_per_worker {
                     if failure.is_none() {
                         if let Err(error) =
@@ -584,6 +657,15 @@ fn execute_cross_thread_cell<A: AllocatorAdapter>(
         }
         ready_barrier.wait();
         let setup_ns = nonzero_ns(setup_started);
+        if let Err(error) = observer
+            .baseline_ready_and_wait_for_begin()
+            .and_then(|()| observer.workload_active())
+        {
+            cancelled.store(true, Ordering::SeqCst);
+            start_barrier.wait();
+            end_barrier.wait();
+            return Err(error);
+        }
         notify_measured_region(true);
         let measured_started = Instant::now();
         start_barrier.wait();
@@ -601,7 +683,7 @@ fn execute_cross_thread_cell<A: AllocatorAdapter>(
         Ok::<_, String>((outcomes, setup_ns, elapsed_ns))
     })?;
     let teardown_started = Instant::now();
-    finish_execution(
+    let outcome = finish_execution(
         cell,
         outcomes,
         &live,
@@ -609,12 +691,15 @@ fn execute_cross_thread_cell<A: AllocatorAdapter>(
         setup_ns,
         elapsed_ns,
         nonzero_ns(teardown_started),
-    )
+    )?;
+    observer.workload_drained(&outcome)?;
+    Ok(outcome)
 }
 
-fn execute_thread_churn<A: AllocatorAdapter>(
+fn execute_thread_churn<A: AllocatorAdapter, O: MeasurementObserver>(
     adapter: &A,
     cell: &ScenarioCell,
+    observer: &mut O,
 ) -> Result<ExecutionResult, String> {
     let setup_started = Instant::now();
     let mut request_buffers = (0..cell.threads)
@@ -631,6 +716,8 @@ fn execute_thread_churn<A: AllocatorAdapter>(
 
     let setup_ns = nonzero_ns(setup_started);
     // Spawning each generation is part of this card's declared workload.
+    observer.baseline_ready_and_wait_for_begin()?;
+    observer.workload_active()?;
     let measured_started = Instant::now();
     for operation in 0..cell.transactions_per_worker {
         for (worker, requests) in request_buffers.iter_mut().enumerate() {
@@ -691,7 +778,7 @@ fn execute_thread_churn<A: AllocatorAdapter>(
     }
     let elapsed_ns = nonzero_ns(measured_started);
     let teardown_started = Instant::now();
-    finish_execution(
+    let outcome = finish_execution(
         cell,
         totals,
         &live,
@@ -699,7 +786,9 @@ fn execute_thread_churn<A: AllocatorAdapter>(
         setup_ns,
         elapsed_ns,
         nonzero_ns(teardown_started),
-    )
+    )?;
+    observer.workload_drained(&outcome)?;
+    Ok(outcome)
 }
 
 fn finish_execution(
@@ -1072,6 +1161,98 @@ fn nonzero_ns(started: Instant) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct PanicAdapter;
+
+    impl AllocatorAdapter for PanicAdapter {
+        fn allocator_id(&self) -> &str {
+            "panic-adapter"
+        }
+
+        fn allocator_version(&self) -> &str {
+            "test"
+        }
+
+        fn source_sha(&self) -> &str {
+            "0000000000000000000000000000000000000000"
+        }
+
+        fn library_sha256(&self) -> &str {
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        }
+
+        fn alloc(&self, _size: usize) -> Result<NonNull<u8>, String> {
+            panic!("cancelled workers must not allocate")
+        }
+
+        fn calloc(&self, _count: usize, _size: usize) -> Result<NonNull<u8>, String> {
+            panic!("cancelled workers must not allocate")
+        }
+
+        unsafe fn realloc(
+            &self,
+            _pointer: NonNull<u8>,
+            _size: usize,
+        ) -> Result<NonNull<u8>, String> {
+            panic!("cancelled workers must not reallocate")
+        }
+
+        fn aligned_alloc(&self, _alignment: usize, _size: usize) -> Result<NonNull<u8>, String> {
+            panic!("cancelled workers must not allocate")
+        }
+
+        unsafe fn free(&self, _pointer: NonNull<u8>) {
+            panic!("cancelled workers must not free")
+        }
+    }
+
+    struct FailingObserver;
+
+    impl MeasurementObserver for FailingObserver {
+        fn baseline_ready_and_wait_for_begin(&mut self) -> Result<(), String> {
+            Err("planted observer failure".into())
+        }
+
+        fn workload_active(&mut self) -> Result<(), String> {
+            panic!("active must not follow a failed baseline callback")
+        }
+
+        fn workload_drained(&mut self, _outcome: &ExecutionResult) -> Result<(), String> {
+            panic!("drained must not follow a failed baseline callback")
+        }
+    }
+
+    #[test]
+    fn observer_failure_releases_ordered_and_cross_thread_workers() {
+        for card in [CardId::LargeObjects, CardId::CrossThreadProducerConsumer] {
+            let (sender, receiver) = std::sync::mpsc::channel();
+            let handle = std::thread::spawn(move || {
+                let point = if card == CardId::LargeObjects {
+                    ThreadPoint::One
+                } else {
+                    ThreadPoint::PhysicalCores
+                };
+                let cell = ScenarioCell::new(
+                    card,
+                    point,
+                    Topology {
+                        physical_cores: 2,
+                        logical_cores: 2,
+                    },
+                    1,
+                    1,
+                )
+                .unwrap();
+                let result = execute_cell_with_observer(&PanicAdapter, &cell, &mut FailingObserver);
+                sender.send(result).unwrap();
+            });
+            let result = receiver
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .expect("observer failure must not strand workers at a barrier");
+            assert_eq!(result.unwrap_err(), "planted observer failure");
+            handle.join().unwrap();
+        }
+    }
 
     #[test]
     fn large_objects_touch_every_cache_line_and_include_the_final_byte() {

--- a/rust/benchmark-suite/src/lib.rs
+++ b/rust/benchmark-suite/src/lib.rs
@@ -8,6 +8,8 @@ pub mod child;
 pub mod comparison_key;
 pub mod config;
 pub mod execution;
+pub mod memory;
+pub mod memory_runner;
 pub mod model;
 pub mod orchestration;
 pub mod provenance;

--- a/rust/benchmark-suite/src/memory.rs
+++ b/rust/benchmark-suite/src/memory.rs
@@ -1,0 +1,1460 @@
+//! Linux process-memory metric and external `/proc` sampling protocol.
+//!
+//! The measured child owns allocator work and the requested-live-byte oracle.
+//! The parent owns every kernel read so sampler allocations never enter the
+//! allocator under measurement.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::{
+    AbsoluteCellSummary, AllocatorBuildIdentity, AllocatorIdentity, BenchmarkChildRequest,
+    BenchmarkChildResponse, CellCalibration, LatestReport, PairedCellSummary, PublicationRunner,
+    RawSample, RunIdentity, RunnerMetadata, ToolchainMetadata, CHILD_PROTOCOL_VERSION,
+};
+use crate::orchestration::ChildProgram;
+use crate::provenance::sha256_bytes;
+use crate::scenarios::{CardId, ThreadPoint, Topology};
+use crate::stats::{summarize_absolute, summarize_paired, MetricDirection, MetricObservation};
+
+pub const MEMORY_SCHEMA_VERSION: &str = "linux-process-memory-v1";
+pub const MEMORY_CONTROL_VERSION: &str = "memory-control-v1";
+pub const MEMORY_SAMPLE_TARGET_NS: u64 = 5_000_000;
+pub const MEMORY_MAX_SAMPLE_GAP_NS: u64 = 100_000_000;
+pub const MEMORY_MIN_BLOCKS: u32 = 15;
+pub const CONTROL_RECORD_BYTES: usize = 32;
+const CONTROL_MAGIC: &[u8; 4] = b"MPM1";
+
+const REFERENCE_ALLOCATOR: &str = "upstream-mimalloc";
+const ALLOCATOR_IDS: [&str; 4] = [
+    "tcmalloc",
+    "jemalloc",
+    "upstream-mimalloc",
+    "mimalloc-pprof",
+];
+const METRICS: [(&str, &str); 5] = [
+    ("sampled-peak-rss-bytes", "bytes"),
+    ("post-drain-rss-100ms-bytes", "bytes"),
+    ("post-drain-rss-1s-bytes", "bytes"),
+    ("post-drain-rss-5s-bytes", "bytes"),
+    ("fragmentation-proxy", "ratio"),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ControlKind {
+    BaselineReady = 1,
+    Begin = 2,
+    WorkloadActive = 3,
+    WorkloadDrained = 4,
+    ExitResult = 5,
+}
+
+impl ControlKind {
+    pub const ALL: [Self; 5] = [
+        Self::BaselineReady,
+        Self::Begin,
+        Self::WorkloadActive,
+        Self::WorkloadDrained,
+        Self::ExitResult,
+    ];
+
+    pub fn from_byte(value: u8) -> Result<Self, String> {
+        Self::ALL
+            .into_iter()
+            .find(|candidate| *candidate as u8 == value)
+            .ok_or_else(|| format!("unknown memory control message {value}"))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ControlRecord {
+    pub kind: ControlKind,
+    pub current_live_requested_bytes: u64,
+    pub peak_live_requested_bytes: u64,
+    pub checksum: u64,
+}
+
+impl ControlRecord {
+    pub const fn empty(kind: ControlKind) -> Self {
+        Self {
+            kind,
+            current_live_requested_bytes: 0,
+            peak_live_requested_bytes: 0,
+            checksum: 0,
+        }
+    }
+
+    pub fn encode(self) -> [u8; CONTROL_RECORD_BYTES] {
+        let mut output = [0_u8; CONTROL_RECORD_BYTES];
+        output[..4].copy_from_slice(CONTROL_MAGIC);
+        output[4] = self.kind as u8;
+        output[8..16].copy_from_slice(&self.current_live_requested_bytes.to_le_bytes());
+        output[16..24].copy_from_slice(&self.peak_live_requested_bytes.to_le_bytes());
+        output[24..32].copy_from_slice(&self.checksum.to_le_bytes());
+        output
+    }
+
+    pub fn decode(input: [u8; CONTROL_RECORD_BYTES]) -> Result<Self, String> {
+        if &input[..4] != CONTROL_MAGIC || input[5..8] != [0, 0, 0] {
+            return Err("invalid memory control record header".into());
+        }
+        let read_u64 = |range: std::ops::Range<usize>| {
+            let mut bytes = [0_u8; 8];
+            bytes.copy_from_slice(&input[range]);
+            u64::from_le_bytes(bytes)
+        };
+        Ok(Self {
+            kind: ControlKind::from_byte(input[4])?,
+            current_live_requested_bytes: read_u64(8..16),
+            peak_live_requested_bytes: read_u64(16..24),
+            checksum: read_u64(24..32),
+        })
+    }
+}
+
+pub fn write_control_record(writer: &mut impl Write, record: ControlRecord) -> Result<(), String> {
+    writer
+        .write_all(&record.encode())
+        .and_then(|()| writer.flush())
+        .map_err(|error| format!("write memory control record: {error}"))
+}
+
+pub fn read_control_record(reader: &mut impl Read) -> Result<ControlRecord, String> {
+    let mut bytes = [0_u8; CONTROL_RECORD_BYTES];
+    reader
+        .read_exact(&mut bytes)
+        .map_err(|error| format!("read memory control record: {error}"))?;
+    ControlRecord::decode(bytes)
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LiveRequestedOracle {
+    current: u64,
+    peak: u64,
+}
+
+impl LiveRequestedOracle {
+    pub fn allocate(&mut self, bytes: u64) -> Result<(), String> {
+        if bytes == 0 {
+            return Err("requested-live oracle cannot add zero bytes".into());
+        }
+        self.current = self
+            .current
+            .checked_add(bytes)
+            .ok_or_else(|| "requested-live oracle overflowed".to_string())?;
+        self.peak = self.peak.max(self.current);
+        Ok(())
+    }
+
+    pub fn free(&mut self, bytes: u64) -> Result<(), String> {
+        if bytes == 0 || bytes > self.current {
+            return Err("requested-live oracle underflowed".into());
+        }
+        self.current -= bytes;
+        Ok(())
+    }
+
+    pub const fn current_bytes(self) -> u64 {
+        self.current
+    }
+
+    pub const fn peak_bytes(self) -> u64 {
+        self.peak
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryTimelinePoint {
+    /// Nanoseconds from the parent-side process spawn timestamp.
+    pub elapsed_ns: u64,
+    pub rss_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SamplingIntervalDistribution {
+    pub target_interval_ns: u64,
+    pub sample_count: u64,
+    pub minimum_interval_ns: u64,
+    pub median_interval_ns: u64,
+    pub p95_interval_ns: u64,
+    pub maximum_interval_ns: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryEnvironment {
+    pub page_size_bytes: u64,
+    pub kernel: String,
+    pub transparent_hugepage: String,
+    /// Exact cgroup v2 `memory.max` text (`max` means unlimited).
+    pub cgroup_memory_max: String,
+    /// Exact cgroup v2 `memory.high` text (`max` means unlimited).
+    pub cgroup_memory_high: String,
+    pub hosted_runner: bool,
+    pub purge_policy: String,
+    pub allocator_runtime_options: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryCompatibility {
+    pub metric_schema_version: String,
+    pub page_size_bytes: u64,
+    pub kernel: String,
+    pub sampling_target_interval_ns: u64,
+    pub purge_policy: String,
+    pub transparent_hugepage: String,
+    pub cgroup_memory_max: String,
+    pub cgroup_memory_high: String,
+    pub allocator_runtime_options: BTreeMap<String, String>,
+}
+
+impl MemoryEnvironment {
+    pub fn compatibility(&self, target_interval_ns: u64) -> MemoryCompatibility {
+        MemoryCompatibility {
+            metric_schema_version: MEMORY_SCHEMA_VERSION.into(),
+            page_size_bytes: self.page_size_bytes,
+            kernel: self.kernel.clone(),
+            sampling_target_interval_ns: target_interval_ns,
+            purge_policy: self.purge_policy.clone(),
+            transparent_hugepage: self.transparent_hugepage.clone(),
+            cgroup_memory_max: self.cgroup_memory_max.clone(),
+            cgroup_memory_high: self.cgroup_memory_high.clone(),
+            allocator_runtime_options: self.allocator_runtime_options.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryRawSample {
+    pub metric_schema_version: String,
+    pub block_id: u32,
+    pub ordinal: u8,
+    pub workload_seed: u64,
+    pub allocator_id: String,
+    pub allocator_source_sha: String,
+    pub child_binary_sha256: String,
+    pub scenario_id: String,
+    pub thread_point: String,
+    pub thread_count: u32,
+    pub baseline_ready_ns: u64,
+    pub workload_active_ns: u64,
+    pub workload_drained_ns: u64,
+    pub post_drain_sample_100ms_ns: u64,
+    pub post_drain_sample_1s_ns: u64,
+    pub post_drain_sample_5s_ns: u64,
+    pub sampler_pid: u32,
+    pub sampled_pid: u32,
+    pub baseline_rss_bytes: u64,
+    pub baseline_hwm_bytes: u64,
+    pub sampled_peak_rss_bytes: u64,
+    pub kernel_peak_hwm_bytes: u64,
+    pub peak_live_requested_bytes: u64,
+    pub post_drain_rss_100ms_bytes: u64,
+    pub post_drain_rss_1s_bytes: u64,
+    pub post_drain_rss_5s_bytes: u64,
+    pub sampled_peak_rss_delta_bytes: i64,
+    pub post_drain_rss_delta_100ms_bytes: i64,
+    pub post_drain_rss_delta_1s_bytes: i64,
+    pub post_drain_rss_delta_5s_bytes: i64,
+    pub fragmentation_proxy: f64,
+    pub hwm_discrepancy: bool,
+    pub hwm_tolerance_bytes: u64,
+    pub sampling: SamplingIntervalDistribution,
+    pub timeline: Vec<MemoryTimelinePoint>,
+    pub environment: MemoryEnvironment,
+    /// The child-owned workload/count/checksum oracle result.
+    pub child_sample: RawSample,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryRawRun {
+    pub metric_schema_version: String,
+    pub status: String,
+    pub run_seed: u64,
+    pub run: RunIdentity,
+    pub runner: PublicationRunner,
+    pub allocator_lock_sha256: String,
+    pub allocators: Vec<AllocatorBuildIdentity>,
+    pub calibrations: Vec<CellCalibration>,
+    pub samples: Vec<MemoryRawSample>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryMetricReport {
+    pub metric_schema_version: String,
+    pub status: String,
+    pub invalid_reason: Option<String>,
+    pub metric_comparison_key: String,
+    pub run: RunIdentity,
+    pub runner: PublicationRunner,
+    pub sampling_target_interval_ns: u64,
+    pub purge_policy: String,
+    pub units: BTreeMap<String, String>,
+    pub direction: MetricDirection,
+    pub informational: bool,
+    pub methodology: MemoryMethodology,
+    pub absolute_summaries: Vec<AbsoluteCellSummary>,
+    pub paired_summaries: Vec<PairedCellSummary>,
+    pub raw_samples: Vec<MemoryRawSample>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryMethodology {
+    pub rss_source: String,
+    pub hwm_source: String,
+    pub baseline_definition: String,
+    pub sampled_peak_definition: String,
+    pub post_drain_definition: String,
+    pub fragmentation_formula: String,
+    pub hwm_discrepancy_tolerance: String,
+    pub page_touch_contract: String,
+    pub purge_policy: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryHistoryReport {
+    pub metric_schema_version: String,
+    pub status: String,
+    pub metric_comparison_key: String,
+    pub run: RunIdentity,
+    pub runner_fingerprint_sha256: String,
+    pub sampling_target_interval_ns: u64,
+    pub purge_policy: String,
+    pub units: BTreeMap<String, String>,
+    pub direction: MetricDirection,
+    pub informational: bool,
+    pub methodology: MemoryMethodology,
+    pub absolute_summaries: Vec<AbsoluteCellSummary>,
+    pub paired_summaries: Vec<PairedCellSummary>,
+}
+
+impl MemoryMetricReport {
+    pub fn history_projection(&self) -> MemoryHistoryReport {
+        MemoryHistoryReport {
+            metric_schema_version: self.metric_schema_version.clone(),
+            status: self.status.clone(),
+            metric_comparison_key: self.metric_comparison_key.clone(),
+            run: self.run.clone(),
+            runner_fingerprint_sha256: self.runner.fingerprint_sha256.clone(),
+            sampling_target_interval_ns: self.sampling_target_interval_ns,
+            purge_policy: self.purge_policy.clone(),
+            units: self.units.clone(),
+            direction: self.direction,
+            informational: self.informational,
+            methodology: self.methodology.clone(),
+            absolute_summaries: self.absolute_summaries.clone(),
+            paired_summaries: self.paired_summaries.clone(),
+        }
+    }
+}
+
+pub fn parse_smaps_rollup(input: &str) -> Result<u64, String> {
+    parse_unique_proc_kb(input, "Rss")
+}
+
+pub fn parse_status_hwm(input: &str) -> Result<u64, String> {
+    parse_unique_proc_kb(input, "VmHWM")
+}
+
+fn parse_unique_proc_kb(input: &str, field: &str) -> Result<u64, String> {
+    let prefix = format!("{field}:");
+    let matches = input
+        .lines()
+        .filter_map(|line| line.strip_prefix(&prefix))
+        .collect::<Vec<_>>();
+    if matches.len() != 1 {
+        return Err(format!("proc field {field} must occur exactly once"));
+    }
+    let parts = matches[0].split_ascii_whitespace().collect::<Vec<_>>();
+    if parts.len() != 2 || parts[1] != "kB" {
+        return Err(format!("proc field {field} must use an integer kB value"));
+    }
+    let kibibytes = parts[0]
+        .parse::<u64>()
+        .map_err(|_| format!("proc field {field} is not an unsigned integer"))?;
+    kibibytes
+        .checked_mul(1024)
+        .ok_or_else(|| format!("proc field {field} overflows bytes"))
+}
+
+pub fn signed_delta(value: u64, baseline: u64) -> Result<i64, String> {
+    let delta = i128::from(value) - i128::from(baseline);
+    i64::try_from(delta).map_err(|_| "memory delta exceeds signed 64-bit range".into())
+}
+
+pub fn fragmentation_proxy(delta_bytes: i64, peak_live_requested: u64) -> Result<f64, String> {
+    if delta_bytes <= 0 || peak_live_requested == 0 {
+        return Err(
+            "fragmentation proxy needs positive RSS delta and live-byte denominator".into(),
+        );
+    }
+    let ratio = delta_bytes as f64 / peak_live_requested as f64;
+    if !ratio.is_finite() || ratio <= 0.0 {
+        return Err("fragmentation proxy is non-finite or non-positive".into());
+    }
+    Ok(ratio)
+}
+
+pub fn validate_sampler_ownership(parent_pid: u32, sampled_pid: u32) -> Result<(), String> {
+    if parent_pid == 0 || sampled_pid == 0 || parent_pid == sampled_pid {
+        return Err("memory sampler must run in the parent and target a distinct child PID".into());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcSnapshot {
+    pub rss_bytes: u64,
+    pub hwm_bytes: u64,
+}
+
+pub fn read_proc_snapshot(pid: u32) -> Result<ProcSnapshot, String> {
+    if pid == 0 {
+        return Err("cannot sample PID zero".into());
+    }
+    let root = PathBuf::from("/proc").join(pid.to_string());
+    let smaps_path = root.join("smaps_rollup");
+    let status_path = root.join("status");
+    let smaps = std::fs::read_to_string(&smaps_path)
+        .map_err(|error| format!("{}: {error}", smaps_path.display()))?;
+    let status = std::fs::read_to_string(&status_path)
+        .map_err(|error| format!("{}: {error}", status_path.display()))?;
+    Ok(ProcSnapshot {
+        rss_bytes: parse_smaps_rollup(&smaps)?,
+        hwm_bytes: parse_status_hwm(&status)?,
+    })
+}
+
+pub fn collect_memory_environment(kernel: &str) -> Result<MemoryEnvironment, String> {
+    if kernel.is_empty() {
+        return Err("memory environment needs a kernel identity".into());
+    }
+    let output = Command::new("getconf")
+        .arg("PAGESIZE")
+        .output()
+        .map_err(|error| format!("run getconf PAGESIZE: {error}"))?;
+    if !output.status.success() || !output.stderr.is_empty() {
+        return Err("getconf PAGESIZE did not complete cleanly".into());
+    }
+    let page_size_bytes = std::str::from_utf8(&output.stdout)
+        .map_err(|error| format!("getconf PAGESIZE was not UTF-8: {error}"))?
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| "getconf PAGESIZE was not an unsigned integer".to_string())?;
+    if page_size_bytes == 0 || !page_size_bytes.is_power_of_two() {
+        return Err("getconf PAGESIZE returned an invalid page size".into());
+    }
+    let transparent_hugepage =
+        read_trimmed_or_not_observable(Path::new("/sys/kernel/mm/transparent_hugepage/enabled"));
+    let cgroup_root = resolve_cgroup_v2_root()?;
+    let cgroup_memory_max = read_trimmed_or_not_observable(&cgroup_root.join("memory.max"));
+    let cgroup_memory_high = read_trimmed_or_not_observable(&cgroup_root.join("memory.high"));
+    Ok(MemoryEnvironment {
+        page_size_bytes,
+        kernel: kernel.into(),
+        transparent_hugepage,
+        cgroup_memory_max,
+        cgroup_memory_high,
+        hosted_runner: std::env::var("GITHUB_ACTIONS").as_deref() == Ok("true"),
+        purge_policy: "natural-only".into(),
+        allocator_runtime_options: BTreeMap::from([
+            ("MIMALLOC_MEMORY_EVENTS".into(), "0".into()),
+            ("MIMALLOC_PROF".into(), "0".into()),
+        ]),
+    })
+}
+
+fn read_trimmed_or_not_observable(path: &Path) -> String {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "not-observable".into())
+}
+
+fn resolve_cgroup_v2_root() -> Result<PathBuf, String> {
+    let cgroup = std::fs::read_to_string("/proc/self/cgroup")
+        .map_err(|error| format!("read /proc/self/cgroup: {error}"))?;
+    let paths = cgroup
+        .lines()
+        .filter_map(|line| line.strip_prefix("0::"))
+        .collect::<Vec<_>>();
+    if paths.len() != 1 {
+        return Ok(PathBuf::from("/sys/fs/cgroup"));
+    }
+    let relative = paths[0].trim_start_matches('/');
+    if relative.split('/').any(|component| component == "..") {
+        return Err("cgroup v2 path contains traversal".into());
+    }
+    Ok(PathBuf::from("/sys/fs/cgroup").join(relative))
+}
+
+enum ReaderEvent {
+    Control(ControlRecord, u64),
+    Result(Box<BenchmarkChildResponse>),
+    Error(String),
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    started.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64
+}
+
+fn remaining(deadline: Instant) -> Duration {
+    deadline.saturating_duration_since(Instant::now())
+}
+
+fn receive_control(
+    receiver: &mpsc::Receiver<ReaderEvent>,
+    expected: ControlKind,
+    timeout: Duration,
+) -> Result<(ControlRecord, u64), String> {
+    match receiver.recv_timeout(timeout) {
+        Ok(ReaderEvent::Control(record, observed_ns)) if record.kind == expected => {
+            Ok((record, observed_ns))
+        }
+        Ok(ReaderEvent::Control(record, _)) => Err(format!(
+            "expected memory control {:?}, received {:?}",
+            expected, record.kind
+        )),
+        Ok(ReaderEvent::Result(_)) => Err("memory child returned a result before exit".into()),
+        Ok(ReaderEvent::Error(error)) => Err(error),
+        Err(error) => Err(format!("wait for memory control {:?}: {error}", expected)),
+    }
+}
+
+fn read_memory_child_events(
+    mut stdout: impl Read,
+    sender: mpsc::Sender<ReaderEvent>,
+    started: Instant,
+) {
+    let result = (|| -> Result<(), String> {
+        for expected in [
+            ControlKind::BaselineReady,
+            ControlKind::WorkloadActive,
+            ControlKind::WorkloadDrained,
+            ControlKind::ExitResult,
+        ] {
+            let record = read_control_record(&mut stdout)?;
+            if record.kind != expected {
+                return Err(format!(
+                    "memory child control order violation: expected {:?}, got {:?}",
+                    expected, record.kind
+                ));
+            }
+            sender
+                .send(ReaderEvent::Control(record, elapsed_ns(started)))
+                .map_err(|_| "memory controller stopped receiving events".to_string())?;
+            if expected == ControlKind::ExitResult {
+                let mut length = [0_u8; 4];
+                stdout
+                    .read_exact(&mut length)
+                    .map_err(|error| format!("read memory child result length: {error}"))?;
+                let length = u32::from_le_bytes(length) as usize;
+                if length == 0 || length > 1024 * 1024 {
+                    return Err("memory child result length is invalid".into());
+                }
+                let mut bytes = vec![0_u8; length];
+                stdout
+                    .read_exact(&mut bytes)
+                    .map_err(|error| format!("read memory child result: {error}"))?;
+                let response = serde_json::from_slice(&bytes)
+                    .map_err(|error| format!("decode memory child result: {error}"))?;
+                sender
+                    .send(ReaderEvent::Result(Box::new(response)))
+                    .map_err(|_| "memory controller stopped receiving result".to_string())?;
+            }
+        }
+        Ok(())
+    })();
+    if let Err(error) = result {
+        let _ = sender.send(ReaderEvent::Error(error));
+    }
+}
+
+fn wait_until(
+    target: Instant,
+    deadline: Instant,
+    process: &mut std::process::Child,
+) -> Result<(), String> {
+    loop {
+        if Instant::now() >= deadline {
+            return Err("memory child exceeded its watchdog deadline".into());
+        }
+        if let Some(status) = process
+            .try_wait()
+            .map_err(|error| format!("poll memory child: {error}"))?
+        {
+            return Err(format!("memory child exited before result: {status}"));
+        }
+        let now = Instant::now();
+        if now >= target {
+            return Ok(());
+        }
+        std::thread::sleep((target - now).min(Duration::from_millis(10)));
+    }
+}
+
+/// Run one measured child while sampling its `/proc` files externally. This
+/// function is intentionally sequential: callers must not execute allocator
+/// children in parallel.
+pub fn run_memory_child_sample(
+    child: &ChildProgram,
+    request: &BenchmarkChildRequest,
+    environment: &MemoryEnvironment,
+    timeout: Duration,
+) -> Result<MemoryRawSample, String> {
+    if cfg!(not(target_os = "linux")) {
+        return Err("linux-process-memory-v1 is Linux-only".into());
+    }
+    if child.allocator != request.allocator || timeout <= Duration::from_secs(5) {
+        return Err("memory child identity mismatch or timeout too short".into());
+    }
+    let encoded = serde_json::to_vec(request)
+        .map_err(|error| format!("serialize memory child request: {error}"))?;
+    if encoded.len() >= 1024 * 1024 {
+        return Err("memory child request exceeded 1 MiB".into());
+    }
+    let mut command = Command::new(&child.program);
+    command
+        .args(&child.arguments)
+        .arg("--memory")
+        .env_clear()
+        .envs(child.environment.iter().map(|(key, value)| (key, value)))
+        .env("MIMALLOC_PROF", "0")
+        .env("MIMALLOC_MEMORY_EVENTS", "0")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let started = Instant::now();
+    let deadline = started + timeout;
+    let mut process = command
+        .spawn()
+        .map_err(|error| format!("spawn memory child: {error}"))?;
+    let sampled_pid = process.id();
+    let sampler_pid = std::process::id();
+    if let Err(error) = validate_sampler_ownership(sampler_pid, sampled_pid) {
+        let _ = process.kill();
+        let _ = process.wait();
+        return Err(error);
+    }
+    let Some(mut stdin) = process.stdin.take() else {
+        let _ = process.kill();
+        let _ = process.wait();
+        return Err("memory child stdin was not piped".into());
+    };
+    if let Err(error) = stdin
+        .write_all(&encoded)
+        .and_then(|()| stdin.write_all(b"\n"))
+        .and_then(|()| stdin.flush())
+    {
+        let _ = process.kill();
+        let _ = process.wait();
+        return Err(format!("write memory child request: {error}"));
+    }
+    let Some(stdout) = process.stdout.take() else {
+        let _ = process.kill();
+        let _ = process.wait();
+        return Err("memory child stdout was not piped".into());
+    };
+    let (sender, receiver) = mpsc::channel();
+    let reader = std::thread::spawn(move || read_memory_child_events(stdout, sender, started));
+
+    let result = (|| -> Result<MemoryRawSample, String> {
+        let (_baseline_record, baseline_ready_ns) =
+            receive_control(&receiver, ControlKind::BaselineReady, remaining(deadline))?;
+        let baseline = read_proc_snapshot(sampled_pid)?;
+        write_control_record(&mut stdin, ControlRecord::empty(ControlKind::Begin))?;
+        let (_active_record, workload_active_ns) =
+            receive_control(&receiver, ControlKind::WorkloadActive, remaining(deadline))?;
+
+        let mut timeline = Vec::with_capacity(512);
+        let mut next_sample = Instant::now();
+        let (drained_record, workload_drained_ns) = loop {
+            if Instant::now() >= deadline {
+                return Err("memory child timed out during workload".into());
+            }
+            match receiver.try_recv() {
+                Ok(ReaderEvent::Control(record, observed_ns))
+                    if record.kind == ControlKind::WorkloadDrained =>
+                {
+                    break (record, observed_ns);
+                }
+                Ok(ReaderEvent::Control(record, _)) => {
+                    return Err(format!("unexpected memory control {:?}", record.kind));
+                }
+                Ok(ReaderEvent::Result(_)) => {
+                    return Err("memory child returned before the post-drain window".into());
+                }
+                Ok(ReaderEvent::Error(error)) => return Err(error),
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    return Err("memory child control channel disconnected".into());
+                }
+                Err(mpsc::TryRecvError::Empty) => {}
+            }
+            if Instant::now() >= next_sample {
+                let snapshot = read_proc_snapshot(sampled_pid)?;
+                timeline.push(MemoryTimelinePoint {
+                    elapsed_ns: elapsed_ns(started),
+                    rss_bytes: snapshot.rss_bytes,
+                });
+                next_sample += Duration::from_nanos(MEMORY_SAMPLE_TARGET_NS);
+            } else {
+                std::thread::sleep(
+                    next_sample
+                        .saturating_duration_since(Instant::now())
+                        .min(Duration::from_millis(1)),
+                );
+            }
+        };
+        let kernel_peak_hwm_bytes = read_proc_snapshot(sampled_pid)?.hwm_bytes;
+        let drain_observed = started + Duration::from_nanos(workload_drained_ns);
+
+        wait_until(
+            drain_observed + Duration::from_millis(100),
+            deadline,
+            &mut process,
+        )?;
+        let post_drain_sample_100ms_ns = elapsed_ns(started);
+        let post_drain_rss_100ms_bytes = read_proc_snapshot(sampled_pid)?.rss_bytes;
+        wait_until(
+            drain_observed + Duration::from_secs(1),
+            deadline,
+            &mut process,
+        )?;
+        let post_drain_sample_1s_ns = elapsed_ns(started);
+        let post_drain_rss_1s_bytes = read_proc_snapshot(sampled_pid)?.rss_bytes;
+        wait_until(
+            drain_observed + Duration::from_secs(5),
+            deadline,
+            &mut process,
+        )?;
+        let post_drain_sample_5s_ns = elapsed_ns(started);
+        let post_drain_rss_5s_bytes = read_proc_snapshot(sampled_pid)?.rss_bytes;
+        write_control_record(&mut stdin, ControlRecord::empty(ControlKind::ExitResult))?;
+
+        let (_exit_record, _) =
+            receive_control(&receiver, ControlKind::ExitResult, remaining(deadline))?;
+        let response = match receiver.recv_timeout(remaining(deadline)) {
+            Ok(ReaderEvent::Result(response)) => *response,
+            Ok(ReaderEvent::Error(error)) => return Err(error),
+            Ok(ReaderEvent::Control(record, _)) => {
+                return Err(format!("unexpected control after exit: {:?}", record.kind));
+            }
+            Err(error) => return Err(format!("wait for memory child result: {error}")),
+        };
+        response.validate_against(request)?;
+        if drained_record.current_live_requested_bytes != 0
+            || drained_record.peak_live_requested_bytes != response.sample.peak_live_requested_bytes
+            || drained_record.checksum != response.sample.checksum
+        {
+            return Err("memory control oracle contradicts the child result".into());
+        }
+        let status = loop {
+            if let Some(status) = process
+                .try_wait()
+                .map_err(|error| format!("poll memory child exit: {error}"))?
+            {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                return Err("memory child did not exit before its watchdog deadline".into());
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        };
+        if !status.success() {
+            return Err(format!("memory child exited unsuccessfully: {status}"));
+        }
+        let mut stderr_bytes = Vec::new();
+        if let Some(mut stderr) = process.stderr.take() {
+            stderr
+                .read_to_end(&mut stderr_bytes)
+                .map_err(|error| format!("read memory child stderr: {error}"))?;
+        }
+        if !stderr_bytes.is_empty() {
+            return Err(format!(
+                "successful memory child wrote stderr: {}",
+                String::from_utf8_lossy(&stderr_bytes)
+            ));
+        }
+        if timeline.len() < 2 {
+            return Err("memory workload ended before two external RSS samples".into());
+        }
+        // The reader timestamps the drain on receipt. A final sample can race
+        // that receipt by microseconds, so retain only the observed workload
+        // window and fail if this leaves insufficient evidence.
+        timeline.retain(|point| {
+            point.elapsed_ns >= workload_active_ns && point.elapsed_ns <= workload_drained_ns
+        });
+        let sampling = validate_timeline(
+            &timeline,
+            workload_active_ns,
+            workload_drained_ns,
+            MEMORY_SAMPLE_TARGET_NS,
+        )?;
+        let sampled_peak_rss_bytes = timeline
+            .iter()
+            .map(|point| point.rss_bytes)
+            .max()
+            .ok_or_else(|| "memory workload timeline is empty".to_string())?;
+        let sampled_peak_rss_delta_bytes =
+            signed_delta(sampled_peak_rss_bytes, baseline.rss_bytes)?;
+        let fragmentation_proxy = fragmentation_proxy(
+            sampled_peak_rss_delta_bytes,
+            response.sample.peak_live_requested_bytes,
+        )?;
+        let hwm_delta = signed_delta(kernel_peak_hwm_bytes, baseline.hwm_bytes)?;
+        let magnitude = sampled_peak_rss_delta_bytes.max(hwm_delta).max(0) as u64;
+        let hwm_tolerance_bytes = (8 * 1024 * 1024).max(magnitude / 5);
+        let hwm_discrepancy = (i128::from(sampled_peak_rss_delta_bytes) - i128::from(hwm_delta))
+            .unsigned_abs()
+            > u128::from(hwm_tolerance_bytes);
+
+        Ok(MemoryRawSample {
+            metric_schema_version: MEMORY_SCHEMA_VERSION.into(),
+            block_id: request.block_id,
+            ordinal: request.ordinal,
+            workload_seed: request.workload_seed,
+            allocator_id: request.allocator.allocator_id.clone(),
+            allocator_source_sha: request.allocator.source_sha.clone(),
+            child_binary_sha256: request.allocator.child_binary_sha256.clone(),
+            scenario_id: request.scenario_id.clone(),
+            thread_point: request.thread_point.clone(),
+            thread_count: response.sample.thread_count,
+            baseline_ready_ns,
+            workload_active_ns,
+            workload_drained_ns,
+            post_drain_sample_100ms_ns,
+            post_drain_sample_1s_ns,
+            post_drain_sample_5s_ns,
+            sampler_pid,
+            sampled_pid,
+            baseline_rss_bytes: baseline.rss_bytes,
+            baseline_hwm_bytes: baseline.hwm_bytes,
+            sampled_peak_rss_bytes,
+            kernel_peak_hwm_bytes,
+            peak_live_requested_bytes: response.sample.peak_live_requested_bytes,
+            post_drain_rss_100ms_bytes,
+            post_drain_rss_1s_bytes,
+            post_drain_rss_5s_bytes,
+            sampled_peak_rss_delta_bytes,
+            post_drain_rss_delta_100ms_bytes: signed_delta(
+                post_drain_rss_100ms_bytes,
+                baseline.rss_bytes,
+            )?,
+            post_drain_rss_delta_1s_bytes: signed_delta(
+                post_drain_rss_1s_bytes,
+                baseline.rss_bytes,
+            )?,
+            post_drain_rss_delta_5s_bytes: signed_delta(
+                post_drain_rss_5s_bytes,
+                baseline.rss_bytes,
+            )?,
+            fragmentation_proxy,
+            hwm_discrepancy,
+            hwm_tolerance_bytes,
+            sampling,
+            timeline,
+            environment: environment.clone(),
+            child_sample: response.sample,
+        })
+    })();
+
+    if result.is_err() {
+        let _ = process.kill();
+        let _ = process.wait();
+    }
+    drop(stdin);
+    if reader.join().is_err() && result.is_ok() {
+        return Err("memory child event reader panicked".into());
+    }
+    result
+}
+
+pub fn validate_timeline(
+    points: &[MemoryTimelinePoint],
+    workload_active_ns: u64,
+    workload_drained_ns: u64,
+    target_interval_ns: u64,
+) -> Result<SamplingIntervalDistribution, String> {
+    if points.len() < 2
+        || target_interval_ns == 0
+        || workload_active_ns >= workload_drained_ns
+        || points.first().map(|point| point.elapsed_ns) < Some(workload_active_ns)
+        || points.last().map(|point| point.elapsed_ns) > Some(workload_drained_ns)
+    {
+        return Err("memory timeline does not cover a valid workload window".into());
+    }
+    let leading_gap = points[0].elapsed_ns - workload_active_ns;
+    let trailing_gap = workload_drained_ns - points[points.len() - 1].elapsed_ns;
+    if leading_gap > MEMORY_MAX_SAMPLE_GAP_NS || trailing_gap > MEMORY_MAX_SAMPLE_GAP_NS {
+        return Err("memory timeline leaves an unobserved workload edge".into());
+    }
+    let mut intervals = Vec::with_capacity(points.len() - 1);
+    for pair in points.windows(2) {
+        let interval = pair[1]
+            .elapsed_ns
+            .checked_sub(pair[0].elapsed_ns)
+            .filter(|value| *value > 0)
+            .ok_or_else(|| "memory timeline timestamps must strictly increase".to_string())?;
+        if interval > MEMORY_MAX_SAMPLE_GAP_NS {
+            return Err(format!(
+                "memory sampler gap {interval}ns exceeds {MEMORY_MAX_SAMPLE_GAP_NS}ns bound"
+            ));
+        }
+        intervals.push(interval);
+    }
+    intervals.sort_unstable();
+    let quantile = |numerator: usize, denominator: usize| -> u64 {
+        let index = (intervals.len() - 1) * numerator / denominator;
+        intervals[index]
+    };
+    Ok(SamplingIntervalDistribution {
+        target_interval_ns,
+        sample_count: points.len() as u64,
+        minimum_interval_ns: intervals[0],
+        median_interval_ns: quantile(1, 2),
+        p95_interval_ns: quantile(95, 100),
+        maximum_interval_ns: *intervals.last().expect("timeline has an interval"),
+    })
+}
+
+pub fn memory_scenario_cells(
+    topology: Topology,
+) -> Result<Vec<(CardId, ThreadPoint, usize)>, String> {
+    topology.validate().map_err(|error| error.to_string())?;
+    let declared = [
+        (CardId::LargeObjects, ThreadPoint::One),
+        (CardId::LargeObjects, ThreadPoint::Two),
+        (CardId::SawtoothRetainDrain, ThreadPoint::One),
+        (CardId::SawtoothRetainDrain, ThreadPoint::PhysicalCores),
+        (CardId::SmallLogMixed, ThreadPoint::PhysicalCores),
+        (
+            CardId::CrossThreadProducerConsumer,
+            ThreadPoint::PhysicalCores,
+        ),
+        (CardId::ThreadChurn, ThreadPoint::PhysicalCores),
+    ];
+    declared
+        .into_iter()
+        .map(|(card, point)| {
+            let threads = topology.resolve(point).map_err(|error| error.to_string())?;
+            if card == CardId::CrossThreadProducerConsumer && threads < 2 {
+                return Err("memory cross-thread cell requires at least two physical cores".into());
+            }
+            Ok((card, point, threads))
+        })
+        .collect()
+}
+
+pub fn memory_comparison_key(input: &MemoryCompatibility) -> Result<String, String> {
+    if input.metric_schema_version.is_empty()
+        || input.page_size_bytes == 0
+        || input.kernel.is_empty()
+        || input.sampling_target_interval_ns == 0
+        || input.purge_policy != "natural-only"
+        || input.transparent_hugepage.is_empty()
+        || input.cgroup_memory_max.is_empty()
+        || input.cgroup_memory_high.is_empty()
+        || input.allocator_runtime_options.is_empty()
+    {
+        return Err("memory comparison compatibility is incomplete".into());
+    }
+    let bytes = serde_json::to_vec(input)
+        .map_err(|error| format!("serialize memory comparison compatibility: {error}"))?;
+    Ok(sha256_bytes(&bytes))
+}
+
+fn sample_value(sample: &MemoryRawSample, metric: &str) -> f64 {
+    match metric {
+        "sampled-peak-rss-bytes" => sample.sampled_peak_rss_bytes as f64,
+        "post-drain-rss-100ms-bytes" => sample.post_drain_rss_100ms_bytes as f64,
+        "post-drain-rss-1s-bytes" => sample.post_drain_rss_1s_bytes as f64,
+        "post-drain-rss-5s-bytes" => sample.post_drain_rss_5s_bytes as f64,
+        "fragmentation-proxy" => sample.fragmentation_proxy,
+        _ => unreachable!("metric list is fixed"),
+    }
+}
+
+pub fn validate_memory_raw_run(raw: &MemoryRawRun) -> Result<(), String> {
+    if raw.metric_schema_version != MEMORY_SCHEMA_VERSION
+        || raw.status != "complete"
+        || raw.run_seed == 0
+    {
+        return Err("memory raw run must be a complete linux-process-memory-v1 value".into());
+    }
+    if raw.allocators.len() != 4 || raw.calibrations.len() != 7 || raw.samples.is_empty() {
+        return Err("memory raw run has an incomplete allocator/cell matrix".into());
+    }
+    let allocator_ids = raw
+        .allocators
+        .iter()
+        .map(|allocator| allocator.allocator_id.as_str())
+        .collect::<Vec<_>>();
+    if allocator_ids != ALLOCATOR_IDS {
+        return Err("memory raw run allocator order or identity is invalid".into());
+    }
+    let topology = Topology {
+        physical_cores: raw.runner.physical_cores as usize,
+        logical_cores: raw.runner.logical_cores as usize,
+    };
+    let required = memory_scenario_cells(topology)?;
+    let required_keys = required
+        .iter()
+        .map(|(card, point, _)| (card.as_str(), point.name()))
+        .collect::<BTreeSet<_>>();
+    let required_threads = required
+        .iter()
+        .map(|(card, point, threads)| ((card.as_str(), point.name()), *threads as u32))
+        .collect::<BTreeMap<_, _>>();
+    let actual_calibrations = raw
+        .calibrations
+        .iter()
+        .map(|value| (value.scenario_id.as_str(), value.thread_point.as_str()))
+        .collect::<BTreeSet<_>>();
+    if actual_calibrations != required_keys {
+        return Err("memory calibrations do not match the declared matrix".into());
+    }
+    let calibrations = raw
+        .calibrations
+        .iter()
+        .map(|value| {
+            (
+                (value.scenario_id.as_str(), value.thread_point.as_str()),
+                value,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    if calibrations.len() != raw.calibrations.len()
+        || raw.calibrations.iter().any(|value| {
+            value.transactions_per_worker == 0
+                || value.warmup_transactions_per_worker == 0
+                || value.thread_count == 0
+                || required_threads.get(&(value.scenario_id.as_str(), value.thread_point.as_str()))
+                    != Some(&value.thread_count)
+                || value.operation_count == 0
+                || !(500_000_000..=2_000_000_000).contains(&value.elapsed_ns)
+        })
+    {
+        return Err("memory calibrations are duplicate or outside the declared contract".into());
+    }
+    let allocators = raw
+        .allocators
+        .iter()
+        .map(|value| (value.allocator_id.as_str(), value))
+        .collect::<BTreeMap<_, _>>();
+    if allocators.len() != raw.allocators.len() {
+        return Err("memory allocator provenance contains duplicate identities".into());
+    }
+    let child_runner = RunnerMetadata {
+        os: raw.runner.os.clone(),
+        architecture: raw.runner.architecture.clone(),
+        physical_cores: raw.runner.physical_cores,
+        logical_cores: raw.runner.logical_cores,
+    };
+    let first = raw
+        .samples
+        .first()
+        .ok_or_else(|| "memory raw run has no samples".to_string())?;
+    let compatibility = first
+        .environment
+        .compatibility(first.sampling.target_interval_ns);
+    memory_comparison_key(&compatibility)?;
+
+    let mut blocks_by_cell: BTreeMap<(&str, &str), BTreeMap<u32, Vec<&MemoryRawSample>>> =
+        BTreeMap::new();
+    for sample in &raw.samples {
+        let calibration = calibrations
+            .get(&(sample.scenario_id.as_str(), sample.thread_point.as_str()))
+            .ok_or_else(|| "memory sample has no matching calibration".to_string())?;
+        let allocator = allocators
+            .get(sample.allocator_id.as_str())
+            .ok_or_else(|| "memory sample has no matching allocator provenance".to_string())?;
+        sample.child_sample.validate()?;
+        let expected_toolchain = ToolchainMetadata {
+            rustc: raw.runner.rustc.clone(),
+            target: raw.runner.target.clone(),
+            compiler: allocator.compiler.clone(),
+            linker: allocator.linker.clone(),
+        };
+        if sample.metric_schema_version != MEMORY_SCHEMA_VERSION
+            || sample.ordinal >= 4
+            || sample.child_sample.run_kind != "headline"
+            || sample.child_sample.execution_mode != "normal"
+            || sample.child_sample.run_seed != raw.run_seed
+            || sample.child_sample.ordinal != sample.ordinal
+            || sample.allocator_id != sample.child_sample.allocator_id
+            || sample.child_sample.allocator_version != allocator.allocator_version
+            || sample.allocator_source_sha != sample.child_sample.allocator_source_sha
+            || sample.child_sample.allocator_source_sha != allocator.source_sha
+            || sample.child_sample.allocator_library_sha256 != allocator.static_library_sha256
+            || sample.child_binary_sha256 != sample.child_sample.child_binary_sha256
+            || sample.child_sample.child_binary_sha256 != allocator.child_binary_sha256
+            || sample.scenario_id != sample.child_sample.scenario_id
+            || sample.thread_point != sample.child_sample.thread_point
+            || sample.thread_count != sample.child_sample.thread_count
+            || sample.thread_count != calibration.thread_count
+            || sample.block_id != sample.child_sample.block_id
+            || sample.workload_seed != sample.child_sample.workload_seed
+            || sample.peak_live_requested_bytes != sample.child_sample.peak_live_requested_bytes
+            || sample.child_sample.operation_count != calibration.operation_count
+            || sample.child_sample.warmup_ns == 0
+            || sample.child_sample.runner != child_runner
+            || sample.child_sample.toolchain != expected_toolchain
+            || sample.baseline_ready_ns >= sample.workload_active_ns
+            || sample.workload_active_ns >= sample.workload_drained_ns
+            || sample.sampling.target_interval_ns != MEMORY_SAMPLE_TARGET_NS
+            || sample.environment.purge_policy != "natural-only"
+            || sample.environment.hosted_runner != (raw.runner.runner_class == "github-hosted")
+            || validate_sampler_ownership(sample.sampler_pid, sample.sampled_pid).is_err()
+        {
+            return Err("memory sample contradicts its child workload result".into());
+        }
+        for (observed, target) in [
+            (sample.post_drain_sample_100ms_ns, 100_000_000_u64),
+            (sample.post_drain_sample_1s_ns, 1_000_000_000_u64),
+            (sample.post_drain_sample_5s_ns, 5_000_000_000_u64),
+        ] {
+            let since_drain = observed
+                .checked_sub(sample.workload_drained_ns)
+                .ok_or_else(|| "post-drain sample precedes workload drain".to_string())?;
+            if since_drain < target || since_drain > target.saturating_add(100_000_000) {
+                return Err("post-drain sample missed its declared observation window".into());
+            }
+        }
+        let maximum = sample
+            .timeline
+            .iter()
+            .map(|point| point.rss_bytes)
+            .max()
+            .ok_or_else(|| "memory sample timeline is empty".to_string())?;
+        if maximum != sample.sampled_peak_rss_bytes
+            || signed_delta(sample.sampled_peak_rss_bytes, sample.baseline_rss_bytes)?
+                != sample.sampled_peak_rss_delta_bytes
+            || signed_delta(sample.post_drain_rss_100ms_bytes, sample.baseline_rss_bytes)?
+                != sample.post_drain_rss_delta_100ms_bytes
+            || signed_delta(sample.post_drain_rss_1s_bytes, sample.baseline_rss_bytes)?
+                != sample.post_drain_rss_delta_1s_bytes
+            || signed_delta(sample.post_drain_rss_5s_bytes, sample.baseline_rss_bytes)?
+                != sample.post_drain_rss_delta_5s_bytes
+            || fragmentation_proxy(
+                sample.sampled_peak_rss_delta_bytes,
+                sample.peak_live_requested_bytes,
+            )? != sample.fragmentation_proxy
+            || sample
+                .environment
+                .compatibility(sample.sampling.target_interval_ns)
+                != compatibility
+        {
+            return Err("memory sample has inconsistent derived values or compatibility".into());
+        }
+        let hwm_delta = signed_delta(sample.kernel_peak_hwm_bytes, sample.baseline_hwm_bytes)?;
+        let magnitude = sample.sampled_peak_rss_delta_bytes.max(hwm_delta).max(0) as u64;
+        let expected_tolerance = (8 * 1024 * 1024).max(magnitude / 5);
+        let expected_discrepancy = (i128::from(sample.sampled_peak_rss_delta_bytes)
+            - i128::from(hwm_delta))
+        .unsigned_abs()
+            > u128::from(expected_tolerance);
+        if sample.hwm_tolerance_bytes != expected_tolerance
+            || sample.hwm_discrepancy != expected_discrepancy
+        {
+            return Err("memory VmHWM discrepancy flag or tolerance is inconsistent".into());
+        }
+        let derived_sampling = validate_timeline(
+            &sample.timeline,
+            sample.workload_active_ns,
+            sample.workload_drained_ns,
+            sample.sampling.target_interval_ns,
+        )?;
+        if derived_sampling != sample.sampling {
+            return Err("memory sampling distribution does not match timestamps".into());
+        }
+        blocks_by_cell
+            .entry((&sample.scenario_id, &sample.thread_point))
+            .or_default()
+            .entry(sample.block_id)
+            .or_default()
+            .push(sample);
+    }
+    if blocks_by_cell.len() != required_keys.len() {
+        return Err("memory samples omit a required scenario/thread cell".into());
+    }
+    for (cell, blocks) in blocks_by_cell {
+        if blocks.len() < MEMORY_MIN_BLOCKS as usize {
+            return Err(format!(
+                "memory cell {cell:?} has fewer than 15 complete blocks"
+            ));
+        }
+        for (block, samples) in blocks {
+            let ids = samples
+                .iter()
+                .map(|sample| sample.allocator_id.as_str())
+                .collect::<BTreeSet<_>>();
+            let ordinals = samples
+                .iter()
+                .map(|sample| sample.ordinal)
+                .collect::<BTreeSet<_>>();
+            let seeds = samples
+                .iter()
+                .map(|sample| sample.workload_seed)
+                .collect::<BTreeSet<_>>();
+            if samples.len() != 4
+                || ids != ALLOCATOR_IDS.into_iter().collect()
+                || ordinals != [0, 1, 2, 3].into_iter().collect()
+                || seeds.len() != 1
+            {
+                return Err(format!(
+                    "memory cell {cell:?} block {block} is not a complete pair"
+                ));
+            }
+            let first_child = &samples[0].child_sample;
+            let same_workload = samples.iter().all(|sample| {
+                let child = &sample.child_sample;
+                child.run_seed == first_child.run_seed
+                    && child.workload_seed == first_child.workload_seed
+                    && child.thread_count == first_child.thread_count
+                    && child.operation_unit == first_child.operation_unit
+                    && child.operation_count == first_child.operation_count
+                    && child.requested_transactions == first_child.requested_transactions
+                    && child.completed_transactions == first_child.completed_transactions
+                    && child.allocation_calls == first_child.allocation_calls
+                    && child.calloc_calls == first_child.calloc_calls
+                    && child.aligned_allocation_calls == first_child.aligned_allocation_calls
+                    && child.free_calls == first_child.free_calls
+                    && child.realloc_calls == first_child.realloc_calls
+                    && child.checksum == first_child.checksum
+            });
+            if !same_workload {
+                return Err(format!(
+                    "memory cell {cell:?} block {block} is not a complete pair"
+                ));
+            }
+            // The deterministic scenario/checksum derivation is allocator-independent,
+            // so validate it once per complete paired block after all four children
+            // proved identical workload identity above.
+            let first = samples[0];
+            let calibration = calibrations
+                .get(&(first.scenario_id.as_str(), first.thread_point.as_str()))
+                .ok_or_else(|| "memory block lost its validated calibration".to_string())?;
+            let allocator = allocators
+                .get(first.allocator_id.as_str())
+                .ok_or_else(|| "memory block lost its validated allocator".to_string())?;
+            let request = BenchmarkChildRequest {
+                protocol_version: CHILD_PROTOCOL_VERSION.into(),
+                schema_version: crate::RAW_SCHEMA_VERSION.into(),
+                suite_version: crate::CORE_SUITE_VERSION.into(),
+                run_kind: "headline".into(),
+                execution_mode: "normal".into(),
+                run_seed: raw.run_seed,
+                block_id: first.block_id,
+                ordinal: first.ordinal,
+                workload_seed: first.workload_seed,
+                allocator: AllocatorIdentity {
+                    allocator_id: allocator.allocator_id.clone(),
+                    allocator_version: allocator.allocator_version.clone(),
+                    source_sha: allocator.source_sha.clone(),
+                    library_sha256: allocator.static_library_sha256.clone(),
+                    child_binary_sha256: allocator.child_binary_sha256.clone(),
+                },
+                scenario_id: first.scenario_id.clone(),
+                scenario_version: crate::CORE_SUITE_VERSION.into(),
+                thread_point: first.thread_point.clone(),
+                physical_cores: raw.runner.physical_cores,
+                logical_cores: raw.runner.logical_cores,
+                transactions_per_worker: calibration.transactions_per_worker,
+                warmup_transactions_per_worker: calibration.warmup_transactions_per_worker,
+                reproduction_command: first_child.reproduction_command.clone(),
+                runner: child_runner.clone(),
+                toolchain: first_child.toolchain.clone(),
+            };
+            BenchmarkChildResponse {
+                protocol_version: CHILD_PROTOCOL_VERSION.into(),
+                sample: first_child.clone(),
+            }
+            .validate_against(&request)?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct RunKey<'a> {
+    protocol: MemoryCompatibility,
+    runner_fingerprint: &'a str,
+    allocator_lock_sha256: &'a str,
+    allocator_sources: Vec<(&'a str, &'a str, &'a str)>,
+    calibrations: Vec<(&'a str, &'a str, u32, u64)>,
+}
+
+fn run_comparison_key(raw: &MemoryRawRun) -> Result<String, String> {
+    let first = raw
+        .samples
+        .first()
+        .ok_or_else(|| "memory raw run has no samples".to_string())?;
+    let mut allocator_sources = raw
+        .allocators
+        .iter()
+        .map(|value| {
+            (
+                value.allocator_id.as_str(),
+                value.source_sha.as_str(),
+                value.child_binary_sha256.as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+    allocator_sources.sort_unstable();
+    let mut calibrations = raw
+        .calibrations
+        .iter()
+        .map(|value| {
+            (
+                value.scenario_id.as_str(),
+                value.thread_point.as_str(),
+                value.thread_count,
+                value.operation_count,
+            )
+        })
+        .collect::<Vec<_>>();
+    calibrations.sort_unstable();
+    let key = RunKey {
+        protocol: first
+            .environment
+            .compatibility(first.sampling.target_interval_ns),
+        runner_fingerprint: &raw.runner.fingerprint_sha256,
+        allocator_lock_sha256: &raw.allocator_lock_sha256,
+        allocator_sources,
+        calibrations,
+    };
+    let bytes =
+        serde_json::to_vec(&key).map_err(|error| format!("serialize memory run key: {error}"))?;
+    Ok(sha256_bytes(&bytes))
+}
+
+pub fn build_memory_report(raw: &MemoryRawRun) -> Result<MemoryMetricReport, String> {
+    validate_memory_raw_run(raw)?;
+    let mut absolute_summaries = Vec::new();
+    let mut paired_summaries = Vec::new();
+    let topology = Topology {
+        physical_cores: raw.runner.physical_cores as usize,
+        logical_cores: raw.runner.logical_cores as usize,
+    };
+    for (card, point, _) in memory_scenario_cells(topology)? {
+        let cell_samples = raw.samples.iter().filter(|sample| {
+            sample.scenario_id == card.as_str() && sample.thread_point == point.name()
+        });
+        for (metric, _unit) in METRICS {
+            let observations = cell_samples
+                .clone()
+                .map(|sample| MetricObservation {
+                    block_id: sample.block_id,
+                    allocator_id: sample.allocator_id.clone(),
+                    value: sample_value(sample, metric),
+                })
+                .collect::<Vec<_>>();
+            let cell_id = format!("{}/{}/{metric}", card.as_str(), point.name());
+            for allocator in ALLOCATOR_IDS {
+                let values = cell_samples
+                    .clone()
+                    .filter(|sample| sample.allocator_id == allocator)
+                    .map(|sample| sample_value(sample, metric))
+                    .collect::<Vec<_>>();
+                absolute_summaries.push(AbsoluteCellSummary {
+                    scenario_id: card.as_str().into(),
+                    thread_point: point.name().into(),
+                    metric_id: metric.into(),
+                    direction: MetricDirection::LowerIsBetter,
+                    allocator_id: allocator.into(),
+                    summary: summarize_absolute(&values).map_err(|error| error.to_string())?,
+                });
+                if allocator != REFERENCE_ALLOCATOR {
+                    paired_summaries.push(PairedCellSummary {
+                        scenario_id: card.as_str().into(),
+                        thread_point: point.name().into(),
+                        metric_id: metric.into(),
+                        summary: summarize_paired(
+                            raw.run_seed,
+                            &cell_id,
+                            allocator,
+                            REFERENCE_ALLOCATOR,
+                            MetricDirection::LowerIsBetter,
+                            &observations,
+                        )
+                        .map_err(|error| error.to_string())?,
+                    });
+                }
+            }
+        }
+    }
+    Ok(MemoryMetricReport {
+        metric_schema_version: MEMORY_SCHEMA_VERSION.into(),
+        status: "complete".into(),
+        invalid_reason: None,
+        metric_comparison_key: run_comparison_key(raw)?,
+        run: raw.run.clone(),
+        runner: raw.runner.clone(),
+        sampling_target_interval_ns: MEMORY_SAMPLE_TARGET_NS,
+        purge_policy: "natural-only".into(),
+        units: METRICS
+            .into_iter()
+            .map(|(metric, unit)| (metric.into(), unit.into()))
+            .collect(),
+        direction: MetricDirection::LowerIsBetter,
+        informational: true,
+        methodology: MemoryMethodology {
+            rss_source: "/proc/<pid>/smaps_rollup Rss, parsed as integer kB * 1024".into(),
+            hwm_source: "/proc/<pid>/status VmHWM, parsed as integer kB * 1024; cross-check only".into(),
+            baseline_definition: "external RSS/HWM after child warmup and baseline-ready, before begin".into(),
+            sampled_peak_definition: "maximum external smaps_rollup RSS timestamped inside workload-active..workload-drained".into(),
+            post_drain_definition: "external smaps_rollup RSS at >=100ms, >=1s, and >=5s after workload-drained".into(),
+            fragmentation_formula: "(sampled_peak_rss_bytes - baseline_rss_bytes) / peak_live_requested_bytes; both operands must be positive".into(),
+            hwm_discrepancy_tolerance: "flag when abs(sampled RSS delta - VmHWM delta) > max(8 MiB, 20% of the larger positive delta)".into(),
+            page_touch_contract: "every allocation touches deterministic boundary bytes and at least one byte per OS page".into(),
+            purge_policy: "natural allocator behavior only; no allocator-specific purge call".into(),
+        },
+        absolute_summaries,
+        paired_summaries,
+        raw_samples: raw.samples.clone(),
+    })
+}
+
+pub fn attach_memory_report(
+    latest: &mut LatestReport,
+    report: MemoryMetricReport,
+) -> Result<(), String> {
+    if report.metric_schema_version != MEMORY_SCHEMA_VERSION
+        || report.status != "complete"
+        || report.invalid_reason.is_some()
+        || report.raw_samples.is_empty()
+        || report.absolute_summaries.is_empty()
+        || report.paired_summaries.is_empty()
+    {
+        return Err("only a complete validated memory report can replace pending state".into());
+    }
+    let pending_ids = latest
+        .pending_metrics
+        .iter()
+        .map(|value| value.metric_id.as_str())
+        .collect::<BTreeSet<_>>();
+    if !pending_ids.contains("memory") && latest.memory.is_none() {
+        return Err("latest report has neither memory pending state nor prior memory data".into());
+    }
+    latest
+        .pending_metrics
+        .retain(|value| value.metric_id != "memory");
+    latest.memory = Some(report);
+    Ok(())
+}

--- a/rust/benchmark-suite/src/memory_runner.rs
+++ b/rust/benchmark-suite/src/memory_runner.rs
@@ -1,0 +1,420 @@
+//! Production runner for the bounded Linux process-memory suite.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+
+use crate::config::AllocatorLock;
+use crate::memory::{
+    collect_memory_environment, memory_scenario_cells, run_memory_child_sample,
+    validate_memory_raw_run, MemoryRawRun,
+};
+use crate::model::{
+    BenchmarkChildRequest, CellCalibration, RunnerMetadata, CHILD_PROTOCOL_VERSION,
+};
+use crate::orchestration::{balanced_block_orders, calibrate_cell};
+use crate::provenance::ProducerProvenance;
+use crate::runner::{
+    children_from_provenance, collect_publication_runner, collect_run_identity, create_new_writer,
+    detect_topology, publication_allocators, write_json_line, write_new_bytes, write_new_json,
+};
+use crate::scenarios::{card, ScenarioCell, Topology};
+use crate::{CORE_SUITE_VERSION, RAW_SCHEMA_VERSION};
+
+const HARD_LIMIT_SECONDS: f64 = 60.0 * 60.0;
+
+#[derive(Debug)]
+struct Options {
+    provenance: PathBuf,
+    output_dir: PathBuf,
+    blocks: u32,
+    run_seed: u64,
+    timeout: Duration,
+    warmup_transactions: u64,
+    initial_transactions: u64,
+    topology: Option<Topology>,
+    reduced_smoke: bool,
+}
+
+pub fn benchmark_memory_run_main() -> Result<(), String> {
+    run(parse_options(std::env::args_os().skip(1))?)
+}
+
+fn run(options: Options) -> Result<(), String> {
+    if cfg!(not(target_os = "linux")) {
+        return Err("linux-process-memory-v1 is Linux-only".into());
+    }
+    if options.output_dir.exists() {
+        return Err(format!(
+            "output directory already exists: {}",
+            options.output_dir.display()
+        ));
+    }
+    std::fs::create_dir_all(&options.output_dir)
+        .map_err(|error| format!("create memory output directory: {error}"))?;
+    if options.reduced_smoke {
+        if options.blocks != 1 {
+            return Err("memory reduced smoke requires --blocks 1".into());
+        }
+    } else if options.blocks < 15 {
+        return Err("complete memory runs require --blocks at least 15".into());
+    }
+
+    let lock =
+        AllocatorLock::parse_and_validate(include_str!("../allocators/allocator-lock.json"))?;
+    let provenance_bytes = std::fs::read(&options.provenance)
+        .map_err(|error| format!("read allocator provenance: {error}"))?;
+    let provenance_text = std::str::from_utf8(&provenance_bytes)
+        .map_err(|error| format!("allocator provenance is not UTF-8: {error}"))?;
+    let provenance = ProducerProvenance::parse_and_validate(provenance_text, &lock)?;
+    provenance.validate_artifact_hashes()?;
+    write_new_bytes(
+        options.output_dir.join("allocator-provenance.json"),
+        &provenance_bytes,
+    )?;
+
+    let topology = options.topology.map_or_else(detect_topology, Ok)?;
+    let children = children_from_provenance(&provenance)?;
+    let upstream = children
+        .iter()
+        .find(|child| child.allocator.allocator_id == "upstream-mimalloc")
+        .ok_or_else(|| "provenance is missing upstream-mimalloc".to_string())?;
+    let run = collect_run_identity(&provenance)?;
+    let publication_runner = collect_publication_runner(topology)?;
+    let runner = RunnerMetadata {
+        os: publication_runner.os.clone(),
+        architecture: publication_runner.architecture.clone(),
+        physical_cores: publication_runner.physical_cores,
+        logical_cores: publication_runner.logical_cores,
+    };
+    let environment = collect_memory_environment(&publication_runner.kernel)?;
+    let cells = memory_scenario_cells(topology)?;
+    let run_kind = if options.reduced_smoke {
+        "reduced-smoke"
+    } else {
+        "headline"
+    };
+    let mut raw_output = create_new_writer(options.output_dir.join("raw-memory-samples.jsonl"))?;
+    let mut timeline_output = create_new_writer(options.output_dir.join("proc-timelines.jsonl"))?;
+    let mut diagnostic_output = create_new_writer(options.output_dir.join("diagnostics.jsonl"))?;
+    write_json_line(
+        &mut diagnostic_output,
+        &json!({
+            "event": "memory-run-start",
+            "metric_schema_version": crate::memory::MEMORY_SCHEMA_VERSION,
+            "run_kind": run_kind,
+            "blocks": options.blocks,
+            "run_seed": options.run_seed,
+            "sampling_target_interval_ns": crate::memory::MEMORY_SAMPLE_TARGET_NS,
+            "purge_policy": "natural-only",
+            "environment": environment,
+        }),
+    )?;
+
+    let runner_started = Instant::now();
+    let mut calibration_wall = Duration::ZERO;
+    let mut block_wall = Duration::ZERO;
+    let mut calibrations = Vec::with_capacity(cells.len());
+    let mut samples = Vec::with_capacity(cells.len() * options.blocks as usize * 4);
+    for (card_id, thread_point, _) in cells {
+        let mut request = BenchmarkChildRequest {
+            protocol_version: CHILD_PROTOCOL_VERSION.into(),
+            schema_version: RAW_SCHEMA_VERSION.into(),
+            suite_version: CORE_SUITE_VERSION.into(),
+            run_kind: run_kind.into(),
+            execution_mode: "normal".into(),
+            run_seed: options.run_seed,
+            block_id: 0,
+            ordinal: 0,
+            workload_seed: 0,
+            allocator: upstream.allocator.clone(),
+            scenario_id: card_id.as_str().into(),
+            scenario_version: CORE_SUITE_VERSION.into(),
+            thread_point: thread_point.name().into(),
+            physical_cores: topology.physical_cores as u32,
+            logical_cores: topology.logical_cores as u32,
+            transactions_per_worker: options.initial_transactions,
+            warmup_transactions_per_worker: options.warmup_transactions,
+            reproduction_command: "memory calibration placeholder".into(),
+            runner: runner.clone(),
+            toolchain: upstream.toolchain.clone(),
+        };
+        let calibration_started = Instant::now();
+        let calibration = calibrate_cell(upstream, &request, options.timeout)?;
+        calibration_wall = calibration_wall.saturating_add(calibration_started.elapsed());
+        request.transactions_per_worker = calibration.transactions_per_worker;
+        let cell = ScenarioCell::new(
+            card_id,
+            thread_point,
+            topology,
+            calibration.transactions_per_worker,
+            1,
+        )
+        .map_err(|error| error.to_string())?;
+        calibrations.push(CellCalibration {
+            scenario_id: card_id.as_str().into(),
+            thread_point: thread_point.name().into(),
+            thread_count: cell.threads as u32,
+            transactions_per_worker: calibration.transactions_per_worker,
+            warmup_transactions_per_worker: options.warmup_transactions,
+            operation_count: calibration.operation_count,
+            elapsed_ns: calibration.elapsed_ns,
+        });
+
+        let block_started = Instant::now();
+        for order in balanced_block_orders(options.blocks, options.run_seed)? {
+            for (ordinal, allocator_id) in order.allocator_ids.iter().enumerate() {
+                let child = children
+                    .iter()
+                    .find(|candidate| candidate.allocator.allocator_id == *allocator_id)
+                    .ok_or_else(|| {
+                        format!(
+                            "validated provenance lost allocator {allocator_id} at block {}",
+                            order.block_id
+                        )
+                    })?;
+                let mut measured = request.clone();
+                measured.block_id = order.block_id;
+                measured.ordinal = ordinal as u8;
+                measured.workload_seed = order.workload_seed;
+                measured.allocator = child.allocator.clone();
+                measured.toolchain = child.toolchain.clone();
+                let request_path = options.output_dir.join("requests").join(format!(
+                    "{}-{}-block-{:04}-ordinal-{}-{}.json",
+                    measured.scenario_id,
+                    measured.thread_point,
+                    measured.block_id,
+                    measured.ordinal,
+                    measured.allocator.allocator_id,
+                ));
+                std::fs::create_dir_all(
+                    request_path
+                        .parent()
+                        .ok_or_else(|| "memory request has no parent directory".to_string())?,
+                )
+                .map_err(|error| format!("create memory request directory: {error}"))?;
+                measured.reproduction_command = format!(
+                    "benchmark-memory-run --run-seed {} --blocks {} --output-dir <new-dir> --build-root <build-root> # scenario={} thread-point={}",
+                    options.run_seed,
+                    options.blocks,
+                    measured.scenario_id,
+                    measured.thread_point,
+                );
+                write_new_json(request_path, &measured)?;
+                let sample = match run_memory_child_sample(
+                    child,
+                    &measured,
+                    &environment,
+                    options.timeout,
+                ) {
+                    Ok(sample) => sample,
+                    Err(error) => {
+                        let invalid = json!({
+                            "metric_schema_version": crate::memory::MEMORY_SCHEMA_VERSION,
+                            "status": "invalid",
+                            "scenario_id": measured.scenario_id,
+                            "thread_point": measured.thread_point,
+                            "block_id": order.block_id,
+                            "ordinal": ordinal,
+                            "allocator_id": allocator_id,
+                            "reason": &error,
+                        });
+                        write_json_line(
+                            &mut diagnostic_output,
+                            &json!({
+                                "event": "memory-sample-invalid",
+                                "status": "invalid",
+                                "scenario_id": measured.scenario_id,
+                                "thread_point": measured.thread_point,
+                                "block_id": order.block_id,
+                                "ordinal": ordinal,
+                                "allocator_id": allocator_id,
+                                "reason": &error,
+                            }),
+                        )?;
+                        write_new_json(options.output_dir.join("memory-invalid.json"), &invalid)?;
+                        return Err(format!(
+                            "memory cell aborted at block {} ordinal {} allocator {}: {error}",
+                            order.block_id, ordinal, allocator_id
+                        ));
+                    }
+                };
+                write_json_line(&mut raw_output, &sample)?;
+                write_json_line(
+                    &mut timeline_output,
+                    &json!({
+                        "metric_schema_version": sample.metric_schema_version,
+                        "scenario_id": sample.scenario_id,
+                        "thread_point": sample.thread_point,
+                        "block_id": sample.block_id,
+                        "allocator_id": sample.allocator_id,
+                        "sampled_pid": sample.sampled_pid,
+                        "workload_active_ns": sample.workload_active_ns,
+                        "workload_drained_ns": sample.workload_drained_ns,
+                        "timeline": sample.timeline,
+                    }),
+                )?;
+                samples.push(sample);
+            }
+        }
+        block_wall = block_wall.saturating_add(block_started.elapsed());
+        write_json_line(
+            &mut diagnostic_output,
+            &json!({
+                "event": "memory-cell-complete",
+                "scenario_id": card_id.as_str(),
+                "thread_point": thread_point.name(),
+                "operation_unit": card(card_id).operation_unit.name(),
+                "samples": options.blocks * 4,
+            }),
+        )?;
+    }
+
+    let observed_wall = runner_started.elapsed();
+    let fixed_wall = observed_wall.saturating_sub(calibration_wall + block_wall);
+    let projected_full_seconds = provenance.build_elapsed_seconds
+        + calibration_wall.as_secs_f64()
+        + block_wall.as_secs_f64() * 15.0 / f64::from(options.blocks)
+        + fixed_wall.as_secs_f64()
+        + 1.0;
+    write_new_json(
+        options.output_dir.join("runtime-projection.json"),
+        &json!({
+            "observed_blocks": options.blocks,
+            "observed_runner_wall_seconds": observed_wall.as_secs_f64(),
+            "observed_calibration_wall_seconds": calibration_wall.as_secs_f64(),
+            "observed_block_wall_seconds": block_wall.as_secs_f64(),
+            "native_build_elapsed_seconds": provenance.build_elapsed_seconds,
+            "projected_headline_blocks": 15,
+            "projected_full_suite_seconds": projected_full_seconds,
+            "hard_limit_seconds": HARD_LIMIT_SECONDS,
+            "fits_limit": projected_full_seconds <= HARD_LIMIT_SECONDS,
+        }),
+    )?;
+    if projected_full_seconds > HARD_LIMIT_SECONDS {
+        let reason = format!(
+            "projected complete memory runtime {:.1}s exceeds the 3600s hard limit",
+            projected_full_seconds
+        );
+        write_new_json(
+            options.output_dir.join("memory-invalid.json"),
+            &json!({
+                "metric_schema_version": crate::memory::MEMORY_SCHEMA_VERSION,
+                "status": "invalid",
+                "reason": reason,
+            }),
+        )?;
+        return Err(reason);
+    }
+    let raw = MemoryRawRun {
+        metric_schema_version: crate::memory::MEMORY_SCHEMA_VERSION.into(),
+        status: if options.reduced_smoke {
+            "incomplete"
+        } else {
+            "complete"
+        }
+        .into(),
+        run_seed: options.run_seed,
+        run,
+        runner: publication_runner,
+        allocator_lock_sha256: provenance.lockfile_sha256.clone(),
+        allocators: publication_allocators(&lock, &provenance)?,
+        calibrations,
+        samples,
+    };
+    if !options.reduced_smoke {
+        validate_memory_raw_run(&raw)?;
+    }
+    write_new_json(options.output_dir.join("memory-raw-run.json"), &raw)?;
+    println!(
+        "PASS memory run: {} samples; projected complete runtime {:.1}s",
+        raw.samples.len(),
+        projected_full_seconds
+    );
+    Ok(())
+}
+
+fn parse_options(arguments: impl Iterator<Item = OsString>) -> Result<Options, String> {
+    let arguments = arguments
+        .map(|value| {
+            value
+                .into_string()
+                .map_err(|_| "memory runner arguments must be UTF-8".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut provenance = None;
+    let mut build_root = None;
+    let mut output_dir = None;
+    let mut blocks = 15;
+    let mut run_seed = 0x6d65_6d6f_7279_7631;
+    let mut timeout_secs = 30;
+    let mut warmup_transactions = 1;
+    let mut initial_transactions = 1;
+    let mut physical_cores = None;
+    let mut logical_cores = None;
+    let mut reduced_smoke = false;
+    let mut index = 0;
+    while index < arguments.len() {
+        let flag = &arguments[index];
+        if flag == "--reduced-smoke" {
+            reduced_smoke = true;
+            index += 1;
+            continue;
+        }
+        let value = arguments
+            .get(index + 1)
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--provenance" => provenance = Some(PathBuf::from(value)),
+            "--build-root" => build_root = Some(PathBuf::from(value)),
+            "--output-dir" => output_dir = Some(PathBuf::from(value)),
+            "--blocks" => blocks = parse_number(flag, value)?,
+            "--run-seed" => run_seed = parse_number(flag, value)?,
+            "--timeout-secs" => timeout_secs = parse_number(flag, value)?,
+            "--warmup-transactions" => warmup_transactions = parse_number(flag, value)?,
+            "--initial-transactions" => initial_transactions = parse_number(flag, value)?,
+            "--physical-cores" => physical_cores = Some(parse_number(flag, value)?),
+            "--logical-cores" => logical_cores = Some(parse_number(flag, value)?),
+            _ => return Err(format!("unknown memory runner argument {flag}")),
+        }
+        index += 2;
+    }
+    if blocks == 0 || run_seed == 0 || timeout_secs <= 5 || initial_transactions == 0 {
+        return Err(
+            "memory seed/blocks/transactions must be nonzero and timeout must exceed 5s".into(),
+        );
+    }
+    if provenance.is_some() && build_root.is_some() {
+        return Err("pass either --provenance or --build-root, not both".into());
+    }
+    let provenance = provenance
+        .or_else(|| build_root.map(|root| root.join("allocator-provenance.json")))
+        .ok_or("--provenance or --build-root is required")?;
+    let topology = match (physical_cores, logical_cores) {
+        (None, None) => None,
+        (Some(physical_cores), Some(logical_cores)) => Some(Topology {
+            physical_cores,
+            logical_cores,
+        }),
+        _ => return Err("physical and logical core overrides must be supplied together".into()),
+    };
+    Ok(Options {
+        provenance,
+        output_dir: output_dir.ok_or("--output-dir is required")?,
+        blocks,
+        run_seed,
+        timeout: Duration::from_secs(timeout_secs),
+        warmup_transactions,
+        initial_transactions,
+        topology,
+        reduced_smoke,
+    })
+}
+
+fn parse_number<T: std::str::FromStr>(flag: &str, value: &str) -> Result<T, String> {
+    value
+        .parse()
+        .map_err(|_| format!("invalid numeric value for {flag}: {value}"))
+}

--- a/rust/benchmark-suite/src/model.rs
+++ b/rust/benchmark-suite/src/model.rs
@@ -224,6 +224,10 @@ pub struct LatestReport {
     pub comparison_key: String,
     pub methodology: MethodologyContract,
     pub pending_metrics: Vec<PendingMetric>,
+    /// Backward-compatible Phase 6 extension. Absence means the metric was not
+    /// collected under `linux-process-memory-v1`; it never means zero.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<crate::memory::MemoryMetricReport>,
     pub canonical_urls: CanonicalUrls,
     pub reproduction_command: String,
     pub actions_run_url: String,
@@ -241,6 +245,8 @@ pub struct HistoryRow {
     pub allocator_identities: Vec<AllocatorIdentity>,
     pub absolute_summaries: Vec<AbsoluteCellSummary>,
     pub paired_summaries: Vec<PairedCellSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<crate::memory::MemoryHistoryReport>,
 }
 
 /// Immutable identity supplied by the producer after it hashes the directly

--- a/rust/benchmark-suite/src/report.rs
+++ b/rust/benchmark-suite/src/report.rs
@@ -125,6 +125,7 @@ pub fn build_latest_report(
             pending("scaling", 186),
             pending("pprof-tax", 187),
         ],
+        memory: None,
         canonical_urls: CanonicalUrls {
             pages: "https://zackees.github.io/mimalloc-pprof/".into(),
             stats_branch: "https://github.com/zackees/mimalloc-pprof/tree/benchmark-stats".into(),
@@ -158,6 +159,10 @@ pub fn build_latest_report(
             .collect(),
         absolute_summaries: latest.absolute_summaries.clone(),
         paired_summaries: latest.paired_summaries.clone(),
+        memory: latest
+            .memory
+            .as_ref()
+            .map(|value| value.history_projection()),
     };
     Ok((latest, history))
 }

--- a/rust/benchmark-suite/src/runner.rs
+++ b/rust/benchmark-suite/src/runner.rs
@@ -298,7 +298,9 @@ fn run(options: Options) -> Result<(), String> {
     Ok(())
 }
 
-fn children_from_provenance(provenance: &ProducerProvenance) -> Result<Vec<ChildProgram>, String> {
+pub(crate) fn children_from_provenance(
+    provenance: &ProducerProvenance,
+) -> Result<Vec<ChildProgram>, String> {
     provenance
         .allocators
         .iter()
@@ -332,7 +334,7 @@ fn children_from_provenance(provenance: &ProducerProvenance) -> Result<Vec<Child
         .collect()
 }
 
-fn publication_allocators(
+pub(crate) fn publication_allocators(
     lock: &AllocatorLock,
     provenance: &ProducerProvenance,
 ) -> Result<Vec<AllocatorBuildIdentity>, String> {
@@ -413,7 +415,7 @@ fn publication_options(id: &str) -> AllocatorFeatureOptions {
     }
 }
 
-fn collect_run_identity(provenance: &ProducerProvenance) -> Result<RunIdentity, String> {
+pub(crate) fn collect_run_identity(provenance: &ProducerProvenance) -> Result<RunIdentity, String> {
     let source_sha = provenance
         .allocators
         .iter()
@@ -449,7 +451,7 @@ fn collect_run_identity(provenance: &ProducerProvenance) -> Result<RunIdentity, 
     })
 }
 
-fn collect_publication_runner(topology: Topology) -> Result<PublicationRunner, String> {
+pub(crate) fn collect_publication_runner(topology: Topology) -> Result<PublicationRunner, String> {
     let runner_class = if std::env::var("GITHUB_ACTIONS").as_deref() == Ok("true") {
         "github-hosted"
     } else {
@@ -536,7 +538,7 @@ fn command_text(program: &str, arguments: &[&str]) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-fn detect_topology() -> Result<Topology, String> {
+pub(crate) fn detect_topology() -> Result<Topology, String> {
     let logical = std::thread::available_parallelism()
         .map_err(|error| format!("detect logical CPU count: {error}"))?
         .get();
@@ -584,7 +586,7 @@ fn rustc_version() -> String {
         .unwrap_or_else(|| "rustc-version-unavailable".into())
 }
 
-fn create_new_writer(path: PathBuf) -> Result<BufWriter<File>, String> {
+pub(crate) fn create_new_writer(path: PathBuf) -> Result<BufWriter<File>, String> {
     OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -593,7 +595,10 @@ fn create_new_writer(path: PathBuf) -> Result<BufWriter<File>, String> {
         .map_err(|error| format!("create {}: {error}", path.display()))
 }
 
-fn write_json_line<T: Serialize>(writer: &mut BufWriter<File>, value: &T) -> Result<(), String> {
+pub(crate) fn write_json_line<T: Serialize>(
+    writer: &mut BufWriter<File>,
+    value: &T,
+) -> Result<(), String> {
     serde_json::to_writer(&mut *writer, value)
         .map_err(|error| format!("serialize JSONL record: {error}"))?;
     writer
@@ -602,7 +607,7 @@ fn write_json_line<T: Serialize>(writer: &mut BufWriter<File>, value: &T) -> Res
         .map_err(|error| format!("append JSONL record: {error}"))
 }
 
-fn write_new_json<T: Serialize>(path: PathBuf, value: &T) -> Result<(), String> {
+pub(crate) fn write_new_json<T: Serialize>(path: PathBuf, value: &T) -> Result<(), String> {
     let mut writer = create_new_writer(path)?;
     serde_json::to_writer_pretty(&mut writer, value)
         .map_err(|error| format!("serialize JSON artifact: {error}"))?;
@@ -612,7 +617,7 @@ fn write_new_json<T: Serialize>(path: PathBuf, value: &T) -> Result<(), String> 
         .map_err(|error| format!("finish JSON artifact: {error}"))
 }
 
-fn write_new_bytes(path: PathBuf, value: &[u8]) -> Result<(), String> {
+pub(crate) fn write_new_bytes(path: PathBuf, value: &[u8]) -> Result<(), String> {
     let mut file = OpenOptions::new()
         .write(true)
         .create_new(true)

--- a/rust/benchmark-suite/src/validate.rs
+++ b/rust/benchmark-suite/src/validate.rs
@@ -665,11 +665,11 @@ fn validate_block(
             || sample.free_calls != first.free_calls
             || sample.realloc_calls != first.realloc_calls
             || sample.checksum != first.checksum
-            // peak_live_requested_bytes is excluded from the block-identity
-            // check: it is measured via AtomicU64::fetch_max across threads,
-            // and different allocator speeds cause different thread-scheduling
-            // order, so the observed peak is inherently non-deterministic
-            // across allocators in multi-threaded workloads.
+        // peak_live_requested_bytes is excluded from the block-identity
+        // check: it is measured via AtomicU64::fetch_max across threads,
+        // and different allocator speeds cause different thread-scheduling
+        // order, so the observed peak is inherently non-deterministic
+        // across allocators in multi-threaded workloads.
         {
             return Err(ValidationError::new(format!(
                 "cell {}/{} block {block_id} has mismatched seed/count/request identity",
@@ -718,6 +718,10 @@ pub fn selftest() -> Result<(), ValidationError> {
         (
             "history-v1.schema.json",
             include_str!("../schema/history-v1.schema.json"),
+        ),
+        (
+            "memory-v1.schema.json",
+            include_str!("../schema/memory-v1.schema.json"),
         ),
     ] {
         let value: serde_json::Value = serde_json::from_str(schema)

--- a/rust/benchmark-suite/tests/memory_contract.rs
+++ b/rust/benchmark-suite/tests/memory_contract.rs
@@ -1,0 +1,437 @@
+use std::collections::BTreeMap;
+use std::process::Command;
+
+use benchmark_suite::memory::{
+    attach_memory_report, build_memory_report, fragmentation_proxy, memory_comparison_key,
+    memory_scenario_cells, parse_smaps_rollup, parse_status_hwm, read_control_record,
+    read_proc_snapshot, validate_memory_raw_run, validate_sampler_ownership, validate_timeline,
+    write_control_record, ControlKind, ControlRecord, LiveRequestedOracle, MemoryCompatibility,
+    MemoryEnvironment, MemoryRawRun, MemoryRawSample, MemoryTimelinePoint, MEMORY_SAMPLE_TARGET_NS,
+    MEMORY_SCHEMA_VERSION,
+};
+use benchmark_suite::model::LatestReport;
+use benchmark_suite::report::build_latest_report;
+use benchmark_suite::scenarios::{CardId, ThreadPoint, Topology};
+use benchmark_suite::validate::{synthetic_full_fixture, validate_publication_raw};
+
+#[test]
+fn proc_kilobytes_are_parsed_as_exact_bytes() {
+    let smaps = "00400000-00401000 r--p 00000000 00:00 0\nRss:                1234 kB\nPss:                 999 kB\n";
+    let status = "Name:\tfixture\nVmPeak:\t  5000 kB\nVmHWM:\t  4321 kB\nVmRSS:\t  1234 kB\n";
+    assert_eq!(parse_smaps_rollup(smaps).unwrap(), 1_263_616);
+    assert_eq!(parse_status_hwm(status).unwrap(), 4_424_704);
+}
+
+#[test]
+fn missing_or_malformed_proc_fields_fail_closed() {
+    for value in [
+        "Pss: 1 kB\n",
+        "Rss: nope kB\n",
+        "Rss: 1 MB\n",
+        "Rss: 1 kB\nRss: 2 kB\n",
+    ] {
+        assert!(parse_smaps_rollup(value).is_err(), "{value:?}");
+    }
+    for value in [
+        "VmRSS: 1 kB\n",
+        "VmHWM: nope kB\n",
+        "VmHWM: 1 MB\n",
+        "VmHWM: 1 kB\nVmHWM: 2 kB\n",
+    ] {
+        assert!(parse_status_hwm(value).is_err(), "{value:?}");
+    }
+}
+
+#[test]
+fn fragmentation_rejects_nonpositive_inputs_without_clamping() {
+    assert_eq!(fragmentation_proxy(4096, 2048).unwrap(), 2.0);
+    assert!(fragmentation_proxy(0, 2048).is_err());
+    assert!(fragmentation_proxy(-1, 2048).is_err());
+    assert!(fragmentation_proxy(4096, 0).is_err());
+}
+
+#[test]
+fn sampler_timestamps_are_bounded_and_inside_the_workload_window() {
+    let points = vec![
+        MemoryTimelinePoint {
+            elapsed_ns: 10_000_000,
+            rss_bytes: 100,
+        },
+        MemoryTimelinePoint {
+            elapsed_ns: 15_000_000,
+            rss_bytes: 200,
+        },
+        MemoryTimelinePoint {
+            elapsed_ns: 20_500_000,
+            rss_bytes: 150,
+        },
+    ];
+    let summary = validate_timeline(&points, 9_000_000, 21_000_000, 5_000_000).unwrap();
+    assert_eq!(summary.sample_count, 3);
+    assert_eq!(summary.maximum_interval_ns, 5_500_000);
+
+    let mut outside = points.clone();
+    outside[0].elapsed_ns = 8_000_000;
+    assert!(validate_timeline(&outside, 9_000_000, 21_000_000, 5_000_000).is_err());
+    let sparse = vec![
+        MemoryTimelinePoint {
+            elapsed_ns: 10_000_000,
+            rss_bytes: 100,
+        },
+        MemoryTimelinePoint {
+            elapsed_ns: 111_000_000,
+            rss_bytes: 200,
+        },
+    ];
+    assert!(validate_timeline(&sparse, 9_000_000, 120_000_000, 5_000_000).is_err());
+
+    let missed_leading_edge = vec![
+        MemoryTimelinePoint {
+            elapsed_ns: 110_000_001,
+            rss_bytes: 100,
+        },
+        MemoryTimelinePoint {
+            elapsed_ns: 115_000_001,
+            rss_bytes: 200,
+        },
+    ];
+    assert!(validate_timeline(&missed_leading_edge, 10_000_000, 116_000_000, 5_000_000).is_err());
+
+    let missed_trailing_edge = vec![
+        MemoryTimelinePoint {
+            elapsed_ns: 10_000_000,
+            rss_bytes: 100,
+        },
+        MemoryTimelinePoint {
+            elapsed_ns: 15_000_000,
+            rss_bytes: 200,
+        },
+    ];
+    assert!(validate_timeline(&missed_trailing_edge, 9_000_000, 115_000_001, 5_000_000).is_err());
+}
+
+#[test]
+fn sampler_must_observe_a_distinct_child_process() {
+    assert!(validate_sampler_ownership(100, 101).is_ok());
+    assert!(validate_sampler_ownership(100, 100).is_err());
+}
+
+#[test]
+fn fixed_control_records_round_trip_without_dynamic_framing() {
+    let record = ControlRecord {
+        kind: ControlKind::WorkloadDrained,
+        current_live_requested_bytes: 0,
+        peak_live_requested_bytes: 12_345,
+        checksum: 67_890,
+    };
+    let mut bytes = Vec::new();
+    write_control_record(&mut bytes, record).unwrap();
+    assert_eq!(bytes.len(), 32);
+    assert_eq!(read_control_record(&mut bytes.as_slice()).unwrap(), record);
+    bytes[5] = 1;
+    assert!(read_control_record(&mut bytes.as_slice()).is_err());
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn local_proc_sampler_reads_a_distinct_live_process() {
+    let mut child = Command::new("sleep").arg("2").spawn().unwrap();
+    let snapshot = read_proc_snapshot(child.id()).unwrap();
+    assert!(snapshot.rss_bytes > 0);
+    assert!(snapshot.hwm_bytes > 0);
+    assert_ne!(std::process::id(), child.id());
+    child.kill().unwrap();
+    child.wait().unwrap();
+}
+
+#[test]
+fn live_requested_oracle_matches_retain_then_drain() {
+    let mut oracle = LiveRequestedOracle::default();
+    oracle.allocate(4096).unwrap();
+    oracle.allocate(8192).unwrap();
+    oracle.free(4096).unwrap();
+    oracle.allocate(2048).unwrap();
+    oracle.free(8192).unwrap();
+    oracle.free(2048).unwrap();
+    assert_eq!(oracle.current_bytes(), 0);
+    assert_eq!(oracle.peak_bytes(), 12_288);
+    assert!(oracle.free(1).is_err());
+}
+
+#[test]
+fn memory_matrix_is_exact_and_protocol_has_no_purge_message() {
+    let cells = memory_scenario_cells(Topology {
+        physical_cores: 8,
+        logical_cores: 16,
+    })
+    .unwrap();
+    assert_eq!(cells.len(), 7);
+    assert!(cells.contains(&(CardId::LargeObjects, ThreadPoint::One, 1)));
+    assert!(cells.contains(&(CardId::LargeObjects, ThreadPoint::Two, 2)));
+    assert!(cells.contains(&(CardId::SawtoothRetainDrain, ThreadPoint::One, 1)));
+    assert!(cells.contains(&(CardId::SawtoothRetainDrain, ThreadPoint::PhysicalCores, 8)));
+    assert!(cells.contains(&(CardId::SmallLogMixed, ThreadPoint::PhysicalCores, 8)));
+    assert!(cells.contains(&(
+        CardId::CrossThreadProducerConsumer,
+        ThreadPoint::PhysicalCores,
+        8
+    )));
+    assert!(cells.contains(&(CardId::ThreadChurn, ThreadPoint::PhysicalCores, 8)));
+    assert_eq!(
+        ControlKind::ALL,
+        [
+            ControlKind::BaselineReady,
+            ControlKind::Begin,
+            ControlKind::WorkloadActive,
+            ControlKind::WorkloadDrained,
+            ControlKind::ExitResult,
+        ]
+    );
+}
+
+fn compatibility() -> MemoryCompatibility {
+    MemoryCompatibility {
+        metric_schema_version: MEMORY_SCHEMA_VERSION.into(),
+        page_size_bytes: 4096,
+        kernel: "6.8.0-fixture".into(),
+        sampling_target_interval_ns: 5_000_000,
+        purge_policy: "natural-only".into(),
+        transparent_hugepage: "always [madvise] never".into(),
+        cgroup_memory_max: "2147483648".into(),
+        cgroup_memory_high: "max".into(),
+        allocator_runtime_options: BTreeMap::from([
+            ("MIMALLOC_MEMORY_EVENTS".into(), "0".into()),
+            ("MIMALLOC_PROF".into(), "0".into()),
+        ]),
+    }
+}
+
+#[test]
+fn memory_comparison_key_changes_for_protocol_compatibility_fields() {
+    let original = memory_comparison_key(&compatibility()).unwrap();
+    for mutate in [
+        |value: &mut MemoryCompatibility| value.page_size_bytes = 65_536,
+        |value: &mut MemoryCompatibility| value.kernel = "6.9.0-fixture".into(),
+        |value: &mut MemoryCompatibility| value.metric_schema_version = "other-v1".into(),
+    ] {
+        let mut changed = compatibility();
+        mutate(&mut changed);
+        assert_ne!(memory_comparison_key(&changed).unwrap(), original);
+    }
+}
+
+fn memory_fixture() -> MemoryRawRun {
+    let throughput = synthetic_full_fixture().unwrap();
+    let topology = Topology {
+        physical_cores: throughput.runner.physical_cores as usize,
+        logical_cores: throughput.runner.logical_cores as usize,
+    };
+    let cells = memory_scenario_cells(topology).unwrap();
+    let cell_keys = cells
+        .iter()
+        .map(|(card, point, _)| (card.as_str(), point.name()))
+        .collect::<Vec<_>>();
+    let environment = MemoryEnvironment {
+        page_size_bytes: 4096,
+        kernel: throughput.runner.kernel.clone(),
+        transparent_hugepage: "always [madvise] never".into(),
+        cgroup_memory_max: "2147483648".into(),
+        cgroup_memory_high: "max".into(),
+        hosted_runner: throughput.runner.runner_class == "github-hosted",
+        purge_policy: "natural-only".into(),
+        allocator_runtime_options: BTreeMap::from([
+            ("MIMALLOC_MEMORY_EVENTS".into(), "0".into()),
+            ("MIMALLOC_PROF".into(), "0".into()),
+        ]),
+    };
+    let baseline = 100 * 1024 * 1024_u64;
+    let samples = throughput
+        .samples
+        .iter()
+        .filter(|sample| {
+            cell_keys.contains(&(sample.scenario_id.as_str(), sample.thread_point.as_str()))
+        })
+        .cloned()
+        .map(|child_sample| {
+            let delta_mib = match child_sample.allocator_id.as_str() {
+                "tcmalloc" => 120,
+                "jemalloc" => 110,
+                "upstream-mimalloc" => 100,
+                "mimalloc-pprof" => 90,
+                _ => unreachable!(),
+            } + u64::from(child_sample.block_id);
+            let delta = delta_mib * 1024 * 1024;
+            let sampled_peak = baseline + delta;
+            let post = baseline + delta / 2;
+            MemoryRawSample {
+                metric_schema_version: MEMORY_SCHEMA_VERSION.into(),
+                block_id: child_sample.block_id,
+                ordinal: child_sample.ordinal,
+                workload_seed: child_sample.workload_seed,
+                allocator_id: child_sample.allocator_id.clone(),
+                allocator_source_sha: child_sample.allocator_source_sha.clone(),
+                child_binary_sha256: child_sample.child_binary_sha256.clone(),
+                scenario_id: child_sample.scenario_id.clone(),
+                thread_point: child_sample.thread_point.clone(),
+                thread_count: child_sample.thread_count,
+                baseline_ready_ns: 1_000_000,
+                workload_active_ns: 9_000_000,
+                workload_drained_ns: 21_000_000,
+                post_drain_sample_100ms_ns: 121_000_000,
+                post_drain_sample_1s_ns: 1_021_000_000,
+                post_drain_sample_5s_ns: 5_021_000_000,
+                sampler_pid: 100,
+                sampled_pid: 101 + child_sample.ordinal as u32,
+                baseline_rss_bytes: baseline,
+                baseline_hwm_bytes: baseline,
+                sampled_peak_rss_bytes: sampled_peak,
+                kernel_peak_hwm_bytes: sampled_peak,
+                peak_live_requested_bytes: child_sample.peak_live_requested_bytes,
+                post_drain_rss_100ms_bytes: post,
+                post_drain_rss_1s_bytes: post,
+                post_drain_rss_5s_bytes: post,
+                sampled_peak_rss_delta_bytes: delta as i64,
+                post_drain_rss_delta_100ms_bytes: (delta / 2) as i64,
+                post_drain_rss_delta_1s_bytes: (delta / 2) as i64,
+                post_drain_rss_delta_5s_bytes: (delta / 2) as i64,
+                fragmentation_proxy: delta as f64 / child_sample.peak_live_requested_bytes as f64,
+                hwm_discrepancy: false,
+                hwm_tolerance_bytes: (8 * 1024 * 1024).max(delta / 5),
+                sampling: benchmark_suite::memory::SamplingIntervalDistribution {
+                    target_interval_ns: MEMORY_SAMPLE_TARGET_NS,
+                    sample_count: 3,
+                    minimum_interval_ns: 5_000_000,
+                    median_interval_ns: 5_000_000,
+                    p95_interval_ns: 5_000_000,
+                    maximum_interval_ns: 5_000_000,
+                },
+                timeline: vec![
+                    MemoryTimelinePoint {
+                        elapsed_ns: 10_000_000,
+                        rss_bytes: baseline + delta / 2,
+                    },
+                    MemoryTimelinePoint {
+                        elapsed_ns: 15_000_000,
+                        rss_bytes: sampled_peak,
+                    },
+                    MemoryTimelinePoint {
+                        elapsed_ns: 20_000_000,
+                        rss_bytes: baseline + delta * 3 / 4,
+                    },
+                ],
+                environment: environment.clone(),
+                child_sample,
+            }
+        })
+        .collect();
+    MemoryRawRun {
+        metric_schema_version: MEMORY_SCHEMA_VERSION.into(),
+        status: "complete".into(),
+        run_seed: throughput.run_seed,
+        run: throughput.run,
+        runner: throughput.runner,
+        allocator_lock_sha256: throughput.allocator_lock_sha256,
+        allocators: throughput.allocators,
+        calibrations: throughput
+            .calibrations
+            .into_iter()
+            .filter(|value| {
+                cell_keys.contains(&(value.scenario_id.as_str(), value.thread_point.as_str()))
+            })
+            .collect(),
+        samples,
+    }
+}
+
+#[test]
+fn complete_memory_fixture_uses_paired_lower_is_better_statistics() {
+    let raw = memory_fixture();
+    validate_memory_raw_run(&raw).unwrap();
+    let report = build_memory_report(&raw).unwrap();
+    assert_eq!(report.status, "complete");
+    assert_eq!(report.raw_samples.len(), 7 * 15 * 4);
+    assert_eq!(report.absolute_summaries.len(), 7 * 5 * 4);
+    assert_eq!(report.paired_summaries.len(), 7 * 5 * 3);
+    let planted = report
+        .paired_summaries
+        .iter()
+        .find(|summary| {
+            summary.metric_id == "sampled-peak-rss-bytes"
+                && summary.summary.candidate_id == "mimalloc-pprof"
+        })
+        .unwrap();
+    assert!(planted.summary.effect > 1.0);
+}
+
+#[test]
+fn incomplete_mixed_or_untouched_memory_data_is_rejected() {
+    let mut incomplete = memory_fixture();
+    incomplete.samples.pop();
+    assert!(validate_memory_raw_run(&incomplete).is_err());
+
+    let mut mixed = memory_fixture();
+    mixed.samples[0].environment.page_size_bytes = 65_536;
+    assert!(validate_memory_raw_run(&mixed).is_err());
+
+    let mut untouched = memory_fixture();
+    untouched.samples[0].child_sample.checksum = 0;
+    assert!(validate_memory_raw_run(&untouched).is_err());
+
+    let mut wrong_seed = memory_fixture();
+    wrong_seed.samples[0].child_sample.run_seed ^= 1;
+    assert!(validate_memory_raw_run(&wrong_seed).is_err());
+
+    let mut wrong_ordinal = memory_fixture();
+    wrong_ordinal.samples[0].child_sample.ordinal = 3;
+    assert!(validate_memory_raw_run(&wrong_ordinal).is_err());
+
+    let mut wrong_provenance = memory_fixture();
+    wrong_provenance.samples[0]
+        .child_sample
+        .allocator_library_sha256 = "f".repeat(64);
+    assert!(validate_memory_raw_run(&wrong_provenance).is_err());
+
+    let mut wrong_calibration = memory_fixture();
+    wrong_calibration.calibrations[0].operation_count += 1;
+    assert!(validate_memory_raw_run(&wrong_calibration).is_err());
+
+    let mut wrong_calibration_threads = memory_fixture();
+    wrong_calibration_threads.calibrations[0].thread_count += 1;
+    assert!(validate_memory_raw_run(&wrong_calibration_threads).is_err());
+
+    let mut mismatched_pair = memory_fixture();
+    let original = mismatched_pair.samples[0].child_sample.checksum;
+    mismatched_pair.samples[0].child_sample.checksum = original.wrapping_add(1);
+    mismatched_pair.samples[0].child_sample.checksum =
+        mismatched_pair.samples[0].child_sample.checksum.max(1);
+    assert!(validate_memory_raw_run(&mismatched_pair).is_err());
+
+    let mut zero_seed = memory_fixture();
+    zero_seed.run_seed = 0;
+    for sample in &mut zero_seed.samples {
+        sample.child_sample.run_seed = 0;
+    }
+    assert!(validate_memory_raw_run(&zero_seed).is_err());
+}
+
+#[test]
+fn old_latest_stays_pending_until_complete_memory_is_attached() {
+    let throughput = synthetic_full_fixture().unwrap();
+    let validation = validate_publication_raw(&throughput).unwrap();
+    let (old, _) = build_latest_report(&throughput, validation).unwrap();
+    let old_json = serde_json::to_vec(&old).unwrap();
+    let mut decoded: LatestReport = serde_json::from_slice(&old_json).unwrap();
+    assert!(decoded.memory.is_none());
+    assert!(decoded
+        .pending_metrics
+        .iter()
+        .any(|value| value.metric_id == "memory"));
+
+    let report = build_memory_report(&memory_fixture()).unwrap();
+    attach_memory_report(&mut decoded, report).unwrap();
+    assert!(decoded.memory.is_some());
+    assert!(!decoded
+        .pending_metrics
+        .iter()
+        .any(|value| value.metric_id == "memory"));
+}

--- a/rust/benchmark-suite/tests/timed_allocation_audit.rs
+++ b/rust/benchmark-suite/tests/timed_allocation_audit.rs
@@ -131,7 +131,10 @@ impl AllocatorAdapter for InstrumentedAdapter {
 }
 
 #[test]
-#[cfg_attr(target_os = "macos", ignore = "macOS realloc may route through the global allocator")]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "macOS realloc may route through the global allocator"
+)]
 fn ordinary_measured_region_performs_zero_harness_allocations() {
     let adapter = InstrumentedAdapter {
         layouts: Mutex::new(HashMap::new()),

--- a/rust/benchmark-suite/tests/validation.rs
+++ b/rust/benchmark-suite/tests/validation.rs
@@ -201,6 +201,7 @@ fn checked_in_schemas_are_valid_strict_json() {
         include_str!("../schema/raw-run-v1.schema.json"),
         include_str!("../schema/latest-v1.schema.json"),
         include_str!("../schema/history-v1.schema.json"),
+        include_str!("../schema/memory-v1.schema.json"),
     ] {
         let value: Value = serde_json::from_str(schema).unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary

- add the `linux-process-memory-v1` external `/proc` RSS and VmHWM protocol for all seven required memory cells and four allocators
- add strict Rust/schema/Python validation, paired lower-is-better statistics, real memory rendering, compact history, and daily carry-forward
- add a bounded weekly/manual memory workflow with raw timeline retention and sealed branch/Pages publication

## Why

Phase 6A requires process memory to be measured externally without confusing allocator counters with RSS or allowing sampler allocations to perturb the allocator under test. The child now owns workload/checksum/live-byte state while the parent owns fixed-interval kernel sampling and post-drain observations.

## Validation

- `soldr cargo test -p benchmark-suite` (Linux Docker; 67 tests plus doctests)
- real Linux `/proc/<pid>/smaps_rollup` and `/proc/<pid>/status` test against a distinct child
- `python ci/tests/test_benchmark_report.py` (15 tests)
- `python ci/tests/test_benchmark_memory_workflow.py` (5 tests)
- `python ci/tests/test_benchmark_workflow.py` (19 tests)
- Ruff, Pyright, `actionlint`, report/workflow selftests
- `/clud-review`: clean after resolving measurement-window, provenance, watchdog, and fail-closed findings

The full default-branch memory run and live publication evidence are intentionally deferred until the remaining Phase 6 feature PRs are merged, per the parent execution plan. This PR therefore references rather than closes the work package.

Refs #184
