### PR TITLE
docs(readme): document cross-compilation and the 0.9.3 ARM64 atomics fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,25 @@ rustflags = ["-Cforce-frame-pointers=yes"]
 Windows x64 uses unwind information instead; keep the generated PDB for
 symbolization.
 
+### Cross-compilation
+
+The crate vendors mimalloc as a single amalgamated C translation unit with no
+autotools or CMake step, so it builds wherever `cc-rs` can reach a C compiler,
+cross-compiled builds included.
+
+`aarch64-pc-windows-msvc` needs one adjustment, and `build.rs` makes it itself.
+In plain C mode mimalloc models C11 atomics with a deprecated MSVC
+`Interlocked` wrapper whose `_acq`/`_rel` ARM64 intrinsics `clang-cl` does not
+declare, so a `cargo-xwin` cross build cannot compile it. Since **0.9.3** the
+build script compiles that target against clang's C11 `stdatomic`
+implementation instead.
+
+Selecting this inside `build.rs` is the point. `CFLAGS` applies to every
+`cc-rs` build script in a build, so a consumer forcing mimalloc's C++ atomics
+path from the outside with `CFLAGS=-TP` also flips the language mode of every
+other native dependency in the graph — `ring`, for one, fails to compile as
+C++. No consumer should have to know how this crate selects its atomics.
+
 ---
 
 ## Profiler reference

--- a/rust/mimalloc-pprof/README.md
+++ b/rust/mimalloc-pprof/README.md
@@ -86,6 +86,26 @@ println!(
 );
 ```
 
+## Platforms and cross-compilation
+
+The crate vendors mimalloc as a single amalgamated C translation unit with no
+autotools or CMake step, so it builds wherever `cc-rs` can reach a C compiler —
+including cross-compiled builds, in every direction.
+
+Windows ARM64 needs one adjustment, and the crate makes it itself. In plain C
+mode mimalloc models C11 atomics with a deprecated MSVC `Interlocked` wrapper
+whose `_acq`/`_rel` ARM64 intrinsics `clang-cl` does not declare, so a
+`cargo-xwin` cross build of `aarch64-pc-windows-msvc` cannot compile it. Since
+**0.9.3** the build script selects clang's C11 `stdatomic` implementation for
+that target instead.
+
+That choice is deliberately made in `build.rs` rather than left to the caller:
+`CFLAGS` is process-global for every `cc-rs` build script in a build, so a
+consumer trying to fix this from the outside — for example with `CFLAGS=-TP` to
+force mimalloc's C++ atomics path — also changes the language mode of every
+other native dependency in the graph. Nothing outside this crate should have to
+know how its atomics are selected.
+
 ## Notes
 
 - On Linux and macOS, keep frame pointers for reliable stack walking:


### PR DESCRIPTION
## Summary

#224 taught `build.rs` to select C11 atomics for `aarch64-pc-windows-msvc`, but neither README mentions it. A consumer hitting the ARM64 build failure cannot discover that the fix exists, which version carries it, or why the obvious external workaround is wrong.

- crate README (docs.rs / crates.io front page): new **Platforms and cross-compilation** section
- repo README: new **Cross-compilation** subsection under Rust integration

Both state that the vendored amalgamation cross-compiles in every direction, that Windows ARM64 switched to clang's C11 `stdatomic` in **0.9.3**, and that the choice belongs in `build.rs` because `CFLAGS` is process-global — a consumer forcing the C++ atomics path with `CFLAGS=-TP` also flips every other `cc-rs` dependency into C++ mode (`ring` fails outright).

## Validation

Docs-only. No doctests or embed tests reference the edited regions.

Refs #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)