### PR TITLE
chore(release): bump mimalloc-pprof to 0.9.4

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "cc",
  "regex",

--- a/rust/mimalloc-pprof/CHANGELOG.md
+++ b/rust/mimalloc-pprof/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.9.4
+
+Detect C11 atomics instead of allowlisting one target (#230).
+
+- **Fix: clang-cl selected the MSVC atomics wrapper on every target, not just ARM64.**
+  `include/mimalloc/atomic.h` chose its backend on `defined(_MSC_VER)`, which means
+  "claims MSVC source compatibility" rather than "lacks C11 atomics" -- and clang-cl
+  defines it while being clang. The wrapper then reaches for `__ldar64`/`__stlr64`,
+  Interlocked intrinsics clang-cl does not declare on ARM64. The wrapper is now gated on
+  `MI_HAS_C11_ATOMICS`, derived from the standard capability test
+  `__STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)`.
+
+  0.9.3 fixed this from the Rust build script, as a one-triple allowlist
+  (`aarch64-pc-windows-msvc`). That only ever reached consumers who build through the
+  build script -- CMake, `src/static.c`, and anyone vendoring the C directly still hit
+  the bug. It also could not see that `x86_64-pc-windows-msvc` takes the same wrong
+  branch and merely survives because x64 has the intrinsics ARM64 lacks. The allowlist
+  and its `MI_USE_C11_ATOMICS` define are gone; the detection lives in the header, so
+  every consumer gets it.
+
+  Real MSVC is unaffected: it omits `__STDC_VERSION__` entirely without `/std:c11`, and
+  defines `__STDC_NO_ATOMICS__` under `/std:c11` unless `/experimental:c11atomics` is
+  also passed. `MI_USE_C11_ATOMICS` still works as an explicit override, and
+  `MI_HAS_C11_ATOMICS` can be defined to 0/1 to override the detection.
+
+  Verified on CI against the `aarch64-pc-windows-msvc` clang/xwin cross-build with no
+  build-script define, alongside green MSVC and MinGW `ctest` gates proving the wrapper's
+  population is unchanged for real MSVC.
+
 ## 0.9.3
 
 - Fix the Rust crate's bundled allocator build on `aarch64-pc-windows-msvc` by using

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimalloc-pprof"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 license = "MIT"
 description = "mimalloc global allocator with pprof-compatible sampled heap profiling"


### PR DESCRIPTION
Releases #230 / #231.

Follows the 0.9.3 bump (#225) exactly: crate version, `rust/Cargo.lock`, and a `CHANGELOG.md` entry. All three are `rust/` paths, so this is one commit under repo rule 2.

## What 0.9.4 ships

#231 replaced the 0.9.3 build-script allowlist with a capability test in `include/mimalloc/atomic.h`. The MSVC atomics wrapper is now gated on `MI_HAS_C11_ATOMICS`, derived from `__STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)`.

0.9.3 fixed the ARM64 clang-cl failure from the Rust build script, matching exactly one triple. That only ever reached consumers building through the build script — CMake, `src/static.c`, and direct-vendoring consumers still hit the bug, and `x86_64-pc-windows-msvc` took the same wrong branch while surviving only because x64 has the intrinsics ARM64 lacks. The detection now lives in the header, so every consumer gets it, and the `MI_USE_C11_ATOMICS` define is no longer needed.

Real MSVC is unaffected — it omits `__STDC_VERSION__` without `/std:c11` and defines `__STDC_NO_ATOMICS__` under `/std:c11` unless `/experimental:c11atomics` is also passed. #231's CI confirmed this: the ARM64 clang/xwin cross-build passed with no build-script define, alongside green MSVC and MinGW `ctest` gates.

## Verification

`soldr cargo test -p mimalloc-pprof --test vendored_atomics` green at the new version; lockfile re-resolved.

## Note on CI

`cross.yml`'s `test (<triple>)` matrix is red on this branch, as it is on `main` and has been since at least 2026-08-14 — unrelated to this change. The "Run every staged test binary" step globs the artifact directory and runs a bench-harness test that spawns a benchmark executable the build job never stages (`Spawn(Os { code: 2, kind: NotFound })`, exit 101). Worth a separate issue.

## After merge

Release via `auto-release` — `workflow_dispatch` with `dry_run: true` first, or push a `v0.9.4` tag for a real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
