### PR TITLE
test: control run for rust-native win-gnu baseline

### DIFF
--- a/rust/benchmark-suite/src/lib.rs
+++ b/rust/benchmark-suite/src/lib.rs
@@ -23,3 +23,5 @@ pub mod validate;
 
 pub const RAW_SCHEMA_VERSION: &str = "benchmark-raw-v1";
 pub const CORE_SUITE_VERSION: &str = "core-throughput-v1";
+
+// control: verify rust-native win-gnu baseline (no functional change)


### PR DESCRIPTION
Temporary control. Verifies whether rust-native test-win-gnu is red on unmodified main with the current runner image, independent of #204. Will be closed once the comparison is recorded.