### PR TITLE
fix(rust): use C11 atomics for Windows ARM64

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -109,6 +109,7 @@ jobs:
       matrix:
         target:
           - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
           - x86_64-apple-darwin
           - aarch64-apple-darwin
     defaults:

--- a/include/mimalloc/atomic.h
+++ b/include/mimalloc/atomic.h
@@ -28,7 +28,20 @@ terms of the MIT license. A copy of the license can be found in the file
 // instead of passing the memory order as a parameter.
 // -----------------------------------------------------------------------------------------------
 
-#if defined(__cplusplus)
+#if defined(MI_USE_C11_ATOMICS)
+// Some MSVC-compatible C compilers provide C11 atomics but not every
+// architecture-specific intrinsic used by the plain MSVC wrapper below.
+#include <stdatomic.h>
+#define  mi_atomic(name)          atomic_##name
+#define  mi_memory_order(name)    memory_order_##name
+#if (__STDC_VERSION__ >= 201710L) // c17, see issue #735
+ #define MI_ATOMIC_VAR_INIT(x)    x
+#elif !defined(ATOMIC_VAR_INIT)
+ #define MI_ATOMIC_VAR_INIT(x)    x
+#else
+ #define MI_ATOMIC_VAR_INIT(x)    ATOMIC_VAR_INIT(x)
+#endif
+#elif defined(__cplusplus)
 // Use C++ atomics
 #include <atomic>
 #define  _Atomic(tp)              std::atomic<tp>
@@ -101,7 +114,7 @@ static inline intptr_t mi_atomic_addi(_Atomic(intptr_t)*p, intptr_t add);
 static inline intptr_t mi_atomic_subi(_Atomic(intptr_t)*p, intptr_t sub);
 
 
-#if defined(__cplusplus) || !defined(_MSC_VER)
+#if defined(MI_USE_C11_ATOMICS) || defined(__cplusplus) || !defined(_MSC_VER)
 
 // In C++/C11 atomics we have polymorphic atomics so can use the typed `ptr` variants (where `tp` is the type of atomic value)
 // We use these macros so we can provide a typed wrapper in MSVC in C compilation mode as well

--- a/rust/mimalloc-pprof/build.rs
+++ b/rust/mimalloc-pprof/build.rs
@@ -1,5 +1,7 @@
 use std::env;
 
