### PR TITLE
test(benchmark-suite): stop a poisoned TEST_GATE faking a second failure

### DIFF
--- a/rust/benchmark-suite/tests/timed_allocation_audit.rs
+++ b/rust/benchmark-suite/tests/timed_allocation_audit.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::sync::{Mutex, PoisonError};
 
 use benchmark_suite::execution::{
     execute_cell, execute_latency_cell, set_measured_region_hook, AllocatorAdapter,
@@ -12,6 +12,16 @@ use benchmark_suite::scenarios::{cards, CardId, ScenarioCell, Topology};
 
 static MEASURED: AtomicBool = AtomicBool::new(false);
 static HARNESS_ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+// Serializes the two audits: they share `MEASURED`, `HARNESS_ALLOCATIONS`, and the
+// process-wide measured-region hook, so they cannot overlap.
+//
+// Acquired with `unwrap_or_else(PoisonError::into_inner)`, never `unwrap()`. These
+// tests assert, and an assertion panic while holding the guard poisons the mutex --
+// so a plain `unwrap()` made the *other* test panic on `PoisonError` at its lock
+// line. One real failure was reported as two, the second pointing at a lock
+// acquisition that has nothing to do with allocations. Recovering is correct rather
+// than a workaround: the guard provides mutual exclusion only, and a `()` payload
+// cannot be left in an inconsistent state. See #236.
 static TEST_GATE: Mutex<()> = Mutex::new(());
 
 thread_local! {
@@ -139,7 +149,7 @@ impl AllocatorAdapter for InstrumentedAdapter {
     ignore = "macOS realloc may route through the global allocator"
 )]
 fn ordinary_measured_region_performs_zero_harness_allocations() {
-    let _test_guard = TEST_GATE.lock().unwrap();
+    let _test_guard = TEST_GATE.lock().unwrap_or_else(PoisonError::into_inner);
     let adapter = InstrumentedAdapter {
         layouts: Mutex::new(HashMap::new()),
     };
@@ -196,7 +206,7 @@ fn audit_cell(adapter: &InstrumentedAdapter, cell: &ScenarioCell) {
     ignore = "macOS realloc may route through the global allocator"
 )]
 fn latency_sampling_buffers_do_not_allocate_after_warmup() {
-    let _test_guard = TEST_GATE.lock().unwrap();
+    let _test_guard = TEST_GATE.lock().unwrap_or_else(PoisonError::into_inner);
     let adapter = InstrumentedAdapter {
         layouts: Mutex::new(HashMap::new()),
     };


### PR DESCRIPTION
Addresses the **reporting** half of #236. Test-only — no crate change, no release needed.

## The bug

Both audits serialize on `static TEST_GATE: Mutex<()>`, acquired with `.unwrap()`. They are assertion tests, so a failure panics *while holding the guard*, poisoning the mutex — and the other test then panics on `PoisonError` at its own lock line.

One real failure was reported as two, and the phantom pointed at a lock acquisition that has nothing to do with allocations, in the test that did not fail.

That is why `main` and #233 disagreed at the same commit `154633e6`:

| Run | Reported | Reality |
|---|---|---|
| `main` [32658015900](https://github.com/zackees/mimalloc-pprof/actions/runs/32658015900) | 2 failures — `:232` and `:142` | one real (`:232`), one phantom (`:142` is the lock) |
| #233 [32658147470](https://github.com/zackees/mimalloc-pprof/actions/runs/32658147470) | 1 failure — `:185` | one real |

The phantom's presence depends on execution order, so neither the failure count nor the named test could be trusted.

## The fix

```rust
let _test_guard = TEST_GATE.lock().unwrap_or_else(PoisonError::into_inner);
```

Recovering from poisoning is **correct here, not a workaround**: the guard provides mutual exclusion only, and a `()` payload cannot be left in an inconsistent state. Poisoning exists to protect data invariants; there is no data.

## Verification — reproduced both directions

Deliberately panicked while holding the guard, `--test-threads=4`:

```
.unwrap()                            (pre-fix)
  test latency_sampling_...                  ... FAILED
  test ordinary_measured_region_...          ... FAILED
  panicked at :152:40: called `Result::unwrap()` on an `Err` value: PoisonError { .. }
  test result: FAILED. 0 passed; 2 failed
```

```
unwrap_or_else(PoisonError::into_inner)   (this PR)
  test latency_sampling_...                  ... FAILED
  test ordinary_measured_region_...          ... ok
  test result: FAILED. 1 passed; 1 failed
```

The first output matches `main`'s CI signature exactly, including the failure at the lock line. Clean run with the fix and no simulated panic: **2 passed, 0 failed**.

## What this does *not* fix

The underlying flake — `HARNESS_ALLOCATIONS != 0` inside the measured region on `test (ubuntu-latest)` — remains open in #236. The measured region spans `std::thread::scope` workers in `execute_cell`/`execute_latency_cell`, so a stray allocation can come from a thread the thread-local `INSIDE_ADAPTER` guard does not cover, and it does not reproduce locally. I have not guessed at a fix.

What changes is that when it does fire, it will report as **one** failure at the assertion that actually failed, instead of two with a misleading second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
