### PR TITLE
docs: 0.9.x release history in the README, and the missing 0.9.0 changelog entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,38 @@ test suite looks. That risk is real and testing cannot retire it — see
 
 ---
 
+## Release history
+
+Published versions of the [`mimalloc-pprof`](https://crates.io/crates/mimalloc-pprof)
+crate on the v3 line, newest first. Dates are crates.io publish dates (UTC). This table
+is a summary; the full notes, with the reasoning behind each fix, are the record in
+[`rust/mimalloc-pprof/CHANGELOG.md`](rust/mimalloc-pprof/CHANGELOG.md).
+
+| Version | Published | What landed |
+|---|---|---|
+| **0.9.3** | 2026-08-21 | **Fix:** the crate would not build for `aarch64-pc-windows-msvc`. mimalloc's MSVC atomics wrapper reaches for ARM64 `Interlocked` intrinsics that `clang-cl` does not declare, so a `cargo-xwin` cross build failed to compile ([#223](https://github.com/zackees/mimalloc-pprof/issues/223), [#224](https://github.com/zackees/mimalloc-pprof/pull/224)). **Also the first release carrying the v4 line**, merged into `main` after 0.9.2 ([#129](https://github.com/zackees/mimalloc-pprof/pull/129)): upstream engine pin `579f8c0e` -> `bcee5a88` ([#80](https://github.com/zackees/mimalloc-pprof/issues/80), [#113](https://github.com/zackees/mimalloc-pprof/pull/113)), the new experimental `mi_option_purge_zeroes` zero-tracking option ([#67](https://github.com/zackees/mimalloc-pprof/issues/67), [#79](https://github.com/zackees/mimalloc-pprof/pull/79)), the zeroing-`realloc` family exposed from Rust ([#83](https://github.com/zackees/mimalloc-pprof/issues/83), [#108](https://github.com/zackees/mimalloc-pprof/pull/108)), and several allocator fixes. |
+| **0.9.2** | 2026-08-01 | **Fix:** seeded sampling is now actually reproducible. `mi_prof_start_seeded` and `MIMALLOC_PROF_SEED` mixed the ASLR-randomised address of the thread's allocator state into the seed, so a pinned seed produced a different sample sequence in every process while the docs promised determinism ([#91](https://github.com/zackees/mimalloc-pprof/issues/91)). |
+| **0.9.1** | 2026-08-01 | Hardening release, no API change. **Fixes:** a `-DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF` build failed to link, because four test targets hardcoded `mimalloc-static` ([#62](https://github.com/zackees/mimalloc-pprof/issues/62), [#68](https://github.com/zackees/mimalloc-pprof/pull/68)); `-Wmaybe-uninitialized` on `fmt_buf` in `src/profile.c` ([#72](https://github.com/zackees/mimalloc-pprof/pull/72)). Plus five new [CI gates](#ci-gates), each with a positive control proving it can fail. |
+| **0.9.0** | 2026-07-31 | **Features:** first release of the v3 line -- profiler and memory-events ported onto mimalloc v3 ([#29](https://github.com/zackees/mimalloc-pprof/issues/29), [#44](https://github.com/zackees/mimalloc-pprof/pull/44)), v3 promoted to mainline with v2 preserved on the `v2` branch ([#46](https://github.com/zackees/mimalloc-pprof/pull/46)), and the v3 allocator counters exposed in the profile, surfaced from Rust as `ProfStats::heap` ([#43](https://github.com/zackees/mimalloc-pprof/issues/43)). **Fixes:** two upstream mimalloc defects -- MinGW thread-exit cleanup and the `mi_heap_new` / `mi_subproc_new` bootstrap crash (both #43, detailed under [Bugs fixed in older versions](#bugs-fixed-in-older-versions)). |
+
+**0.9.4 -- merged to `main`, not yet released.** The `aarch64-pc-windows-msvc` fix that
+shipped in 0.9.3 was a build-script allowlist matching a single target triple, so it only
+helped consumers building through the Rust crate -- CMake, `src/static.c`, and anyone
+vendoring the C directly still selected the broken path. It is replaced by a capability
+test in `include/mimalloc/atomic.h`: the MSVC atomics wrapper is now gated on
+`MI_HAS_C11_ATOMICS`, derived from `__STDC_VERSION__ >= 201112L &&
+!defined(__STDC_NO_ATOMICS__)` ([#230](https://github.com/zackees/mimalloc-pprof/issues/230), [#231](https://github.com/zackees/mimalloc-pprof/pull/231)). `_MSC_VER` means "claims
+MSVC source compatibility", not "lacks C11 atomics", and `clang-cl` defines it but is
+clang. Real MSVC keeps the wrapper: it omits `__STDC_VERSION__` without `/std:c11`, and
+under `/std:c11` defines `__STDC_NO_ATOMICS__` unless `/experimental:c11atomics` is also
+passed. Until 0.9.4 is published, [Cross-compilation](#cross-compilation) describes the
+mechanism that is actually on crates.io.
+
+The v2 line (0.8.x) is maintained on the
+[`v2`](https://github.com/zackees/mimalloc-pprof/tree/v2) branch.
+
+---
+
 ## Bugs fixed in older versions
 
 This section exists because the bugs below are **defects in upstream

--- a/rust/mimalloc-pprof/CHANGELOG.md
+++ b/rust/mimalloc-pprof/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 - Fix the Rust crate's bundled allocator build on `aarch64-pc-windows-msvc` by using
   C11 atomics for that target, avoiding unsupported MSVC C atomic syntax (#223).
+- Carries the v4 line's work, merged into `main`
+  ([#129](https://github.com/zackees/mimalloc-pprof/pull/129)) after 0.9.2 shipped:
+  - the upstream engine pin moves from `579f8c0e` to `bcee5a88`
+    ([#80](https://github.com/zackees/mimalloc-pprof/issues/80),
+    [#113](https://github.com/zackees/mimalloc-pprof/pull/113));
+  - experimental zero-tracking behind `mi_option_purge_zeroes`
+    ([#67](https://github.com/zackees/mimalloc-pprof/issues/67),
+    [#79](https://github.com/zackees/mimalloc-pprof/pull/79)) -- the new public option
+    the 0.9.1 notes deferred to v4;
+  - the zeroing-`realloc` family exposed from Rust, with profiler accounting tests
+    ([#83](https://github.com/zackees/mimalloc-pprof/issues/83),
+    [#108](https://github.com/zackees/mimalloc-pprof/pull/108));
+  - allocator fixes: `mi_subproc_destroy` leaked the subproc's own main heap, the TLS
+    slot array is allocated from the main heap and zeroed after growth, and
+    `mi_process_info`'s `current_rss` reported committed bytes on Linux
+    ([#128](https://github.com/zackees/mimalloc-pprof/issues/128),
+    [#78](https://github.com/zackees/mimalloc-pprof/issues/78));
+  - the sampling decision no longer takes the global lock
+    ([#78](https://github.com/zackees/mimalloc-pprof/issues/78)).
 
 ## 0.9.2
 
@@ -49,6 +68,39 @@ Hardening release. No API changes -- everything here is a fix or a CI gate.
 
 Four of those gates were found to be silently checking nothing when first written; the
 controls are why that was noticed. See the README's "CI gates" section.
+
+## 0.9.0
+
+First release of the **v3 line**. The profiler and the memory-events API are ported onto
+mimalloc v3 (`upstream/dev3`) and published as 0.9.x, while 0.8.x keeps serving the v2
+engine from the [`v2`](https://github.com/zackees/mimalloc-pprof/tree/v2) branch. The
+public API, environment variables, and pprof output are unchanged from 0.8.x -- moving
+between the lines is a version bump, not a code change.
+
+- **Sampling profiler and memory-events ported to v3**
+  ([#29](https://github.com/zackees/mimalloc-pprof/issues/29),
+  [#44](https://github.com/zackees/mimalloc-pprof/pull/44)). v3 replaced the segment
+  allocator with an arena-of-slices allocator plus a page-map and split per-thread state
+  into `mi_heap_t` / `mi_theap_t`, so every hook site moved.
+- **v3 promoted to mainline**, v2 preserved on the `v2` branch
+  ([#46](https://github.com/zackees/mimalloc-pprof/pull/46)).
+- **New: allocator statistics in the profile.** `mi_prof_stats_t` mirrors the v3
+  allocator counters (`MI_PROF_STAT_VERSION` 3) and Rust surfaces them as
+  `ProfStats::heap`, a `HeapStats` struct
+  ([#43](https://github.com/zackees/mimalloc-pprof/issues/43)). `tests/t15_heap_stats.rs`
+  doubles as the ABI guard for that layout mirror -- without it `prof::stats()` would
+  silently return all zeros on a size/version mismatch rather than fail to compile.
+- **Fix: thread-exit cleanup never ran on Windows/MinGW** (#43). Every exiting thread
+  leaked its thread-local heap and all its pages -- about 0.24 GB per `test-stress`
+  iteration. A defect in upstream mimalloc, not in the profiler; see the README's
+  "Bugs fixed in older versions".
+- **Fix: `mi_heap_new` / `mi_subproc_new` did not bootstrap the library** (#43) when
+  either was the first mimalloc call in a process, so both allocated from a still-`NULL`
+  `subproc->heap_main`. Also an upstream defect, and not debug-only.
+- Test coverage for degenerate memory patterns, a leak regression guard, aligned
+  allocations, and empty-profile dumps
+  ([#49](https://github.com/zackees/mimalloc-pprof/pull/49),
+  [#51](https://github.com/zackees/mimalloc-pprof/pull/51)).
 
 ## 0.8.0
 


### PR DESCRIPTION
## What this adds

A **Release history** section in the root `README.md`, placed immediately after
"Choosing a version: v2 or v3" — the reader picks a line, then sees what happened on it.
One table row per published 0.9.x version (0.9.3, 0.9.2, 0.9.1, 0.9.0) with the
crates.io publish date and a summary of what landed, followed by a short note on the
unreleased 0.9.4 work already merged to `main`.

## On duplication: summary in the README, record in the CHANGELOG

`rust/mimalloc-pprof/CHANGELOG.md` already carries good long-form notes. Restating them
in the README guarantees the two drift apart the first time someone updates one and not
the other, so the README section is deliberately a **table plus a link**: 1–3 lines per
version, and an explicit sentence saying the CHANGELOG is the record. A table rather
than prose because the README is already table-heavy (the version-choice matrix, the
bug tables, the benchmark tables) and it matches that voice.

The consequence is that the link target has to be complete, which is why this PR also
touches the CHANGELOG — see below.

**Two commits, strictly separated**, per the repo rule against mixing paths:

| Commit | Paths |
|---|---|
| `docs(rust): add the missing 0.9.0 changelog entry, complete 0.9.3` | `rust/mimalloc-pprof/CHANGELOG.md` only |
| `docs: add a 0.9.x release history to the README` | root `README.md` only |

No C-core path (`src/`, `include/`, `test/`, `CMakeLists.txt`) is touched. No version is
bumped and no `0.9.4`/Unreleased section is added to the CHANGELOG — the bump PR owns
that entry.

## Two gaps found while deriving this

**1. The CHANGELOG had no 0.9.0 entry.** It jumps from 0.9.1 to 0.8.0, whose entry still
reads "0.9.0 is reserved for a v3 mimalloc port (issue #29, in progress)". 0.9.0 shipped
2026-07-31 and is the release that put the v3 line on crates.io. Reconstructed from the
`v0.8.0..v0.9.0` range and the issues its commits cite: the v3 port of the profiler and
memory-events (#29, #44), v3 promoted to mainline with v2 preserved on the `v2` branch
(#46), v3 allocator counters exposed as `ProfStats::heap` (#43), the MinGW thread-exit
leak and the `mi_heap_new`/`mi_subproc_new` bootstrap crash (both `#43`-tagged commits;
the README's "Bugs fixed in older versions" independently records both as fixed in
0.9.0), and the new degenerate-pattern/leak-guard/aligned-alloc tests (#49, #51).

**2. 0.9.3 is more than the ARM64 atomics fix.** The CHANGELOG lists only #223. But
#129 ("Migrate the v4 line into v3 (main)") merged after 0.9.2 shipped and is an
ancestor of the `v0.9.3` tag, so 0.9.3 is also the first release carrying: the upstream
engine pin `579f8c0e` → `bcee5a88` (#80, #113), `mi_option_purge_zeroes` (#67, #79),
the zeroing-`realloc` family from Rust (#83, #108), and several allocator fixes
(#128, #78). `mi_option_purge_zeroes` is new public API that the 0.9.1 notes explicitly
deferred to v4, so omitting it understates the release.

Verified rather than assumed:

```
git merge-base --is-ancestor eec74891 v0.9.3   # yes
git merge-base --is-ancestor eec74891 v0.9.2   # no
git show v0.9.3:rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h | grep purge_zeroes
git show v0.9.3:rust/mimalloc-pprof/src/lib.rs | grep rezalloc
```

## Sources

- `git log v0.8.0..v0.9.0`, `v0.9.2..v0.9.3`, and the release-bump commit messages
  (`4c140b68`, `0d367832`, `6ad84e4d`, `49785a4d`), whose bodies are unusually detailed.
- `rust/mimalloc-pprof/CHANGELOG.md` for 0.9.1–0.9.3.
- crates.io API for publish dates — parsed structurally, **UTC**, not commit dates:
  0.9.0 `2026-07-31`, 0.9.1 `2026-08-01`, 0.9.2 `2026-08-01`, 0.9.3 `2026-08-21`.
  0.9.1/0.9.2 were committed Jul 31 local (`-0700`); the README says the dates are
  crates.io publish dates so the two don't look self-contradictory.
- `gh issue view` / `gh pr view` on **every** number cited: 29, 43, 44, 46, 49, 51, 62,
  67, 68, 72, 78, 79, 80, 83, 91, 108, 113, 128, 129, 223, 224, 230, 231.
- For 0.9.4: commits `35a490f6` (C-core) + `be3e621f` (`rust/`) from #231 / issue #230.

## Left out, or hedged

- **`Cross-compilation` is untouched.** It still describes the 0.9.3 build-script
  allowlist, which is what is actually on crates.io today. Rewriting it now would
  document an unreleased mechanism. The 0.9.4 note points at it and says so explicitly —
  **that section will need updating when 0.9.4 actually ships.**
- **No 0.9.4 date and no CHANGELOG entry for it.** It is described as "merged to `main`,
  not yet released", phrased to be promotable or deletable in one edit.
- **The 0.9.3 v4-rollup summary is not exhaustive.** #129 merged a large branch; the
  README lists the user-visible items and the CHANGELOG lists a few more, both ending in
  "and several allocator fixes" rather than enumerating every commit.
- **No claim about which fixes were accepted upstream.** Commits reference
  `microsoft/mimalloc#1351` for the bootstrap fix, but that filing postdates the v0.9.0
  tag, so it is not attributed to any release here.
- The 0.8.0 entry's trailing "0.9.0 is reserved for a v3 mimalloc port" line is left in
  place as historical record; the new 0.9.0 entry directly above it resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
