### PR TITLE
fix(benchmarks): make the metric overlay survive a real run (#220)

### DIFF
--- a/rust/bench-harness/Cargo.toml
+++ b/rust/bench-harness/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 stress-harness = { path = "../stress-harness" }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["float_roundtrip"] }
 
 [dev-dependencies]
 mimalloc-pprof = { path = "../mimalloc-pprof" }

--- a/rust/benchmark-suite/Cargo.toml
+++ b/rust/benchmark-suite/Cargo.toml
@@ -48,6 +48,6 @@ path = "src/bin/benchmark-scaling-validate.rs"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["float_roundtrip"] }
 
 [build-dependencies]

--- a/rust/benchmark-suite/src/scaling.rs
+++ b/rust/benchmark-suite/src/scaling.rs
@@ -1251,6 +1251,14 @@ pub struct ScalingRawSample {
     pub reproduction_command: String,
     /// Externally sampled peak RSS of the child process while the measured
     /// block ran (bytes). Observed by the runner, never reported by the child.
+    ///
+    /// Defaulted, not required: rows published before the RSS side-car existed
+    /// carry no observation, and every validator that reads a prior
+    /// `latest.json` (`--base-latest`) has to deserialize those rows. A fresh
+    /// producer run always sets it, and `validate_scaling_raw_run` rejects a
+    /// zero there, so the default cannot smuggle a missing observation into a
+    /// new run.
+    #[serde(default)]
     pub peak_rss_bytes: u64,
     pub response: ScalingChildResponse,
 }

--- a/rust/dashboard/Cargo.toml
+++ b/rust/dashboard/Cargo.toml
@@ -14,4 +14,4 @@ bench-harness = { path = "../bench-harness" }
 stress-harness = { path = "../stress-harness" }
 mimalloc-pprof = { path = "../mimalloc-pprof" }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["float_roundtrip"] }

--- a/rust/stress-harness/Cargo.toml
+++ b/rust/stress-harness/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["float_roundtrip"] }
 
 [dev-dependencies]
 mimalloc-pprof = { path = "../mimalloc-pprof" }


### PR DESCRIPTION
Fixes #220. Also fixes a regression from #218 (issue #211 WP4) that currently breaks the daily producer on `main`.

Two defects that only a real measurement run could expose. `benchmark-memory` had **never been run** — zero runs in its history, and the published envelope still says `pending - metric protocol not implemented`. I dispatched it (run `31770268760`) to populate the panels #211 added. It produced 420 good samples and then failed to publish, for two independent reasons.

## 1. serde_json parses f64 one ULP low without `float_roundtrip`

`memory.rs:1154` recomputes `fragmentation_proxy` and compares it to the stored value with exact `!=`. I reproduced the failure locally against the run's raw artifact and instrumented the branch:

```
DBG peak=false delta_peak=false d100=false d1s=false d5s=false frag=true compat=false
DBG scenario=large-objects alloc=tcmalloc block=2 ord=3
    delta=13807616 live=13430709
    recomputed_bits=0x3ff072f24474748e
    stored_bits   =0x3ff072f24474748d
```

The literal on disk is `1.0280630754489581`. The correctly-rounded double for that literal — and for `13807616 / 13430709` — is `0x…748e`; Python's `strtod` agrees. serde_json reads `0x…748d`, so the validator rejected a sample whose stored value was in fact correct.

That is documented serde_json behavior without the `float_roundtrip` feature, which exists to "ensure that they will round-trip exactly". Every recompute-and-compare check in the validators (throughput medians, latency percentiles) had the same latent exposure; the fixtures never caught it because their hand-picked values round-trip cleanly. Enabled on all four crates that parse published JSON.

## 2. WP4 made scaling's `peak_rss_bytes` required, breaking every read of a published envelope

Regression from #218. Every validator that overlays onto the live envelope takes `--base-latest`, and the published scaling report carries 144 `raw_samples` recorded before the RSS side-car existed:

```
latest.json: missing field `peak_rss_bytes` at line 1 column 3279544
```

This breaks the **daily producer**, not only the memory overlay — it is live on `main` right now. #218 made the *Python* validator lineage-aware and missed the Rust struct; this is the same class of bug on the other side of the contract.

Marked `#[serde(default)]`. A fresh producer run always sets the field and `validate_scaling_raw_run` still rejects a zero there, so the default cannot smuggle a missing observation into a new run — it only lets pre-side-car rows deserialize, which is exactly the lineage guarantee #218 established for the Python side.

## Verification

Against the real raw artifact from run `31770268760`, which fails on `main`:

```
before: benchmark-memory-validate: memory sample has inconsistent derived values or compatibility
after:  PASS validated 420 memory samples; key=58082590b2fc49a015cd59e425833fe926e80af8272e94d0f25213e21ce82bf5
```

`Cargo.lock` is unchanged and `--locked` still resolves.

## Known-failing check

`timed_allocation_audit` fails on this branch — and equally on unmodified `main`. Control, run locally just now: with these changes stashed, `main` fails **4/4**. Tracked in #219, which also documents the same test breaking on CI's win-gnu and macOS jobs within the last hour on commits that were green before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
