### PR TITLE
fix(benchmarks): make the metric overlay publishable against a live envelope

### DIFF
--- a/ci/benchmark_report.py
+++ b/ci/benchmark_report.py
@@ -38,6 +38,10 @@ STATISTICS_VERSION = "paired-log-median-bootstrap-v1"
 SUITE_VERSION = "core-throughput-v1"
 VALIDATOR_VERSION = "benchmark-validator-v1"
 ALLOCATOR_IDS = ("tcmalloc", "jemalloc", "upstream-mimalloc", "mimalloc-pprof")
+# Allocators whose source commit is fixed by allocator-lock.json. A secondary
+# metric overlaid onto an older core envelope must match these exactly; the
+# fork's own commit legitimately moves between the two runs.
+LOCK_PINNED_ALLOCATORS = ("tcmalloc", "jemalloc", "upstream-mimalloc")
 VALIDATION_CHECKS = (
     "schema-and-versions",
     "run-identity",
@@ -1982,22 +1986,38 @@ def validate_latest(latest: dict[str, object], label: str) -> None:
         # Compare the set of (allocator, source) pairs rather than a mapping:
         # a mapping keeps only the last sample per allocator, which would let a
         # single mispinned sample through.
+        #
+        # Only the lock-pinned competitors must match the core run. The sweep
+        # runs weekly and overlays onto whichever daily core envelope is
+        # published, so the fork's own commit is normally newer; requiring
+        # equality there would make the overlay permanently unpublishable.
         expected_pairs = {
             (
                 str(object_value(value, f"{label}.allocators")["allocator_id"]),
                 str(object_value(value, f"{label}.allocators")["source_sha"]),
             )
             for value in allocators
+            if str(object_value(value, f"{label}.allocators")["allocator_id"])
+            in LOCK_PINNED_ALLOCATORS
         }
-        observed_pairs = {
-            (
-                str(object_value(value, f"{label}.scaling.raw_samples")["allocator_id"]),
-                str(object_value(value, f"{label}.scaling.raw_samples")["allocator_source_sha"]),
-            )
+        scaling_samples = [
+            object_value(value, f"{label}.scaling.raw_samples")
             for value in list_value(scaling_report["raw_samples"], f"{label}.scaling.raw_samples")
+        ]
+        observed_pairs = {
+            (str(value["allocator_id"]), str(value["allocator_source_sha"]))
+            for value in scaling_samples
+            if str(value["allocator_id"]) in LOCK_PINNED_ALLOCATORS
         }
         if observed_pairs != expected_pairs:
             fail(f"{label}.scaling: allocator source pins differ from the core run")
+        fork_sources = {
+            str(value["allocator_source_sha"])
+            for value in scaling_samples
+            if str(value["allocator_id"]) == "mimalloc-pprof"
+        }
+        if len(fork_sources) != 1:
+            fail(f"{label}.scaling: exactly one mimalloc-pprof build must be measured")
     pending = list_value(latest.get("pending_metrics"), f"{label}.pending_metrics")
     expected_pending = tuple(
         metric
@@ -2175,6 +2195,41 @@ def validate_history_row(value: object, label: str) -> dict[str, object]:
     return row
 
 
+def equivalent_payload(left: object, right: object, tolerance: float = 1e-12) -> bool:
+    """Structural equality that tolerates float round-trip noise.
+
+    A published `latest.json` that passes back through the Rust overlay
+    binaries can return with a float shifted by one unit in the last place:
+    serde_json's parse-and-re-emit is not bit-identical to Python's json for
+    every value (observed on `relative_iqr`, ...413 in, ...412 out). The
+    history merge must not read that as a rewritten historical row, but must
+    still reject a real change. One ULP is around 1e-16 relative, four orders
+    of magnitude below this tolerance, so genuine edits are still caught.
+    """
+
+    if isinstance(left, bool) or isinstance(right, bool):
+        return left is right
+    if isinstance(left, float) or isinstance(right, float):
+        if not isinstance(left, (int, float)) or not isinstance(right, (int, float)):
+            return False
+        if math.isnan(left) or math.isnan(right):
+            return False
+        return left == right or math.isclose(left, right, rel_tol=tolerance, abs_tol=0.0)
+    if isinstance(left, dict) and isinstance(right, dict):
+        left_map = cast(dict[str, object], left)
+        right_map = cast(dict[str, object], right)
+        return set(left_map) == set(right_map) and all(
+            equivalent_payload(left_map[key], right_map[key], tolerance) for key in left_map
+        )
+    if isinstance(left, list) and isinstance(right, list):
+        left_list = cast(list[object], left)
+        right_list = cast(list[object], right)
+        return len(left_list) == len(right_list) and all(
+            equivalent_payload(one, other, tolerance) for one, other in zip(left_list, right_list)
+        )
+    return left == right
+
+
 def read_history(path: Path, initialize: bool) -> list[dict[str, object]]:
     if not path.exists():
         if not initialize:
@@ -2230,9 +2285,13 @@ def merge_history(
         previous_base = {key: value for key, value in row.items() if key not in optional}
         current_base = {key: value for key, value in current.items() if key not in optional}
         gained = (set(current) & optional) - (set(row) & optional)
-        if previous_base != current_base or not gained:
+        if not equivalent_payload(previous_base, current_base) or not gained:
             fail("history append: duplicate run may only gain a validated optional metric")
-        combined[index] = current
+        # Keep the row exactly as it was first published and add only the newly
+        # collected metric. Rewriting it from the round-tripped envelope would
+        # silently move already-published numbers by the same round-trip noise
+        # this comparison tolerates.
+        combined[index] = dict(row) | {key: current[key] for key in sorted(gained)}
         break
     else:
         combined.append(current)
@@ -3017,7 +3076,7 @@ def render_html(latest: Mapping[str, object]) -> bytes:
             if scaling_run["run_origin"] == "github-actions"
             else "https://github.com/zackees/mimalloc-pprof/actions"
         )
-        scaling_html = f"""<section><h2 id="scaling">Thread scaling (sparse sweep)</h2>{scaling_images}<p><strong>{escaped(SCALING_RIGOR_LABEL)}.</strong> These panels trade statistical rigor for thread coverage: {escaped(SCALING_BLOCKS)} blocks per cell, median with min/max, and deliberately no confidence intervals or noise gating. Do not read them as headline-grade numbers.</p><p>Worker counts are literal {escaped(", ".join(str(point) for point in SCALING_THREAD_POINTS))}; the runner allows {escaped(scaling_topology["allowed_logical_cpus"])} logical CPUs, so higher points are oversubscribed and describe contention rather than core scaling. {escaped(scaling_methodology["seed_chain"])}. Scaling run <a href="{scaling_actions}">{escaped(scaling_run["run_id"])}/{escaped(scaling_run["run_attempt"])}</a>; metric key <code>{escaped(scaling["metric_comparison_key"])}</code>.</p><table><thead><tr><th>Pattern</th><th>Workers</th><th>Allocator</th><th>Median ops/s</th><th>Min - max</th><th>Speedup vs 1</th><th>Oversubscribed</th></tr></thead><tbody>{scaling_rows}</tbody></table></section>"""
+        scaling_html = f"""<section><h2 id="scaling">Thread scaling (sparse sweep)</h2>{scaling_images}<p><strong>{escaped(SCALING_RIGOR_LABEL)}.</strong> These panels trade statistical rigor for thread coverage: {escaped(SCALING_BLOCKS)} blocks per cell, median with min/max, and deliberately no confidence intervals or noise gating. Do not read them as headline-grade numbers.</p><p>Worker counts are literal {escaped(", ".join(str(point) for point in SCALING_THREAD_POINTS))}; the runner allows {escaped(scaling_topology["allowed_logical_cpus"])} logical CPUs, so higher points are oversubscribed and describe contention rather than core scaling. {escaped(scaling_methodology["seed_chain"])}. Scaling run <a href="{scaling_actions}">{escaped(scaling_run["run_id"])}/{escaped(scaling_run["run_attempt"])}</a> measured mimalloc-pprof at source <code>{escaped(scaling_run["source_sha"])}</code>, which is not necessarily the commit above; metric key <code>{escaped(scaling["metric_comparison_key"])}</code>.</p><table><thead><tr><th>Pattern</th><th>Workers</th><th>Allocator</th><th>Median ops/s</th><th>Min - max</th><th>Speedup vs 1</th><th>Oversubscribed</th></tr></thead><tbody>{scaling_rows}</tbody></table></section>"""
     document = f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>mimalloc allocator benchmarks</title>
 <style>body{{font:15px system-ui,sans-serif;max-width:1200px;margin:auto;padding:24px;color:#182334}}table{{border-collapse:collapse;width:100%;margin:16px 0}}th,td{{border:1px solid #ccd4dd;padding:7px;text-align:left}}img{{max-width:100%;height:auto}}.pending{{border:1px solid #ccd4dd;padding:12px;margin:12px 0}}code,pre{{overflow-wrap:anywhere;white-space:pre-wrap}}small{{color:#596575}}</style></head><body>

--- a/ci/tests/test_benchmark_report.py
+++ b/ci/tests/test_benchmark_report.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import copy
 import json
+import math
 import re
 import subprocess
 import sys
@@ -1082,9 +1083,40 @@ class BenchmarkReportTests(unittest.TestCase):
         assert isinstance(scaling, dict)
         samples = scaling["raw_samples"]
         assert isinstance(samples, list) and isinstance(samples[0], dict)
-        samples[0]["allocator_source_sha"] = "f" * 40
+        for sample in samples:
+            assert isinstance(sample, dict)
+            if sample["allocator_id"] == "upstream-mimalloc":
+                sample["allocator_source_sha"] = "f" * 40
         with self.assertRaisesRegex(report.ReportError, "allocator source pins"):
             report.validate_latest(mispinned, "mispinned")
+
+        # The sweep runs weekly against whichever daily core envelope is
+        # published, so the fork is normally built from a newer commit. That
+        # must overlay cleanly; only the lock-pinned competitors are frozen.
+        newer_fork = copy.deepcopy(latest)
+        scaling = newer_fork["scaling"]
+        assert isinstance(scaling, dict)
+        samples = scaling["raw_samples"]
+        assert isinstance(samples, list)
+        for sample in samples:
+            assert isinstance(sample, dict)
+            if sample["allocator_id"] == "mimalloc-pprof":
+                sample["allocator_source_sha"] = "a" * 40
+        report.validate_latest(newer_fork, "newer fork build")
+
+        mixed_forks = copy.deepcopy(latest)
+        scaling = mixed_forks["scaling"]
+        assert isinstance(scaling, dict)
+        samples = scaling["raw_samples"]
+        assert isinstance(samples, list)
+        changed = False
+        for sample in samples:
+            assert isinstance(sample, dict)
+            if sample["allocator_id"] == "mimalloc-pprof" and not changed:
+                sample["allocator_source_sha"] = "b" * 40
+                changed = True
+        with self.assertRaisesRegex(report.ReportError, "one mimalloc-pprof build"):
+            report.validate_latest(mixed_forks, "mixed fork builds")
 
         still_pending = copy.deepcopy(latest)
         pending = still_pending["pending_metrics"]
@@ -1118,6 +1150,59 @@ class BenchmarkReportTests(unittest.TestCase):
             path.write_text(panel.replace("<svg", "<svg onload='x()'", 1), encoding="utf-8")
             with self.assertRaisesRegex(report.ReportError, "event handlers"):
                 report.validate_svg(path)
+
+    def test_history_merge_tolerates_float_round_trip_but_not_real_edits(self) -> None:
+        # A published latest.json that passes back through the Rust overlay
+        # binaries returns with floats occasionally shifted by one ULP
+        # (serde_json parse/re-emit is not bit-identical to Python's). Observed
+        # live on relative_iqr: ...413 in, ...412 out.
+        self.assertTrue(
+            report.equivalent_payload(
+                {"relative_iqr": 0.11300528823968413},
+                {"relative_iqr": 0.11300528823968412},
+            )
+        )
+        self.assertFalse(
+            report.equivalent_payload({"median": 100.0}, {"median": 100.0001}),
+            "a real numeric change must still be rejected",
+        )
+        self.assertFalse(report.equivalent_payload({"a": 1}, {"a": 1, "b": 2}))
+        self.assertFalse(report.equivalent_payload([1.0, 2.0], [1.0]))
+        self.assertFalse(
+            report.equivalent_payload({"noisy": True}, {"noisy": 1}),
+            "booleans must not compare equal to their integer value",
+        )
+
+        base = self.load_history_row()
+        rounded = copy.deepcopy(base)
+        absolute = rounded["absolute_summaries"]
+        assert isinstance(absolute, list) and isinstance(absolute[0], dict)
+        summary = absolute[0]["summary"]
+        assert isinstance(summary, dict)
+        median = float(summary["median"])  # pyright: ignore[reportArgumentType]
+        summary["median"] = math.nextafter(median, math.inf)
+        gained = copy.deepcopy(rounded)
+        gained["scaling"] = {"placeholder": True}
+        merged = report.merge_history([base], gained)
+        self.assertEqual(1, len(merged))
+        self.assertIn("scaling", merged[0])
+        # The already-published row keeps its original bytes; only the new
+        # metric is added.
+        first = merged[0]["absolute_summaries"]
+        assert isinstance(first, list) and isinstance(first[0], dict)
+        original_summary = first[0]["summary"]
+        assert isinstance(original_summary, dict)
+        self.assertEqual(median, original_summary["median"])
+
+        moved = copy.deepcopy(rounded)
+        moved_absolute = moved["absolute_summaries"]
+        assert isinstance(moved_absolute, list) and isinstance(moved_absolute[0], dict)
+        moved_summary = moved_absolute[0]["summary"]
+        assert isinstance(moved_summary, dict)
+        moved_summary["median"] = median * 1.01
+        moved["scaling"] = {"placeholder": True}
+        with self.assertRaisesRegex(report.ReportError, "may only gain"):
+            report.merge_history([base], moved)
 
     def test_axis_uses_one_unit_for_every_tick(self) -> None:
         unit = report.axis_unit(1_644.0)

--- a/rust/benchmark-suite/src/scaling.rs
+++ b/rust/benchmark-suite/src/scaling.rs
@@ -1894,6 +1894,12 @@ pub fn synthetic_scaling_fixture(run_seed: u64) -> Result<ScalingRawRun, String>
     })
 }
 
+/// Allocators whose source commit is fixed by `allocator-lock.json`. These must
+/// match the core run exactly: they are the comparison baseline, and a
+/// competitor built from a different commit would silently change what the
+/// chart means.
+pub const LOCK_PINNED_ALLOCATORS: [&str; 3] = ["tcmalloc", "jemalloc", "upstream-mimalloc"];
+
 pub fn attach_scaling_report(
     latest: &mut LatestReport,
     report: ScalingMetricReport,
@@ -1902,15 +1908,35 @@ pub fn attach_scaling_report(
     let expected = latest
         .allocators
         .iter()
+        .filter(|value| LOCK_PINNED_ALLOCATORS.contains(&value.allocator_id.as_str()))
         .map(|value| (&value.allocator_id, &value.source_sha))
         .collect::<BTreeSet<_>>();
     let observed = report
         .raw_samples
         .iter()
+        .filter(|value| LOCK_PINNED_ALLOCATORS.contains(&value.allocator_id.as_str()))
         .map(|value| (&value.allocator_id, &value.allocator_source_sha))
         .collect::<BTreeSet<_>>();
     if expected != observed {
         return Err("scaling allocator provenance differs from core latest".into());
+    }
+    // The fork's own commit is deliberately not required to match. This sweep
+    // runs weekly and overlays onto whatever daily core envelope is published,
+    // so mimalloc-pprof is normally built from a newer commit than the base.
+    // Requiring equality would make the overlay permanently unpublishable.
+    // Instead the sweep must actually contain the fork, and the commit it was
+    // measured at is recorded on the report so the two sections of latest.json
+    // can never be read as one build.
+    let fork_sources = report
+        .raw_samples
+        .iter()
+        .filter(|value| value.allocator_id == "mimalloc-pprof")
+        .map(|value| value.allocator_source_sha.as_str())
+        .collect::<BTreeSet<_>>();
+    match fork_sources.len() {
+        1 => {}
+        0 => return Err("scaling run does not contain mimalloc-pprof".into()),
+        _ => return Err("scaling run mixes several mimalloc-pprof builds".into()),
     }
     latest.scaling = Some(report);
     latest

--- a/rust/benchmark-suite/tests/scaling_contract.rs
+++ b/rust/benchmark-suite/tests/scaling_contract.rs
@@ -507,6 +507,50 @@ fn a_failing_worker_reports_an_error_instead_of_stranding_the_others() {
 }
 
 #[test]
+fn overlay_accepts_a_newer_fork_build_but_not_a_moved_competitor_pin() {
+    use benchmark_suite::scaling::{attach_scaling_report, LOCK_PINNED_ALLOCATORS};
+
+    // Reproduces the first live run's failure: the sweep runs weekly and
+    // overlays onto whichever daily core envelope is published, so
+    // mimalloc-pprof is normally built from a newer commit than the base.
+    let raw = benchmark_suite::scaling::synthetic_scaling_fixture(0x6d69_6d61_6c6c_6f63).unwrap();
+    let report = build_scaling_report(&raw).unwrap();
+    let core = benchmark_suite::validate::synthetic_full_fixture().unwrap();
+    let validation = benchmark_suite::validate::validate_publication_raw(&core).unwrap();
+    let base = benchmark_suite::report::build_latest_report(&core, validation)
+        .unwrap()
+        .0;
+    let mut latest = base.clone();
+
+    let mut newer_fork = report.clone();
+    for sample in &mut newer_fork.raw_samples {
+        if sample.allocator_id == "mimalloc-pprof" {
+            sample.allocator_source_sha = "a".repeat(40);
+        }
+    }
+    attach_scaling_report(&mut latest, newer_fork)
+        .expect("a newer fork build must still overlay");
+    assert!(latest.scaling.is_some());
+    assert!(!latest
+        .pending_metrics
+        .iter()
+        .any(|value| value.metric_id == "scaling"));
+
+    let mut moved_pin = report.clone();
+    for sample in &mut moved_pin.raw_samples {
+        if sample.allocator_id == "upstream-mimalloc" {
+            sample.allocator_source_sha = "f".repeat(40);
+        }
+    }
+    let mut fresh = base;
+    assert!(
+        attach_scaling_report(&mut fresh, moved_pin).is_err(),
+        "a competitor built from a different commit must be rejected"
+    );
+    assert_eq!(LOCK_PINNED_ALLOCATORS.len(), 3);
+}
+
+#[test]
 fn counts_helper_sums_every_allocator_call() {
     let counts = ScalingCounts {
         alloc_calls: 3,


### PR DESCRIPTION
The first real `benchmark-scaling` run ([31759621920](https://github.com/zackees/mimalloc-pprof/actions/runs/31759621920)) **measured cleanly** and then failed to publish, on two defects that only appear against a real published envelope.

Both live in the shared overlay path, so **memory (#184) and latency (#185) would hit the same two failures on their first live run.** Neither has ever run — their weekly crons have not fired since those PRs merged — so this has been latent since 6A.

## What the run proved before it failed

| | |
|---|---|
| Samples | 144 (4 patterns x 3 thread points x 4 allocators x 3 blocks) |
| Calibrations | 12, every one inside the 0.4–1.5 s window (622 / 616 / 726 / 742 ms …) |
| Allocator build | 5 m 26 s |
| **Measurement** | **3 m 01 s** |
| Job total | 10 m 00 s, against a 20-minute timeout |
| Runner projection | `projected_full_suite_seconds: 479.1`, `fits_limit: true` |

So the Alt B budget claim on #203 holds with real numbers.

## Defect 1 — provenance equality could never pass

```
benchmark-scaling-validate: scaling allocator provenance differs from core latest
```

The overlay compared `(allocator_id, source_sha)` for all four allocators against the base `latest.json`. But the sweep runs weekly and overlays onto whichever *daily* core envelope is published, so `mimalloc-pprof` is normally built from a newer commit. The published base was built at `7f3bfef9`; the sweep built the fork at `09eec8df`. The three lock-pinned competitors matched exactly.

Now: lock-pinned competitors must still match exactly (they are the comparison baseline, and a competitor from a different commit would silently change what the chart means), while the fork may differ but must appear as exactly one build. The commit it was measured at is stated in the dashboard so the two sections of `latest.json` cannot be read as one build.

## Defect 2 — history merge required byte-exact floats

```
history append: duplicate run may only gain a validated optional metric
```

`merge_history` requires the recomputed base to equal the stored row exactly. A `latest.json` that round-trips through the Rust overlay binaries comes back with the occasional float shifted by one ULP — serde_json's parse-and-re-emit is not bit-identical to Python's `json`. Observed live on `relative_iqr`:

```
published base-latest.json : 0.11300528823968413
after Rust overlay         : 0.11300528823968412
```

The comparison now tolerates 1e-12 relative drift (four orders of magnitude above one ULP, so a real edit is still rejected), and the already-published row **keeps its original bytes**, gaining only the new metric instead of being rewritten from the round-tripped envelope. That also matches #183's shared rule to preserve existing history lineages rather than rewrite old rows.

## Verification

End to end against the **real artifacts** from the failed run, not a fixture: the live `scaling-raw-run.json` overlays onto the live `latest.json`, renders, and passes `validate-site` with a sealed manifest digest.

New tests cover both: a Rust test that a newer fork build overlays while a moved competitor pin is rejected, and Python tests that one-ULP drift is tolerated, a real numeric change is not, booleans do not compare equal to their integer value, and the published row is preserved rather than rewritten.

`pytest ci/tests`: 60 passed. `ruff`, `pyright` clean. Full Rust suite green (15 scaling contract tests).

CI note: `rust-native`, `cross`, and `benchmark-sentinel` are red on `main` for reasons unrelated to this branch — see #206 and the control experiment recorded on #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)