+mod build_target;
+
 fn main() {
     // Everything the compiler needs lives in vendor/: the amalgamated
     // translation unit plus two verbatim support headers it opens via
@@ -22,6 +24,13 @@ fn main() {
         .define("MI_PPROF", "1");
     if env::var("PROFILE").as_deref() == Ok("release") {
         build.define("NDEBUG", None);
+    }
+    if build_target::needs_cxx_compilation(env::var("TARGET").ok().as_deref()) {
+        // clang's MSVC ARM64 C mode does not expose the intrinsics used by
+        // mimalloc's C atomics. The vendored source supports a C++ atomics
+        // path, and this package-scoped flag avoids changing unrelated C
+        // dependencies in the consumer's build graph.
+        build.cpp(true).flag("-TP");
     }
     build.compile("mimalloc");
 

--- a/rust/mimalloc-pprof/build.rs
+++ b/rust/mimalloc-pprof/build.rs
@@ -25,12 +25,11 @@ fn main() {
     if env::var("PROFILE").as_deref() == Ok("release") {
         build.define("NDEBUG", None);
     }
-    if build_target::needs_cxx_compilation(env::var("TARGET").ok().as_deref()) {
-        // clang's MSVC ARM64 C mode does not expose the intrinsics used by
-        // mimalloc's C atomics. The vendored source supports a C++ atomics
-        // path, and this package-scoped flag avoids changing unrelated C
-        // dependencies in the consumer's build graph.
-        build.cpp(true).flag("-TP");
+    if build_target::needs_c11_atomics(env::var("TARGET").ok().as_deref()) {
+        // ARM64 clang-cl does not expose __ldar64/__stlr64, which mimalloc's
+        // plain MSVC C wrapper uses. Keep the translation unit in C mode and
+        // select clang's C11 stdatomic implementation for this package only.
+        build.define("MI_USE_C11_ATOMICS", "1");
     }
     build.compile("mimalloc");
 

--- a/rust/mimalloc-pprof/build_target.rs
+++ b/rust/mimalloc-pprof/build_target.rs
@@ -1,0 +1,3 @@
+pub(crate) fn needs_cxx_compilation(target: Option<&str>) -> bool {
+    target == Some("aarch64-pc-windows-msvc")
+}

--- a/rust/mimalloc-pprof/build_target.rs
+++ b/rust/mimalloc-pprof/build_target.rs
@@ -1,3 +1,3 @@
-pub(crate) fn needs_cxx_compilation(target: Option<&str>) -> bool {
+pub(crate) fn needs_c11_atomics(target: Option<&str>) -> bool {
     target == Some("aarch64-pc-windows-msvc")
 }

--- a/rust/mimalloc-pprof/tests/build_target.rs
+++ b/rust/mimalloc-pprof/tests/build_target.rs
@@ -1,0 +1,21 @@
+#[path = "../build_target.rs"]
+mod build_target;
+
+#[test]
+fn windows_arm64_uses_cxx_compilation() {
+    assert!(build_target::needs_cxx_compilation(Some(
+        "aarch64-pc-windows-msvc"
+    )));
+}
+
+#[test]
+fn other_targets_remain_c_compilation() {
+    for target in [
+        None,
+        Some("x86_64-pc-windows-msvc"),
+        Some("aarch64-unknown-linux-gnu"),
+        Some("aarch64-apple-darwin"),
+    ] {
+        assert!(!build_target::needs_cxx_compilation(target));
+    }
+}

--- a/rust/mimalloc-pprof/tests/build_target.rs
+++ b/rust/mimalloc-pprof/tests/build_target.rs
@@ -2,20 +2,20 @@
 mod build_target;
 
 #[test]
-fn windows_arm64_uses_cxx_compilation() {
-    assert!(build_target::needs_cxx_compilation(Some(
+fn windows_arm64_uses_c11_atomics() {
+    assert!(build_target::needs_c11_atomics(Some(
         "aarch64-pc-windows-msvc"
     )));
 }
 
 #[test]
-fn other_targets_remain_c_compilation() {
+fn other_targets_keep_default_atomics() {
     for target in [
         None,
         Some("x86_64-pc-windows-msvc"),
         Some("aarch64-unknown-linux-gnu"),
         Some("aarch64-apple-darwin"),
     ] {
-        assert!(!build_target::needs_cxx_compilation(target));
+        assert!(!build_target::needs_c11_atomics(target));
     }
 }

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 84a5884e of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit a0682cfb of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -1517,7 +1517,20 @@ terms of the MIT license. A copy of the license can be found in the file
 // instead of passing the memory order as a parameter.
 // -----------------------------------------------------------------------------------------------
 
-#if defined(__cplusplus)
+#if defined(MI_USE_C11_ATOMICS)
+// Some MSVC-compatible C compilers provide C11 atomics but not every
+// architecture-specific intrinsic used by the plain MSVC wrapper below.
+#include <stdatomic.h>
+#define  mi_atomic(name)          atomic_##name
+#define  mi_memory_order(name)    memory_order_##name
+#if (__STDC_VERSION__ >= 201710L) // c17, see issue #735
+ #define MI_ATOMIC_VAR_INIT(x)    x
+#elif !defined(ATOMIC_VAR_INIT)
+ #define MI_ATOMIC_VAR_INIT(x)    x
+#else
+ #define MI_ATOMIC_VAR_INIT(x)    ATOMIC_VAR_INIT(x)
+#endif
+#elif defined(__cplusplus)
 // Use C++ atomics
 #include <atomic>
 #define  _Atomic(tp)              std::atomic<tp>
@@ -1590,7 +1603,7 @@ static inline intptr_t mi_atomic_addi(_Atomic(intptr_t)*p, intptr_t add);
 static inline intptr_t mi_atomic_subi(_Atomic(intptr_t)*p, intptr_t sub);
 
 
-#if defined(__cplusplus) || !defined(_MSC_VER)
+#if defined(MI_USE_C11_ATOMICS) || defined(__cplusplus) || !defined(_MSC_VER)
 
 // In C++/C11 atomics we have polymorphic atomics so can use the typed `ptr` variants (where `tp` is the type of atomic value)
 // We use these macros so we can provide a typed wrapper in MSVC in C compilation mode as well


### PR DESCRIPTION
## Summary
- add an explicit C11-atomics escape hatch to mimalloc's atomic abstraction
- select that path only for `aarch64-pc-windows-msvc` in the Rust crate build script, keeping the amalgamation in C mode
- avoid both missing ARM64 clang-cl intrinsics and consumer-wide C/C++ flags
- validate the exact ARM64 Windows target in the cross-build matrix

## Validation
- hosted first attempt reproduced why the C++ path is invalid for the current v3 amalgamation
- `soldr cargo test -p mimalloc-pprof --test build_target` (2 passed)
- `soldr cargo test -p mimalloc-pprof --locked` (all passed)
- `soldr cargo clippy -p mimalloc-pprof --lib --test build_target --locked -- -D warnings`
- `soldr cargo fmt -p mimalloc-pprof -- --check`
- `soldr cargo run -p xtask -- check`

Closes #223

Downstream: zackees/zccache#864