### PR TITLE
ci(cross): stage only mimalloc-pprof test binaries

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -34,10 +34,10 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             # Plain cargo, not `soldr cargo`: see the comment on cmd= in build-cross.
-            command: cargo test --no-run
+            command: cargo test -p mimalloc-pprof --no-run
             cflags: ""
           - target: aarch64-unknown-linux-gnu
-            command: soldr cargo zigbuild --tests
+            command: soldr cargo zigbuild -p mimalloc-pprof --tests
             cflags: -Wno-error=date-time
     defaults:
       run:
@@ -167,7 +167,7 @@ jobs:
           #
           # Already tested and disproved: build-cache:false, linker:platform-default,
           # and cache:false (the action's own "skip zccache wrapping entirely" switch).
-          cmd="cargo test --no-run"
+          cmd="cargo test -p mimalloc-pprof --no-run"
           if ! run_build "$cmd"; then
             echo "::warning::build failed; retrying with the soldr compile cache bypassed (soldr#1969)"
             run_build "${cmd/soldr/soldr --no-cache}"
@@ -212,7 +212,7 @@ jobs:
         shell: pwsh
         run: |
           $metadata = Join-Path $PWD 'bins.jsonl'
-          soldr --no-cache cargo test --no-run --target x86_64-pc-windows-gnu --release --message-format=json | Tee-Object -FilePath $metadata
+          soldr --no-cache cargo test -p mimalloc-pprof --no-run --target x86_64-pc-windows-gnu --release --message-format=json | Tee-Object -FilePath $metadata
           if ($LASTEXITCODE -ne 0) { throw 'Soldr test build failed' }
           $bins = Get-Content $metadata | ForEach-Object {
             try { $_ | ConvertFrom-Json } catch { $null }


### PR DESCRIPTION
Closes #234.

## The bug

`test (<triple>)` has been red on `main` since at least 2026-08-14 — six jobs every run — failing in `Run every staged test binary`:

```
valid normal benchmark: Spawn(Os { code: 2, kind: NotFound, message: "No such file or directory" })
##[error]Process completed with exit code 101.
```

Staging ran `cargo test --no-run` workspace-wide, building test binaries for all six members (36 total), and the consumer ran every one. `bench-harness/tests/planted_control.rs` was among them, and it spawns a **stress-harness `bin`**. The staging filter selects `.profile.test` executables, so that bin was never staged and does not exist on the consumer runner.

Structural, not flaky: a test that shells out to a sibling binary cannot survive being copied to another machine without it.

## The fix

Scope all four staging sites to `-p mimalloc-pprof`:

| Site | Job |
|---|---|
| `command: cargo test --no-run` | `build-linux` (x86_64-linux-gnu) |
| `command: soldr cargo zigbuild --tests` | `build-linux` (aarch64-linux-gnu) |
| `cmd="cargo test --no-run"` | `build-cross` (4 targets) |
| PowerShell `soldr --no-cache cargo test --no-run` | `build-win-gnu` |

`cross.yml` validates the **allocator** on cross targets. `bench-harness`, `benchmark-suite`, `dashboard`, and `stress-harness` are host-side tooling with no cross-target meaning, and benchmarks have their own `benchmark-sentinel` jobs. The workflow already assumed this — it asserts `t3_stats-*` (a `mimalloc-pprof` test) is staged and fails if not.

## Verification

Simulated the consumer loop exactly, using the workflow's own `jq` filter against real `cargo test -p mimalloc-pprof --no-run --release --message-format=json` output:

```
18 staged binaries, 0 failures
t3_stats present: yes
bench/stress binaries staged: 0
```

Before: 36 binaries staged, 6 jobs failing. The 18 include `vendored_atomics` from #231.

## Trade-off, stated plainly

**This narrows what is staged.** The harness crates' tests no longer run on cross targets — but they do not run today either; they fail. The alternative, staging the non-test `bin`s too, is worse: the consumer loop would execute them as if they were test binaries, running real benchmarks on foreign runners. Cross coverage of the harness crates needs its own job with a different run strategy, not this loop.

## Note

This should land before #232 (the 0.9.4 bump), which is on hold until this matrix is genuinely green — 0.9.4 is an atomics change, and `test (<triple>)` is exactly the gate that would catch a target-specific regression in one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
