### PR TITLE
feat(benchmarks): measure honest transaction latency

### DIFF
--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -1,0 +1,302 @@
+name: benchmark-latency
+
+# Linux-only weekly/manual transaction-latency collection. It serializes with the
+# daily producer and publishes through the same sealed branch/Pages pipeline.
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "full (publishable, >=15 blocks) or smoke (1 block, artifact only)"
+        type: choice
+        options: [full, smoke]
+        default: full
+      run_seed:
+        description: "Explicit seed (empty derives and records one)"
+        required: false
+        type: string
+      blocks:
+        description: "Blocks per cell (minimum 15 for full; smoke must use 1)"
+        type: number
+        default: 15
+        required: false
+  schedule:
+    - cron: "41 8 * * 0"
+
+concurrency:
+  group: benchmark-stats-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PUBLISH_REF: refs/heads/benchmark-stats
+
+jobs:
+  build-and-measure:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    outputs:
+      publish_eligible: ${{ steps.eligibility.outputs.publish_eligible }}
+      mode: ${{ inputs.mode || 'full' }}
+      prior_branch_sha: ${{ steps.prior.outputs.prior_sha }}
+    steps:
+      - uses: actions/checkout@v4.4.0
+        with:
+          persist-credentials: false
+      - uses: zackees/setup-soldr@62d1596b70168e422156f12273a2ed476d3a16dc
+      - name: build native allocator libraries
+        run: |
+          set -euxo pipefail
+          python3 ci/build_benchmark_allocators.py --build-root rust/target/release --jobs "$(nproc)"
+      - name: resolve prior public site
+        id: prior
+        run: |
+          set -euxo pipefail
+          git ls-remote --exit-code origin "$PUBLISH_REF" >/dev/null
+          PRIOR_SHA=$(git ls-remote origin "$PUBLISH_REF" | awk '{print $1}')
+          test -n "$PRIOR_SHA"
+          echo "prior_sha=$PRIOR_SHA" >> "$GITHUB_OUTPUT"
+          git fetch origin "$PUBLISH_REF" --depth=1
+          git checkout FETCH_HEAD -- history.jsonl latest.json
+          test -s history.jsonl
+          test -s latest.json
+          cp history.jsonl "$RUNNER_TEMP/history-input.jsonl"
+          cp latest.json "$RUNNER_TEMP/base-latest.json"
+      - name: build benchmark suite
+        run: |
+          set -euxo pipefail
+          cd rust
+          soldr cargo build -p benchmark-suite --release --locked
+      - name: determine run seed
+        id: seed
+        env:
+          INPUT_RUN_SEED: ${{ inputs.run_seed }}
+        run: |
+          set -euo pipefail
+          SEED="$INPUT_RUN_SEED"
+          if [ -z "$SEED" ]; then
+            SEED=$(( RANDOM << 17 | RANDOM << 1 | RANDOM >> 14 ))
+          fi
+          case "$SEED" in
+            *[!0-9]*) echo "::error::run_seed must be a positive decimal integer"; exit 1 ;;
+          esac
+          test "$SEED" -gt 0
+          echo "seed=$SEED" >> "$GITHUB_OUTPUT"
+      - name: run transaction latency suite
+        env:
+          LATENCY_MODE: ${{ inputs.mode || 'full' }}
+          LATENCY_BLOCKS: ${{ inputs.blocks || 15 }}
+          LATENCY_RUN_SEED: ${{ steps.seed.outputs.seed }}
+        run: |
+          set -euxo pipefail
+          cd rust
+          MODE="$LATENCY_MODE"
+          BLOCKS="$LATENCY_BLOCKS"
+          SMOKE_FLAG=""
+          if [ "$MODE" = "smoke" ]; then
+            test "$BLOCKS" = "1"
+            SMOKE_FLAG="--reduced-smoke"
+          fi
+          soldr cargo run -p benchmark-suite --bin benchmark-latency-run --release -- \
+            $SMOKE_FLAG \
+            --blocks "$BLOCKS" \
+            --run-seed "$LATENCY_RUN_SEED" \
+            --output-dir "$RUNNER_TEMP/latency-output-${{ github.run_id }}" \
+            --build-root target/release
+      - name: validate and overlay complete latency report
+        if: (inputs.mode || 'full') == 'full'
+        run: |
+          set -euxo pipefail
+          cd rust
+          soldr cargo run -p benchmark-suite --bin benchmark-latency-validate --release -- \
+            --input "$RUNNER_TEMP/latency-output-${{ github.run_id }}/latency-raw-run.json" \
+            --base-latest "$RUNNER_TEMP/base-latest.json" \
+            --report-out "$RUNNER_TEMP/latency-report.json" \
+            --latest-out "$RUNNER_TEMP/latest.json"
+      - name: render sealed site
+        if: (inputs.mode || 'full') == 'full'
+        run: |
+          set -euxo pipefail
+          mkdir -p "$RUNNER_TEMP/site"
+          python ci/benchmark_report.py render \
+            --input "$RUNNER_TEMP/latest.json" \
+            --history-in "$RUNNER_TEMP/history-input.jsonl" \
+            --output-dir "$RUNNER_TEMP/site" \
+            --detached-digest-out "$RUNNER_TEMP/manifest.sha256"
+          python ci/benchmark_report.py validate-site \
+            --site-dir "$RUNNER_TEMP/site" \
+            --detached-digest "$RUNNER_TEMP/manifest.sha256"
+      - name: compute publication eligibility
+        id: eligibility
+        if: success()
+        env:
+          LATENCY_REPOSITORY: ${{ github.repository }}
+          LATENCY_REF: ${{ github.ref }}
+          LATENCY_MODE: ${{ inputs.mode || 'full' }}
+          LATENCY_BLOCKS: ${{ inputs.blocks || 15 }}
+        run: |
+          set -euo pipefail
+          ELIGIBLE=false
+          if [ "$LATENCY_REPOSITORY" = "zackees/mimalloc-pprof" ] && \
+             [ "$LATENCY_REF" = "refs/heads/main" ] && \
+             [ "$LATENCY_MODE" = "full" ] && \
+             [ "$LATENCY_BLOCKS" -ge 15 ]; then
+            ELIGIBLE=true
+          fi
+          echo "publish_eligible=$ELIGIBLE" >> "$GITHUB_OUTPUT"
+      - name: upload raw latency artifact
+        if: always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: benchmark-latency-raw-${{ github.run_id }}-${{ github.run_attempt }}
+          path: "${{ runner.temp }}/latency-output-${{ github.run_id }}/"
+          include-hidden-files: true
+          retention-days: 30
+          if-no-files-found: error
+      - name: upload validation artifact
+        if: (inputs.mode || 'full') == 'full' && always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: benchmark-latency-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/latency-report.json
+            ${{ runner.temp }}/manifest.sha256
+          retention-days: 30
+          if-no-files-found: error
+      - name: upload site artifact
+        if: (inputs.mode || 'full') == 'full' && success()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/site/
+          include-hidden-files: true
+          retention-days: 30
+          if-no-files-found: error
+
+  artifact-audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: build-and-measure
+    if: needs.build-and-measure.outputs.mode == 'full'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit/site/
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-latency-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit/validation/
+      - name: audit sealed latency site
+        run: |
+          python ci/benchmark_report.py validate-site \
+            --site-dir audit/site/ \
+            --detached-digest audit/validation/manifest.sha256
+
+  publish-branch:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [build-and-measure, artifact-audit]
+    if: needs.build-and-measure.outputs.publish_eligible == 'true'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: site-temp/
+      - name: publish exact latency site revision
+        run: |
+          set -euxo pipefail
+          MANIFEST_DIGEST=$(sha256sum site-temp/manifest.json | awk '{print $1}')
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          WORKTREE=$(mktemp -d)
+          git worktree add --detach "$WORKTREE" HEAD
+          python ci/benchmark_report.py prepare-branch \
+            --worktree "$WORKTREE" \
+            --site-dir "$GITHUB_WORKSPACE/site-temp"
+          cd "$WORKTREE"
+          git commit -m "benchmark-latency run=${{ github.run_id }}/${{ github.run_attempt }} src=${{ github.sha }} manifest=$MANIFEST_DIGEST"
+          python "$GITHUB_WORKSPACE/ci/benchmark_report.py" validate-revision \
+            --repository "$WORKTREE" \
+            --revision HEAD \
+            --site-dir "$GITHUB_WORKSPACE/site-temp"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git push origin "HEAD:$PUBLISH_REF" --force-with-lease="refs/heads/benchmark-stats:${{ needs.build-and-measure.outputs.prior_branch_sha }}"
+          test "$(git ls-remote origin "$PUBLISH_REF" | awk '{print $1}')" = "$(git rev-parse HEAD)"
+          cd "$GITHUB_WORKSPACE"
+          git worktree remove --force "$WORKTREE"
+
+  package-pages:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [build-and-measure, artifact-audit, publish-branch]
+    if: needs.build-and-measure.outputs.publish_eligible == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: _site/
+      - uses: actions/upload-pages-artifact@v4.0.0
+        with:
+          path: _site/
+          include-hidden-files: true
+
+  deploy-pages:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [build-and-measure, artifact-audit, publish-branch, package-pages]
+    if: needs.build-and-measure.outputs.publish_eligible == 'true'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4.0.5
+        id: deployment
+
+  publication-audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: [build-and-measure, publish-branch, deploy-pages]
+    if: needs.build-and-measure.outputs.publish_eligible == 'true' && always()
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          path: audit/site/
+      - name: audit latency publication
+        run: |
+          set -euxo pipefail
+          git fetch origin refs/heads/benchmark-stats --depth=1
+          python ci/benchmark_report.py validate-revision \
+            --repository . \
+            --revision FETCH_HEAD \
+            --site-dir audit/site/
+          python ci/benchmark_report.py audit-pages \
+            --site-dir audit/site/ \
+            --page-url "${{ needs.deploy-pages.outputs.page_url }}"
+          echo "Latency publication branch and Pages bytes match." >> "$GITHUB_STEP_SUMMARY"

--- a/ci/benchmark_report.py
+++ b/ci/benchmark_report.py
@@ -70,7 +70,7 @@ TOP_LEVEL_FIELDS = {
     "reproduction_command",
     "actions_run_url",
 }
