### PR TITLE
chore(release): bump mimalloc-pprof to 0.9.3

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "cc",
  "regex",

--- a/rust/mimalloc-pprof/CHANGELOG.md
+++ b/rust/mimalloc-pprof/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.3
+
+- Fix the Rust crate's bundled allocator build on `aarch64-pc-windows-msvc` by using
+  C11 atomics for that target, avoiding unsupported MSVC C atomic syntax (#223).
+
 ## 0.9.2
 
 One behavioural fix: **seeded sampling is now actually reproducible.**

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimalloc-pprof"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "MIT"
 description = "mimalloc global allocator with pprof-compatible sampled heap profiling"


### PR DESCRIPTION
## Summary
- bump the Rust crate and lockfile to 0.9.3
- document the Windows ARM64 build fix from issue #223

## Validation
- soldr cargo check -p mimalloc-pprof