-OPTIONAL_TOP_LEVEL_FIELDS = {"memory"}
+OPTIONAL_TOP_LEVEL_FIELDS = {"memory", "latency"}
 HISTORY_FIELDS = {
     "history_schema_version",
     "statistics_version",
@@ -82,7 +82,7 @@ HISTORY_FIELDS = {
     "absolute_summaries",
     "paired_summaries",
 }
-OPTIONAL_HISTORY_FIELDS = {"memory"}
+OPTIONAL_HISTORY_FIELDS = {"memory", "latency"}
 RUN_FIELDS = {
     "source_repository",
     "source_sha",
@@ -153,7 +153,7 @@ ROLES = {
     "benchmark-throughput.png": "throughput-chart",
     "benchmark-history.png": "history-chart",
     "benchmark-memory.png": "memory-panel",
-    "benchmark-latency.png": "pending-latency-panel",
+    "benchmark-latency.png": "latency-panel",
     "benchmark-scaling.png": "pending-scaling-panel",
     "benchmark-pprof-tax.png": "pending-pprof-tax-panel",
 }
@@ -175,6 +175,31 @@ MEMORY_CELLS = (
     ("cross-thread-producer-consumer", "physical-core"),
     ("thread-churn", "physical-core"),
 )
+LATENCY_SCHEMA = "transaction-latency-v1"
+LATENCY_CHILD_PROTOCOL = "transaction-latency-child-v1"
+LATENCY_CELLS = (
+    ("tiny-fixed-64", "1"),
+    ("small-log-mixed", "1"),
+    ("small-log-mixed", "physical-core"),
+    ("cross-thread-producer-consumer", "physical-core"),
+    ("large-objects", "1"),
+)
+LATENCY_REPORT_FIELDS = {
+    "metric_schema_version",
+    "status",
+    "invalid_reason",
+    "metric_comparison_key",
+    "run",
+    "runner",
+    "direction",
+    "informational",
+    "sampling_denominators",
+    "methodology",
+    "absolute_summaries",
+    "paired_summaries",
+    "block_summaries",
+    "raw_samples",
+}
 MEMORY_REPORT_FIELDS = {
     "metric_schema_version",
     "status",
@@ -1095,6 +1120,664 @@ def validate_memory_report(
     return report
 
 
+def validate_latency_distribution(value: object, label: str) -> dict[str, object]:
+    distribution = object_value(value, label)
+    exact_fields(
+        distribution,
+        {
+            "count",
+            "p50_ns",
+            "p95_ns",
+            "p99_ns",
+            "min_ns",
+            "max_ns",
+            "median_absolute_deviation_ns",
+            "iqr_ns",
+            "zero_count",
+        },
+        label,
+    )
+    count = int_value(distribution.get("count"), f"{label}.count", 1)
+    p50 = float_value(distribution.get("p50_ns"), f"{label}.p50_ns", True)
+    p95 = float_value(distribution.get("p95_ns"), f"{label}.p95_ns", True)
+    p99 = float_value(distribution.get("p99_ns"), f"{label}.p99_ns", True)
+    minimum = int_value(distribution.get("min_ns"), f"{label}.min_ns", 1)
+    maximum = int_value(distribution.get("max_ns"), f"{label}.max_ns", 1)
+    float_value(
+        distribution.get("median_absolute_deviation_ns"),
+        f"{label}.median_absolute_deviation_ns",
+    )
+    float_value(distribution.get("iqr_ns"), f"{label}.iqr_ns")
+    if (
+        distribution.get("zero_count") != 0
+        or not minimum <= p50 <= p95 <= p99 <= maximum
+        or count < 1
+    ):
+        fail(f"{label}: invalid latency order statistics or zero duration")
+    return distribution
+
+
+def latency_type7(values: Sequence[int | float], probability: float) -> float:
+    if not values or not 0.0 <= probability <= 1.0:
+        fail("latency Type-7 input is empty or has an invalid probability")
+    ordered = sorted(float(value) for value in values)
+    position = (len(ordered) - 1) * probability
+    lower = math.floor(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    return ordered[lower] + (position - lower) * (ordered[upper] - ordered[lower])
+
+
+def summarize_latency_values(values: Sequence[int]) -> dict[str, object]:
+    if not values or any(value <= 0 for value in values):
+        fail("latency raw distribution is empty or contains a non-positive duration")
+    p50 = latency_type7(values, 0.50)
+    q1 = latency_type7(values, 0.25)
+    q3 = latency_type7(values, 0.75)
+    return {
+        "count": len(values),
+        "p50_ns": p50,
+        "p95_ns": latency_type7(values, 0.95),
+        "p99_ns": latency_type7(values, 0.99),
+        "min_ns": min(values),
+        "max_ns": max(values),
+        "median_absolute_deviation_ns": latency_type7(
+            [abs(float(value) - p50) for value in values], 0.50
+        ),
+        "iqr_ns": q3 - q1,
+        "zero_count": 0,
+    }
+
+
+def validate_latency_scheduling(value: object, label: str) -> dict[str, object]:
+    scheduling = object_value(value, label)
+    exact_fields(
+        scheduling,
+        {
+            "affinity_policy",
+            "actual_cpu_ids",
+            "thread_count",
+            "physical_cores",
+            "logical_cores",
+            "context_switches",
+            "runner_class",
+            "clock",
+        },
+        label,
+    )
+    string_value(scheduling.get("affinity_policy"), f"{label}.affinity_policy")
+    string_value(scheduling.get("runner_class"), f"{label}.runner_class")
+    thread_count = int_value(scheduling.get("thread_count"), f"{label}.thread_count", 1)
+    physical = int_value(scheduling.get("physical_cores"), f"{label}.physical_cores", 1)
+    logical = int_value(scheduling.get("logical_cores"), f"{label}.logical_cores", 1)
+    if physical > logical:
+        fail(f"{label}: physical cores exceed logical cores")
+    cpu_ids = list_value(scheduling.get("actual_cpu_ids"), f"{label}.actual_cpu_ids")
+    if len(cpu_ids) != thread_count:
+        fail(f"{label}.actual_cpu_ids: expected one observation per worker")
+    for index, cpu in enumerate(cpu_ids):
+        if cpu is not None:
+            int_value(cpu, f"{label}.actual_cpu_ids[{index}]")
+    switches = object_value(scheduling.get("context_switches"), f"{label}.context_switches")
+    exact_fields(switches, {"voluntary", "involuntary"}, f"{label}.context_switches")
+    int_value(switches.get("voluntary"), f"{label}.context_switches.voluntary")
+    int_value(switches.get("involuntary"), f"{label}.context_switches.involuntary")
+    clock = object_value(scheduling.get("clock"), f"{label}.clock")
+    exact_fields(clock, {"source", "implementation", "resolution_ns"}, f"{label}.clock")
+    if clock.get("source") != "monotonic":
+        fail(f"{label}.clock.source: monotonic clock required")
+    string_value(clock.get("implementation"), f"{label}.clock.implementation")
+    int_value(clock.get("resolution_ns"), f"{label}.clock.resolution_ns", 1)
+    return scheduling
+
+
+def validate_latency_child(value: object, label: str, control: bool) -> dict[str, object]:
+    child = object_value(value, label)
+    exact_fields(
+        child,
+        {
+            "protocol_version",
+            "metric_schema_version",
+            "control",
+            "completed_transactions",
+            "checksum",
+            "observations",
+            "scheduling",
+        },
+        label,
+    )
+    if (
+        child.get("protocol_version") != LATENCY_CHILD_PROTOCOL
+        or child.get("metric_schema_version") != LATENCY_SCHEMA
+        or child.get("control") is not control
+    ):
+        fail(f"{label}: latency child identity/control mismatch")
+    int_value(child.get("completed_transactions"), f"{label}.completed_transactions", 1)
+    int_value(child.get("checksum"), f"{label}.checksum", 1)
+    observations = list_value(child.get("observations"), f"{label}.observations")
+    if not observations:
+        fail(f"{label}.observations: empty")
+    previous: tuple[int, int] | None = None
+    for index, value in enumerate(observations):
+        item = object_value(value, f"{label}.observations[{index}]")
+        exact_fields(
+            item,
+            {"thread_index", "transaction_index", "duration_ns"},
+            f"{label}.observations[{index}]",
+        )
+        key = (
+            int_value(item.get("thread_index"), f"{label}.observations[{index}].thread_index"),
+            int_value(
+                item.get("transaction_index"),
+                f"{label}.observations[{index}].transaction_index",
+            ),
+        )
+        int_value(item.get("duration_ns"), f"{label}.observations[{index}].duration_ns", 1)
+        if previous is not None and key <= previous:
+            fail(f"{label}.observations: schedule must be strictly ordered")
+        previous = key
+    validate_latency_scheduling(child.get("scheduling"), f"{label}.scheduling")
+    return child
+
+
+def latency_schedule(child: Mapping[str, object], label: str) -> list[tuple[int, int]]:
+    return [
+        (
+            cast(int, object_value(value, label)["thread_index"]),
+            cast(int, object_value(value, label)["transaction_index"]),
+        )
+        for value in list_value(child["observations"], label)
+    ]
+
+
+def validate_latency_paired(value: object, label: str) -> dict[str, object]:
+    item = object_value(value, label)
+    exact_fields(item, {"scenario_id", "thread_point", "quantile", "summary"}, label)
+    if (item.get("scenario_id"), item.get("thread_point")) not in LATENCY_CELLS:
+        fail(f"{label}: undeclared latency cell")
+    if item.get("quantile") not in ("p50", "p95", "p99"):
+        fail(f"{label}.quantile: unsupported")
+    summary = object_value(item.get("summary"), f"{label}.summary")
+    exact_fields(
+        summary,
+        {
+            "candidate_id",
+            "reference_id",
+            "direction",
+            "block_count",
+            "effect",
+            "confidence_interval",
+            "bootstrap",
+            "informational",
+        },
+        f"{label}.summary",
+    )
+    if (
+        summary.get("candidate_id") not in set(ALLOCATOR_IDS) - {"upstream-mimalloc"}
+        or summary.get("reference_id") != "upstream-mimalloc"
+        or summary.get("direction") != "lower-is-better"
+        or summary.get("informational") is not True
+    ):
+        fail(f"{label}.summary: invalid paired latency identity")
+    int_value(summary.get("block_count"), f"{label}.summary.block_count", 15)
+    float_value(summary.get("effect"), f"{label}.summary.effect", True)
+    interval = object_value(summary.get("confidence_interval"), f"{label}.summary.interval")
+    exact_fields(interval, {"lower", "upper", "confidence_level"}, f"{label}.summary.interval")
+    lower = float_value(interval.get("lower"), f"{label}.summary.interval.lower", True)
+    upper = float_value(interval.get("upper"), f"{label}.summary.interval.upper", True)
+    if interval.get("confidence_level") != 0.95 or lower > upper:
+        fail(f"{label}.summary.interval: invalid")
+    bootstrap = object_value(summary.get("bootstrap"), f"{label}.summary.bootstrap")
+    exact_fields(
+        bootstrap, {"seed", "resample_count", "method", "prng"}, f"{label}.summary.bootstrap"
+    )
+    if (
+        int_value(bootstrap.get("seed"), f"{label}.summary.bootstrap.seed") < 0
+        or bootstrap.get("resample_count") != 10_000
+        or bootstrap.get("method") != "percentile-whole-block-transaction-quantile-type7-v1"
+        or bootstrap.get("prng") != "splitmix64-rejection-v1"
+    ):
+        fail(f"{label}.summary.bootstrap: unsupported block bootstrap")
+    return item
+
+
+def validate_latency_report(
+    value: object, label: str, *, compact: bool = False
+) -> dict[str, object]:
+    report = object_value(value, label)
+    required = LATENCY_REPORT_FIELDS - (
+        {"invalid_reason", "runner", "raw_samples"} if compact else set()
+    )
+    if compact:
+        required.add("runner_fingerprint_sha256")
+    exact_fields(report, required, label)
+    if (
+        report.get("metric_schema_version") != LATENCY_SCHEMA
+        or report.get("status") != "complete"
+        or report.get("direction") != "lower-is-better"
+        or report.get("informational") is not True
+    ):
+        fail(f"{label}: complete informational lower-is-better latency required")
+    comparison_digest(report.get("metric_comparison_key"), f"{label}.metric_comparison_key")
+    validate_run(report.get("run"), f"{label}.run")
+    runner: dict[str, object] | None = None
+    if compact:
+        digest = string_value(
+            report.get("runner_fingerprint_sha256"), f"{label}.runner_fingerprint_sha256"
+        )
+        if not HEX_64.fullmatch(digest):
+            fail(f"{label}.runner_fingerprint_sha256: invalid")
+    else:
+        if report.get("invalid_reason") is not None:
+            fail(f"{label}.invalid_reason: must be null")
+        runner = validate_runner(report.get("runner"), f"{label}.runner")
+    rates = object_value(report.get("sampling_denominators"), f"{label}.sampling_denominators")
+    if set(rates) != {f"{scenario}/{point}" for scenario, point in LATENCY_CELLS}:
+        fail(f"{label}.sampling_denominators: exact latency cell matrix required")
+    for cell, rate in rates.items():
+        denominator = int_value(rate, f"{label}.sampling_denominators.{cell}", 1)
+        if denominator > 1024:
+            fail(f"{label}.sampling_denominators.{cell}: exceeds protocol maximum")
+    methodology = object_value(report.get("methodology"), f"{label}.methodology")
+    exact_fields(
+        methodology,
+        {
+            "transaction_boundaries",
+            "quantile_method",
+            "sampling_schedule",
+            "overhead_control",
+            "bootstrap",
+            "storage_decision",
+            "tail_policy",
+        },
+        f"{label}.methodology",
+    )
+    boundaries = object_value(
+        methodology.get("transaction_boundaries"), f"{label}.methodology.transaction_boundaries"
+    )
+    exact_fields(
+        boundaries,
+        {"local", "cross-thread", "large-object"},
+        f"{label}.methodology.transaction_boundaries",
+    )
+    for field in (
+        "quantile_method",
+        "sampling_schedule",
+        "overhead_control",
+        "bootstrap",
+        "storage_decision",
+        "tail_policy",
+    ):
+        string_value(methodology.get(field), f"{label}.methodology.{field}")
+    for key in boundaries:
+        definition = string_value(
+            boundaries[key], f"{label}.methodology.transaction_boundaries.{key}"
+        )
+        if "free" not in definition or "allocation" not in definition:
+            fail(f"{label}.methodology: transaction boundary must include allocation through free")
+
+    absolute = list_value(report.get("absolute_summaries"), f"{label}.absolute_summaries")
+    if len(absolute) != 20:
+        fail(f"{label}.absolute_summaries: expected exact 5x4 matrix")
+    absolute_keys: set[tuple[str, str, str]] = set()
+    for index, value in enumerate(absolute):
+        item = object_value(value, f"{label}.absolute_summaries[{index}]")
+        exact_fields(
+            item,
+            {
+                "allocator_id",
+                "scenario_id",
+                "thread_point",
+                "transaction_definition",
+                "measured",
+                "control",
+                "overhead_valid",
+            },
+            f"{label}.absolute_summaries[{index}]",
+        )
+        key = (
+            cast(str, item.get("scenario_id")),
+            cast(str, item.get("thread_point")),
+            cast(str, item.get("allocator_id")),
+        )
+        if key[:2] not in LATENCY_CELLS or key[2] not in ALLOCATOR_IDS or key in absolute_keys:
+            fail(f"{label}.absolute_summaries[{index}]: duplicate or undeclared cell")
+        absolute_keys.add(key)
+        definition = string_value(
+            item.get("transaction_definition"),
+            f"{label}.absolute_summaries[{index}].transaction_definition",
+        )
+        if (
+            "allocation" not in definition
+            or "free" not in definition
+            or "allocator-call" in definition
+        ):
+            fail(f"{label}.absolute_summaries[{index}]: dishonest transaction label")
+        measured = validate_latency_distribution(
+            item.get("measured"), f"{label}.absolute_summaries[{index}].measured"
+        )
+        control = validate_latency_distribution(
+            item.get("control"), f"{label}.absolute_summaries[{index}].control"
+        )
+        if (
+            int_value(measured["count"], "latency measured count") < 10_000
+            or int_value(control["count"], "latency control count") < 10_000
+            or item.get("overhead_valid") is not True
+            or cast(float, control["p50_ns"]) > cast(float, measured["p50_ns"]) * 0.05
+            or cast(float, measured["p99_ns"]) <= cast(float, control["p99_ns"]) * 2.0
+        ):
+            fail(f"{label}.absolute_summaries[{index}]: control/sample threshold failed")
+
+    paired = list_value(report.get("paired_summaries"), f"{label}.paired_summaries")
+    if len(paired) != 45:
+        fail(f"{label}.paired_summaries: expected exact quantile matrix")
+    paired_keys: set[tuple[str, str, str, str]] = set()
+    for index, value in enumerate(paired):
+        item = validate_latency_paired(value, f"{label}.paired_summaries[{index}]")
+        summary = object_value(item["summary"], f"{label}.paired_summaries[{index}].summary")
+        key = (
+            cast(str, item["scenario_id"]),
+            cast(str, item["thread_point"]),
+            cast(str, item["quantile"]),
+            cast(str, summary["candidate_id"]),
+        )
+        if key in paired_keys:
+            fail(f"{label}.paired_summaries[{index}]: duplicate")
+        paired_keys.add(key)
+
+    blocks = list_value(report.get("block_summaries"), f"{label}.block_summaries")
+    if len(blocks) < 300:
+        fail(f"{label}.block_summaries: at least 15 blocks per allocator/cell required")
+    block_keys: set[tuple[str, str, str, int]] = set()
+    for index, value in enumerate(blocks):
+        item = object_value(value, f"{label}.block_summaries[{index}]")
+        exact_fields(
+            item,
+            {"block_id", "allocator_id", "scenario_id", "thread_point", "measured", "control"},
+            f"{label}.block_summaries[{index}]",
+        )
+        key = (
+            cast(str, item.get("scenario_id")),
+            cast(str, item.get("thread_point")),
+            cast(str, item.get("allocator_id")),
+            int_value(item.get("block_id"), f"{label}.block_summaries[{index}].block_id"),
+        )
+        if key[:2] not in LATENCY_CELLS or key[2] not in ALLOCATOR_IDS or key in block_keys:
+            fail(f"{label}.block_summaries[{index}]: duplicate or undeclared")
+        block_keys.add(key)
+        validate_latency_distribution(
+            item.get("measured"), f"{label}.block_summaries[{index}].measured"
+        )
+        validate_latency_distribution(
+            item.get("control"), f"{label}.block_summaries[{index}].control"
+        )
+    for scenario, point in LATENCY_CELLS:
+        for allocator in ALLOCATOR_IDS:
+            if sum(1 for key in block_keys if key[:3] == (scenario, point, allocator)) < 15:
+                fail(f"{label}: incomplete block matrix for {scenario}/{point}/{allocator}")
+
+    if compact:
+        return report
+    raw = list_value(report.get("raw_samples"), f"{label}.raw_samples")
+    if len(raw) < 300:
+        fail(f"{label}.raw_samples: incomplete")
+    raw_groups: dict[tuple[str, str, str], list[dict[str, object]]] = {}
+    raw_blocks: dict[tuple[str, str, int], list[dict[str, object]]] = {}
+    paired_schedules: dict[tuple[str, str, int], tuple[int, list[tuple[int, int]]]] = {}
+    allocator_identities: dict[str, tuple[object, object]] = {}
+    common_clock: object | None = None
+    common_block_ids: set[int] | None = None
+    for index, value in enumerate(raw):
+        item = object_value(value, f"{label}.raw_samples[{index}]")
+        exact_fields(
+            item,
+            {
+                "metric_schema_version",
+                "block_id",
+                "ordinal",
+                "workload_seed",
+                "allocator_id",
+                "allocator_source_sha",
+                "child_binary_sha256",
+                "scenario_id",
+                "thread_point",
+                "thread_count",
+                "sample_denominator",
+                "transaction_definition",
+                "measured",
+                "control",
+            },
+            f"{label}.raw_samples[{index}]",
+        )
+        if item.get("metric_schema_version") != LATENCY_SCHEMA:
+            fail(f"{label}.raw_samples[{index}]: schema mismatch")
+        scenario = string_value(
+            item.get("scenario_id"), f"{label}.raw_samples[{index}].scenario_id"
+        )
+        point = string_value(item.get("thread_point"), f"{label}.raw_samples[{index}].thread_point")
+        allocator = string_value(
+            item.get("allocator_id"), f"{label}.raw_samples[{index}].allocator_id"
+        )
+        if (scenario, point) not in LATENCY_CELLS or allocator not in ALLOCATOR_IDS:
+            fail(f"{label}.raw_samples[{index}]: undeclared cell or allocator")
+        if not HEX_40.fullmatch(
+            string_value(
+                item.get("allocator_source_sha"),
+                f"{label}.raw_samples[{index}].allocator_source_sha",
+            )
+        ):
+            fail(f"{label}.raw_samples[{index}].allocator_source_sha: invalid")
+        comparison_digest(
+            item.get("child_binary_sha256"), f"{label}.raw_samples[{index}].child_binary_sha256"
+        )
+        block = int_value(item.get("block_id"), f"{label}.raw_samples[{index}].block_id")
+        ordinal = int_value(item.get("ordinal"), f"{label}.raw_samples[{index}].ordinal")
+        if ordinal > 3:
+            fail(f"{label}.raw_samples[{index}].ordinal: invalid")
+        seed = int_value(
+            item.get("workload_seed"), f"{label}.raw_samples[{index}].workload_seed", 1
+        )
+        denominator = int_value(
+            item.get("sample_denominator"), f"{label}.raw_samples[{index}].sample_denominator", 1
+        )
+        if denominator != rates[f"{scenario}/{point}"]:
+            fail(f"{label}.raw_samples[{index}]: sample rate differs from comparison key input")
+        definition = string_value(
+            item.get("transaction_definition"),
+            f"{label}.raw_samples[{index}].transaction_definition",
+        )
+        if (
+            "allocation" not in definition
+            or "free" not in definition
+            or "allocator-call" in definition
+        ):
+            fail(f"{label}.raw_samples[{index}]: invalid transaction definition")
+        measured = validate_latency_child(
+            item.get("measured"), f"{label}.raw_samples[{index}].measured", False
+        )
+        control = validate_latency_child(
+            item.get("control"), f"{label}.raw_samples[{index}].control", True
+        )
+        measured_schedule = latency_schedule(measured, f"{label}.raw_samples[{index}].measured")
+        if measured_schedule != latency_schedule(control, f"{label}.raw_samples[{index}].control"):
+            fail(f"{label}.raw_samples[{index}]: measured/control schedules differ")
+        measured_scheduling = object_value(measured["scheduling"], "latency measured scheduling")
+        control_scheduling = object_value(control["scheduling"], "latency control scheduling")
+        for field in (
+            "affinity_policy",
+            "thread_count",
+            "physical_cores",
+            "logical_cores",
+            "clock",
+        ):
+            if measured_scheduling[field] != control_scheduling[field]:
+                fail(f"{label}.raw_samples[{index}]: measured/control scheduling differs")
+        thread_count = int_value(
+            item.get("thread_count"), f"{label}.raw_samples[{index}].thread_count", 1
+        )
+        expected_threads = (
+            1
+            if point == "1"
+            else cast(int, runner["physical_cores"])
+            if runner is not None
+            else thread_count
+        )
+        completed = int_value(
+            measured.get("completed_transactions"),
+            f"{label}.raw_samples[{index}].measured.completed_transactions",
+            1,
+        )
+        if (
+            control.get("completed_transactions") != completed
+            or completed % thread_count != 0
+            or thread_count != expected_threads
+            or measured_scheduling["thread_count"] != thread_count
+            or control.get("checksum") != 1
+            or measured.get("checksum") == 1
+            or any(
+                worker >= thread_count or transaction >= completed // thread_count
+                for worker, transaction in measured_schedule
+            )
+        ):
+            fail(f"{label}.raw_samples[{index}]: transaction count/checksum/topology mismatch")
+        if runner is not None:
+            affinity = object_value(runner["affinity"], f"{label}.runner.affinity")
+            if (
+                measured_scheduling["physical_cores"] != runner["physical_cores"]
+                or measured_scheduling["logical_cores"] != runner["logical_cores"]
+                or measured_scheduling["runner_class"] != runner["runner_class"]
+                or control_scheduling["runner_class"] != runner["runner_class"]
+                or measured_scheduling["affinity_policy"] != affinity["policy"]
+            ):
+                fail(f"{label}.raw_samples[{index}]: scheduling contradicts report runner")
+            if affinity["policy"] == "pinned":
+                allowed = set(cast(list[int], affinity["logical_cpu_ids"]))
+                observed = list_value(
+                    measured_scheduling["actual_cpu_ids"], "latency measured CPU IDs"
+                ) + list_value(control_scheduling["actual_cpu_ids"], "latency control CPU IDs")
+                if any(cpu is None or cpu not in allowed for cpu in observed):
+                    fail(f"{label}.raw_samples[{index}]: pinned CPU assignment was not observed")
+        clock = measured_scheduling["clock"]
+        if common_clock is None:
+            common_clock = clock
+        elif clock != common_clock:
+            fail(f"{label}.raw_samples[{index}]: mixed monotonic clocks")
+        identity = (item["allocator_source_sha"], item["child_binary_sha256"])
+        prior_identity = allocator_identities.setdefault(allocator, identity)
+        if identity != prior_identity:
+            fail(f"{label}.raw_samples[{index}]: allocator provenance changed within run")
+        pair_key = (scenario, point, block)
+        if pair_key in paired_schedules:
+            expected_seed, expected_schedule = paired_schedules[pair_key]
+            if seed != expected_seed or measured_schedule != expected_schedule:
+                fail(
+                    f"{label}.raw_samples[{index}]: allocator sample schedule differs within block"
+                )
+        else:
+            paired_schedules[pair_key] = (seed, measured_schedule)
+        raw_groups.setdefault((scenario, point, allocator), []).append(item)
+        raw_blocks.setdefault(pair_key, []).append(item)
+    for scenario, point in LATENCY_CELLS:
+        cell_block_ids: set[int] | None = None
+        for allocator in ALLOCATOR_IDS:
+            group = raw_groups.get((scenario, point, allocator), [])
+            block_ids = {cast(int, item["block_id"]) for item in group}
+            if len(group) < 15 or len(block_ids) != len(group):
+                fail(f"{label}: incomplete/duplicate raw blocks for {scenario}/{point}/{allocator}")
+            if cell_block_ids is None:
+                cell_block_ids = block_ids
+            elif block_ids != cell_block_ids:
+                fail(f"{label}: allocators do not share an exact raw block set")
+            for child_name in ("measured", "control"):
+                count = sum(
+                    len(
+                        list_value(
+                            object_value(item[child_name], "latency child")["observations"],
+                            "latency observations",
+                        )
+                    )
+                    for item in group
+                )
+                if count < 10_000:
+                    fail(
+                        f"{label}: {scenario}/{point}/{allocator}/{child_name} has fewer than 10000 samples"
+                    )
+        if cell_block_ids is None:
+            fail(f"{label}: latency cell contains no blocks")
+        if common_block_ids is None:
+            common_block_ids = cell_block_ids
+        elif cell_block_ids != common_block_ids:
+            fail(f"{label}: latency cells do not share an exact raw block set")
+    if common_block_ids is None or common_block_ids != set(range(len(common_block_ids))):
+        fail(f"{label}: latency block IDs must be contiguous from zero")
+    if len(raw) != len(LATENCY_CELLS) * len(ALLOCATOR_IDS) * len(common_block_ids):
+        fail(f"{label}: raw latency matrix contains missing or extra records")
+    for (scenario, point, block_id), group in raw_blocks.items():
+        if (
+            len(group) != 4
+            or {item["allocator_id"] for item in group} != set(ALLOCATOR_IDS)
+            or {item["ordinal"] for item in group} != {0, 1, 2, 3}
+            or len({item["workload_seed"] for item in group}) != 1
+        ):
+            fail(f"{label}: incomplete paired raw block {scenario}/{point}/{block_id}")
+
+    raw_keys = {
+        (
+            cast(str, item["scenario_id"]),
+            cast(str, item["thread_point"]),
+            cast(str, item["allocator_id"]),
+            cast(int, item["block_id"]),
+        )
+        for item in cast(list[dict[str, object]], raw)
+    }
+    if raw_keys != block_keys or len(blocks) != len(raw):
+        fail(f"{label}: block summaries do not exactly cover raw latency records")
+    block_by_key = {
+        (
+            cast(str, object_value(item, "latency block")["scenario_id"]),
+            cast(str, object_value(item, "latency block")["thread_point"]),
+            cast(str, object_value(item, "latency block")["allocator_id"]),
+            cast(int, object_value(item, "latency block")["block_id"]),
+        ): object_value(item, "latency block")
+        for item in blocks
+    }
+    absolute_by_key = {
+        (
+            cast(str, object_value(item, "latency absolute")["scenario_id"]),
+            cast(str, object_value(item, "latency absolute")["thread_point"]),
+            cast(str, object_value(item, "latency absolute")["allocator_id"]),
+        ): object_value(item, "latency absolute")
+        for item in absolute
+    }
+    for group_key, group in raw_groups.items():
+        measured_values: list[int] = []
+        control_values: list[int] = []
+        for item in group:
+            measured = object_value(item["measured"], "latency measured")
+            control = object_value(item["control"], "latency control")
+            measured_block = [
+                cast(int, object_value(value, "latency observation")["duration_ns"])
+                for value in list_value(measured["observations"], "latency observations")
+            ]
+            control_block = [
+                cast(int, object_value(value, "latency observation")["duration_ns"])
+                for value in list_value(control["observations"], "latency observations")
+            ]
+            measured_values.extend(measured_block)
+            control_values.extend(control_block)
+            key = (*group_key, cast(int, item["block_id"]))
+            block_summary = block_by_key[key]
+            if block_summary["measured"] != summarize_latency_values(
+                measured_block
+            ) or block_summary["control"] != summarize_latency_values(control_block):
+                fail(f"{label}: latency block summary differs from raw durations")
+        absolute_summary = absolute_by_key[group_key]
+        if absolute_summary["measured"] != summarize_latency_values(
+            measured_values
+        ) or absolute_summary["control"] != summarize_latency_values(control_values):
+            fail(f"{label}: latency absolute summary differs from raw durations")
+    return report
+
+
 def validate_latest(latest: dict[str, object], label: str) -> None:
     exact_fields_with_optional(latest, TOP_LEVEL_FIELDS, OPTIONAL_TOP_LEVEL_FIELDS, label)
     versions = {
@@ -1252,11 +1935,33 @@ def validate_latest(latest: dict[str, object], label: str) -> None:
         }
         if observed_sources != expected_sources:
             fail(f"{label}.memory: allocator source pins differ from the core run")
+    latency = latest.get("latency")
+    if latency is not None:
+        latency_report = validate_latency_report(latency, f"{label}.latency")
+        expected_sources = {
+            object_value(value, f"{label}.allocators")["allocator_id"]: object_value(
+                value, f"{label}.allocators"
+            )["source_sha"]
+            for value in allocators
+        }
+        observed_sources = {
+            object_value(value, f"{label}.latency.raw_samples")["allocator_id"]: object_value(
+                value, f"{label}.latency.raw_samples"
+            )["allocator_source_sha"]
+            for value in list_value(latency_report["raw_samples"], f"{label}.latency.raw_samples")
+        }
+        if observed_sources != expected_sources:
+            fail(f"{label}.latency: allocator source pins differ from the core run")
     pending = list_value(latest.get("pending_metrics"), f"{label}.pending_metrics")
-    expected_pending = (
-        ("latency", "scaling", "pprof-tax")
-        if memory is not None
-        else ("memory", "latency", "scaling", "pprof-tax")
+    expected_pending = tuple(
+        metric
+        for metric, complete in (
+            ("memory", memory is not None),
+            ("latency", latency is not None),
+            ("scaling", False),
+            ("pprof-tax", False),
+        )
+        if not complete
     )
     if len(pending) != len(expected_pending):
         fail(f"{label}.pending_metrics: does not match collected optional metrics")
@@ -1342,6 +2047,14 @@ def history_row(
             for key, value in memory.items()
             if key not in {"invalid_reason", "runner", "raw_samples"}
         } | {"runner_fingerprint_sha256": runner["fingerprint_sha256"]}
+    if include_optional_metrics and "latency" in latest:
+        latency = validate_latency_report(latest["latency"], "latest.latency")
+        runner = object_value(latency["runner"], "latest.latency.runner")
+        row["latency"] = {
+            key: value
+            for key, value in latency.items()
+            if key not in {"invalid_reason", "runner", "raw_samples"}
+        } | {"runner_fingerprint_sha256": runner["fingerprint_sha256"]}
     return row
 
 
@@ -1401,6 +2114,8 @@ def validate_history_row(value: object, label: str) -> dict[str, object]:
         validate_paired(item, f"{label}.paired_summaries[{index}]")
     if "memory" in row:
         validate_memory_report(row["memory"], f"{label}.memory", compact=True)
+    if "latency" in row:
+        validate_latency_report(row["latency"], f"{label}.latency", compact=True)
     return row
 
 
@@ -1455,9 +2170,11 @@ def merge_history(
         run = object_value(row["run"], "history run")
         if (run["run_id"], run["run_attempt"]) != current_identity:
             continue
-        previous_base = {key: value for key, value in row.items() if key != "memory"}
-        current_base = {key: value for key, value in current.items() if key != "memory"}
-        if previous_base != current_base or "memory" not in current:
+        optional = {"memory", "latency"}
+        previous_base = {key: value for key, value in row.items() if key not in optional}
+        current_base = {key: value for key, value in current.items() if key not in optional}
+        gained = (set(current) & optional) - (set(row) & optional)
+        if previous_base != current_base or not gained:
             fail("history append: duplicate run may only gain a validated optional metric")
         combined[index] = current
         break
@@ -1626,18 +2343,61 @@ def memory_png(memory: Mapping[str, object]) -> bytes:
     return encode_png(960, 540, canvas.pixels, "Linux process RSS; lower is better")
 
 
+def latency_png(latency: Mapping[str, object]) -> bytes:
+    canvas = Canvas(960, 540, (248, 250, 252))
+    canvas.rectangle(0, 0, 960, 62, (24, 35, 52))
+    records = [
+        object_value(value, "latency absolute summary")
+        for value in list_value(latency["absolute_summaries"], "latency absolute summaries")
+    ]
+    cells: dict[tuple[str, str], list[dict[str, object]]] = {}
+    for record in records:
+        key = (cast(str, record["scenario_id"]), cast(str, record["thread_point"]))
+        cells.setdefault(key, []).append(record)
+    for ordinal, (_key, values) in enumerate(sorted(cells.items())):
+        column, row = ordinal % 2, ordinal // 2
+        left, top = 45 + column * 460, 85 + row * 145
+        canvas.rectangle(left, top, 420, 120, (235, 240, 246))
+        values.sort(key=lambda value: ALLOCATOR_IDS.index(cast(str, value["allocator_id"])))
+        p99_values = [
+            float_value(
+                object_value(value["measured"], "latency measured")["p99_ns"],
+                "latency p99",
+                True,
+            )
+            for value in values
+        ]
+        maximum = max(p99_values)
+        for index, duration in enumerate(p99_values):
+            canvas.rectangle(
+                left + 14,
+                top + 13 + index * 24,
+                max(1, int(380 * duration / maximum)),
+                14,
+                COLORS[index],
+            )
+    return encode_png(
+        960,
+        540,
+        canvas.pixels,
+        "Transaction latency p99; allocation plus touch/checksum through free; lower is better",
+    )
+
+
 def carry_forward_optional_metrics(latest: dict[str, object], prior: dict[str, object]) -> bool:
     validate_latest(prior, "prior latest")
-    if "memory" not in latest and "memory" in prior:
-        latest["memory"] = copy.deepcopy(prior["memory"])
-        pending = list_value(latest["pending_metrics"], "latest.pending_metrics")
-        latest["pending_metrics"] = [
-            value
-            for value in pending
-            if object_value(value, "latest pending metric").get("metric_id") != "memory"
-        ]
-        return True
-    return False
+    carried = False
+    for metric in ("memory", "latency"):
+        if metric not in latest and metric in prior:
+            latest[metric] = copy.deepcopy(prior[metric])
+            pending = list_value(latest["pending_metrics"], "latest.pending_metrics")
+            latest["pending_metrics"] = [
+                value
+                for value in pending
+                if object_value(value, "latest pending metric").get("metric_id") != metric
+            ]
+            carried = True
+    return carried
 
 
 def escaped(value: object) -> str:
@@ -1697,6 +2457,46 @@ def render_html(latest: Mapping[str, object]) -> bytes:
             else "https://github.com/zackees/mimalloc-pprof/actions"
         )
         memory_html = f"""<section><h2 id="memory">Linux process memory</h2><img src="benchmark-memory.png" alt="Absolute Linux process RSS for all four allocators; lower is better"><p>Externally sampled from <code>/proc/&lt;pid&gt;/smaps_rollup</code> every {escaped(memory["sampling_target_interval_ns"])} ns with VmHWM cross-checks and natural purge only. Runner: {escaped(memory_runner["runner_class"])}; results are informational. Memory run <a href="{memory_actions}">{escaped(memory_run["run_id"])}/{escaped(memory_run["run_attempt"])}</a>; metric key <code>{escaped(memory["metric_comparison_key"])}</code>.</p><table><thead><tr><th>Scenario</th><th>Threads</th><th>Metric</th><th>Allocator</th><th>Median (MiB or ratio)</th></tr></thead><tbody>{memory_rows}</tbody></table></section>"""
+    latency_html = ""
+    if "latency" in latest:
+        latency = validate_latency_report(latest["latency"], "latest.latency")
+        latency_run = object_value(latency["run"], "latest.latency.run")
+        latency_runner = object_value(latency["runner"], "latest.latency.runner")
+        latency_absolute = [
+            object_value(value, "latency absolute")
+            for value in list_value(latency["absolute_summaries"], "latency absolute summaries")
+        ]
+        latency_rows = "".join(
+            f"<tr><td>{escaped(value['scenario_id'])}</td><td>{escaped(value['thread_point'])}</td><td>{escaped(value['allocator_id'])}</td><td>{escaped(round(float_value(object_value(value['measured'], 'latency measured')['p50_ns'], 'latency p50'), 3))}</td><td>{escaped(round(float_value(object_value(value['measured'], 'latency measured')['p95_ns'], 'latency p95'), 3))}</td><td>{escaped(round(float_value(object_value(value['measured'], 'latency measured')['p99_ns'], 'latency p99'), 3))}</td><td>control OK ({escaped(object_value(value['control'], 'latency control')['p50_ns'])} ns p50)</td><td>{escaped(object_value(value['measured'], 'latency measured')['count'])}</td></tr>"
+            for value in latency_absolute
+        )
+        first_raw = object_value(
+            list_value(latency["raw_samples"], "latency raw samples")[0], "latency raw sample"
+        )
+        scheduling = object_value(
+            object_value(first_raw["measured"], "latency measured")["scheduling"],
+            "latency scheduling",
+        )
+        definitions = object_value(
+            object_value(latency["methodology"], "latency methodology")["transaction_boundaries"],
+            "latency transaction boundaries",
+        )
+        latency_actions = (
+            f"https://github.com/zackees/mimalloc-pprof/actions/runs/{escaped(latency_run['run_id'])}"
+            if latency_run["run_origin"] == "github-actions"
+            else "https://github.com/zackees/mimalloc-pprof/actions"
+        )
+        block_count = min(
+            cast(
+                int,
+                object_value(
+                    object_value(value, "latency paired")["summary"],
+                    "latency paired summary",
+                )["block_count"],
+            )
+            for value in list_value(latency["paired_summaries"], "latency paired summaries")
+        )
+        latency_html = f"""<section><h2 id="latency">Transaction latency</h2><img src="benchmark-latency.png" alt="End-to-end transaction latency p99 for all four allocators; lower is better"><p><strong>Lower is better; informational hosted-runner measurements.</strong> These are transaction latencies, never allocator-call latencies and never throughput reciprocals. Local: {escaped(definitions["local"])}. Cross-thread: {escaped(definitions["cross-thread"])}. Large object: {escaped(definitions["large-object"])}.</p><p>Each allocator/cell has at least 10,000 raw samples across {escaped(block_count)} paired blocks. Controls are reported without subtraction. Runner: {escaped(latency_runner["runner_class"])}; affinity: {escaped(scheduling["affinity_policy"])}; upstream reference: <code>upstream-mimalloc</code>. Latency run <a href="{latency_actions}">{escaped(latency_run["run_id"])}/{escaped(latency_run["run_attempt"])}</a>; metric key <code>{escaped(latency["metric_comparison_key"])}</code>.</p><table><thead><tr><th>Scenario</th><th>Threads</th><th>Allocator</th><th>p50 ns</th><th>p95 ns</th><th>p99 ns</th><th>Overhead</th><th>Samples</th></tr></thead><tbody>{latency_rows}</tbody></table></section>"""
     document = f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>mimalloc allocator benchmarks</title>
 <style>body{{font:15px system-ui,sans-serif;max-width:1200px;margin:auto;padding:24px;color:#182334}}table{{border-collapse:collapse;width:100%;margin:16px 0}}th,td{{border:1px solid #ccd4dd;padding:7px;text-align:left}}img{{max-width:100%;height:auto}}.pending{{border:1px solid #ccd4dd;padding:12px;margin:12px 0}}code,pre{{overflow-wrap:anywhere;white-space:pre-wrap}}small{{color:#596575}}</style></head><body>
@@ -1705,7 +2505,7 @@ def render_html(latest: Mapping[str, object]) -> bytes:
 <h2 id="throughput">Throughput</h2><img src="benchmark-throughput.png" alt="Per-scenario absolute throughput bars for all four allocators"><table><thead><tr><th>Scenario</th><th>Threads</th><th>Allocator</th><th>Median</th><th>Noisy</th></tr></thead><tbody>{absolute_rows}</tbody></table>
 <h2>Paired effects</h2><table><thead><tr><th>Scenario</th><th>Candidate</th><th>Effect</th><th>95% interval</th><th>Interpretation</th></tr></thead><tbody>{paired_rows}</tbody></table>
 <h2 id="history">Compatible history</h2><img src="benchmark-history.png" alt="History connected only across the selected identical comparison key">
-{memory_html}<h2>Pending Phase 6 panels</h2>{pending_html}<section id="phase-6"><p>Pending panels contain no measured values.</p></section>
+{memory_html}{latency_html}<h2>Pending Phase 6 panels</h2>{pending_html}<section id="phase-6"><p>Pending panels contain no measured values.</p></section>
 <h2>Provenance</h2><p>Run {escaped(run["run_id"])}, attempt {escaped(run["run_attempt"])}; target {escaped(runner["target"])}; fingerprint <code>{escaped(runner["fingerprint_sha256"])}</code>.</p><table><thead><tr><th>Allocator</th><th>Source</th><th>Binary</th></tr></thead><tbody>{allocator_rows}</tbody></table><p><a href="{escaped(latest["actions_run_url"])}">Actions run</a></p>
 <h2>Methodology</h2><pre>{escaped(json.dumps(latest["methodology"], sort_keys=True, ensure_ascii=False))}</pre><h2>Reproduce</h2><pre><code>{escaped(latest["reproduction_command"])}</code></pre>
 </body></html>"""
@@ -1792,7 +2592,15 @@ def render(
         (output / image_names["memory"]).write_bytes(
             pending_png("memory", cast(str, item["reason"]))
         )
-    for metric in ("latency", "scaling", "pprof-tax"):
+    if "latency" in latest:
+        latency = validate_latency_report(latest["latency"], "latest.latency")
+        (output / image_names["latency"]).write_bytes(latency_png(latency))
+    else:
+        item = pending["latency"]
+        (output / image_names["latency"]).write_bytes(
+            pending_png("latency", cast(str, item["reason"]))
+        )
+    for metric in ("scaling", "pprof-tax"):
         item = pending[metric]
         (output / image_names[metric]).write_bytes(pending_png(metric, cast(str, item["reason"])))
     (output / "manifest.json").write_bytes(compact_json(manifest_for(output)))

--- a/ci/check_benchmark_latency_workflow.py
+++ b/ci/check_benchmark_latency_workflow.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Fail-closed policy checker for the Linux transaction-latency workflow."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import NoReturn, cast
+
+import yaml
+
+from check_benchmark_workflow import check_action_ref
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "benchmark-latency.yml"
+JOBS = {
+    "build-and-measure",
+    "artifact-audit",
+    "publish-branch",
+    "package-pages",
+    "deploy-pages",
+    "publication-audit",
+}
+
+
+class LatencyWorkflowError(RuntimeError):
+    """A transaction-latency workflow policy assertion failed."""
+
+
+def fail(message: str) -> NoReturn:
+    raise LatencyWorkflowError(message)
+
+
+def mapping(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        fail(f"{label}: expected object")
+    return cast(dict[str, object], value)
+
+
+def steps_by_name(job: Mapping[str, object]) -> dict[str, dict[str, object]]:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        fail("job.steps: expected array")
+    result: dict[str, dict[str, object]] = {}
+    for value in cast(list[object], steps):
+        step = mapping(value, "job step")
+        name = step.get("name")
+        if isinstance(name, str):
+            result[name] = step
+        action = step.get("uses")
+        if isinstance(action, str):
+            try:
+                check_action_ref(action, "latency workflow action")
+            except Exception as error:
+                fail(str(error))
+    return result
+
+
+def validate(workflow: Mapping[str, object]) -> None:
+    raw_workflow = cast(Mapping[object, object], workflow)
+    on = workflow.get("on", raw_workflow.get(True))  # PyYAML 1.1 treats `on` as true.
+    triggers = mapping(on, "workflow.on")
+    if set(triggers) != {"workflow_dispatch", "schedule"}:
+        fail("workflow.on: only weekly schedule and manual dispatch are allowed")
+    schedule = triggers.get("schedule")
+    if not isinstance(schedule, list) or len(cast(list[object], schedule)) != 1:
+        fail("workflow.on.schedule: expected one weekly schedule")
+    dispatch = mapping(triggers.get("workflow_dispatch"), "workflow.on.workflow_dispatch")
+    inputs = mapping(dispatch.get("inputs"), "workflow.on.workflow_dispatch.inputs")
+    if set(inputs) != {"mode", "run_seed", "blocks"}:
+        fail("workflow dispatch inputs must be exactly mode/run_seed/blocks")
+    mode = mapping(inputs["mode"], "workflow input mode")
+    if mode.get("options") != ["full", "smoke"] or mode.get("default") != "full":
+        fail("workflow input mode must default to full with full/smoke choices")
+
+    concurrency = mapping(workflow.get("concurrency"), "workflow.concurrency")
+    if concurrency != {"group": "benchmark-stats-production", "cancel-in-progress": False}:
+        fail("latency workflow must serialize with the production publication group")
+    if mapping(workflow.get("permissions"), "workflow.permissions") != {"contents": "read"}:
+        fail("workflow permissions must be contents: read")
+
+    jobs = mapping(workflow.get("jobs"), "workflow.jobs")
+    if set(jobs) != JOBS:
+        fail(f"workflow jobs mismatch: expected {sorted(JOBS)}")
+    for name, value in jobs.items():
+        job = mapping(value, f"workflow.jobs.{name}")
+        if job.get("runs-on") != "ubuntu-24.04":
+            fail(f"workflow.jobs.{name}.runs-on: expected ubuntu-24.04")
+        timeout = job.get("timeout-minutes")
+        if not isinstance(timeout, int) or timeout > 60:
+            fail(f"workflow.jobs.{name}.timeout-minutes: expected <=60")
+        if "strategy" in job:
+            fail(f"workflow.jobs.{name}: parallel matrices are forbidden")
+        steps_by_name(job)
+
+    build = mapping(jobs["build-and-measure"], "build-and-measure")
+    if build.get("timeout-minutes") != 60:
+        fail("build-and-measure must enforce the 60-minute hard limit")
+    steps = steps_by_name(build)
+    run_step = mapping(steps.get("run transaction latency suite"), "run transaction latency suite")
+    run = run_step.get("run")
+    if not isinstance(run, str) or "benchmark-latency-run" not in run or "--blocks" not in run:
+        fail("latency measurement step must execute benchmark-latency-run with explicit blocks")
+    if " &" in run or "parallel" in run or "xargs" in run:
+        fail("latency allocators must execute sequentially")
+    for step_name in (
+        "determine run seed",
+        "run transaction latency suite",
+        "compute publication eligibility",
+    ):
+        step = mapping(steps.get(step_name), step_name)
+        if "${{ inputs." in str(step.get("run", "")):
+            fail(f"{step_name}: workflow inputs must enter shell through env, not source text")
+    seed_step = mapping(steps.get("determine run seed"), "determine run seed")
+    seed_env = mapping(seed_step.get("env"), "determine run seed.env")
+    if "INPUT_RUN_SEED" not in seed_env or "*[!0-9]*" not in str(seed_step.get("run", "")):
+        fail("run seed must use an env boundary and strict decimal validation")
+    raw = mapping(steps.get("upload raw latency artifact"), "upload raw latency artifact")
+    if raw.get("if") != "always()":
+        fail("raw latency artifact must upload with if: always()")
+    raw_with = mapping(raw.get("with"), "upload raw latency artifact.with")
+    if raw_with.get("retention-days") != 30 or raw_with.get("include-hidden-files") is not True:
+        fail("raw latency/control artifact must retain all bytes for 30 days")
+    eligibility = mapping(steps.get("compute publication eligibility"), "eligibility")
+    eligibility_run = eligibility.get("run")
+    if not isinstance(eligibility_run, str):
+        fail("eligibility step needs a shell policy")
+    for required in ("refs/heads/main", "full", "-ge 15"):
+        if required not in eligibility_run:
+            fail(f"eligibility step is missing {required!r}")
+
+    publish = mapping(jobs["publish-branch"], "publish-branch")
+    if mapping(publish.get("permissions"), "publish permissions") != {"contents": "write"}:
+        fail("only publish-branch may use contents: write")
+    deploy = mapping(jobs["deploy-pages"], "deploy-pages")
+    if mapping(deploy.get("permissions"), "deploy permissions") != {
+        "pages": "write",
+        "id-token": "write",
+    }:
+        fail("deploy-pages requires only pages/id-token write")
+    if mapping(deploy.get("environment"), "deploy environment").get("name") != "github-pages":
+        fail("deploy-pages must target the github-pages environment")
+    publish_text = str(publish)
+    if "--force-with-lease" not in publish_text or "prepare-branch" not in publish_text:
+        fail("branch publication must use exact replacement and a lease")
+    package_text = str(jobs["package-pages"])
+    if (
+        "benchmark-latency-site-" not in publish_text
+        or "benchmark-latency-site-" not in package_text
+    ):
+        fail("branch and Pages must consume the same sealed latency site artifact")
+    audit_text = str(jobs["publication-audit"])
+    for required in ("validate-revision", "audit-pages"):
+        if required not in audit_text:
+            fail(f"publication audit is missing {required}")
+
+
+def load(path: Path) -> dict[str, object]:
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return mapping(value, str(path))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow", type=Path, default=WORKFLOW)
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+    validate(load(args.workflow))
+    if args.selftest:
+        print("PASS benchmark latency workflow policy selftest")
+    else:
+        print(f"PASS benchmark latency workflow policy: {args.workflow}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except LatencyWorkflowError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/ci/tests/test_benchmark_latency_workflow.py
+++ b/ci/tests/test_benchmark_latency_workflow.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+# pyright: reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false
+# ruff: noqa: I001
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_benchmark_latency_workflow as policy
+
+
+class BenchmarkLatencyWorkflowTests(unittest.TestCase):
+    def workflow(self) -> dict[str, object]:
+        return policy.load(policy.WORKFLOW)
+
+    def test_production_workflow_passes(self) -> None:
+        policy.validate(self.workflow())
+
+    def test_parallel_matrix_is_rejected(self) -> None:
+        value = self.workflow()
+        jobs = value["jobs"]
+        assert isinstance(jobs, dict)
+        build = jobs["build-and-measure"]
+        assert isinstance(build, dict)
+        build["strategy"] = {"matrix": {"allocator": ["a", "b"]}}
+        with self.assertRaisesRegex(policy.LatencyWorkflowError, "parallel matrices"):
+            policy.validate(value)
+
+    def test_nondefault_publication_and_missing_raw_retention_are_rejected(self) -> None:
+        value = self.workflow()
+        jobs = value["jobs"]
+        assert isinstance(jobs, dict)
+        build = jobs["build-and-measure"]
+        assert isinstance(build, dict)
+        steps = build["steps"]
+        assert isinstance(steps, list)
+        eligibility = next(
+            item
+            for item in steps
+            if isinstance(item, dict) and item.get("name") == "compute publication eligibility"
+        )
+        eligibility["run"] = str(eligibility["run"]).replace(
+            "refs/heads/main", "refs/heads/feature"
+        )
+        with self.assertRaisesRegex(policy.LatencyWorkflowError, "refs/heads/main"):
+            policy.validate(value)
+
+        value = self.workflow()
+        jobs = value["jobs"]
+        assert isinstance(jobs, dict)
+        build = jobs["build-and-measure"]
+        assert isinstance(build, dict)
+        raw = policy.steps_by_name(build)["upload raw latency artifact"]
+        raw_with = raw["with"]
+        assert isinstance(raw_with, dict)
+        raw_with["retention-days"] = 1
+        with self.assertRaisesRegex(policy.LatencyWorkflowError, "30 days"):
+            policy.validate(value)
+
+    def test_separate_concurrency_group_is_rejected(self) -> None:
+        value = copy.deepcopy(self.workflow())
+        value["concurrency"] = {"group": "latency-only", "cancel-in-progress": False}
+        with self.assertRaisesRegex(policy.LatencyWorkflowError, "serialize"):
+            policy.validate(value)
+
+    def test_shell_interpolated_seed_is_rejected(self) -> None:
+        value = self.workflow()
+        jobs = value["jobs"]
+        assert isinstance(jobs, dict)
+        build = jobs["build-and-measure"]
+        assert isinstance(build, dict)
+        seed = policy.steps_by_name(build)["determine run seed"]
+        seed["run"] = 'SEED="${{ inputs.run_seed }}"'
+        with self.assertRaisesRegex(policy.LatencyWorkflowError, "through env"):
+            policy.validate(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_benchmark_report.py
+++ b/ci/tests/test_benchmark_report.py
@@ -223,6 +223,189 @@ class BenchmarkReportTests(unittest.TestCase):
         ]
         return value
 
+    def with_complete_latency(self, latest: dict[str, object]) -> dict[str, object]:
+        value = copy.deepcopy(latest)
+        runner = value["runner"]
+        allocators = value["allocators"]
+        assert isinstance(runner, dict) and isinstance(allocators, list)
+        allocator_sources = {
+            str(item["allocator_id"]): (str(item["source_sha"]), str(item["child_binary_sha256"]))
+            for item in allocators
+            if isinstance(item, dict)
+        }
+        rates = {f"{scenario}/{point}": 1 for scenario, point in report.LATENCY_CELLS}
+        raw: list[dict[str, object]] = []
+        block_summaries: list[dict[str, object]] = []
+        absolute: list[dict[str, object]] = []
+        paired: list[dict[str, object]] = []
+
+        def distribution(values: list[int]) -> dict[str, object]:
+            return report.summarize_latency_values(values)
+
+        definitions = {
+            "tiny-fixed-64": "allocation plus required touch/checksum plus free",
+            "small-log-mixed": "allocation plus required touch/checksum plus free",
+            "cross-thread-producer-consumer": "producer allocation through consumer free completion, including queue and ownership transfer",
+            "large-objects": "allocation plus one-byte-per-page touch/checksum plus free",
+        }
+        for scenario, point in report.LATENCY_CELLS:
+            thread_count = 1 if point == "1" else int(runner["physical_cores"])
+            for allocator_index, allocator in enumerate(report.ALLOCATOR_IDS):
+                base = 1_000 + allocator_index * 100
+                if allocator != "upstream-mimalloc":
+                    for quantile in ("p50", "p95", "p99"):
+                        paired.append(
+                            {
+                                "scenario_id": scenario,
+                                "thread_point": point,
+                                "quantile": quantile,
+                                "summary": {
+                                    "candidate_id": allocator,
+                                    "reference_id": "upstream-mimalloc",
+                                    "direction": "lower-is-better",
+                                    "block_count": 15,
+                                    "effect": 1.05,
+                                    "confidence_interval": {
+                                        "lower": 1.01,
+                                        "upper": 1.09,
+                                        "confidence_level": 0.95,
+                                    },
+                                    "bootstrap": {
+                                        "seed": 1,
+                                        "resample_count": 10_000,
+                                        "method": "percentile-whole-block-transaction-quantile-type7-v1",
+                                        "prng": "splitmix64-rejection-v1",
+                                    },
+                                    "informational": True,
+                                },
+                            }
+                        )
+                all_measured: list[int] = []
+                all_control: list[int] = []
+                for block in range(15):
+                    observations = [
+                        {
+                            "thread_index": index % thread_count,
+                            "transaction_index": index // thread_count,
+                            "duration_ns": base + index % 41,
+                        }
+                        for index in range(667)
+                    ]
+                    observations.sort(
+                        key=lambda item: (item["thread_index"], item["transaction_index"])
+                    )
+                    control_observations = [
+                        item | {"duration_ns": 40 + int(item["transaction_index"]) % 3}
+                        for item in observations
+                    ]
+                    measured_values = [int(item["duration_ns"]) for item in observations]
+                    control_values = [int(item["duration_ns"]) for item in control_observations]
+                    all_measured.extend(measured_values)
+                    all_control.extend(control_values)
+                    scheduling = {
+                        "affinity_policy": runner["affinity"]["policy"],
+                        "actual_cpu_ids": list(range(thread_count)),
+                        "thread_count": thread_count,
+                        "physical_cores": runner["physical_cores"],
+                        "logical_cores": runner["logical_cores"],
+                        "context_switches": {"voluntary": 0, "involuntary": 0},
+                        "runner_class": runner["runner_class"],
+                        "clock": {
+                            "source": "monotonic",
+                            "implementation": "std::time::Instant/CLOCK_MONOTONIC",
+                            "resolution_ns": 1,
+                        },
+                    }
+                    child_base = {
+                        "protocol_version": report.LATENCY_CHILD_PROTOCOL,
+                        "metric_schema_version": report.LATENCY_SCHEMA,
+                        "completed_transactions": thread_count * 1_000,
+                        "checksum": 2,
+                        "scheduling": copy.deepcopy(scheduling),
+                    }
+                    source_sha, child_sha = allocator_sources[allocator]
+                    raw.append(
+                        {
+                            "metric_schema_version": report.LATENCY_SCHEMA,
+                            "block_id": block,
+                            "ordinal": allocator_index,
+                            "workload_seed": block + 1,
+                            "allocator_id": allocator,
+                            "allocator_source_sha": source_sha,
+                            "child_binary_sha256": child_sha,
+                            "scenario_id": scenario,
+                            "thread_point": point,
+                            "thread_count": thread_count,
+                            "sample_denominator": 1,
+                            "transaction_definition": definitions[scenario],
+                            "measured": child_base
+                            | {"control": False, "observations": observations},
+                            "control": copy.deepcopy(child_base)
+                            | {
+                                "control": True,
+                                "checksum": 1,
+                                "observations": control_observations,
+                            },
+                        }
+                    )
+                    block_summaries.append(
+                        {
+                            "block_id": block,
+                            "allocator_id": allocator,
+                            "scenario_id": scenario,
+                            "thread_point": point,
+                            "measured": distribution(measured_values),
+                            "control": distribution(control_values),
+                        }
+                    )
+                absolute.append(
+                    {
+                        "allocator_id": allocator,
+                        "scenario_id": scenario,
+                        "thread_point": point,
+                        "transaction_definition": definitions[scenario],
+                        "measured": distribution(all_measured),
+                        "control": distribution(all_control),
+                        "overhead_valid": True,
+                    }
+                )
+        value["latency"] = {
+            "metric_schema_version": report.LATENCY_SCHEMA,
+            "status": "complete",
+            "invalid_reason": None,
+            "metric_comparison_key": "c" * 64,
+            "run": copy.deepcopy(value["run"]),
+            "runner": copy.deepcopy(runner),
+            "direction": "lower-is-better",
+            "informational": True,
+            "sampling_denominators": rates,
+            "methodology": {
+                "transaction_boundaries": {
+                    "local": definitions["tiny-fixed-64"],
+                    "cross-thread": definitions["cross-thread-producer-consumer"],
+                    "large-object": definitions["large-objects"],
+                },
+                "quantile_method": "R/NumPy Type 7 linear interpolation",
+                "sampling_schedule": "deterministic paired 1/N indices",
+                "overhead_control": "reported separately and never subtracted",
+                "bootstrap": "whole blocks with transaction quantile recomputation",
+                "storage_decision": "raw vectors fit the public cap",
+                "tail_policy": "all scheduler tails retained",
+            },
+            "absolute_summaries": absolute,
+            "paired_summaries": paired,
+            "block_summaries": block_summaries,
+            "raw_samples": raw,
+        }
+        pending = value["pending_metrics"]
+        assert isinstance(pending, list)
+        value["pending_metrics"] = [
+            item
+            for item in pending
+            if isinstance(item, dict) and item.get("metric_id") != "latency"
+        ]
+        return value
+
     def render_fixture(self, root: Path) -> tuple[Path, Path]:
         site = root / "site"
         digest = root / "manifest.sha256"
@@ -445,6 +628,66 @@ class BenchmarkReportTests(unittest.TestCase):
         assert isinstance(pending, list)
         self.assertNotIn(
             "memory", [item["metric_id"] for item in pending if isinstance(item, dict)]
+        )
+
+    def test_complete_latency_replaces_pending_with_transaction_chart_and_compact_history(
+        self,
+    ) -> None:
+        latest = self.with_complete_latency(self.load_latest())
+        report.validate_latest(latest, "latency fixture")
+        history = report.history_row(latest)
+        self.assertIn("latency", history)
+        latency_history = history["latency"]
+        assert isinstance(latency_history, dict)
+        self.assertNotIn("raw_samples", latency_history)
+        report.validate_history_row(history, "latency history")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "latest.json"
+            self.write_json(source, latest)
+            site = root / "site"
+            report.render(source, FIXTURE / "history.jsonl", site, root / "digest", False)
+            page = (site / "index.html").read_text(encoding="utf-8")
+            self.assertIn('<h2 id="latency">Transaction latency</h2>', page)
+            self.assertIn("never allocator-call latencies", page)
+            self.assertIn("p50 ns", page)
+            self.assertIn("p95 ns", page)
+            self.assertIn("p99 ns", page)
+            self.assertNotIn("latency: pending", page)
+            chart = (site / "benchmark-latency.png").read_bytes()
+            self.assertIn(b"Transaction latency", chart)
+            self.assertIn(b"through free", chart)
+
+    def test_incomplete_or_failed_control_latency_cannot_replace_pending(self) -> None:
+        complete = self.with_complete_latency(self.load_latest())
+        incomplete = copy.deepcopy(complete)
+        latency = incomplete["latency"]
+        assert isinstance(latency, dict)
+        raw = latency["raw_samples"]
+        assert isinstance(raw, list)
+        raw.pop()
+        with self.assertRaisesRegex(report.ReportError, "incomplete"):
+            report.validate_latest(incomplete, "incomplete latency")
+
+        failed_control = copy.deepcopy(complete)
+        latency = failed_control["latency"]
+        assert isinstance(latency, dict)
+        absolute = latency["absolute_summaries"]
+        assert isinstance(absolute, list) and isinstance(absolute[0], dict)
+        control = absolute[0]["control"]
+        assert isinstance(control, dict)
+        control.update(p50_ns=60.0, p95_ns=61.0, p99_ns=62.0, max_ns=62)
+        with self.assertRaisesRegex(report.ReportError, "control/sample threshold"):
+            report.validate_latest(failed_control, "failed latency control")
+
+        carried = self.load_latest()
+        self.assertTrue(report.carry_forward_optional_metrics(carried, complete))
+        report.validate_latest(carried, "carried latency")
+        self.assertIn("latency", carried)
+        pending = carried["pending_metrics"]
+        assert isinstance(pending, list)
+        self.assertNotIn(
+            "latency", [item["metric_id"] for item in pending if isinstance(item, dict)]
         )
 
     def test_readme_embeds_only_real_charts_and_clicks_through_to_pages(self) -> None:

--- a/rust/benchmark-suite/Cargo.toml
+++ b/rust/benchmark-suite/Cargo.toml
@@ -30,6 +30,14 @@ path = "src/bin/benchmark-memory-run.rs"
 name = "benchmark-memory-validate"
 path = "src/bin/benchmark-memory-validate.rs"
 
+[[bin]]
+name = "benchmark-latency-run"
+path = "src/bin/benchmark-latency-run.rs"
+
+[[bin]]
+name = "benchmark-latency-validate"
+path = "src/bin/benchmark-latency-validate.rs"
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/benchmark-suite/schema/history-v1.schema.json
+++ b/rust/benchmark-suite/schema/history-v1.schema.json
@@ -15,7 +15,8 @@
     "allocator_identities": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "$ref": "#/$defs/allocatorIdentity" } },
     "absolute_summaries": { "type": "array", "minItems": 120, "items": { "$ref": "latest-v1.schema.json#/$defs/absoluteCell" } },
     "paired_summaries": { "type": "array", "minItems": 90, "items": { "$ref": "latest-v1.schema.json#/$defs/pairedCell" } },
-    "memory": { "$ref": "memory-v1.schema.json#/$defs/history" }
+    "memory": { "$ref": "memory-v1.schema.json#/$defs/history" },
+    "latency": { "$ref": "latency-v1.schema.json#/$defs/history" }
   },
   "$defs": {
     "allocatorIdentity": {

--- a/rust/benchmark-suite/schema/latency-v1.schema.json
+++ b/rust/benchmark-suite/schema/latency-v1.schema.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/zackees/mimalloc-pprof/schema/latency-v1.schema.json",
+  "title": "mimalloc-pprof transaction latency v1",
+  "type": "object",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "complete" } }, "required": ["status"] },
+      "then": { "properties": { "samples": { "minItems": 300 } } }
+    }
+  ],
+  "required": ["metric_schema_version", "status", "run_seed", "run", "runner", "allocator_lock_sha256", "allocators", "calibrations", "sampling_denominators", "samples"],
+  "properties": {
+    "metric_schema_version": { "const": "transaction-latency-v1" },
+    "status": { "enum": ["complete", "incomplete"] },
+    "run_seed": { "type": "integer", "minimum": 1 },
+    "run": { "$ref": "raw-run-v1.schema.json#/$defs/run" },
+    "runner": { "$ref": "raw-run-v1.schema.json#/$defs/runner" },
+    "allocator_lock_sha256": { "$ref": "raw-run-v1.schema.json#/$defs/sha256" },
+    "allocators": { "type": "array", "minItems": 4, "maxItems": 4, "items": { "$ref": "raw-run-v1.schema.json#/$defs/allocator" } },
+    "calibrations": { "type": "array", "minItems": 5, "maxItems": 5, "items": { "$ref": "raw-run-v1.schema.json#/$defs/calibration" } },
+    "sampling_denominators": { "$ref": "#/$defs/samplingDenominators" },
+    "samples": { "type": "array", "minItems": 20, "items": { "$ref": "#/$defs/sample" } }
+  },
+  "$defs": {
+    "nonempty": { "type": "string", "minLength": 1 },
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "observation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["thread_index", "transaction_index", "duration_ns"],
+      "properties": { "thread_index": { "type": "integer", "minimum": 0 }, "transaction_index": { "type": "integer", "minimum": 0 }, "duration_ns": { "type": "integer", "minimum": 1 } }
+    },
+    "clock": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "implementation", "resolution_ns"],
+      "properties": { "source": { "const": "monotonic" }, "implementation": { "$ref": "#/$defs/nonempty" }, "resolution_ns": { "type": "integer", "minimum": 1 } }
+    },
+    "contextSwitches": {
+      "type": "object", "additionalProperties": false,
+      "required": ["voluntary", "involuntary"],
+      "properties": { "voluntary": { "type": "integer", "minimum": 0 }, "involuntary": { "type": "integer", "minimum": 0 } }
+    },
+    "scheduling": {
+      "type": "object", "additionalProperties": false,
+      "required": ["affinity_policy", "actual_cpu_ids", "thread_count", "physical_cores", "logical_cores", "context_switches", "runner_class", "clock"],
+      "properties": {
+        "affinity_policy": { "$ref": "#/$defs/nonempty" }, "actual_cpu_ids": { "type": "array", "minItems": 1, "items": { "type": ["integer", "null"], "minimum": 0 } },
+        "thread_count": { "type": "integer", "minimum": 1 }, "physical_cores": { "type": "integer", "minimum": 1 }, "logical_cores": { "type": "integer", "minimum": 1 },
+        "context_switches": { "$ref": "#/$defs/contextSwitches" }, "runner_class": { "$ref": "#/$defs/nonempty" }, "clock": { "$ref": "#/$defs/clock" }
+      }
+    },
+    "child": {
+      "type": "object", "additionalProperties": false,
+      "required": ["protocol_version", "metric_schema_version", "control", "completed_transactions", "checksum", "observations", "scheduling"],
+      "properties": {
+        "protocol_version": { "const": "transaction-latency-child-v1" }, "metric_schema_version": { "const": "transaction-latency-v1" }, "control": { "type": "boolean" },
+        "completed_transactions": { "type": "integer", "minimum": 1 }, "checksum": { "type": "integer", "minimum": 1 },
+        "observations": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/observation" } }, "scheduling": { "$ref": "#/$defs/scheduling" }
+      }
+    },
+    "sample": {
+      "type": "object", "additionalProperties": false,
+      "required": ["metric_schema_version", "block_id", "ordinal", "workload_seed", "allocator_id", "allocator_source_sha", "child_binary_sha256", "scenario_id", "thread_point", "thread_count", "sample_denominator", "transaction_definition", "measured", "control"],
+      "properties": {
+        "metric_schema_version": { "const": "transaction-latency-v1" }, "block_id": { "type": "integer", "minimum": 0 }, "ordinal": { "type": "integer", "minimum": 0, "maximum": 3 }, "workload_seed": { "type": "integer", "minimum": 1 },
+        "allocator_id": { "enum": ["tcmalloc", "jemalloc", "upstream-mimalloc", "mimalloc-pprof"] }, "allocator_source_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" }, "child_binary_sha256": { "$ref": "#/$defs/sha256" },
+        "scenario_id": { "enum": ["tiny-fixed-64", "small-log-mixed", "cross-thread-producer-consumer", "large-objects"] }, "thread_point": { "enum": ["1", "physical-core"] }, "thread_count": { "type": "integer", "minimum": 1 },
+        "sample_denominator": { "type": "integer", "minimum": 1, "maximum": 1024 }, "transaction_definition": { "$ref": "#/$defs/nonempty" }, "measured": { "$ref": "#/$defs/child" }, "control": { "$ref": "#/$defs/child" }
+      }
+    },
+    "distribution": {
+      "type": "object", "additionalProperties": false,
+      "required": ["count", "p50_ns", "p95_ns", "p99_ns", "min_ns", "max_ns", "median_absolute_deviation_ns", "iqr_ns", "zero_count"],
+      "properties": {
+        "count": { "type": "integer", "minimum": 1 }, "p50_ns": { "type": "number", "exclusiveMinimum": 0 }, "p95_ns": { "type": "number", "exclusiveMinimum": 0 }, "p99_ns": { "type": "number", "exclusiveMinimum": 0 },
+        "min_ns": { "type": "integer", "minimum": 1 }, "max_ns": { "type": "integer", "minimum": 1 }, "median_absolute_deviation_ns": { "type": "number", "minimum": 0 }, "iqr_ns": { "type": "number", "minimum": 0 }, "zero_count": { "const": 0 }
+      }
+    },
+    "samplingDenominators": {
+      "type": "object", "additionalProperties": false,
+      "required": ["tiny-fixed-64/1", "small-log-mixed/1", "small-log-mixed/physical-core", "cross-thread-producer-consumer/physical-core", "large-objects/1"],
+      "properties": {
+        "tiny-fixed-64/1": { "type": "integer", "minimum": 1, "maximum": 1024 },
+        "small-log-mixed/1": { "type": "integer", "minimum": 1, "maximum": 1024 },
+        "small-log-mixed/physical-core": { "type": "integer", "minimum": 1, "maximum": 1024 },
+        "cross-thread-producer-consumer/physical-core": { "type": "integer", "minimum": 1, "maximum": 1024 },
+        "large-objects/1": { "type": "integer", "minimum": 1, "maximum": 1024 }
+      }
+    },
+    "methodology": {
+      "type": "object", "additionalProperties": false,
+      "required": ["transaction_boundaries", "quantile_method", "sampling_schedule", "overhead_control", "bootstrap", "storage_decision", "tail_policy"],
+      "properties": {
+        "transaction_boundaries": {
+          "type": "object", "additionalProperties": false,
+          "required": ["local", "cross-thread", "large-object"],
+          "properties": {
+            "local": { "$ref": "#/$defs/nonempty" },
+            "cross-thread": { "$ref": "#/$defs/nonempty" },
+            "large-object": { "$ref": "#/$defs/nonempty" }
+          }
+        },
+        "quantile_method": { "$ref": "#/$defs/nonempty" },
+        "sampling_schedule": { "$ref": "#/$defs/nonempty" },
+        "overhead_control": { "$ref": "#/$defs/nonempty" },
+        "bootstrap": { "$ref": "#/$defs/nonempty" },
+        "storage_decision": { "$ref": "#/$defs/nonempty" },
+        "tail_policy": { "$ref": "#/$defs/nonempty" }
+      }
+    },
+    "absoluteSummary": {
+      "type": "object", "additionalProperties": false,
+      "required": ["allocator_id", "scenario_id", "thread_point", "transaction_definition", "measured", "control", "overhead_valid"],
+      "properties": {
+        "allocator_id": { "enum": ["tcmalloc", "jemalloc", "upstream-mimalloc", "mimalloc-pprof"] },
+        "scenario_id": { "enum": ["tiny-fixed-64", "small-log-mixed", "cross-thread-producer-consumer", "large-objects"] },
+        "thread_point": { "enum": ["1", "physical-core"] },
+        "transaction_definition": { "$ref": "#/$defs/nonempty" },
+        "measured": { "$ref": "#/$defs/distribution" },
+        "control": { "$ref": "#/$defs/distribution" },
+        "overhead_valid": { "const": true }
+      }
+    },
+    "blockSummary": {
+      "type": "object", "additionalProperties": false,
+      "required": ["block_id", "allocator_id", "scenario_id", "thread_point", "measured", "control"],
+      "properties": {
+        "block_id": { "type": "integer", "minimum": 0 },
+        "allocator_id": { "enum": ["tcmalloc", "jemalloc", "upstream-mimalloc", "mimalloc-pprof"] },
+        "scenario_id": { "enum": ["tiny-fixed-64", "small-log-mixed", "cross-thread-producer-consumer", "large-objects"] },
+        "thread_point": { "enum": ["1", "physical-core"] },
+        "measured": { "$ref": "#/$defs/distribution" },
+        "control": { "$ref": "#/$defs/distribution" }
+      }
+    },
+    "confidenceInterval": {
+      "type": "object", "additionalProperties": false,
+      "required": ["lower", "upper", "confidence_level"],
+      "properties": {
+        "lower": { "type": "number", "exclusiveMinimum": 0 },
+        "upper": { "type": "number", "exclusiveMinimum": 0 },
+        "confidence_level": { "const": 0.95 }
+      }
+    },
+    "bootstrapMetadata": {
+      "type": "object", "additionalProperties": false,
+      "required": ["seed", "resample_count", "method", "prng"],
+      "properties": {
+        "seed": { "type": "integer", "minimum": 0 },
+        "resample_count": { "const": 10000 },
+        "method": { "const": "percentile-whole-block-transaction-quantile-type7-v1" },
+        "prng": { "const": "splitmix64-rejection-v1" }
+      }
+    },
+    "pairedEffect": {
+      "type": "object", "additionalProperties": false,
+      "required": ["candidate_id", "reference_id", "direction", "block_count", "effect", "confidence_interval", "bootstrap", "informational"],
+      "properties": {
+        "candidate_id": { "enum": ["tcmalloc", "jemalloc", "mimalloc-pprof"] },
+        "reference_id": { "const": "upstream-mimalloc" },
+        "direction": { "const": "lower-is-better" },
+        "block_count": { "type": "integer", "minimum": 15 },
+        "effect": { "type": "number", "exclusiveMinimum": 0 },
+        "confidence_interval": { "$ref": "#/$defs/confidenceInterval" },
+        "bootstrap": { "$ref": "#/$defs/bootstrapMetadata" },
+        "informational": { "const": true }
+      }
+    },
+    "pairedSummary": {
+      "type": "object", "additionalProperties": false,
+      "required": ["scenario_id", "thread_point", "quantile", "summary"],
+      "properties": {
+        "scenario_id": { "enum": ["tiny-fixed-64", "small-log-mixed", "cross-thread-producer-consumer", "large-objects"] },
+        "thread_point": { "enum": ["1", "physical-core"] },
+        "quantile": { "enum": ["p50", "p95", "p99"] },
+        "summary": { "$ref": "#/$defs/pairedEffect" }
+      }
+    },
+    "report": {
+      "type": "object", "additionalProperties": false,
+      "required": ["metric_schema_version", "status", "invalid_reason", "metric_comparison_key", "run", "runner", "direction", "informational", "sampling_denominators", "methodology", "absolute_summaries", "paired_summaries", "block_summaries", "raw_samples"],
+      "properties": {
+        "metric_schema_version": { "const": "transaction-latency-v1" }, "status": { "const": "complete" }, "invalid_reason": { "type": "null" }, "metric_comparison_key": { "$ref": "#/$defs/sha256" },
+        "run": { "$ref": "raw-run-v1.schema.json#/$defs/run" }, "runner": { "$ref": "raw-run-v1.schema.json#/$defs/runner" }, "direction": { "const": "lower-is-better" }, "informational": { "const": true },
+        "sampling_denominators": { "$ref": "#/$defs/samplingDenominators" }, "methodology": { "$ref": "#/$defs/methodology" },
+        "absolute_summaries": { "type": "array", "minItems": 20, "maxItems": 20, "items": { "$ref": "#/$defs/absoluteSummary" } },
+        "paired_summaries": { "type": "array", "minItems": 45, "maxItems": 45, "items": { "$ref": "#/$defs/pairedSummary" } },
+        "block_summaries": { "type": "array", "minItems": 300, "items": { "$ref": "#/$defs/blockSummary" } },
+        "raw_samples": { "type": "array", "minItems": 300, "items": { "$ref": "#/$defs/sample" } }
+      }
+    },
+    "history": {
+      "type": "object", "additionalProperties": false,
+      "required": ["metric_schema_version", "status", "metric_comparison_key", "run", "runner_fingerprint_sha256", "direction", "informational", "sampling_denominators", "methodology", "absolute_summaries", "paired_summaries", "block_summaries"],
+      "properties": {
+        "metric_schema_version": { "const": "transaction-latency-v1" }, "status": { "const": "complete" }, "metric_comparison_key": { "$ref": "#/$defs/sha256" }, "run": { "$ref": "raw-run-v1.schema.json#/$defs/run" }, "runner_fingerprint_sha256": { "$ref": "#/$defs/sha256" },
+        "direction": { "const": "lower-is-better" }, "informational": { "const": true },
+        "sampling_denominators": { "$ref": "#/$defs/samplingDenominators" }, "methodology": { "$ref": "#/$defs/methodology" },
+        "absolute_summaries": { "type": "array", "minItems": 20, "maxItems": 20, "items": { "$ref": "#/$defs/absoluteSummary" } },
+        "paired_summaries": { "type": "array", "minItems": 45, "maxItems": 45, "items": { "$ref": "#/$defs/pairedSummary" } },
+        "block_summaries": { "type": "array", "minItems": 300, "items": { "$ref": "#/$defs/blockSummary" } }
+      }
+    }
+  }
+}

--- a/rust/benchmark-suite/schema/latest-v1.schema.json
+++ b/rust/benchmark-suite/schema/latest-v1.schema.json
@@ -20,8 +20,9 @@
     "paired_summaries": { "type": "array", "minItems": 90, "items": { "$ref": "#/$defs/pairedCell" } },
     "comparison_key": { "$ref": "#/$defs/sha256" },
     "methodology": { "$ref": "#/$defs/methodology" },
-    "pending_metrics": { "type": "array", "minItems": 3, "maxItems": 4, "items": { "$ref": "#/$defs/pending" } },
+    "pending_metrics": { "type": "array", "minItems": 2, "maxItems": 4, "items": { "$ref": "#/$defs/pending" } },
     "memory": { "$ref": "memory-v1.schema.json#/$defs/report" },
+    "latency": { "$ref": "latency-v1.schema.json#/$defs/report" },
     "canonical_urls": { "$ref": "#/$defs/urls" },
     "reproduction_command": { "$ref": "#/$defs/nonempty" },
     "actions_run_url": { "type": "string" }

--- a/rust/benchmark-suite/src/bin/benchmark-latency-run.rs
+++ b/rust/benchmark-suite/src/bin/benchmark-latency-run.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if let Err(error) = benchmark_suite::latency_runner::benchmark_latency_run_main() {
+        eprintln!("benchmark-latency-run: {error}");
+        std::process::exit(1);
+    }
+}

--- a/rust/benchmark-suite/src/bin/benchmark-latency-validate.rs
+++ b/rust/benchmark-suite/src/bin/benchmark-latency-validate.rs
@@ -1,0 +1,73 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use benchmark_suite::latency::{attach_latency_report, build_latency_report, LatencyRawRun};
+use benchmark_suite::model::LatestReport;
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("benchmark-latency-validate: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut arguments = std::env::args().skip(1);
+    let mut input = None;
+    let mut base_latest = None;
+    let mut report_out = None;
+    let mut latest_out = None;
+    while let Some(argument) = arguments.next() {
+        let target = match argument.as_str() {
+            "--input" => &mut input,
+            "--base-latest" => &mut base_latest,
+            "--report-out" => &mut report_out,
+            "--latest-out" => &mut latest_out,
+            "--help" | "-h" => {
+                println!("usage: benchmark-latency-validate --input <latency-raw-run.json> --base-latest <latest.json> --report-out <latency-report.json> --latest-out <latest.json>");
+                return Ok(());
+            }
+            _ => return Err(format!("unknown argument: {argument}")),
+        };
+        *target = Some(PathBuf::from(
+            arguments
+                .next()
+                .ok_or_else(|| format!("{argument} requires a path"))?,
+        ));
+    }
+    let raw: LatencyRawRun = read_json(&input.ok_or("--input is required")?)?;
+    let report = build_latency_report(&raw)?;
+    let mut latest: LatestReport = read_json(&base_latest.ok_or("--base-latest is required")?)?;
+    if latest.validation_report.status != "valid"
+        || !latest.validation_report.headline_eligible
+        || !latest.validation_report.errors.is_empty()
+    {
+        return Err("base latest report is not validated/headline-eligible".into());
+    }
+    attach_latency_report(&mut latest, report.clone())?;
+    write_new_json(&report_out.ok_or("--report-out is required")?, &report)?;
+    write_new_json(&latest_out.ok_or("--latest-out is required")?, &latest)?;
+    println!(
+        "PASS validated {} latency pairs; key={}",
+        report.raw_samples.len(),
+        report.metric_comparison_key
+    );
+    Ok(())
+}
+
+fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, String> {
+    let bytes = std::fs::read(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    serde_json::from_slice(&bytes).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+fn write_new_json<T: serde::Serialize>(path: &Path, value: &T) -> Result<(), String> {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    serde_json::to_writer_pretty(&mut file, value)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    file.write_all(b"\n")
+        .map_err(|error| format!("{}: {error}", path.display()))
+}

--- a/rust/benchmark-suite/src/child.rs
+++ b/rust/benchmark-suite/src/child.rs
@@ -9,6 +9,7 @@ use crate::execution::{
     execute_child_request, execute_child_request_with_observer, ExecutionResult,
     MeasurementObserver,
 };
+use crate::latency::{execute_latency_child_request, LatencyChildRequest};
 use crate::memory::{read_control_record, write_control_record, ControlKind, ControlRecord};
 use crate::model::BenchmarkChildRequest;
 
@@ -35,8 +36,32 @@ pub fn benchmark_child_main() -> Result<(), String> {
         Some(argument) if argument == "--memory" && arguments.next().is_none() => {
             run_memory_measurement()
         }
-        Some(_) => Err("usage: benchmark-child [--adapter-smoke|--memory]".into()),
+        Some(argument) if argument == "--latency" && arguments.next().is_none() => {
+            run_latency_measurement()
+        }
+        Some(_) => Err("usage: benchmark-child [--adapter-smoke|--memory|--latency]".into()),
     }
+}
+
+fn run_latency_measurement() -> Result<(), String> {
+    let adapter = LinkedAdapter::load().map_err(|error| error.to_string())?;
+    let mut input = Vec::new();
+    std::io::stdin()
+        .take(1024 * 1024 + 1)
+        .read_to_end(&mut input)
+        .map_err(|error| format!("read latency child request: {error}"))?;
+    if input.len() > 1024 * 1024 {
+        return Err("latency child request exceeded 1 MiB".into());
+    }
+    let request: LatencyChildRequest = serde_json::from_slice(&input)
+        .map_err(|error| format!("expected exactly one latency child request: {error}"))?;
+    let response = execute_latency_child_request(&adapter, request)?;
+    let output = serde_json::to_vec(&response)
+        .map_err(|error| format!("serialize latency child response: {error}"))?;
+    std::io::stdout()
+        .lock()
+        .write_all(&output)
+        .map_err(|error| format!("write latency child response: {error}"))
 }
 
 struct MemoryChildObserver<'a, R: Read, W: Write> {

--- a/rust/benchmark-suite/src/execution.rs
+++ b/rust/benchmark-suite/src/execution.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::time::Instant;
 
 use crate::adapter::LinkedAdapter;
+use crate::latency::{deterministic_sample_indices, LatencyExecutionResult, LatencyObservation};
 use crate::model::{
     BenchmarkChildRequest, BenchmarkChildResponse, RawSample, CHILD_PROTOCOL_VERSION,
 };
@@ -360,6 +361,385 @@ pub fn execute_cell<A: AllocatorAdapter>(
     cell: &ScenarioCell,
 ) -> Result<ExecutionResult, String> {
     execute_cell_with_observer(adapter, cell, &mut NoopObserver)
+}
+
+/// Execute one of the five `transaction-latency-v1` cells. The sampling
+/// schedule and every output buffer are built before the measured-region hook
+/// is entered. `control` keeps the same worker topology, sample branch, clock
+/// reads, and barriers while replacing the allocator transaction with a
+/// black-box operation.
+pub fn execute_latency_cell<A: AllocatorAdapter>(
+    adapter: &A,
+    cell: &ScenarioCell,
+    sample_denominator: u64,
+    control: bool,
+) -> Result<LatencyExecutionResult, String> {
+    if sample_denominator == 0 {
+        return Err("latency sample denominator must be nonzero".into());
+    }
+    match (cell.card, cell.thread_point) {
+        (CardId::TinyFixed64, ThreadPoint::One)
+        | (CardId::SmallLogMixed, ThreadPoint::One)
+        | (CardId::SmallLogMixed, ThreadPoint::PhysicalCores)
+        | (CardId::CrossThreadProducerConsumer, ThreadPoint::PhysicalCores)
+        | (CardId::LargeObjects, ThreadPoint::One) => {}
+        _ => return Err("cell is outside transaction-latency-v1".into()),
+    }
+    if cell.card == CardId::CrossThreadProducerConsumer {
+        execute_cross_thread_latency(adapter, cell, sample_denominator, control)
+    } else {
+        execute_ordered_latency(adapter, cell, sample_denominator, control)
+    }
+}
+
+fn execute_ordered_latency<A: AllocatorAdapter>(
+    adapter: &A,
+    cell: &ScenarioCell,
+    sample_denominator: u64,
+    control: bool,
+) -> Result<LatencyExecutionResult, String> {
+    let ready_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let start_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let end_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let live = Arc::new(AtomicU64::new(0));
+    let peak = Arc::new(AtomicU64::new(0));
+    let outcomes = std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(cell.threads);
+        for worker in 0..cell.threads {
+            let indices = deterministic_sample_indices(
+                cell.seed,
+                worker as u32,
+                cell.transactions_per_worker,
+                sample_denominator,
+            )?;
+            let start_barrier = Arc::clone(&start_barrier);
+            let ready_barrier = Arc::clone(&ready_barrier);
+            let end_barrier = Arc::clone(&end_barrier);
+            let live = Arc::clone(&live);
+            let peak = Arc::clone(&peak);
+            handles.push(scope.spawn(move || {
+                let mut allocations =
+                    Vec::with_capacity(card(cell.card).max_live_allocations_per_worker());
+                let mut requests = Vec::with_capacity(MAX_REQUESTS_PER_TRANSACTION);
+                let mut observations = Vec::with_capacity(indices.len());
+                let mut sample_cursor = 0_usize;
+                let mut counts = ExpectedCounts::default();
+                let mut checksum = 0_u64;
+                let mut failure = None;
+                // Some libc implementations initialize CPU-query state on the
+                // first sched_getcpu call. Prime that state before the timed
+                // gate so recording the actual end CPU cannot allocate.
+                std::hint::black_box(current_cpu_id());
+                ready_barrier.wait();
+                start_barrier.wait();
+                for operation in 0..cell.transactions_per_worker {
+                    if let Err(error) =
+                        cell.fill_worker_transaction(worker, operation, &mut requests)
+                    {
+                        failure = Some(error.to_string());
+                        break;
+                    }
+                    let sampled =
+                        sample_cursor < indices.len() && indices[sample_cursor] == operation;
+                    let started = sampled.then(Instant::now);
+                    if control {
+                        for request in &requests {
+                            std::hint::black_box((request.kind, request.size, request.token));
+                        }
+                    } else {
+                        for request in &requests {
+                            if let Err(error) = execute_one(
+                                adapter,
+                                cell.card,
+                                request,
+                                &mut allocations,
+                                &mut counts,
+                                &mut checksum,
+                                &live,
+                                &peak,
+                            ) {
+                                failure = Some(error);
+                                break;
+                            }
+                        }
+                    }
+                    if let Some(started) = started {
+                        if observations.len() == observations.capacity() {
+                            failure =
+                                Some("preallocated latency observation buffer exhausted".into());
+                            break;
+                        }
+                        observations.push(LatencyObservation {
+                            thread_index: worker as u32,
+                            transaction_index: operation,
+                            duration_ns: started.elapsed().as_nanos().min(u128::from(u64::MAX))
+                                as u64,
+                        });
+                        sample_cursor += 1;
+                    }
+                    if failure.is_some() {
+                        break;
+                    }
+                }
+                std::hint::black_box(checksum);
+                let actual_cpu_id = current_cpu_id();
+                end_barrier.wait();
+                for (_, allocation) in allocations {
+                    unsafe { adapter.free(allocation.pointer) };
+                    subtract_live(&live, allocation.size as u64);
+                }
+                match failure {
+                    Some(error) => Err(error),
+                    None if sample_cursor != indices.len() => {
+                        Err("latency sample schedule was not completely observed".into())
+                    }
+                    None => Ok((
+                        WorkerOutcome { counts, checksum },
+                        observations,
+                        actual_cpu_id,
+                    )),
+                }
+            }));
+        }
+        ready_barrier.wait();
+        notify_measured_region(true);
+        start_barrier.wait();
+        end_barrier.wait();
+        notify_measured_region(false);
+        handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .map_err(|_| "latency worker panicked".to_string())?
+            })
+            .collect::<Result<Vec<_>, String>>()
+    })?;
+    finish_latency_execution(cell, outcomes, &live, control)
+}
+
+fn execute_cross_thread_latency<A: AllocatorAdapter>(
+    adapter: &A,
+    cell: &ScenarioCell,
+    sample_denominator: u64,
+    control: bool,
+) -> Result<LatencyExecutionResult, String> {
+    let ready_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let start_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let end_barrier = Arc::new(Barrier::new(cell.threads + 1));
+    let operation_barrier = Arc::new(Barrier::new(cell.threads));
+    let live = Arc::new(AtomicU64::new(0));
+    let peak = Arc::new(AtomicU64::new(0));
+    let handoffs: HandoffQueues = Arc::new(
+        (0..cell.threads)
+            .map(|_| Mutex::new(Vec::with_capacity(1)))
+            .collect(),
+    );
+    let outcomes = std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(cell.threads);
+        for worker in 0..cell.threads {
+            let indices = deterministic_sample_indices(
+                cell.seed,
+                worker as u32,
+                cell.transactions_per_worker,
+                sample_denominator,
+            )?;
+            let start_barrier = Arc::clone(&start_barrier);
+            let ready_barrier = Arc::clone(&ready_barrier);
+            let end_barrier = Arc::clone(&end_barrier);
+            let operation_barrier = Arc::clone(&operation_barrier);
+            let live = Arc::clone(&live);
+            let peak = Arc::clone(&peak);
+            let handoffs = Arc::clone(&handoffs);
+            handles.push(scope.spawn(move || {
+                let mut allocations = Vec::with_capacity(1);
+                let mut requests = Vec::with_capacity(MAX_REQUESTS_PER_TRANSACTION);
+                let mut observations = Vec::with_capacity(indices.len());
+                let mut sample_cursor = 0_usize;
+                let mut counts = ExpectedCounts::default();
+                let mut checksum = 0_u64;
+                let mut failure: Option<String> = None;
+                std::hint::black_box(current_cpu_id());
+                ready_barrier.wait();
+                start_barrier.wait();
+                for operation in 0..cell.transactions_per_worker {
+                    if failure.is_none() {
+                        if let Err(error) =
+                            cell.fill_worker_transaction(worker, operation, &mut requests)
+                        {
+                            failure = Some(error.to_string());
+                        }
+                    }
+                    let sampled =
+                        sample_cursor < indices.len() && indices[sample_cursor] == operation;
+                    let started = sampled.then(Instant::now);
+                    let mut transfer = None;
+                    if control {
+                        for request in &requests {
+                            std::hint::black_box((request.kind, request.size, request.token));
+                        }
+                    } else if failure.is_none() {
+                        for request in &requests {
+                            if request.kind == RequestKind::Free
+                                && request.owner_worker != request.executor_worker
+                            {
+                                transfer = Some(*request);
+                            } else if let Err(error) = execute_one(
+                                adapter,
+                                cell.card,
+                                request,
+                                &mut allocations,
+                                &mut counts,
+                                &mut checksum,
+                                &live,
+                                &peak,
+                            ) {
+                                failure = Some(error);
+                                break;
+                            }
+                        }
+                        if let Some(request) = transfer {
+                            match remove_slot(&mut allocations, request.token) {
+                                Some(allocation) => handoffs[request.executor_worker]
+                                    .lock()
+                                    .expect("handoff queue lock poisoned")
+                                    .push((request, allocation)),
+                                None => {
+                                    failure =
+                                        Some("latency remote-transfer token was not live".into())
+                                }
+                            }
+                        }
+                    }
+                    operation_barrier.wait();
+                    if !control {
+                        let mut inbox = handoffs[worker]
+                            .lock()
+                            .expect("handoff queue lock poisoned");
+                        for (request, allocation) in inbox.drain(..) {
+                            allocations.push((request.token, allocation));
+                            if failure.is_none() {
+                                if let Err(error) = execute_one(
+                                    adapter,
+                                    cell.card,
+                                    &request,
+                                    &mut allocations,
+                                    &mut counts,
+                                    &mut checksum,
+                                    &live,
+                                    &peak,
+                                ) {
+                                    failure = Some(error);
+                                }
+                            }
+                        }
+                    }
+                    operation_barrier.wait();
+                    if let Some(started) = started {
+                        if observations.len() == observations.capacity() {
+                            failure =
+                                Some("preallocated latency observation buffer exhausted".into());
+                        } else {
+                            observations.push(LatencyObservation {
+                                thread_index: worker as u32,
+                                transaction_index: operation,
+                                duration_ns: started.elapsed().as_nanos().min(u128::from(u64::MAX))
+                                    as u64,
+                            });
+                            sample_cursor += 1;
+                        }
+                    }
+                }
+                std::hint::black_box(checksum);
+                let actual_cpu_id = current_cpu_id();
+                end_barrier.wait();
+                for (_, allocation) in allocations {
+                    unsafe { adapter.free(allocation.pointer) };
+                    subtract_live(&live, allocation.size as u64);
+                }
+                match failure {
+                    Some(error) => Err(error),
+                    None if sample_cursor != indices.len() => {
+                        Err("latency sample schedule was not completely observed".into())
+                    }
+                    None => Ok((
+                        WorkerOutcome { counts, checksum },
+                        observations,
+                        actual_cpu_id,
+                    )),
+                }
+            }));
+        }
+        ready_barrier.wait();
+        notify_measured_region(true);
+        start_barrier.wait();
+        end_barrier.wait();
+        notify_measured_region(false);
+        handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .map_err(|_| "latency worker panicked".to_string())?
+            })
+            .collect::<Result<Vec<_>, String>>()
+    })?;
+    finish_latency_execution(cell, outcomes, &live, control)
+}
+
+fn finish_latency_execution(
+    cell: &ScenarioCell,
+    outcomes: Vec<(WorkerOutcome, Vec<LatencyObservation>, Option<u32>)>,
+    live: &AtomicU64,
+    control: bool,
+) -> Result<LatencyExecutionResult, String> {
+    if live.load(Ordering::SeqCst) != 0 {
+        return Err("latency workload finished with live requested bytes".into());
+    }
+    let mut counts = ExpectedCounts {
+        requested_transactions: cell.requested_transactions(),
+        completed_transactions: cell.requested_transactions(),
+        ..ExpectedCounts::default()
+    };
+    let mut checksum = FNV_OFFSET;
+    let mut observations = Vec::new();
+    let mut actual_cpu_ids = Vec::with_capacity(outcomes.len());
+    for (worker, (outcome, mut worker_observations, cpu)) in outcomes.into_iter().enumerate() {
+        if !control {
+            add_counts(&mut counts, outcome.counts);
+            checksum = fnv_u64(checksum, worker as u64);
+            checksum = fnv_u64(checksum, outcome.checksum);
+        }
+        observations.append(&mut worker_observations);
+        actual_cpu_ids.push(cpu);
+    }
+    if !control {
+        let expected = cell.expected_counts().map_err(|error| error.to_string())?;
+        if counts != expected || checksum != expected_touch_checksum(cell)? {
+            return Err("latency execution contradicted scenario counts or checksum".into());
+        }
+    }
+    observations.sort_by_key(|value| (value.thread_index, value.transaction_index));
+    Ok(LatencyExecutionResult {
+        observations,
+        completed_transactions: cell.requested_transactions(),
+        checksum: if control { 1 } else { checksum },
+        actual_cpu_ids,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn current_cpu_id() -> Option<u32> {
+    unsafe extern "C" {
+        fn sched_getcpu() -> std::os::raw::c_int;
+    }
+    let cpu = unsafe { sched_getcpu() };
+    (cpu >= 0).then_some(cpu as u32)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn current_cpu_id() -> Option<u32> {
+    None
 }
 
 fn execute_cell_with_observer<A: AllocatorAdapter, O: MeasurementObserver>(

--- a/rust/benchmark-suite/src/latency.rs
+++ b/rust/benchmark-suite/src/latency.rs
@@ -1,0 +1,1932 @@
+//! Honest end-to-end transaction latency measurement and publication.
+//!
+//! This protocol never derives latency from throughput. Every duration is a
+//! paired monotonic-clock observation around one declared transaction.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::execution::{
+    execute_cell, execute_latency_cell, expected_touch_checksum, AllocatorAdapter,
+};
+use crate::model::{
+    AllocatorBuildIdentity, BenchmarkChildRequest, CellCalibration, LatestReport,
+    PublicationRunner, RunIdentity,
+};
+use crate::orchestration::{balanced_block_orders, ChildProgram};
+use crate::provenance::sha256_bytes;
+use crate::scenarios::{card, CardId, ScenarioCell, ThreadPoint, Topology};
+use crate::stats::{
+    BootstrapMetadata, ConfidenceInterval, MetricDirection, PairedEffectSummary, BOOTSTRAP_PRNG,
+};
+
+pub const LATENCY_SCHEMA_VERSION: &str = "transaction-latency-v1";
+pub const LATENCY_CHILD_PROTOCOL_VERSION: &str = "transaction-latency-child-v1";
+pub const LATENCY_MIN_BLOCKS: u32 = 15;
+pub const LATENCY_MIN_SAMPLES: usize = 10_000;
+pub const LATENCY_INITIAL_SAMPLE_DENOMINATOR: u64 = 1024;
+pub const LATENCY_BOOTSTRAP_RESAMPLES: u32 = 10_000;
+const REFERENCE_ALLOCATOR: &str = "upstream-mimalloc";
+const ALLOCATOR_IDS: [&str; 4] = [
+    "tcmalloc",
+    "jemalloc",
+    "upstream-mimalloc",
+    "mimalloc-pprof",
+];
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyObservation {
+    pub thread_index: u32,
+    pub transaction_index: u64,
+    pub duration_ns: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LatencyExecutionResult {
+    pub observations: Vec<LatencyObservation>,
+    pub completed_transactions: u64,
+    pub checksum: u64,
+    pub actual_cpu_ids: Vec<Option<u32>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyClock {
+    pub source: String,
+    pub implementation: String,
+    pub resolution_ns: u64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ContextSwitchCounts {
+    pub voluntary: u64,
+    pub involuntary: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyScheduling {
+    pub affinity_policy: String,
+    pub actual_cpu_ids: Vec<Option<u32>>,
+    pub thread_count: u32,
+    pub physical_cores: u32,
+    pub logical_cores: u32,
+    pub context_switches: ContextSwitchCounts,
+    pub runner_class: String,
+    pub clock: LatencyClock,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyChildRequest {
+    pub protocol_version: String,
+    pub metric_schema_version: String,
+    pub sample_denominator: u64,
+    pub control: bool,
+    pub runner_class: String,
+    pub affinity_policy: String,
+    pub benchmark: BenchmarkChildRequest,
+}
+
+impl LatencyChildRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.protocol_version != LATENCY_CHILD_PROTOCOL_VERSION
+            || self.metric_schema_version != LATENCY_SCHEMA_VERSION
+            || self.sample_denominator == 0
+            || self.runner_class.is_empty()
+            || self.affinity_policy.is_empty()
+        {
+            return Err("unsupported latency child protocol, schema, or sample rate".into());
+        }
+        self.benchmark.validate()?;
+        latency_cell(
+            &self.benchmark.scenario_id,
+            &self.benchmark.thread_point,
+            Topology {
+                physical_cores: self.benchmark.physical_cores as usize,
+                logical_cores: self.benchmark.logical_cores as usize,
+            },
+            self.benchmark.transactions_per_worker,
+            self.benchmark.workload_seed,
+        )?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyChildResponse {
+    pub protocol_version: String,
+    pub metric_schema_version: String,
+    pub control: bool,
+    pub completed_transactions: u64,
+    pub checksum: u64,
+    pub observations: Vec<LatencyObservation>,
+    pub scheduling: LatencyScheduling,
+}
+
+impl LatencyChildResponse {
+    pub fn validate_against(&self, request: &LatencyChildRequest) -> Result<(), String> {
+        request.validate()?;
+        if self.protocol_version != LATENCY_CHILD_PROTOCOL_VERSION
+            || self.metric_schema_version != LATENCY_SCHEMA_VERSION
+            || self.control != request.control
+        {
+            return Err("latency child response identity mismatch".into());
+        }
+        let cell = latency_cell(
+            &request.benchmark.scenario_id,
+            &request.benchmark.thread_point,
+            Topology {
+                physical_cores: request.benchmark.physical_cores as usize,
+                logical_cores: request.benchmark.logical_cores as usize,
+            },
+            request.benchmark.transactions_per_worker,
+            request.benchmark.workload_seed,
+        )?;
+        let expected = all_sample_indices(&cell, request.sample_denominator)?;
+        let observed = self
+            .observations
+            .iter()
+            .map(|value| (value.thread_index, value.transaction_index))
+            .collect::<Vec<_>>();
+        let expected_checksum = if request.control {
+            1
+        } else {
+            expected_touch_checksum(&cell)?
+        };
+        if observed != expected
+            || self.completed_transactions != cell.requested_transactions()
+            || self.checksum != expected_checksum
+            || self.scheduling.thread_count != cell.threads as u32
+            || self.scheduling.physical_cores != request.benchmark.physical_cores
+            || self.scheduling.logical_cores != request.benchmark.logical_cores
+            || self.scheduling.runner_class != request.runner_class
+            || self.scheduling.affinity_policy != request.affinity_policy
+            || self.scheduling.actual_cpu_ids.len() != cell.threads
+            || self.scheduling.clock.source.is_empty()
+            || self.scheduling.clock.implementation.is_empty()
+            || self.scheduling.clock.resolution_ns == 0
+            || self.observations.iter().any(|value| value.duration_ns == 0)
+        {
+            return Err(
+                "latency child response contradicts its schedule, clock, or topology".into(),
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyRawSample {
+    pub metric_schema_version: String,
+    pub block_id: u32,
+    pub ordinal: u8,
+    pub workload_seed: u64,
+    pub allocator_id: String,
+    pub allocator_source_sha: String,
+    pub child_binary_sha256: String,
+    pub scenario_id: String,
+    pub thread_point: String,
+    pub thread_count: u32,
+    pub sample_denominator: u64,
+    pub transaction_definition: String,
+    pub measured: LatencyChildResponse,
+    pub control: LatencyChildResponse,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyRawRun {
+    pub metric_schema_version: String,
+    pub status: String,
+    pub run_seed: u64,
+    pub run: RunIdentity,
+    pub runner: PublicationRunner,
+    pub allocator_lock_sha256: String,
+    pub allocators: Vec<AllocatorBuildIdentity>,
+    pub calibrations: Vec<CellCalibration>,
+    pub sampling_denominators: BTreeMap<String, u64>,
+    pub samples: Vec<LatencyRawSample>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyDistribution {
+    pub count: u64,
+    pub p50_ns: f64,
+    pub p95_ns: f64,
+    pub p99_ns: f64,
+    pub min_ns: u64,
+    pub max_ns: u64,
+    pub median_absolute_deviation_ns: f64,
+    pub iqr_ns: f64,
+    pub zero_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyBlockSummary {
+    pub block_id: u32,
+    pub allocator_id: String,
+    pub scenario_id: String,
+    pub thread_point: String,
+    pub measured: LatencyDistribution,
+    pub control: LatencyDistribution,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyAbsoluteSummary {
+    pub allocator_id: String,
+    pub scenario_id: String,
+    pub thread_point: String,
+    pub transaction_definition: String,
+    pub measured: LatencyDistribution,
+    pub control: LatencyDistribution,
+    pub overhead_valid: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyPairedSummary {
+    pub scenario_id: String,
+    pub thread_point: String,
+    pub quantile: String,
+    pub summary: PairedEffectSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyMethodology {
+    pub transaction_boundaries: BTreeMap<String, String>,
+    pub quantile_method: String,
+    pub sampling_schedule: String,
+    pub overhead_control: String,
+    pub bootstrap: String,
+    pub storage_decision: String,
+    pub tail_policy: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyMetricReport {
+    pub metric_schema_version: String,
+    pub status: String,
+    pub invalid_reason: Option<String>,
+    pub metric_comparison_key: String,
+    pub run: RunIdentity,
+    pub runner: PublicationRunner,
+    pub direction: MetricDirection,
+    pub informational: bool,
+    pub sampling_denominators: BTreeMap<String, u64>,
+    pub methodology: LatencyMethodology,
+    pub absolute_summaries: Vec<LatencyAbsoluteSummary>,
+    pub paired_summaries: Vec<LatencyPairedSummary>,
+    pub block_summaries: Vec<LatencyBlockSummary>,
+    pub raw_samples: Vec<LatencyRawSample>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LatencyHistoryReport {
+    pub metric_schema_version: String,
+    pub status: String,
+    pub metric_comparison_key: String,
+    pub run: RunIdentity,
+    pub runner_fingerprint_sha256: String,
+    pub direction: MetricDirection,
+    pub informational: bool,
+    pub sampling_denominators: BTreeMap<String, u64>,
+    pub methodology: LatencyMethodology,
+    pub absolute_summaries: Vec<LatencyAbsoluteSummary>,
+    pub paired_summaries: Vec<LatencyPairedSummary>,
+    pub block_summaries: Vec<LatencyBlockSummary>,
+}
+
+impl LatencyMetricReport {
+    pub fn history_projection(&self) -> LatencyHistoryReport {
+        LatencyHistoryReport {
+            metric_schema_version: self.metric_schema_version.clone(),
+            status: self.status.clone(),
+            metric_comparison_key: self.metric_comparison_key.clone(),
+            run: self.run.clone(),
+            runner_fingerprint_sha256: self.runner.fingerprint_sha256.clone(),
+            direction: self.direction,
+            informational: self.informational,
+            sampling_denominators: self.sampling_denominators.clone(),
+            methodology: self.methodology.clone(),
+            absolute_summaries: self.absolute_summaries.clone(),
+            paired_summaries: self.paired_summaries.clone(),
+            block_summaries: self.block_summaries.clone(),
+        }
+    }
+}
+
+pub fn latency_scenario_cells(
+    topology: Topology,
+) -> Result<Vec<(CardId, ThreadPoint, &'static str)>, String> {
+    topology.validate().map_err(|error| error.to_string())?;
+    let cells = vec![
+        (
+            CardId::TinyFixed64,
+            ThreadPoint::One,
+            transaction_definition(CardId::TinyFixed64),
+        ),
+        (
+            CardId::SmallLogMixed,
+            ThreadPoint::One,
+            transaction_definition(CardId::SmallLogMixed),
+        ),
+        (
+            CardId::SmallLogMixed,
+            ThreadPoint::PhysicalCores,
+            transaction_definition(CardId::SmallLogMixed),
+        ),
+        (
+            CardId::CrossThreadProducerConsumer,
+            ThreadPoint::PhysicalCores,
+            transaction_definition(CardId::CrossThreadProducerConsumer),
+        ),
+        (
+            CardId::LargeObjects,
+            ThreadPoint::One,
+            transaction_definition(CardId::LargeObjects),
+        ),
+    ];
+    for (card, point, _) in &cells {
+        ScenarioCell::new(*card, *point, topology, 1, 1).map_err(|error| error.to_string())?;
+    }
+    Ok(cells)
+}
+
+pub const fn transaction_definition(card: CardId) -> &'static str {
+    match card {
+        CardId::CrossThreadProducerConsumer => "producer allocation through consumer free completion, including queue and ownership transfer",
+        CardId::LargeObjects => "allocation plus one-byte-per-page touch/checksum plus free",
+        CardId::TinyFixed64 | CardId::SmallLogMixed => "allocation plus required touch/checksum plus free",
+        _ => "not part of transaction-latency-v1",
+    }
+}
+
+fn latency_cell(
+    scenario: &str,
+    point: &str,
+    topology: Topology,
+    transactions: u64,
+    seed: u64,
+) -> Result<ScenarioCell, String> {
+    let card = CardId::parse(scenario).ok_or_else(|| "unknown latency scenario".to_string())?;
+    let point =
+        ThreadPoint::parse(point).ok_or_else(|| "unknown latency thread point".to_string())?;
+    if !latency_scenario_cells(topology)?
+        .iter()
+        .any(|(candidate_card, candidate_point, _)| {
+            *candidate_card == card && *candidate_point == point
+        })
+    {
+        return Err("undeclared transaction-latency-v1 cell".into());
+    }
+    ScenarioCell::new(card, point, topology, transactions, seed).map_err(|error| error.to_string())
+}
+
+/// Deterministic 1/N schedule. The seed-controlled offset prevents a fixed
+/// request-cycle phase from being overrepresented while remaining identical
+/// for all allocators in a paired block.
+pub fn deterministic_sample_indices(
+    workload_seed: u64,
+    worker: u32,
+    transactions: u64,
+    denominator: u64,
+) -> Result<Vec<u64>, String> {
+    if workload_seed == 0 || transactions == 0 || denominator == 0 {
+        return Err("latency schedule requires nonzero seed, transactions, and denominator".into());
+    }
+    let offset =
+        splitmix64(workload_seed ^ 0x6c61_7465_6e63_7901 ^ u64::from(worker)) % denominator;
+    let capacity = transactions.saturating_add(denominator - 1) / denominator;
+    let mut output = Vec::with_capacity(capacity as usize);
+    let mut index = offset;
+    while index < transactions {
+        output.push(index);
+        index = index
+            .checked_add(denominator)
+            .ok_or_else(|| "latency sample schedule overflowed".to_string())?;
+    }
+    Ok(output)
+}
+
+fn all_sample_indices(cell: &ScenarioCell, denominator: u64) -> Result<Vec<(u32, u64)>, String> {
+    let mut output = Vec::new();
+    for worker in 0..cell.threads {
+        output.extend(
+            deterministic_sample_indices(
+                cell.seed,
+                worker as u32,
+                cell.transactions_per_worker,
+                denominator,
+            )?
+            .into_iter()
+            .map(|index| (worker as u32, index)),
+        );
+    }
+    Ok(output)
+}
+
+pub fn minimum_transactions_per_worker(
+    threads: usize,
+    blocks: u32,
+    denominator: u64,
+    minimum_samples: usize,
+) -> Result<u64, String> {
+    if threads == 0 || blocks == 0 || denominator == 0 || minimum_samples == 0 {
+        return Err("latency minimum calculation received zero".into());
+    }
+    let per_block = (minimum_samples as u64).div_ceil(u64::from(blocks));
+    let per_worker = per_block.div_ceil(threads as u64);
+    per_worker
+        .checked_mul(denominator)
+        .and_then(|value| value.checked_add(denominator))
+        .ok_or_else(|| "latency transaction count overflowed".into())
+}
+
+pub fn choose_sample_denominator(
+    calibrated_transactions_per_worker: u64,
+    threads: usize,
+    blocks: u32,
+) -> Result<u64, String> {
+    if threads == 0 || blocks == 0 || calibrated_transactions_per_worker == 0 {
+        return Err("latency rate selection received zero".into());
+    }
+    let total = calibrated_transactions_per_worker
+        .checked_mul(threads as u64)
+        .and_then(|value| value.checked_mul(u64::from(blocks)))
+        .ok_or_else(|| "latency rate selection overflowed".to_string())?;
+    Ok((total / LATENCY_MIN_SAMPLES as u64).clamp(1, LATENCY_INITIAL_SAMPLE_DENOMINATOR))
+}
+
+pub fn execute_latency_child_request<A: AllocatorAdapter>(
+    adapter: &A,
+    request: LatencyChildRequest,
+) -> Result<LatencyChildResponse, String> {
+    request.validate()?;
+    let expected = &request.benchmark.allocator;
+    if adapter.allocator_id() != expected.allocator_id
+        || adapter.allocator_version() != expected.allocator_version
+        || adapter.source_sha() != expected.source_sha
+        || adapter.library_sha256() != expected.library_sha256
+    {
+        return Err("latency request allocator does not match linked adapter".into());
+    }
+    let topology = Topology {
+        physical_cores: request.benchmark.physical_cores as usize,
+        logical_cores: request.benchmark.logical_cores as usize,
+    };
+    if request.benchmark.warmup_transactions_per_worker > 0 {
+        let warmup = latency_cell(
+            &request.benchmark.scenario_id,
+            &request.benchmark.thread_point,
+            topology,
+            request.benchmark.warmup_transactions_per_worker,
+            request.benchmark.workload_seed ^ 0xa076_1d64_78bd_642f,
+        )?;
+        execute_cell(adapter, &warmup)?;
+    }
+    let cell = latency_cell(
+        &request.benchmark.scenario_id,
+        &request.benchmark.thread_point,
+        topology,
+        request.benchmark.transactions_per_worker,
+        request.benchmark.workload_seed,
+    )?;
+    let before = read_context_switches();
+    let execution =
+        execute_latency_cell(adapter, &cell, request.sample_denominator, request.control)?;
+    let after = read_context_switches();
+    let response = LatencyChildResponse {
+        protocol_version: LATENCY_CHILD_PROTOCOL_VERSION.into(),
+        metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+        control: request.control,
+        completed_transactions: execution.completed_transactions,
+        checksum: execution.checksum,
+        observations: execution.observations,
+        scheduling: LatencyScheduling {
+            affinity_policy: request.affinity_policy.clone(),
+            actual_cpu_ids: execution.actual_cpu_ids,
+            thread_count: cell.threads as u32,
+            physical_cores: request.benchmark.physical_cores,
+            logical_cores: request.benchmark.logical_cores,
+            context_switches: ContextSwitchCounts {
+                voluntary: after.voluntary.saturating_sub(before.voluntary),
+                involuntary: after.involuntary.saturating_sub(before.involuntary),
+            },
+            runner_class: request.runner_class.clone(),
+            clock: monotonic_clock(),
+        },
+    };
+    response.validate_against(&request)?;
+    Ok(response)
+}
+
+pub fn run_latency_child(
+    child: &ChildProgram,
+    request: &LatencyChildRequest,
+    timeout: Duration,
+) -> Result<LatencyChildResponse, String> {
+    request.validate()?;
+    if child.allocator != request.benchmark.allocator || timeout.is_zero() {
+        return Err("latency child identity mismatch or zero timeout".into());
+    }
+    let encoded = serde_json::to_vec(request)
+        .map_err(|error| format!("serialize latency request: {error}"))?;
+    let mut process = Command::new(&child.program);
+    process
+        .args(&child.arguments)
+        .arg("--latency")
+        .env_clear()
+        .envs(child.environment.iter().map(|(key, value)| (key, value)))
+        .env("MIMALLOC_PROF", "0")
+        .env("MIMALLOC_MEMORY_EVENTS", "0")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child_process = process
+        .spawn()
+        .map_err(|error| format!("spawn latency child: {error}"))?;
+    child_process
+        .stdin
+        .take()
+        .ok_or_else(|| "latency child stdin was not piped".to_string())?
+        .write_all(&encoded)
+        .map_err(|error| format!("write latency request: {error}"))?;
+    let mut stdout = child_process
+        .stdout
+        .take()
+        .ok_or_else(|| "latency child stdout was not piped".to_string())?;
+    let mut stderr = child_process
+        .stderr
+        .take()
+        .ok_or_else(|| "latency child stderr was not piped".to_string())?;
+    // Drain both pipes while polling so a valid raw vector larger than the
+    // platform pipe capacity cannot deadlock the child before exit.
+    let stdout_reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        stdout
+            .read_to_end(&mut bytes)
+            .map_err(|error| format!("read latency child stdout: {error}"))?;
+        Ok::<_, String>(bytes)
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        stderr
+            .read_to_end(&mut bytes)
+            .map_err(|error| format!("read latency child stderr: {error}"))?;
+        Ok::<_, String>(bytes)
+    });
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child_process
+            .try_wait()
+            .map_err(|error| format!("poll latency child: {error}"))?
+        {
+            break status;
+        }
+        if started.elapsed() >= timeout {
+            let _ = child_process.kill();
+            let _ = child_process.wait();
+            let _ = stdout_reader.join();
+            let error_bytes = stderr_reader
+                .join()
+                .map_err(|_| "latency stderr reader panicked".to_string())??;
+            return Err(format!(
+                "latency child timed out: {}",
+                String::from_utf8_lossy(&error_bytes)
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    };
+    let output = stdout_reader
+        .join()
+        .map_err(|_| "latency stdout reader panicked".to_string())??;
+    let error_bytes = stderr_reader
+        .join()
+        .map_err(|_| "latency stderr reader panicked".to_string())??;
+    if !status.success() || !error_bytes.is_empty() {
+        return Err(format!(
+            "latency child failed: {}",
+            String::from_utf8_lossy(&error_bytes)
+        ));
+    }
+    let response: LatencyChildResponse = serde_json::from_slice(&output)
+        .map_err(|error| format!("decode latency child response: {error}"))?;
+    response.validate_against(request)?;
+    Ok(response)
+}
+
+fn read_context_switches() -> ContextSwitchCounts {
+    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+        return ContextSwitchCounts {
+            voluntary: 0,
+            involuntary: 0,
+        };
+    };
+    let parse = |prefix: &str| {
+        status
+            .lines()
+            .find_map(|line| line.strip_prefix(prefix))
+            .and_then(|value| value.trim().parse().ok())
+            .unwrap_or(0)
+    };
+    ContextSwitchCounts {
+        voluntary: parse("voluntary_ctxt_switches:"),
+        involuntary: parse("nonvoluntary_ctxt_switches:"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn monotonic_clock() -> LatencyClock {
+    #[repr(C)]
+    struct Timespec {
+        tv_sec: std::os::raw::c_long,
+        tv_nsec: std::os::raw::c_long,
+    }
+    unsafe extern "C" {
+        fn clock_getres(clock_id: std::os::raw::c_int, value: *mut Timespec)
+            -> std::os::raw::c_int;
+    }
+    let mut value = Timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    let result = unsafe { clock_getres(1, &mut value) };
+    let resolution = if result == 0 {
+        (value.tv_sec as u64)
+            .saturating_mul(1_000_000_000)
+            .saturating_add(value.tv_nsec as u64)
+            .max(1)
+    } else {
+        1
+    };
+    LatencyClock {
+        source: "monotonic".into(),
+        implementation: "std::time::Instant/CLOCK_MONOTONIC".into(),
+        resolution_ns: resolution,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn monotonic_clock() -> LatencyClock {
+    LatencyClock {
+        source: "monotonic".into(),
+        implementation: "std::time::Instant".into(),
+        resolution_ns: 1,
+    }
+}
+
+pub fn summarize_latency(values: &[u64]) -> Result<LatencyDistribution, String> {
+    if values.is_empty() {
+        return Err("latency distribution is empty".into());
+    }
+    let zero_count = values.iter().filter(|value| **value == 0).count() as u64;
+    if zero_count != 0 {
+        return Err("zero or negative latency duration invalidates the cell".into());
+    }
+    let mut numeric = values.iter().map(|value| *value as f64).collect::<Vec<_>>();
+    numeric.sort_by(f64::total_cmp);
+    let p50 = type7_sorted(&numeric, 0.50);
+    let p95 = type7_sorted(&numeric, 0.95);
+    let p99 = type7_sorted(&numeric, 0.99);
+    let q1 = type7_sorted(&numeric, 0.25);
+    let q3 = type7_sorted(&numeric, 0.75);
+    let mut deviations = numeric
+        .iter()
+        .map(|value| (value - p50).abs())
+        .collect::<Vec<_>>();
+    deviations.sort_by(f64::total_cmp);
+    let mad = type7_sorted(&deviations, 0.50);
+    Ok(LatencyDistribution {
+        count: values.len() as u64,
+        p50_ns: p50,
+        p95_ns: p95,
+        p99_ns: p99,
+        min_ns: *values.iter().min().expect("nonempty"),
+        max_ns: *values.iter().max().expect("nonempty"),
+        median_absolute_deviation_ns: mad,
+        iqr_ns: q3 - q1,
+        zero_count,
+    })
+}
+
+pub fn overhead_is_valid(measured: &LatencyDistribution, control: &LatencyDistribution) -> bool {
+    control.p50_ns <= measured.p50_ns * 0.05 && measured.p99_ns > control.p99_ns * 2.0
+}
+
+pub fn validate_latency_raw_run(raw: &LatencyRawRun) -> Result<(), String> {
+    if raw.metric_schema_version != LATENCY_SCHEMA_VERSION
+        || raw.status != "complete"
+        || raw.run_seed == 0
+        || raw.run.source_repository.is_empty()
+        || !is_lower_hex(&raw.run.source_sha, 40)
+        || raw.run.run_id.is_empty()
+        || raw.run.run_attempt == 0
+        || raw.runner.runner_class.is_empty()
+        || !is_lower_hex(&raw.runner.fingerprint_sha256, 64)
+        || raw.runner.physical_cores == 0
+        || raw.runner.logical_cores == 0
+        || raw.runner.physical_cores > raw.runner.logical_cores
+        || !matches!(raw.runner.affinity.policy.as_str(), "unrestricted" | "pinned")
+        || (raw.runner.affinity.policy == "pinned"
+            && raw.runner.affinity.logical_cpu_ids.is_empty())
+        || raw
+            .runner
+            .affinity
+            .logical_cpu_ids
+            .iter()
+            .collect::<BTreeSet<_>>()
+            .len()
+            != raw.runner.affinity.logical_cpu_ids.len()
+        || !is_lower_hex(&raw.allocator_lock_sha256, 64)
+    {
+        return Err("latency raw run must be complete transaction-latency-v1".into());
+    }
+    let topology = Topology {
+        physical_cores: raw.runner.physical_cores as usize,
+        logical_cores: raw.runner.logical_cores as usize,
+    };
+    let cells = latency_scenario_cells(topology)?;
+    let expected_cells = cells
+        .iter()
+        .map(|(card, point, _)| format!("{}/{}", card.as_str(), point.name()))
+        .collect::<BTreeSet<_>>();
+    if raw
+        .sampling_denominators
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        != expected_cells
+    {
+        return Err("latency sampling-rate matrix is incomplete".into());
+    }
+    if raw
+        .sampling_denominators
+        .values()
+        .any(|value| *value == 0 || *value > LATENCY_INITIAL_SAMPLE_DENOMINATOR)
+    {
+        return Err("latency sampling denominator is outside the versioned range".into());
+    }
+
+    let allocators = raw
+        .allocators
+        .iter()
+        .map(|value| (value.allocator_id.as_str(), value))
+        .collect::<BTreeMap<_, _>>();
+    if raw.allocators.len() != ALLOCATOR_IDS.len()
+        || allocators.keys().copied().collect::<BTreeSet<_>>()
+            != ALLOCATOR_IDS.into_iter().collect()
+    {
+        return Err("latency run does not contain the exact allocator set".into());
+    }
+    for allocator in raw.allocators.iter() {
+        if !is_lower_hex(&allocator.source_sha, 40)
+            || !is_lower_hex(&allocator.child_binary_sha256, 64)
+        {
+            return Err("latency allocator provenance contains an invalid digest".into());
+        }
+    }
+
+    let calibrations = raw
+        .calibrations
+        .iter()
+        .map(|value| {
+            (
+                (value.scenario_id.as_str(), value.thread_point.as_str()),
+                value,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    if calibrations.len() != cells.len() || raw.calibrations.len() != cells.len() {
+        return Err("latency calibration matrix is incomplete or duplicated".into());
+    }
+    for (card_id, thread_point, _) in &cells {
+        let calibration = calibrations
+            .get(&(card_id.as_str(), thread_point.name()))
+            .ok_or("latency calibration matrix is missing a declared cell")?;
+        let cell = ScenarioCell::new(
+            *card_id,
+            *thread_point,
+            topology,
+            calibration.transactions_per_worker,
+            1,
+        )
+        .map_err(|error| error.to_string())?;
+        let expected_operations = card(*card_id)
+            .operation_count(&cell.expected_counts().map_err(|error| error.to_string())?);
+        if calibration.thread_count != cell.threads as u32
+            || calibration.transactions_per_worker == 0
+            || calibration.operation_count != expected_operations
+            || calibration.elapsed_ns == 0
+        {
+            return Err("latency calibration contradicts its declared workload".into());
+        }
+    }
+
+    let mut grouped: BTreeMap<(String, String, String), Vec<&LatencyRawSample>> = BTreeMap::new();
+    let mut common_clock: Option<LatencyClock> = None;
+    for sample in &raw.samples {
+        if sample.metric_schema_version != LATENCY_SCHEMA_VERSION
+            || sample.ordinal >= 4
+            || sample.workload_seed == 0
+        {
+            return Err("latency sample has invalid identity".into());
+        }
+        let key = format!("{}/{}", sample.scenario_id, sample.thread_point);
+        if !expected_cells.contains(&key) {
+            return Err("latency sample names an undeclared cell".into());
+        }
+        let allocator = allocators
+            .get(sample.allocator_id.as_str())
+            .ok_or("latency sample names an undeclared allocator")?;
+        let calibration = calibrations
+            .get(&(sample.scenario_id.as_str(), sample.thread_point.as_str()))
+            .ok_or("latency sample has no matching calibration")?;
+        let card_id = CardId::parse(&sample.scenario_id).ok_or("unknown latency card")?;
+        let thread_point =
+            ThreadPoint::parse(&sample.thread_point).ok_or("unknown latency thread point")?;
+        let cell = ScenarioCell::new(
+            card_id,
+            thread_point,
+            topology,
+            calibration.transactions_per_worker,
+            sample.workload_seed,
+        )
+        .map_err(|error| error.to_string())?;
+        let expected_schedule = all_sample_indices(&cell, sample.sample_denominator)?;
+        let expected_checksum = expected_touch_checksum(&cell)?;
+        if raw.sampling_denominators.get(&key) != Some(&sample.sample_denominator)
+            || sample.allocator_source_sha != allocator.source_sha
+            || sample.child_binary_sha256 != allocator.child_binary_sha256
+            || sample.thread_count != cell.threads as u32
+            || sample.transaction_definition != transaction_definition(card_id)
+            || sample.measured.protocol_version != LATENCY_CHILD_PROTOCOL_VERSION
+            || sample.control.protocol_version != LATENCY_CHILD_PROTOCOL_VERSION
+            || sample.measured.metric_schema_version != LATENCY_SCHEMA_VERSION
+            || sample.control.metric_schema_version != LATENCY_SCHEMA_VERSION
+            || sample.measured.control
+            || !sample.control.control
+            || sample.measured.completed_transactions != cell.requested_transactions()
+            || sample.control.completed_transactions != cell.requested_transactions()
+            || sample.measured.checksum != expected_checksum
+            || sample.control.checksum != 1
+        {
+            return Err("latency sample contradicts protocol metadata".into());
+        }
+        let measured_schedule = sample
+            .measured
+            .observations
+            .iter()
+            .map(|value| (value.thread_index, value.transaction_index))
+            .collect::<Vec<_>>();
+        let control_schedule = sample
+            .control
+            .observations
+            .iter()
+            .map(|value| (value.thread_index, value.transaction_index))
+            .collect::<Vec<_>>();
+        if measured_schedule != expected_schedule
+            || control_schedule != expected_schedule
+            || sample
+                .measured
+                .observations
+                .iter()
+                .chain(&sample.control.observations)
+                .any(|value| value.duration_ns == 0)
+        {
+            return Err(
+                "latency measured/control schedules differ or contain zero duration".into(),
+            );
+        }
+        if sample.measured.scheduling.clock != sample.control.scheduling.clock
+            || sample.measured.scheduling.affinity_policy
+                != sample.control.scheduling.affinity_policy
+            || sample.measured.scheduling.thread_count != sample.thread_count
+            || sample.control.scheduling.thread_count != sample.thread_count
+            || sample.measured.scheduling.physical_cores != raw.runner.physical_cores
+            || sample.control.scheduling.physical_cores != raw.runner.physical_cores
+            || sample.measured.scheduling.logical_cores != raw.runner.logical_cores
+            || sample.control.scheduling.logical_cores != raw.runner.logical_cores
+            || sample.measured.scheduling.runner_class != raw.runner.runner_class
+            || sample.control.scheduling.runner_class != raw.runner.runner_class
+            || sample.measured.scheduling.affinity_policy != raw.runner.affinity.policy
+            || sample.measured.scheduling.actual_cpu_ids.len() != cell.threads
+            || sample.control.scheduling.actual_cpu_ids.len() != cell.threads
+            || sample.measured.scheduling.clock.source.is_empty()
+            || sample.measured.scheduling.clock.implementation.is_empty()
+            || sample.measured.scheduling.clock.resolution_ns == 0
+        {
+            return Err("latency control uses incompatible scheduling or clock metadata".into());
+        }
+        if raw.runner.affinity.policy == "pinned"
+            && sample
+                .measured
+                .scheduling
+                .actual_cpu_ids
+                .iter()
+                .chain(&sample.control.scheduling.actual_cpu_ids)
+                .any(|cpu| {
+                    cpu.is_none()
+                        || !raw
+                            .runner
+                            .affinity
+                            .logical_cpu_ids
+                            .contains(&cpu.unwrap_or_default())
+                })
+        {
+            return Err("latency pinned affinity was not observed on an allowed CPU".into());
+        }
+        match &common_clock {
+            Some(clock) if clock != &sample.measured.scheduling.clock => {
+                return Err("latency run mixes incompatible clocks".into());
+            }
+            None => common_clock = Some(sample.measured.scheduling.clock.clone()),
+            _ => {}
+        }
+        grouped
+            .entry((
+                sample.scenario_id.clone(),
+                sample.thread_point.clone(),
+                sample.allocator_id.clone(),
+            ))
+            .or_default()
+            .push(sample);
+    }
+    let mut common_blocks: Option<BTreeSet<u32>> = None;
+    for (card, point, _) in cells {
+        let mut reference_seeds: BTreeMap<u32, (u64, Vec<(u32, u64)>)> = BTreeMap::new();
+        let mut cell_blocks: Option<BTreeSet<u32>> = None;
+        for allocator in ALLOCATOR_IDS {
+            let key = (
+                card.as_str().to_string(),
+                point.name().to_string(),
+                allocator.to_string(),
+            );
+            let samples = grouped.get(&key).ok_or_else(|| {
+                format!(
+                    "missing latency allocator/cell {allocator} {}/{}",
+                    card.as_str(),
+                    point.name()
+                )
+            })?;
+            if samples.len() < LATENCY_MIN_BLOCKS as usize {
+                return Err(
+                    "every latency allocator/cell requires at least 15 complete blocks".into(),
+                );
+            }
+            let blocks = samples
+                .iter()
+                .map(|value| value.block_id)
+                .collect::<BTreeSet<_>>();
+            if blocks.len() != samples.len() {
+                return Err("duplicate latency allocator/cell block".into());
+            }
+            match &cell_blocks {
+                Some(expected) if expected != &blocks => {
+                    return Err("latency allocators do not share an exact block set".into());
+                }
+                None => cell_blocks = Some(blocks.clone()),
+                _ => {}
+            }
+            let measured_count: usize = samples
+                .iter()
+                .map(|value| value.measured.observations.len())
+                .sum();
+            let control_count: usize = samples
+                .iter()
+                .map(|value| value.control.observations.len())
+                .sum();
+            if measured_count < LATENCY_MIN_SAMPLES || control_count < LATENCY_MIN_SAMPLES {
+                return Err(
+                    "every latency allocator/cell requires 10000 measured and control samples"
+                        .into(),
+                );
+            }
+            for sample in samples {
+                let schedule = sample
+                    .measured
+                    .observations
+                    .iter()
+                    .map(|value| (value.thread_index, value.transaction_index))
+                    .collect::<Vec<_>>();
+                match reference_seeds.get(&sample.block_id) {
+                    Some((seed, expected))
+                        if *seed != sample.workload_seed || *expected != schedule =>
+                    {
+                        return Err(
+                            "latency sample schedule must match across allocators within a block"
+                                .into(),
+                        );
+                    }
+                    None => {
+                        reference_seeds.insert(sample.block_id, (sample.workload_seed, schedule));
+                    }
+                    _ => {}
+                }
+            }
+            let measured = samples
+                .iter()
+                .flat_map(|value| {
+                    value
+                        .measured
+                        .observations
+                        .iter()
+                        .map(|observation| observation.duration_ns)
+                })
+                .collect::<Vec<_>>();
+            let control = samples
+                .iter()
+                .flat_map(|value| {
+                    value
+                        .control
+                        .observations
+                        .iter()
+                        .map(|observation| observation.duration_ns)
+                })
+                .collect::<Vec<_>>();
+            if !overhead_is_valid(
+                &summarize_latency(&measured)?,
+                &summarize_latency(&control)?,
+            ) {
+                return Err(format!(
+                    "latency overhead threshold failed for {allocator} {}/{}",
+                    card.as_str(),
+                    point.name()
+                ));
+            }
+        }
+        let blocks = cell_blocks.ok_or("latency cell has no blocks")?;
+        match &common_blocks {
+            Some(expected) if expected != &blocks => {
+                return Err("latency cells do not share an exact block set".into());
+            }
+            None => common_blocks = Some(blocks.clone()),
+            _ => {}
+        }
+        for block_id in blocks {
+            let block = raw
+                .samples
+                .iter()
+                .filter(|sample| {
+                    sample.scenario_id == card.as_str()
+                        && sample.thread_point == point.name()
+                        && sample.block_id == block_id
+                })
+                .collect::<Vec<_>>();
+            if block.len() != ALLOCATOR_IDS.len()
+                || block
+                    .iter()
+                    .map(|sample| sample.allocator_id.as_str())
+                    .collect::<BTreeSet<_>>()
+                    != ALLOCATOR_IDS.into_iter().collect()
+                || block
+                    .iter()
+                    .map(|sample| sample.ordinal)
+                    .collect::<BTreeSet<_>>()
+                    != (0_u8..4).collect()
+            {
+                return Err("latency block is not an exact four-allocator permutation".into());
+            }
+        }
+    }
+    let blocks = common_blocks.ok_or("latency run contains no complete blocks")?;
+    if blocks != (0..blocks.len() as u32).collect::<BTreeSet<_>>() {
+        return Err("latency block IDs must be contiguous from zero".into());
+    }
+    let orders = balanced_block_orders(blocks.len() as u32, raw.run_seed)?;
+    for order in orders {
+        for sample in raw
+            .samples
+            .iter()
+            .filter(|sample| sample.block_id == order.block_id)
+        {
+            if sample.workload_seed != order.workload_seed
+                || order.allocator_ids.get(sample.ordinal as usize) != Some(&sample.allocator_id)
+            {
+                return Err("latency block order or seed differs from the paired protocol".into());
+            }
+        }
+    }
+    if raw.samples.len() != expected_cells.len() * ALLOCATOR_IDS.len() * blocks.len() {
+        return Err("latency raw sample matrix contains missing or extra records".into());
+    }
+    Ok(())
+}
+
+pub fn build_latency_report(raw: &LatencyRawRun) -> Result<LatencyMetricReport, String> {
+    validate_latency_raw_run(raw)?;
+    let topology = Topology {
+        physical_cores: raw.runner.physical_cores as usize,
+        logical_cores: raw.runner.logical_cores as usize,
+    };
+    let mut absolute_summaries = Vec::new();
+    let mut block_summaries = Vec::new();
+    let mut paired_summaries = Vec::new();
+    for (card, point, definition) in latency_scenario_cells(topology)? {
+        for allocator in ALLOCATOR_IDS {
+            let samples = raw
+                .samples
+                .iter()
+                .filter(|sample| {
+                    sample.scenario_id == card.as_str()
+                        && sample.thread_point == point.name()
+                        && sample.allocator_id == allocator
+                })
+                .collect::<Vec<_>>();
+            let measured = samples
+                .iter()
+                .flat_map(|sample| {
+                    sample
+                        .measured
+                        .observations
+                        .iter()
+                        .map(|value| value.duration_ns)
+                })
+                .collect::<Vec<_>>();
+            let control = samples
+                .iter()
+                .flat_map(|sample| {
+                    sample
+                        .control
+                        .observations
+                        .iter()
+                        .map(|value| value.duration_ns)
+                })
+                .collect::<Vec<_>>();
+            let measured_summary = summarize_latency(&measured)?;
+            let control_summary = summarize_latency(&control)?;
+            absolute_summaries.push(LatencyAbsoluteSummary {
+                allocator_id: allocator.into(),
+                scenario_id: card.as_str().into(),
+                thread_point: point.name().into(),
+                transaction_definition: definition.into(),
+                overhead_valid: overhead_is_valid(&measured_summary, &control_summary),
+                measured: measured_summary,
+                control: control_summary,
+            });
+            for sample in samples {
+                block_summaries.push(LatencyBlockSummary {
+                    block_id: sample.block_id,
+                    allocator_id: allocator.into(),
+                    scenario_id: card.as_str().into(),
+                    thread_point: point.name().into(),
+                    measured: summarize_latency(
+                        &sample
+                            .measured
+                            .observations
+                            .iter()
+                            .map(|value| value.duration_ns)
+                            .collect::<Vec<_>>(),
+                    )?,
+                    control: summarize_latency(
+                        &sample
+                            .control
+                            .observations
+                            .iter()
+                            .map(|value| value.duration_ns)
+                            .collect::<Vec<_>>(),
+                    )?,
+                });
+            }
+            if allocator != REFERENCE_ALLOCATOR {
+                for (name, summary) in block_bootstrap_quantile_effects(
+                    raw.run_seed,
+                    &format!("{}/{}", card.as_str(), point.name()),
+                    allocator,
+                    REFERENCE_ALLOCATOR,
+                    &raw.samples,
+                )? {
+                    paired_summaries.push(LatencyPairedSummary {
+                        scenario_id: card.as_str().into(),
+                        thread_point: point.name().into(),
+                        quantile: name.into(),
+                        summary,
+                    });
+                }
+            }
+        }
+    }
+    Ok(LatencyMetricReport {
+        metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+        status: "complete".into(),
+        invalid_reason: None,
+        metric_comparison_key: latency_comparison_key(raw)?,
+        run: raw.run.clone(),
+        runner: raw.runner.clone(),
+        direction: MetricDirection::LowerIsBetter,
+        informational: true,
+        sampling_denominators: raw.sampling_denominators.clone(),
+        methodology: methodology(),
+        absolute_summaries,
+        paired_summaries,
+        block_summaries,
+        raw_samples: raw.samples.clone(),
+    })
+}
+
+pub fn attach_latency_report(
+    latest: &mut LatestReport,
+    report: LatencyMetricReport,
+) -> Result<(), String> {
+    validate_latency_report(&report)?;
+    let expected = latest
+        .allocators
+        .iter()
+        .map(|value| (&value.allocator_id, &value.source_sha))
+        .collect::<BTreeSet<_>>();
+    let observed = report
+        .raw_samples
+        .iter()
+        .map(|value| (&value.allocator_id, &value.allocator_source_sha))
+        .collect::<BTreeSet<_>>();
+    if expected != observed {
+        return Err("latency allocator provenance differs from core latest".into());
+    }
+    latest.latency = Some(report);
+    latest
+        .pending_metrics
+        .retain(|value| value.metric_id != "latency");
+    Ok(())
+}
+
+pub fn validate_latency_report(report: &LatencyMetricReport) -> Result<(), String> {
+    if report.status != "complete"
+        || report.invalid_reason.is_some()
+        || report.metric_schema_version != LATENCY_SCHEMA_VERSION
+        || report.direction != MetricDirection::LowerIsBetter
+        || !report.informational
+        || report.metric_comparison_key.len() != 64
+        || !report
+            .metric_comparison_key
+            .bytes()
+            .all(|value| value.is_ascii_digit() || (b'a'..=b'f').contains(&value))
+        || report.methodology != methodology()
+    {
+        return Err("only a complete validated latency report can replace pending".into());
+    }
+    let topology = Topology {
+        physical_cores: report.runner.physical_cores as usize,
+        logical_cores: report.runner.logical_cores as usize,
+    };
+    let cells = latency_scenario_cells(topology)?;
+    let expected_cells = cells
+        .iter()
+        .map(|(card, point, _)| format!("{}/{}", card.as_str(), point.name()))
+        .collect::<BTreeSet<_>>();
+    if report
+        .sampling_denominators
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        != expected_cells
+        || report
+            .sampling_denominators
+            .values()
+            .any(|value| *value == 0 || *value > LATENCY_INITIAL_SAMPLE_DENOMINATOR)
+    {
+        return Err("latency report sampling-rate matrix is invalid".into());
+    }
+    if report.absolute_summaries.len() != cells.len() * ALLOCATOR_IDS.len()
+        || report.paired_summaries.len() != cells.len() * (ALLOCATOR_IDS.len() - 1) * 3
+        || report.raw_samples.is_empty()
+        || report.block_summaries.len() != report.raw_samples.len()
+    {
+        return Err("latency report summary matrix is incomplete".into());
+    }
+    for sample in &report.raw_samples {
+        let key = format!("{}/{}", sample.scenario_id, sample.thread_point);
+        let measured_schedule = sample
+            .measured
+            .observations
+            .iter()
+            .map(|value| (value.thread_index, value.transaction_index))
+            .collect::<Vec<_>>();
+        let control_schedule = sample
+            .control
+            .observations
+            .iter()
+            .map(|value| (value.thread_index, value.transaction_index))
+            .collect::<Vec<_>>();
+        if sample.metric_schema_version != LATENCY_SCHEMA_VERSION
+            || !expected_cells.contains(&key)
+            || !ALLOCATOR_IDS.contains(&sample.allocator_id.as_str())
+            || sample.ordinal >= 4
+            || sample.workload_seed == 0
+            || report.sampling_denominators.get(&key) != Some(&sample.sample_denominator)
+            || sample.measured.protocol_version != LATENCY_CHILD_PROTOCOL_VERSION
+            || sample.control.protocol_version != LATENCY_CHILD_PROTOCOL_VERSION
+            || sample.measured.metric_schema_version != LATENCY_SCHEMA_VERSION
+            || sample.control.metric_schema_version != LATENCY_SCHEMA_VERSION
+            || sample.measured.control
+            || !sample.control.control
+            || measured_schedule != control_schedule
+            || measured_schedule.windows(2).any(|pair| pair[0] >= pair[1])
+            || sample
+                .measured
+                .observations
+                .iter()
+                .chain(&sample.control.observations)
+                .any(|value| value.duration_ns == 0 || value.thread_index >= sample.thread_count)
+            || sample.measured.scheduling.clock != sample.control.scheduling.clock
+            || sample.measured.scheduling.thread_count != sample.thread_count
+            || sample.control.scheduling.thread_count != sample.thread_count
+            || sample.measured.scheduling.physical_cores != report.runner.physical_cores
+            || sample.measured.scheduling.logical_cores != report.runner.logical_cores
+            || sample.measured.scheduling.runner_class != report.runner.runner_class
+            || sample.measured.scheduling.affinity_policy != report.runner.affinity.policy
+            || sample.measured.scheduling.actual_cpu_ids.len() != sample.thread_count as usize
+            || sample.control.scheduling.actual_cpu_ids.len() != sample.thread_count as usize
+            || sample.measured.scheduling.clock.resolution_ns == 0
+        {
+            return Err("latency report raw evidence contradicts its protocol".into());
+        }
+    }
+    let mut common_blocks: Option<BTreeSet<u32>> = None;
+    for (card, point, definition) in cells {
+        let cell_key = format!("{}/{}", card.as_str(), point.name());
+        let cell_blocks = report
+            .raw_samples
+            .iter()
+            .filter(|value| {
+                value.scenario_id == card.as_str() && value.thread_point == point.name()
+            })
+            .map(|value| value.block_id)
+            .collect::<BTreeSet<_>>();
+        if cell_blocks.len() < LATENCY_MIN_BLOCKS as usize {
+            return Err("latency report is missing complete raw blocks".into());
+        }
+        match &common_blocks {
+            Some(expected) if expected != &cell_blocks => {
+                return Err("latency report cells do not share an exact block set".into());
+            }
+            None => common_blocks = Some(cell_blocks.clone()),
+            _ => {}
+        }
+        for block_id in &cell_blocks {
+            let block = report
+                .raw_samples
+                .iter()
+                .filter(|value| {
+                    value.scenario_id == card.as_str()
+                        && value.thread_point == point.name()
+                        && value.block_id == *block_id
+                })
+                .collect::<Vec<_>>();
+            if block.len() != ALLOCATOR_IDS.len()
+                || block
+                    .iter()
+                    .map(|value| value.allocator_id.as_str())
+                    .collect::<BTreeSet<_>>()
+                    != ALLOCATOR_IDS.into_iter().collect()
+                || block
+                    .iter()
+                    .map(|value| value.ordinal)
+                    .collect::<BTreeSet<_>>()
+                    != (0_u8..4).collect()
+                || block
+                    .iter()
+                    .map(|value| value.workload_seed)
+                    .collect::<BTreeSet<_>>()
+                    .len()
+                    != 1
+            {
+                return Err("latency report raw block is not a paired permutation".into());
+            }
+        }
+        for allocator in ALLOCATOR_IDS {
+            let raw_samples = report
+                .raw_samples
+                .iter()
+                .filter(|value| {
+                    value.scenario_id == card.as_str()
+                        && value.thread_point == point.name()
+                        && value.allocator_id == allocator
+                })
+                .collect::<Vec<_>>();
+            if raw_samples.len() != cell_blocks.len()
+                || raw_samples
+                    .iter()
+                    .map(|value| value.block_id)
+                    .collect::<BTreeSet<_>>()
+                    != cell_blocks
+            {
+                return Err("latency report raw allocator/block matrix is incomplete".into());
+            }
+            let measured = raw_samples
+                .iter()
+                .flat_map(|value| {
+                    value
+                        .measured
+                        .observations
+                        .iter()
+                        .map(|item| item.duration_ns)
+                })
+                .collect::<Vec<_>>();
+            let control = raw_samples
+                .iter()
+                .flat_map(|value| {
+                    value
+                        .control
+                        .observations
+                        .iter()
+                        .map(|item| item.duration_ns)
+                })
+                .collect::<Vec<_>>();
+            let expected_measured = summarize_latency(&measured)?;
+            let expected_control = summarize_latency(&control)?;
+            let absolute = report
+                .absolute_summaries
+                .iter()
+                .filter(|value| {
+                    value.scenario_id == card.as_str()
+                        && value.thread_point == point.name()
+                        && value.allocator_id == allocator
+                })
+                .collect::<Vec<_>>();
+            if absolute.len() != 1
+                || absolute[0].transaction_definition != definition
+                || !absolute[0].overhead_valid
+                || absolute[0].measured != expected_measured
+                || absolute[0].control != expected_control
+                || !overhead_is_valid(&expected_measured, &expected_control)
+                || absolute[0].measured.count < LATENCY_MIN_SAMPLES as u64
+                || absolute[0].control.count < LATENCY_MIN_SAMPLES as u64
+                || absolute[0].measured.zero_count != 0
+                || absolute[0].control.zero_count != 0
+            {
+                return Err(
+                    "latency report has incomplete allocator/control/sample evidence".into(),
+                );
+            }
+            let block_count = report
+                .block_summaries
+                .iter()
+                .filter(|value| {
+                    value.scenario_id == card.as_str()
+                        && value.thread_point == point.name()
+                        && value.allocator_id == allocator
+                })
+                .count();
+            if block_count != cell_blocks.len() {
+                return Err("latency report is missing complete block summaries".into());
+            }
+            for raw_sample in raw_samples {
+                let block = report
+                    .block_summaries
+                    .iter()
+                    .filter(|value| {
+                        value.scenario_id == card.as_str()
+                            && value.thread_point == point.name()
+                            && value.allocator_id == allocator
+                            && value.block_id == raw_sample.block_id
+                    })
+                    .collect::<Vec<_>>();
+                let measured = raw_sample
+                    .measured
+                    .observations
+                    .iter()
+                    .map(|value| value.duration_ns)
+                    .collect::<Vec<_>>();
+                let control = raw_sample
+                    .control
+                    .observations
+                    .iter()
+                    .map(|value| value.duration_ns)
+                    .collect::<Vec<_>>();
+                if block.len() != 1
+                    || block[0].measured != summarize_latency(&measured)?
+                    || block[0].control != summarize_latency(&control)?
+                {
+                    return Err("latency block summary differs from raw evidence".into());
+                }
+            }
+            if allocator != REFERENCE_ALLOCATOR {
+                for (quantile, probability) in [("p50", 0.50), ("p95", 0.95), ("p99", 0.99)] {
+                    let paired = report
+                        .paired_summaries
+                        .iter()
+                        .filter(|value| {
+                            value.scenario_id == card.as_str()
+                                && value.thread_point == point.name()
+                                && value.quantile == quantile
+                                && value.summary.candidate_id == allocator
+                                && value.summary.reference_id == REFERENCE_ALLOCATOR
+                        })
+                        .collect::<Vec<_>>();
+                    if paired.len() != 1
+                        || paired[0].summary.direction != MetricDirection::LowerIsBetter
+                        || !paired[0].summary.informational
+                        || paired[0].summary.block_count != cell_blocks.len() as u64
+                        || paired[0].summary.bootstrap.resample_count != LATENCY_BOOTSTRAP_RESAMPLES
+                        || paired[0].summary.bootstrap.prng != BOOTSTRAP_PRNG
+                        || paired[0].summary.effect
+                            != point_quantile_effect(
+                                &cell_key,
+                                allocator,
+                                REFERENCE_ALLOCATOR,
+                                probability,
+                                &report.raw_samples,
+                            )?
+                        || !paired[0].summary.effect.is_finite()
+                        || paired[0].summary.effect <= 0.0
+                        || !paired[0].summary.confidence_interval.lower.is_finite()
+                        || !paired[0].summary.confidence_interval.upper.is_finite()
+                        || paired[0].summary.confidence_interval.lower <= 0.0
+                        || paired[0].summary.confidence_interval.upper <= 0.0
+                        || paired[0].summary.confidence_interval.lower
+                            > paired[0].summary.confidence_interval.upper
+                        || paired[0].summary.confidence_interval.confidence_level != 0.95
+                    {
+                        return Err("latency report paired quantile matrix is incomplete".into());
+                    }
+                }
+            }
+        }
+    }
+    let blocks = common_blocks.ok_or("latency report contains no blocks")?;
+    if blocks != (0..blocks.len() as u32).collect::<BTreeSet<_>>()
+        || report.raw_samples.len() != expected_cells.len() * ALLOCATOR_IDS.len() * blocks.len()
+    {
+        return Err("latency report contains missing, extra, or noncontiguous blocks".into());
+    }
+    Ok(())
+}
+
+pub fn latency_comparison_key(raw: &LatencyRawRun) -> Result<String, String> {
+    #[derive(Serialize)]
+    struct Key<'a> {
+        schema: &'a str,
+        rates: &'a BTreeMap<String, u64>,
+        runner_fingerprint: &'a str,
+        affinity_policy: &'a str,
+        clock: &'a LatencyClock,
+        allocator_lock_sha256: &'a str,
+        allocator_sources: BTreeMap<&'a str, &'a str>,
+        definitions: BTreeMap<&'a str, &'a str>,
+    }
+    let first = raw
+        .samples
+        .first()
+        .ok_or_else(|| "latency run has no samples".to_string())?;
+    let value = Key {
+        schema: LATENCY_SCHEMA_VERSION,
+        rates: &raw.sampling_denominators,
+        runner_fingerprint: &raw.runner.fingerprint_sha256,
+        affinity_policy: &first.measured.scheduling.affinity_policy,
+        clock: &first.measured.scheduling.clock,
+        allocator_lock_sha256: &raw.allocator_lock_sha256,
+        allocator_sources: raw
+            .allocators
+            .iter()
+            .map(|value| (value.allocator_id.as_str(), value.source_sha.as_str()))
+            .collect(),
+        definitions: latency_scenario_cells(Topology {
+            physical_cores: raw.runner.physical_cores as usize,
+            logical_cores: raw.runner.logical_cores as usize,
+        })?
+        .into_iter()
+        .map(|(card, _, definition)| (card.as_str(), definition))
+        .collect(),
+    };
+    serde_json::to_vec(&value)
+        .map(|bytes| sha256_bytes(&bytes))
+        .map_err(|error| error.to_string())
+}
+
+fn methodology() -> LatencyMethodology {
+    LatencyMethodology {
+        transaction_boundaries: BTreeMap::from([
+            ("local".into(), "allocation plus required touch/checksum plus free".into()),
+            ("cross-thread".into(), "producer allocation through consumer free completion, including queue and ownership transfer".into()),
+            ("large-object".into(), "allocation plus one-byte-per-page touch/checksum plus free".into()),
+        ]),
+        quantile_method: "R/NumPy Type 7 linear interpolation".into(),
+        sampling_schedule: "deterministic seed-offset 1/N indices, identical across allocators within each block".into(),
+        overhead_control: "separate no-op/black-box distribution; never subtracted; control p50 <= 5% measured p50 and measured p99 > 2x control p99".into(),
+        bootstrap: "paired lower-is-better log effect; whole blocks resampled and target quantile recomputed from every selected transaction".into(),
+        storage_decision: "raw block/thread/index/duration vectors fit the checked public latest size cap and are retained verbatim; history retains summaries only".into(),
+        tail_policy: "all scheduler/preemption tails retained; no outlier deletion".into(),
+    }
+}
+
+pub fn block_bootstrap_quantile_effect(
+    run_seed: u64,
+    cell_id: &str,
+    candidate_id: &str,
+    reference_id: &str,
+    probability: f64,
+    samples: &[LatencyRawSample],
+) -> Result<PairedEffectSummary, String> {
+    let (cell_id, quantile) = match cell_id.rsplit_once('/') {
+        Some((cell, "p50")) => (cell, "p50"),
+        Some((cell, "p95")) => (cell, "p95"),
+        Some((cell, "p99")) => (cell, "p99"),
+        _ if probability == 0.50 => (cell_id, "p50"),
+        _ if probability == 0.95 => (cell_id, "p95"),
+        _ if probability == 0.99 => (cell_id, "p99"),
+        _ => return Err("latency bootstrap supports only p50, p95, and p99".into()),
+    };
+    if (quantile == "p50" && probability != 0.50)
+        || (quantile == "p95" && probability != 0.95)
+        || (quantile == "p99" && probability != 0.99)
+    {
+        return Err("latency bootstrap quantile label and probability differ".into());
+    }
+    block_bootstrap_quantile_effects(run_seed, cell_id, candidate_id, reference_id, samples)?
+        .into_iter()
+        .find_map(|(name, summary)| (name == quantile).then_some(summary))
+        .ok_or_else(|| "latency bootstrap omitted a required quantile".into())
+}
+
+fn latency_block_pairs(
+    cell_id: &str,
+    candidate_id: &str,
+    reference_id: &str,
+    samples: &[LatencyRawSample],
+) -> Result<Vec<(Vec<u64>, Vec<u64>)>, String> {
+    if cell_id.is_empty()
+        || candidate_id.is_empty()
+        || reference_id.is_empty()
+        || candidate_id == reference_id
+    {
+        return Err("latency bootstrap identity is invalid".into());
+    }
+    let mut blocks: BTreeMap<u32, BTreeMap<&str, Vec<u64>>> = BTreeMap::new();
+    for sample in samples {
+        if format!("{}/{}", sample.scenario_id, sample.thread_point) != cell_id {
+            continue;
+        }
+        if sample.allocator_id == candidate_id || sample.allocator_id == reference_id {
+            if blocks
+                .entry(sample.block_id)
+                .or_default()
+                .insert(
+                    &sample.allocator_id,
+                    sample
+                        .measured
+                        .observations
+                        .iter()
+                        .map(|value| value.duration_ns)
+                        .collect(),
+                )
+                .is_some()
+            {
+                return Err("latency bootstrap block duplicates an allocator".into());
+            }
+        }
+    }
+    if blocks.is_empty() {
+        return Err("latency bootstrap has no blocks".into());
+    }
+    blocks
+        .into_iter()
+        .map(|(block, values)| {
+            let candidate = values
+                .get(candidate_id)
+                .ok_or_else(|| format!("block {block} missing candidate"))?;
+            let reference = values
+                .get(reference_id)
+                .ok_or_else(|| format!("block {block} missing reference"))?;
+            if candidate.is_empty()
+                || reference.is_empty()
+                || candidate.iter().chain(reference).any(|value| *value == 0)
+            {
+                return Err(format!("block {block} has an invalid latency distribution"));
+            }
+            Ok((candidate.clone(), reference.clone()))
+        })
+        .collect()
+}
+
+fn point_quantile_effect(
+    cell_id: &str,
+    candidate_id: &str,
+    reference_id: &str,
+    probability: f64,
+    samples: &[LatencyRawSample],
+) -> Result<f64, String> {
+    let pairs = latency_block_pairs(cell_id, candidate_id, reference_id, samples)?;
+    let logs = pairs
+        .iter()
+        .map(|(candidate, reference)| {
+            Ok(
+                (quantile_u64(reference, probability)? / quantile_u64(candidate, probability)?)
+                    .ln(),
+            )
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    crate::stats::type7_quantile(&logs, 0.5)
+        .map_err(|error| error.to_string())
+        .map(f64::exp)
+}
+
+fn block_bootstrap_quantile_effects(
+    run_seed: u64,
+    cell_id: &str,
+    candidate_id: &str,
+    reference_id: &str,
+    samples: &[LatencyRawSample],
+) -> Result<Vec<(&'static str, PairedEffectSummary)>, String> {
+    let blocks = latency_block_pairs(cell_id, candidate_id, reference_id, samples)?;
+    let probabilities = [0.50, 0.95, 0.99];
+    let mut point_logs: [Vec<f64>; 3] = std::array::from_fn(|_| Vec::with_capacity(blocks.len()));
+    for (candidate, reference) in &blocks {
+        for (index, probability) in probabilities.into_iter().enumerate() {
+            point_logs[index].push(
+                (quantile_u64(reference, probability)? / quantile_u64(candidate, probability)?)
+                    .ln(),
+            );
+        }
+    }
+    let mut point_effects = [0.0; 3];
+    for (index, logs) in point_logs.iter().enumerate() {
+        point_effects[index] = crate::stats::type7_quantile(logs, 0.5)
+            .map_err(|error| error.to_string())?
+            .exp();
+    }
+
+    let mut candidate_sorted = blocks
+        .iter()
+        .enumerate()
+        .flat_map(|(block, (candidate, _))| {
+            candidate.iter().copied().map(move |value| (value, block))
+        })
+        .collect::<Vec<_>>();
+    let mut reference_sorted = blocks
+        .iter()
+        .enumerate()
+        .flat_map(|(block, (_, reference))| {
+            reference.iter().copied().map(move |value| (value, block))
+        })
+        .collect::<Vec<_>>();
+    candidate_sorted.sort_unstable();
+    reference_sorted.sort_unstable();
+
+    let seed_material =
+        format!("latency-bootstrap-v2\0{run_seed}\0{cell_id}\0{candidate_id}\0{reference_id}");
+    let digest = sha256_bytes(seed_material.as_bytes());
+    let seed = u64::from_str_radix(&digest[..16], 16).map_err(|error| error.to_string())?;
+    let mut rng = SplitMix64 { state: seed };
+    let mut effects: [Vec<f64>; 3] =
+        std::array::from_fn(|_| Vec::with_capacity(LATENCY_BOOTSTRAP_RESAMPLES as usize));
+    let mut multiplicities = vec![0_u32; blocks.len()];
+    for _ in 0..LATENCY_BOOTSTRAP_RESAMPLES {
+        multiplicities.fill(0);
+        for _ in 0..blocks.len() {
+            let selected = rng.uniform_below(blocks.len() as u64) as usize;
+            multiplicities[selected] += 1;
+        }
+        let candidate_quantiles = weighted_type7_three(&candidate_sorted, &multiplicities)?;
+        let reference_quantiles = weighted_type7_three(&reference_sorted, &multiplicities)?;
+        for index in 0..3 {
+            effects[index].push((reference_quantiles[index] / candidate_quantiles[index]).ln());
+        }
+    }
+    for values in &mut effects {
+        values.sort_by(f64::total_cmp);
+    }
+    Ok(["p50", "p95", "p99"]
+        .into_iter()
+        .enumerate()
+        .map(|(index, name)| {
+            (
+                name,
+                PairedEffectSummary {
+                    candidate_id: candidate_id.into(),
+                    reference_id: reference_id.into(),
+                    direction: MetricDirection::LowerIsBetter,
+                    block_count: blocks.len() as u64,
+                    effect: point_effects[index],
+                    confidence_interval: ConfidenceInterval {
+                        lower: type7_sorted(&effects[index], 0.025).exp(),
+                        upper: type7_sorted(&effects[index], 0.975).exp(),
+                        confidence_level: 0.95,
+                    },
+                    bootstrap: BootstrapMetadata {
+                        seed,
+                        resample_count: LATENCY_BOOTSTRAP_RESAMPLES,
+                        method: "percentile-whole-block-transaction-quantile-type7-v1".into(),
+                        prng: BOOTSTRAP_PRNG.into(),
+                    },
+                    informational: true,
+                },
+            )
+        })
+        .collect())
+}
+
+fn weighted_type7_three(
+    sorted: &[(u64, usize)],
+    multiplicities: &[u32],
+) -> Result<[f64; 3], String> {
+    let total = sorted.iter().try_fold(0_u64, |total, (_, block)| {
+        total
+            .checked_add(u64::from(*multiplicities.get(*block).ok_or(
+                "latency bootstrap block index is outside the multiplicity vector",
+            )?))
+            .ok_or("latency bootstrap weighted sample count overflowed")
+    })?;
+    if total == 0 {
+        return Err("latency bootstrap selected no observations".into());
+    }
+    let probabilities = [0.50, 0.95, 0.99];
+    let mut ranks = [0_u64; 6];
+    let mut fractions = [0.0; 3];
+    for (index, probability) in probabilities.into_iter().enumerate() {
+        let position = (total - 1) as f64 * probability;
+        ranks[index * 2] = position.floor() as u64;
+        ranks[index * 2 + 1] = position.ceil() as u64;
+        fractions[index] = position - position.floor();
+    }
+    let mut values = [0_u64; 6];
+    let mut rank_cursor = 0;
+    let mut cumulative = 0_u64;
+    for (value, block) in sorted {
+        let weight = u64::from(multiplicities[*block]);
+        let next = cumulative + weight;
+        while rank_cursor < ranks.len() && ranks[rank_cursor] < next {
+            values[rank_cursor] = *value;
+            rank_cursor += 1;
+        }
+        cumulative = next;
+        if rank_cursor == ranks.len() {
+            break;
+        }
+    }
+    if rank_cursor != ranks.len() {
+        return Err("latency bootstrap could not resolve a weighted quantile".into());
+    }
+    Ok(std::array::from_fn(|index| {
+        let lower = values[index * 2] as f64;
+        let upper = values[index * 2 + 1] as f64;
+        lower + fractions[index] * (upper - lower)
+    }))
+}
+
+fn quantile_u64(values: &[u64], probability: f64) -> Result<f64, String> {
+    crate::stats::type7_quantile(
+        &values.iter().map(|value| *value as f64).collect::<Vec<_>>(),
+        probability,
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn type7_sorted(values: &[f64], probability: f64) -> f64 {
+    if values.len() == 1 {
+        return values[0];
+    }
+    let index = (values.len() - 1) as f64 * probability;
+    let lower = index.floor() as usize;
+    values[lower]
+        + (index - lower as f64) * (values[(lower + 1).min(values.len() - 1)] - values[lower])
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+struct SplitMix64 {
+    state: u64,
+}
+impl SplitMix64 {
+    fn next(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = self.state;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+    fn uniform_below(&mut self, bound: u64) -> u64 {
+        let zone = u64::MAX - u64::MAX % bound;
+        loop {
+            let value = self.next();
+            if value < zone {
+                return value % bound;
+            }
+        }
+    }
+}

--- a/rust/benchmark-suite/src/latency_runner.rs
+++ b/rust/benchmark-suite/src/latency_runner.rs
@@ -1,0 +1,440 @@
+//! Production runner for the bounded transaction-latency suite.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+
+use crate::config::AllocatorLock;
+use crate::latency::{
+    choose_sample_denominator, latency_scenario_cells, minimum_transactions_per_worker,
+    run_latency_child, validate_latency_raw_run, LatencyChildRequest, LatencyRawRun,
+    LatencyRawSample, LATENCY_CHILD_PROTOCOL_VERSION, LATENCY_MIN_SAMPLES, LATENCY_SCHEMA_VERSION,
+};
+use crate::model::{
+    BenchmarkChildRequest, CellCalibration, RunnerMetadata, CHILD_PROTOCOL_VERSION,
+};
+use crate::orchestration::{balanced_block_orders, calibrate_cell, run_child_sample};
+use crate::provenance::ProducerProvenance;
+use crate::runner::{
+    children_from_provenance, collect_publication_runner, collect_run_identity, create_new_writer,
+    detect_topology, publication_allocators, write_json_line, write_new_bytes, write_new_json,
+};
+use crate::scenarios::{card, ScenarioCell, Topology};
+use crate::{CORE_SUITE_VERSION, RAW_SCHEMA_VERSION};
+
+const HARD_LIMIT_SECONDS: f64 = 60.0 * 60.0;
+
+#[derive(Debug)]
+struct Options {
+    provenance: PathBuf,
+    output_dir: PathBuf,
+    blocks: u32,
+    run_seed: u64,
+    timeout: Duration,
+    warmup_transactions: u64,
+    initial_transactions: u64,
+    topology: Option<Topology>,
+    reduced_smoke: bool,
+}
+
+pub fn benchmark_latency_run_main() -> Result<(), String> {
+    let options = parse_options(std::env::args_os().skip(1))?;
+    let output_dir = options.output_dir.clone();
+    let output_preexisted = output_dir.exists();
+    match run(options) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            if !output_preexisted && output_dir.is_dir() {
+                record_invalid_run(&output_dir, &error)?;
+            }
+            Err(error)
+        }
+    }
+}
+
+fn record_invalid_run(output_dir: &std::path::Path, reason: &str) -> Result<(), String> {
+    let invalid = output_dir.join("latency-invalid.json");
+    if !invalid.exists() {
+        write_new_json(
+            invalid,
+            &json!({
+                "metric_schema_version": LATENCY_SCHEMA_VERSION,
+                "status": "invalid",
+                "reason": reason,
+            }),
+        )?;
+    }
+    let diagnostics_path = output_dir.join("diagnostics.jsonl");
+    let diagnostics_file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&diagnostics_path)
+        .map_err(|error| format!("open {}: {error}", diagnostics_path.display()))?;
+    let mut diagnostics = std::io::BufWriter::new(diagnostics_file);
+    write_json_line(
+        &mut diagnostics,
+        &json!({
+            "event": "latency-run-invalid",
+            "metric_schema_version": LATENCY_SCHEMA_VERSION,
+            "reason": reason,
+        }),
+    )
+}
+
+fn run(options: Options) -> Result<(), String> {
+    if cfg!(not(target_os = "linux")) {
+        return Err("transaction-latency-v1 production collection is Linux-only".into());
+    }
+    if options.output_dir.exists() {
+        return Err(format!(
+            "output directory already exists: {}",
+            options.output_dir.display()
+        ));
+    }
+    std::fs::create_dir_all(&options.output_dir)
+        .map_err(|error| format!("create latency output: {error}"))?;
+    if options.reduced_smoke {
+        if options.blocks != 1 {
+            return Err("latency reduced smoke requires --blocks 1".into());
+        }
+    } else if options.blocks < 15 {
+        return Err("complete latency runs require --blocks at least 15".into());
+    }
+
+    let lock =
+        AllocatorLock::parse_and_validate(include_str!("../allocators/allocator-lock.json"))?;
+    let provenance_bytes = std::fs::read(&options.provenance)
+        .map_err(|error| format!("read allocator provenance: {error}"))?;
+    let provenance_text = std::str::from_utf8(&provenance_bytes)
+        .map_err(|error| format!("allocator provenance is not UTF-8: {error}"))?;
+    let provenance = ProducerProvenance::parse_and_validate(provenance_text, &lock)?;
+    provenance.validate_artifact_hashes()?;
+    write_new_bytes(
+        options.output_dir.join("allocator-provenance.json"),
+        &provenance_bytes,
+    )?;
+
+    let topology = options.topology.map_or_else(detect_topology, Ok)?;
+    let children = children_from_provenance(&provenance)?;
+    let upstream = children
+        .iter()
+        .find(|child| child.allocator.allocator_id == "upstream-mimalloc")
+        .ok_or("provenance is missing upstream-mimalloc")?;
+    let run_identity = collect_run_identity(&provenance)?;
+    let publication_runner = collect_publication_runner(topology)?;
+    let runner = RunnerMetadata {
+        os: publication_runner.os.clone(),
+        architecture: publication_runner.architecture.clone(),
+        physical_cores: publication_runner.physical_cores,
+        logical_cores: publication_runner.logical_cores,
+    };
+    let run_kind = if options.reduced_smoke {
+        "reduced-smoke"
+    } else {
+        "headline"
+    };
+    let cells = latency_scenario_cells(topology)?;
+    let mut raw_jsonl = create_new_writer(options.output_dir.join("raw-latency-samples.jsonl"))?;
+    let mut diagnostics = create_new_writer(options.output_dir.join("diagnostics.jsonl"))?;
+    write_json_line(
+        &mut diagnostics,
+        &json!({
+            "event": "latency-run-start", "metric_schema_version": LATENCY_SCHEMA_VERSION,
+            "run_kind": run_kind, "blocks": options.blocks, "run_seed": options.run_seed,
+            "minimum_samples_per_allocator_cell": LATENCY_MIN_SAMPLES,
+        }),
+    )?;
+
+    let runner_started = Instant::now();
+    let mut calibration_wall = Duration::ZERO;
+    let mut block_wall = Duration::ZERO;
+    let mut calibrations = Vec::with_capacity(cells.len());
+    let mut denominators = BTreeMap::new();
+    let mut samples = Vec::with_capacity(cells.len() * options.blocks as usize * 4);
+    for (card_id, thread_point, definition) in cells {
+        let mut template = BenchmarkChildRequest {
+            protocol_version: CHILD_PROTOCOL_VERSION.into(),
+            schema_version: RAW_SCHEMA_VERSION.into(),
+            suite_version: CORE_SUITE_VERSION.into(),
+            run_kind: run_kind.into(),
+            execution_mode: "normal".into(),
+            run_seed: options.run_seed,
+            block_id: 0,
+            ordinal: 0,
+            workload_seed: 1,
+            allocator: upstream.allocator.clone(),
+            scenario_id: card_id.as_str().into(),
+            scenario_version: CORE_SUITE_VERSION.into(),
+            thread_point: thread_point.name().into(),
+            physical_cores: topology.physical_cores as u32,
+            logical_cores: topology.logical_cores as u32,
+            transactions_per_worker: options.initial_transactions,
+            warmup_transactions_per_worker: options.warmup_transactions,
+            reproduction_command: "latency calibration placeholder".into(),
+            runner: runner.clone(),
+            toolchain: upstream.toolchain.clone(),
+        };
+        let started = Instant::now();
+        let calibration = calibrate_cell(upstream, &template, options.timeout)?;
+        let denominator = choose_sample_denominator(
+            calibration.transactions_per_worker,
+            topology
+                .resolve(thread_point)
+                .map_err(|error| error.to_string())?,
+            options.blocks,
+        )?;
+        let minimum_transactions = minimum_transactions_per_worker(
+            topology
+                .resolve(thread_point)
+                .map_err(|error| error.to_string())?,
+            options.blocks,
+            denominator,
+            if options.reduced_smoke {
+                1
+            } else {
+                LATENCY_MIN_SAMPLES
+            },
+        )?;
+        // Freeze the smallest workload that guarantees the raw-sample floor.
+        // The upstream calibration only selects a denominator that keeps this
+        // bounded; retaining its potentially much larger transaction count
+        // would make fast cells produce unbounded public JSON.
+        template.transactions_per_worker = minimum_transactions;
+        let mut request = template.clone();
+        request.block_id = u32::MAX;
+        request.workload_seed = 0x6c61_7465_6e63_79;
+        request.reproduction_command = "latency realized-count calibration".into();
+        let sample = run_child_sample(upstream, &request, options.timeout)?;
+        let realized = crate::orchestration::CalibrationResult {
+            transactions_per_worker: template.transactions_per_worker,
+            operation_count: sample.operation_count,
+            elapsed_ns: sample.elapsed_ns,
+        };
+        calibration_wall = calibration_wall.saturating_add(started.elapsed());
+        let cell = ScenarioCell::new(
+            card_id,
+            thread_point,
+            topology,
+            realized.transactions_per_worker,
+            1,
+        )
+        .map_err(|error| error.to_string())?;
+        calibrations.push(CellCalibration {
+            scenario_id: card_id.as_str().into(),
+            thread_point: thread_point.name().into(),
+            thread_count: cell.threads as u32,
+            transactions_per_worker: realized.transactions_per_worker,
+            warmup_transactions_per_worker: options.warmup_transactions,
+            operation_count: card(card_id)
+                .operation_count(&cell.expected_counts().map_err(|error| error.to_string())?),
+            elapsed_ns: realized.elapsed_ns,
+        });
+        let cell_key = format!("{}/{}", card_id.as_str(), thread_point.name());
+        denominators.insert(cell_key.clone(), denominator);
+
+        let started = Instant::now();
+        for order in balanced_block_orders(options.blocks, options.run_seed)? {
+            for (ordinal, allocator_id) in order.allocator_ids.iter().enumerate() {
+                let child = children
+                    .iter()
+                    .find(|value| value.allocator.allocator_id == *allocator_id)
+                    .ok_or_else(|| format!("missing latency allocator {allocator_id}"))?;
+                let mut benchmark = template.clone();
+                benchmark.block_id = order.block_id;
+                benchmark.ordinal = ordinal as u8;
+                benchmark.workload_seed = order.workload_seed;
+                benchmark.allocator = child.allocator.clone();
+                benchmark.toolchain = child.toolchain.clone();
+                benchmark.reproduction_command = format!("benchmark-latency-run --run-seed {} --blocks {} --output-dir <new-dir> --build-root <build-root> # cell={cell_key}", options.run_seed, options.blocks);
+                let request_dir = options.output_dir.join("requests");
+                std::fs::create_dir_all(&request_dir)
+                    .map_err(|error| format!("create latency request dir: {error}"))?;
+                let request_path = request_dir.join(format!(
+                    "{}-{}-block-{:04}-ordinal-{}-{}.json",
+                    card_id.as_str(),
+                    thread_point.name(),
+                    order.block_id,
+                    ordinal,
+                    allocator_id
+                ));
+                let measured_request = LatencyChildRequest {
+                    protocol_version: LATENCY_CHILD_PROTOCOL_VERSION.into(),
+                    metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+                    sample_denominator: denominator,
+                    control: false,
+                    runner_class: publication_runner.runner_class.clone(),
+                    affinity_policy: publication_runner.affinity.policy.clone(),
+                    benchmark: benchmark.clone(),
+                };
+                write_new_json(request_path, &measured_request)?;
+                let measured = run_latency_child(child, &measured_request, options.timeout)?;
+                let mut control_request = measured_request.clone();
+                control_request.control = true;
+                let control = run_latency_child(child, &control_request, options.timeout)?;
+                let sample = LatencyRawSample {
+                    metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+                    block_id: order.block_id,
+                    ordinal: ordinal as u8,
+                    workload_seed: order.workload_seed,
+                    allocator_id: allocator_id.clone(),
+                    allocator_source_sha: child.allocator.source_sha.clone(),
+                    child_binary_sha256: child.allocator.child_binary_sha256.clone(),
+                    scenario_id: card_id.as_str().into(),
+                    thread_point: thread_point.name().into(),
+                    thread_count: cell.threads as u32,
+                    sample_denominator: denominator,
+                    transaction_definition: definition.into(),
+                    measured,
+                    control,
+                };
+                write_json_line(&mut raw_jsonl, &sample)?;
+                samples.push(sample);
+            }
+        }
+        block_wall = block_wall.saturating_add(started.elapsed());
+        write_json_line(
+            &mut diagnostics,
+            &json!({
+                "event": "latency-cell-complete", "cell": cell_key, "sample_denominator": denominator,
+                "transactions_per_worker": realized.transactions_per_worker, "raw_pairs": options.blocks * 4,
+            }),
+        )?;
+    }
+
+    let observed_wall = runner_started.elapsed();
+    let fixed_wall = observed_wall.saturating_sub(calibration_wall + block_wall);
+    let projected_full_seconds = provenance.build_elapsed_seconds
+        + calibration_wall.as_secs_f64()
+        + block_wall.as_secs_f64() * 15.0 / f64::from(options.blocks)
+        + fixed_wall.as_secs_f64()
+        + 1.0;
+    write_new_json(
+        options.output_dir.join("runtime-projection.json"),
+        &json!({
+            "observed_blocks": options.blocks, "observed_runner_wall_seconds": observed_wall.as_secs_f64(),
+            "observed_calibration_wall_seconds": calibration_wall.as_secs_f64(), "observed_block_wall_seconds": block_wall.as_secs_f64(),
+            "native_build_elapsed_seconds": provenance.build_elapsed_seconds, "projected_headline_blocks": 15,
+            "projected_full_suite_seconds": projected_full_seconds, "hard_limit_seconds": HARD_LIMIT_SECONDS,
+            "fits_limit": projected_full_seconds <= HARD_LIMIT_SECONDS,
+        }),
+    )?;
+    if projected_full_seconds > HARD_LIMIT_SECONDS {
+        let reason = format!("projected complete latency runtime {projected_full_seconds:.1}s exceeds the 3600s hard limit");
+        write_new_json(
+            options.output_dir.join("latency-invalid.json"),
+            &json!({ "metric_schema_version": LATENCY_SCHEMA_VERSION, "status": "invalid", "reason": reason }),
+        )?;
+        return Err(reason);
+    }
+    let raw = LatencyRawRun {
+        metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+        status: if options.reduced_smoke {
+            "incomplete"
+        } else {
+            "complete"
+        }
+        .into(),
+        run_seed: options.run_seed,
+        run: run_identity,
+        runner: publication_runner,
+        allocator_lock_sha256: provenance.lockfile_sha256.clone(),
+        allocators: publication_allocators(&lock, &provenance)?,
+        calibrations,
+        sampling_denominators: denominators,
+        samples,
+    };
+    if !options.reduced_smoke {
+        validate_latency_raw_run(&raw)?;
+    }
+    write_new_json(options.output_dir.join("latency-raw-run.json"), &raw)?;
+    println!(
+        "PASS latency run: {} paired raw records; projected complete runtime {:.1}s",
+        raw.samples.len(),
+        projected_full_seconds
+    );
+    Ok(())
+}
+
+fn parse_options(arguments: impl Iterator<Item = OsString>) -> Result<Options, String> {
+    let arguments = arguments
+        .map(|value| {
+            value
+                .into_string()
+                .map_err(|_| "latency runner arguments must be UTF-8".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut provenance = None;
+    let mut build_root = None;
+    let mut output_dir = None;
+    let mut blocks = 15;
+    let mut run_seed = 0x6c61_7465_6e63_79;
+    let mut timeout_secs = 30;
+    let mut warmup_transactions = 1;
+    let mut initial_transactions = 1;
+    let mut physical_cores = None;
+    let mut logical_cores = None;
+    let mut reduced_smoke = false;
+    let mut index = 0;
+    while index < arguments.len() {
+        let flag = &arguments[index];
+        if flag == "--reduced-smoke" {
+            reduced_smoke = true;
+            index += 1;
+            continue;
+        }
+        let value = arguments
+            .get(index + 1)
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--provenance" => provenance = Some(PathBuf::from(value)),
+            "--build-root" => build_root = Some(PathBuf::from(value)),
+            "--output-dir" => output_dir = Some(PathBuf::from(value)),
+            "--blocks" => blocks = parse_number(flag, value)?,
+            "--run-seed" => run_seed = parse_number(flag, value)?,
+            "--timeout-secs" => timeout_secs = parse_number(flag, value)?,
+            "--warmup-transactions" => warmup_transactions = parse_number(flag, value)?,
+            "--initial-transactions" => initial_transactions = parse_number(flag, value)?,
+            "--physical-cores" => physical_cores = Some(parse_number(flag, value)?),
+            "--logical-cores" => logical_cores = Some(parse_number(flag, value)?),
+            _ => return Err(format!("unknown latency runner argument {flag}")),
+        }
+        index += 2;
+    }
+    if blocks == 0 || run_seed == 0 || timeout_secs < 2 || initial_transactions == 0 {
+        return Err("latency seed/blocks/transactions/timeout must be nonzero".into());
+    }
+    if provenance.is_some() && build_root.is_some() {
+        return Err("pass either --provenance or --build-root, not both".into());
+    }
+    let provenance = provenance
+        .or_else(|| build_root.map(|root| root.join("allocator-provenance.json")))
+        .ok_or("--provenance or --build-root is required")?;
+    let topology = match (physical_cores, logical_cores) {
+        (None, None) => None,
+        (Some(physical_cores), Some(logical_cores)) => Some(Topology {
+            physical_cores,
+            logical_cores,
+        }),
+        _ => return Err("physical and logical core overrides must be supplied together".into()),
+    };
+    Ok(Options {
+        provenance,
+        output_dir: output_dir.ok_or("--output-dir is required")?,
+        blocks,
+        run_seed,
+        timeout: Duration::from_secs(timeout_secs),
+        warmup_transactions,
+        initial_transactions,
+        topology,
+        reduced_smoke,
+    })
+}
+
+fn parse_number<T: std::str::FromStr>(flag: &str, value: &str) -> Result<T, String> {
+    value
+        .parse()
+        .map_err(|_| format!("invalid numeric value for {flag}: {value}"))
+}

--- a/rust/benchmark-suite/src/lib.rs
+++ b/rust/benchmark-suite/src/lib.rs
@@ -8,6 +8,8 @@ pub mod child;
 pub mod comparison_key;
 pub mod config;
 pub mod execution;
+pub mod latency;
+pub mod latency_runner;
 pub mod memory;
 pub mod memory_runner;
 pub mod model;

--- a/rust/benchmark-suite/src/model.rs
+++ b/rust/benchmark-suite/src/model.rs
@@ -228,6 +228,10 @@ pub struct LatestReport {
     /// collected under `linux-process-memory-v1`; it never means zero.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory: Option<crate::memory::MemoryMetricReport>,
+    /// Backward-compatible Phase 6 extension. Absence means no validated
+    /// `transaction-latency-v1` collection is available; it never means zero.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latency: Option<crate::latency::LatencyMetricReport>,
     pub canonical_urls: CanonicalUrls,
     pub reproduction_command: String,
     pub actions_run_url: String,
@@ -247,6 +251,8 @@ pub struct HistoryRow {
     pub paired_summaries: Vec<PairedCellSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory: Option<crate::memory::MemoryHistoryReport>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latency: Option<crate::latency::LatencyHistoryReport>,
 }
 
 /// Immutable identity supplied by the producer after it hashes the directly

--- a/rust/benchmark-suite/src/report.rs
+++ b/rust/benchmark-suite/src/report.rs
@@ -126,6 +126,7 @@ pub fn build_latest_report(
             pending("pprof-tax", 187),
         ],
         memory: None,
+        latency: None,
         canonical_urls: CanonicalUrls {
             pages: "https://zackees.github.io/mimalloc-pprof/".into(),
             stats_branch: "https://github.com/zackees/mimalloc-pprof/tree/benchmark-stats".into(),
@@ -161,6 +162,10 @@ pub fn build_latest_report(
         paired_summaries: latest.paired_summaries.clone(),
         memory: latest
             .memory
+            .as_ref()
+            .map(|value| value.history_projection()),
+        latency: latest
+            .latency
             .as_ref()
             .map(|value| value.history_projection()),
     };

--- a/rust/benchmark-suite/tests/latency_contract.rs
+++ b/rust/benchmark-suite/tests/latency_contract.rs
@@ -1,0 +1,343 @@
+use std::collections::BTreeMap;
+
+use benchmark_suite::execution::expected_touch_checksum;
+use benchmark_suite::latency::{
+    block_bootstrap_quantile_effect, deterministic_sample_indices, overhead_is_valid,
+    summarize_latency, transaction_definition, validate_latency_raw_run, ContextSwitchCounts,
+    LatencyChildResponse, LatencyClock, LatencyObservation, LatencyRawRun, LatencyRawSample,
+    LatencyScheduling, LATENCY_CHILD_PROTOCOL_VERSION, LATENCY_SCHEMA_VERSION,
+};
+use benchmark_suite::model::CellCalibration;
+use benchmark_suite::scenarios::{card, CardId, ScenarioCell, ThreadPoint, Topology};
+use benchmark_suite::validate::synthetic_full_fixture;
+
+fn response(control: bool, values: &[u64]) -> LatencyChildResponse {
+    LatencyChildResponse {
+        protocol_version: LATENCY_CHILD_PROTOCOL_VERSION.into(),
+        metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+        control,
+        completed_transactions: values.len() as u64,
+        checksum: 1,
+        observations: values
+            .iter()
+            .enumerate()
+            .map(|(index, duration_ns)| LatencyObservation {
+                thread_index: 0,
+                transaction_index: index as u64,
+                duration_ns: *duration_ns,
+            })
+            .collect(),
+        scheduling: LatencyScheduling {
+            affinity_policy: "linux:unrestricted".into(),
+            actual_cpu_ids: vec![Some(0)],
+            thread_count: 1,
+            physical_cores: 1,
+            logical_cores: 1,
+            context_switches: ContextSwitchCounts {
+                voluntary: 0,
+                involuntary: 0,
+            },
+            runner_class: "test".into(),
+            clock: LatencyClock {
+                source: "monotonic".into(),
+                implementation: "fixture".into(),
+                resolution_ns: 1,
+            },
+        },
+    }
+}
+
+fn sample(block: u32, allocator: &str, measured: &[u64]) -> LatencyRawSample {
+    LatencyRawSample {
+        metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+        block_id: block,
+        ordinal: 0,
+        workload_seed: 17 + u64::from(block),
+        allocator_id: allocator.into(),
+        allocator_source_sha: "a".repeat(40),
+        child_binary_sha256: "b".repeat(64),
+        scenario_id: "tiny-fixed-64".into(),
+        thread_point: "1".into(),
+        thread_count: 1,
+        sample_denominator: 1,
+        transaction_definition: transaction_definition(CardId::TinyFixed64).into(),
+        measured: response(false, measured),
+        control: response(true, &vec![1; measured.len()]),
+    }
+}
+
+#[test]
+fn reciprocal_throughput_is_not_latency_input() {
+    let reciprocal = br#"{"metric_schema_version":"transaction-latency-v1","ns_per_op":12.5}"#;
+    assert!(serde_json::from_slice::<benchmark_suite::latency::LatencyRawRun>(reciprocal).is_err());
+}
+
+#[test]
+fn deterministic_schedule_replays_and_pairs_allocators() {
+    let first = deterministic_sample_indices(123, 2, 10_000, 1024).unwrap();
+    let second = deterministic_sample_indices(123, 2, 10_000, 1024).unwrap();
+    let other_seed = deterministic_sample_indices(124, 2, 10_000, 1024).unwrap();
+    assert_eq!(first, second);
+    assert_ne!(first, other_seed);
+    assert!(first.windows(2).all(|pair| pair[1] - pair[0] == 1024));
+}
+
+#[test]
+fn type7_quantiles_mad_iqr_and_extreme_tail_are_retained() {
+    let ordinary = summarize_latency(&[1, 2, 3, 4]).unwrap();
+    assert_eq!(ordinary.p50_ns, 2.5);
+    assert_eq!(ordinary.p95_ns, 3.8499999999999996);
+    assert_eq!(ordinary.iqr_ns, 1.5);
+    assert_eq!(ordinary.median_absolute_deviation_ns, 1.0);
+
+    let mut tail = vec![100; 99];
+    tail.push(100_000);
+    let summary = summarize_latency(&tail).unwrap();
+    assert_eq!(summary.count, 100);
+    assert_eq!(summary.max_ns, 100_000);
+    assert!(summary.p99_ns > 100.0);
+}
+
+#[test]
+fn zero_duration_and_overhead_thresholds_fail_closed() {
+    assert!(summarize_latency(&[1, 0, 2]).is_err());
+    let measured = summarize_latency(&vec![1_000; 100]).unwrap();
+    let good_control = summarize_latency(&vec![40; 100]).unwrap();
+    let median_too_high = summarize_latency(&vec![51; 100]).unwrap();
+    let tail_too_close = summarize_latency(&vec![600; 100]).unwrap();
+    assert!(overhead_is_valid(&measured, &good_control));
+    assert!(!overhead_is_valid(&measured, &median_too_high));
+    assert!(!overhead_is_valid(&measured, &tail_too_close));
+}
+
+#[test]
+fn block_bootstrap_keeps_within_block_transactions_and_is_lower_better() {
+    let samples = vec![
+        sample(0, "mimalloc-pprof", &[50, 50, 50]),
+        sample(0, "upstream-mimalloc", &[100, 100, 100]),
+        sample(1, "mimalloc-pprof", &[100, 100, 100]),
+        sample(1, "upstream-mimalloc", &[200, 200, 200]),
+    ];
+    let effect = block_bootstrap_quantile_effect(
+        99,
+        "tiny-fixed-64/1/p99",
+        "mimalloc-pprof",
+        "upstream-mimalloc",
+        0.99,
+        &samples,
+    )
+    .unwrap();
+    assert_eq!(effect.effect, 2.0);
+    assert_eq!(effect.confidence_interval.lower, 2.0);
+    assert_eq!(effect.confidence_interval.upper, 2.0);
+    assert_eq!(effect.block_count, 2);
+    assert_eq!(
+        effect.bootstrap.method,
+        "percentile-whole-block-transaction-quantile-type7-v1"
+    );
+}
+
+#[test]
+fn transaction_labels_are_end_to_end_not_allocator_calls() {
+    for card in [
+        CardId::TinyFixed64,
+        CardId::SmallLogMixed,
+        CardId::CrossThreadProducerConsumer,
+        CardId::LargeObjects,
+    ] {
+        let definition = transaction_definition(card);
+        assert!(!definition.contains("allocator-call"));
+        assert!(definition.contains("allocation"));
+        assert!(definition.contains("free"));
+    }
+}
+
+fn complete_raw_fixture() -> LatencyRawRun {
+    let throughput = synthetic_full_fixture().unwrap();
+    let topology = Topology {
+        physical_cores: throughput.runner.physical_cores as usize,
+        logical_cores: throughput.runner.logical_cores as usize,
+    };
+    let cells = benchmark_suite::latency::latency_scenario_cells(topology).unwrap();
+    let cell_keys = cells
+        .iter()
+        .map(|(card, point, _)| (card.as_str(), point.name()))
+        .collect::<Vec<_>>();
+    let mut transactions = BTreeMap::new();
+    let calibrations = cells
+        .iter()
+        .map(|(card_id, point, _)| {
+            let threads = topology.resolve(*point).unwrap();
+            let count = benchmark_suite::latency::minimum_transactions_per_worker(
+                threads, 15, 1, 10_000,
+            )
+            .unwrap();
+            transactions.insert((card_id.as_str(), point.name()), count);
+            let cell = ScenarioCell::new(*card_id, *point, topology, count, 1).unwrap();
+            CellCalibration {
+                scenario_id: card_id.as_str().into(),
+                thread_point: point.name().into(),
+                thread_count: threads as u32,
+                transactions_per_worker: count,
+                warmup_transactions_per_worker: 1,
+                operation_count: card(*card_id).operation_count(&cell.expected_counts().unwrap()),
+                elapsed_ns: 1_000_000,
+            }
+        })
+        .collect::<Vec<_>>();
+    let orders = benchmark_suite::orchestration::balanced_block_orders(15, throughput.run_seed)
+        .unwrap();
+    let samples = throughput
+        .samples
+        .iter()
+        .filter(|sample| {
+            cell_keys.contains(&(sample.scenario_id.as_str(), sample.thread_point.as_str()))
+        })
+        .map(|sample| {
+            let order = &orders[sample.block_id as usize];
+            let card_id = CardId::parse(&sample.scenario_id).unwrap();
+            let point = ThreadPoint::parse(&sample.thread_point).unwrap();
+            let count = transactions[&(card_id.as_str(), point.name())];
+            let cell = ScenarioCell::new(card_id, point, topology, count, order.workload_seed)
+                .unwrap();
+            let schedule = (0..cell.threads)
+                .flat_map(|worker| {
+                    deterministic_sample_indices(
+                        cell.seed,
+                        worker as u32,
+                        cell.transactions_per_worker,
+                        1,
+                    )
+                    .unwrap()
+                    .into_iter()
+                    .map(move |transaction_index| (worker as u32, transaction_index))
+                })
+                .collect::<Vec<_>>();
+            let allocator_offset = match sample.allocator_id.as_str() {
+                "tcmalloc" => 300,
+                "jemalloc" => 200,
+                "upstream-mimalloc" => 100,
+                "mimalloc-pprof" => 0,
+                _ => unreachable!(),
+            };
+            let scheduling = LatencyScheduling {
+                affinity_policy: throughput.runner.affinity.policy.clone(),
+                actual_cpu_ids: vec![None; cell.threads],
+                thread_count: cell.threads as u32,
+                physical_cores: throughput.runner.physical_cores,
+                logical_cores: throughput.runner.logical_cores,
+                context_switches: ContextSwitchCounts {
+                    voluntary: 0,
+                    involuntary: 0,
+                },
+                runner_class: throughput.runner.runner_class.clone(),
+                clock: LatencyClock {
+                    source: "monotonic".into(),
+                    implementation: "fixture-clock".into(),
+                    resolution_ns: 1,
+                },
+            };
+            let observations = schedule
+                .iter()
+                .map(|(thread_index, transaction_index)| LatencyObservation {
+                    thread_index: *thread_index,
+                    transaction_index: *transaction_index,
+                    duration_ns: 1_000 + allocator_offset + transaction_index % 41,
+                })
+                .collect::<Vec<_>>();
+            let controls = schedule
+                .iter()
+                .map(|(thread_index, transaction_index)| LatencyObservation {
+                    thread_index: *thread_index,
+                    transaction_index: *transaction_index,
+                    duration_ns: 40 + transaction_index % 3,
+                })
+                .collect::<Vec<_>>();
+            LatencyRawSample {
+                metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+                block_id: sample.block_id,
+                ordinal: order
+                    .allocator_ids
+                    .iter()
+                    .position(|allocator| allocator == &sample.allocator_id)
+                    .unwrap() as u8,
+                workload_seed: order.workload_seed,
+                allocator_id: sample.allocator_id.clone(),
+                allocator_source_sha: sample.allocator_source_sha.clone(),
+                child_binary_sha256: sample.child_binary_sha256.clone(),
+                scenario_id: sample.scenario_id.clone(),
+                thread_point: sample.thread_point.clone(),
+                thread_count: cell.threads as u32,
+                sample_denominator: 1,
+                transaction_definition: transaction_definition(card_id).into(),
+                measured: LatencyChildResponse {
+                    protocol_version: LATENCY_CHILD_PROTOCOL_VERSION.into(),
+                    metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+                    control: false,
+                    completed_transactions: cell.requested_transactions(),
+                    checksum: expected_touch_checksum(&cell).unwrap(),
+                    observations,
+                    scheduling: scheduling.clone(),
+                },
+                control: LatencyChildResponse {
+                    protocol_version: LATENCY_CHILD_PROTOCOL_VERSION.into(),
+                    metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+                    control: true,
+                    completed_transactions: cell.requested_transactions(),
+                    checksum: 1,
+                    observations: controls,
+                    scheduling,
+                },
+            }
+        })
+        .collect::<Vec<_>>();
+    LatencyRawRun {
+        metric_schema_version: LATENCY_SCHEMA_VERSION.into(),
+        status: "complete".into(),
+        run_seed: throughput.run_seed,
+        run: throughput.run,
+        runner: throughput.runner,
+        allocator_lock_sha256: throughput.allocator_lock_sha256,
+        allocators: throughput.allocators,
+        calibrations,
+        sampling_denominators: cells
+            .into_iter()
+            .map(|(card, point, _)| (format!("{}/{}", card.as_str(), point.name()), 1))
+            .collect(),
+        samples,
+    }
+}
+
+#[test]
+fn complete_latency_raw_matrix_is_bound_to_calibration_provenance_and_schedule() {
+    let raw = complete_raw_fixture();
+    validate_latency_raw_run(&raw).unwrap();
+
+    {
+        let mut wrong_schedule = raw.clone();
+        wrong_schedule.samples[0].measured.observations[0].transaction_index += 1;
+        assert!(validate_latency_raw_run(&wrong_schedule).is_err());
+    }
+    {
+        let mut wrong_provenance = raw.clone();
+        wrong_provenance.samples[0].child_binary_sha256 = "f".repeat(64);
+        assert!(validate_latency_raw_run(&wrong_provenance).is_err());
+    }
+    {
+        let mut mixed_clock = raw.clone();
+        mixed_clock.samples[0]
+            .measured
+            .scheduling
+            .clock
+            .resolution_ns = 2;
+        mixed_clock.samples[0]
+            .control
+            .scheduling
+            .clock
+            .resolution_ns = 2;
+        assert!(validate_latency_raw_run(&mixed_clock).is_err());
+    }
+    let mut wrong_checksum = raw;
+    wrong_checksum.samples[0].measured.checksum ^= 1;
+    assert!(validate_latency_raw_run(&wrong_checksum).is_err());
+}

--- a/rust/benchmark-suite/tests/timed_allocation_audit.rs
+++ b/rust/benchmark-suite/tests/timed_allocation_audit.rs
@@ -5,11 +5,14 @@ use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
 
-use benchmark_suite::execution::{execute_cell, set_measured_region_hook, AllocatorAdapter};
+use benchmark_suite::execution::{
+    execute_cell, execute_latency_cell, set_measured_region_hook, AllocatorAdapter,
+};
 use benchmark_suite::scenarios::{cards, CardId, ScenarioCell, Topology};
 
 static MEASURED: AtomicBool = AtomicBool::new(false);
 static HARNESS_ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static TEST_GATE: Mutex<()> = Mutex::new(());
 
 thread_local! {
     static INSIDE_ADAPTER: Cell<bool> = const { Cell::new(false) };
@@ -136,6 +139,7 @@ impl AllocatorAdapter for InstrumentedAdapter {
     ignore = "macOS realloc may route through the global allocator"
 )]
 fn ordinary_measured_region_performs_zero_harness_allocations() {
+    let _test_guard = TEST_GATE.lock().unwrap();
     let adapter = InstrumentedAdapter {
         layouts: Mutex::new(HashMap::new()),
     };
@@ -184,4 +188,48 @@ fn audit_cell(adapter: &InstrumentedAdapter, cell: &ScenarioCell) {
         "Rust control-plane allocation entered the measured interval for {:?}",
         cell.card
     );
+}
+
+#[test]
+fn latency_sampling_buffers_do_not_allocate_after_warmup() {
+    let _test_guard = TEST_GATE.lock().unwrap();
+    let adapter = InstrumentedAdapter {
+        layouts: Mutex::new(HashMap::new()),
+    };
+    let topology = Topology {
+        physical_cores: 2,
+        logical_cores: 2,
+    };
+    for (card, point) in [
+        (
+            CardId::TinyFixed64,
+            benchmark_suite::scenarios::ThreadPoint::One,
+        ),
+        (
+            CardId::SmallLogMixed,
+            benchmark_suite::scenarios::ThreadPoint::PhysicalCores,
+        ),
+        (
+            CardId::CrossThreadProducerConsumer,
+            benchmark_suite::scenarios::ThreadPoint::PhysicalCores,
+        ),
+        (
+            CardId::LargeObjects,
+            benchmark_suite::scenarios::ThreadPoint::One,
+        ),
+    ] {
+        let cell = ScenarioCell::new(card, point, topology, 8, 0x5eed).unwrap();
+        for control in [false, true] {
+            HARNESS_ALLOCATIONS.store(0, Ordering::SeqCst);
+            set_measured_region_hook(Some(timing_hook));
+            let result = execute_latency_cell(&adapter, &cell, 2, control);
+            set_measured_region_hook(None);
+            result.unwrap();
+            assert_eq!(
+                HARNESS_ALLOCATIONS.load(Ordering::SeqCst),
+                0,
+                "latency sampling allocated in the measured region for {card:?}, control={control}"
+            );
+        }
+    }
 }

--- a/rust/benchmark-suite/tests/validation.rs
+++ b/rust/benchmark-suite/tests/validation.rs
@@ -202,6 +202,7 @@ fn checked_in_schemas_are_valid_strict_json() {
         include_str!("../schema/latest-v1.schema.json"),
         include_str!("../schema/history-v1.schema.json"),
         include_str!("../schema/memory-v1.schema.json"),
+        include_str!("../schema/latency-v1.schema.json"),
     ] {
         let value: Value = serde_json::from_str(schema).unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary
- add the sealed transaction-latency-v1 runner, raw artifact, schema, and strict validator
- publish a serialized weekly/manual latency workflow to benchmark-stats and render the README-ready latency panel
- enforce deterministic schedules, calibration, control-overhead gates, affinity/clock provenance, paired block statistics, and report binding

## Validation
- benchmark-suite full test suite via Docker/soldr
- focused Python renderer and workflow tests
- Ruff, Pyright, actionlint, workflow policy self-test
- pre-push review: clean

Closes #185