### PR TITLE
feat(rust): make pprof hooks feature-selectable

### DIFF
--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - 'rust/**'
+      - 'ci/check_crate_package.py'
       - '.github/workflows/rust-native.yml'
 
 jobs:
@@ -31,6 +32,9 @@ jobs:
       - run: soldr cargo test --locked
       - name: cargo publish --dry-run (mimalloc-pprof)
         run: soldr cargo publish --dry-run -p mimalloc-pprof --locked
+      - name: Verify publish archive contains feature gate and DHAT
+        shell: bash
+        run: python ../ci/check_crate_package.py target/package
 
   test-win-gnu:
     runs-on: windows-latest

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -58,3 +58,19 @@ jobs:
           $env:PATH = "C:\msys64\mingw64\bin;$env:PATH"
           $env:CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "x86_64-w64-mingw32-gcc"
           soldr --no-cache cargo test --locked --target x86_64-pc-windows-gnu
+
+  test-no-pprof:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+          build-cache-mode: full
+      - name: Test allocator-only build (profiler compiled out)
+        run: soldr cargo test -p mimalloc-pprof --no-default-features --locked

--- a/README.md
+++ b/README.md
@@ -186,23 +186,12 @@ is a summary; the full notes, with the reasoning behind each fix, are the record
 
 | Version | Published | What landed |
 |---|---|---|
+| **0.9.5** | Unreleased | **Feature:** Rust consumers can compile sampled pprof hooks out with `default-features = false` while retaining the allocator, profiler no-op stubs, and internal exact DHAT. |
+| **0.9.4** | 2026-08-23 | **Fix:** replace the Rust-only ARM64 atomics allowlist with capability detection shared by every integration path. |
 | **0.9.3** | 2026-08-21 | **Fix:** the crate would not build for `aarch64-pc-windows-msvc`. mimalloc's MSVC atomics wrapper reaches for ARM64 `Interlocked` intrinsics that `clang-cl` does not declare, so a `cargo-xwin` cross build failed to compile ([#223](https://github.com/zackees/mimalloc-pprof/issues/223), [#224](https://github.com/zackees/mimalloc-pprof/pull/224)). **Also the first release carrying the v4 line**, merged into `main` after 0.9.2 ([#129](https://github.com/zackees/mimalloc-pprof/pull/129)): upstream engine pin `579f8c0e` -> `bcee5a88` ([#80](https://github.com/zackees/mimalloc-pprof/issues/80), [#113](https://github.com/zackees/mimalloc-pprof/pull/113)), the new experimental `mi_option_purge_zeroes` zero-tracking option ([#67](https://github.com/zackees/mimalloc-pprof/issues/67), [#79](https://github.com/zackees/mimalloc-pprof/pull/79)), the zeroing-`realloc` family exposed from Rust ([#83](https://github.com/zackees/mimalloc-pprof/issues/83), [#108](https://github.com/zackees/mimalloc-pprof/pull/108)), and several allocator fixes. |
 | **0.9.2** | 2026-08-01 | **Fix:** seeded sampling is now actually reproducible. `mi_prof_start_seeded` and `MIMALLOC_PROF_SEED` mixed the ASLR-randomised address of the thread's allocator state into the seed, so a pinned seed produced a different sample sequence in every process while the docs promised determinism ([#91](https://github.com/zackees/mimalloc-pprof/issues/91)). |
 | **0.9.1** | 2026-08-01 | Hardening release, no API change. **Fixes:** a `-DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF` build failed to link, because four test targets hardcoded `mimalloc-static` ([#62](https://github.com/zackees/mimalloc-pprof/issues/62), [#68](https://github.com/zackees/mimalloc-pprof/pull/68)); `-Wmaybe-uninitialized` on `fmt_buf` in `src/profile.c` ([#72](https://github.com/zackees/mimalloc-pprof/pull/72)). Plus five new [CI gates](#ci-gates), each with a positive control proving it can fail. |
 | **0.9.0** | 2026-07-31 | **Features:** first release of the v3 line -- profiler and memory-events ported onto mimalloc v3 ([#29](https://github.com/zackees/mimalloc-pprof/issues/29), [#44](https://github.com/zackees/mimalloc-pprof/pull/44)), v3 promoted to mainline with v2 preserved on the `v2` branch ([#46](https://github.com/zackees/mimalloc-pprof/pull/46)), and the v3 allocator counters exposed in the profile, surfaced from Rust as `ProfStats::heap` ([#43](https://github.com/zackees/mimalloc-pprof/issues/43)). **Fixes:** two upstream mimalloc defects -- MinGW thread-exit cleanup and the `mi_heap_new` / `mi_subproc_new` bootstrap crash (both #43, detailed under [Bugs fixed in older versions](#bugs-fixed-in-older-versions)). |
-
-**0.9.4 -- merged to `main`, not yet released.** The `aarch64-pc-windows-msvc` fix that
-shipped in 0.9.3 was a build-script allowlist matching a single target triple, so it only
-helped consumers building through the Rust crate -- CMake, `src/static.c`, and anyone
-vendoring the C directly still selected the broken path. It is replaced by a capability
-test in `include/mimalloc/atomic.h`: the MSVC atomics wrapper is now gated on
-`MI_HAS_C11_ATOMICS`, derived from `__STDC_VERSION__ >= 201112L &&
-!defined(__STDC_NO_ATOMICS__)` ([#230](https://github.com/zackees/mimalloc-pprof/issues/230), [#231](https://github.com/zackees/mimalloc-pprof/pull/231)). `_MSC_VER` means "claims
-MSVC source compatibility", not "lacks C11 atomics", and `clang-cl` defines it but is
-clang. Real MSVC keeps the wrapper: it omits `__STDC_VERSION__` without `/std:c11`, and
-under `/std:c11` defines `__STDC_NO_ATOMICS__` unless `/experimental:c11atomics` is also
-passed. Until 0.9.4 is published, [Cross-compilation](#cross-compilation) describes the
-mechanism that is actually on crates.io.
 
 The v2 line (0.8.x) is maintained on the
 [`v2`](https://github.com/zackees/mimalloc-pprof/tree/v2) branch.

--- a/ci/check_crate_package.py
+++ b/ci/check_crate_package.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Verify the publishable archive, not the maintainer checkout."""
+
+from __future__ import annotations
+
+import argparse
+import tarfile
+from pathlib import Path
+
+
+def member_text(archive: tarfile.TarFile, suffix: str) -> str:
+    matches = [member for member in archive.getmembers() if member.name.endswith(suffix)]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one {suffix!r} member, found {len(matches)}")
+    stream = archive.extractfile(matches[0])
+    if stream is None:
+        raise AssertionError(f"cannot read {matches[0].name}")
+    return stream.read().decode("utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("archive", type=Path)
+    args = parser.parse_args()
+
+    archive_path = args.archive
+    if archive_path.is_dir():
+        matches = list(archive_path.rglob("mimalloc-pprof-0.9.5.crate"))
+        if len(matches) != 1:
+            raise AssertionError(f"expected one packaged archive, found {len(matches)}")
+        archive_path = matches[0]
+
+    with tarfile.open(archive_path, "r:gz") as archive:
+        manifest = member_text(archive, "/Cargo.toml.orig")
+        build = member_text(archive, "/build.rs")
+        library = member_text(archive, "/src/lib.rs")
+        native = member_text(archive, "/vendor/mimalloc-pprof-amalgamated.c")
+
+    required_manifest = ('version = "0.9.5"', 'default = ["pprof"]', 'pprof = []')
+    for text in required_manifest:
+        if text not in manifest:
+            raise AssertionError(f"published manifest missing {text!r}")
+    if 'var_os("CARGO_FEATURE_PPROF")' not in build or '"MI_PPROF"' not in build:
+        raise AssertionError("published build script does not select MI_PPROF from the feature")
+    if "pub mod dhat" not in library or "mi_dhat_start" not in native:
+        raise AssertionError("published archive lost internal DHAT")
+
+    print(f"verified publish archive: {archive_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cc",
  "regex",

--- a/rust/mimalloc-pprof/CHANGELOG.md
+++ b/rust/mimalloc-pprof/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.5
+
+- Add a default `pprof` feature so allocator-only consumers can compile sampled
+  profiling hooks out with `default-features = false` while retaining linkable
+  no-op profiler stubs.
+- Retain exact DHAT allocation and lifetime profiling in both feature modes.
+- Add package-facing feature-contract coverage for sampled profiling and DHAT.
+
 ## 0.9.4
 
 Detect C11 atomics instead of allowlisting one target (#230).

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimalloc-pprof"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 license = "MIT"
 description = "mimalloc global allocator with pprof-compatible sampled heap profiling"
@@ -63,6 +63,9 @@ required-features = ["pprof"]
 [[test]]
 name = "t17_realloc_profiling"
 required-features = ["pprof"]
+
+[[test]]
+name = "feature_contract"
 
 [build-dependencies]
 cc = "1.2"

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -15,6 +15,55 @@ build = "build.rs"
 
 [dependencies]
 
+[features]
+# Profiling remains enabled by default for compatibility. Consumers that only
+# need the allocator can compile the profiler out with `default-features = false`.
+default = ["pprof"]
+pprof = []
+
+[[test]]
+name = "t1_smoke"
+required-features = ["pprof"]
+[[test]]
+name = "t2_format"
+required-features = ["pprof"]
+[[test]]
+name = "t3_stats"
+required-features = ["pprof"]
+[[test]]
+name = "t4_accum"
+required-features = ["pprof"]
+[[test]]
+name = "t5_stacks"
+required-features = ["pprof"]
+[[test]]
+name = "t6_concurrency"
+required-features = ["pprof"]
+[[test]]
+name = "t8_query"
+required-features = ["pprof"]
+[[test]]
+name = "t9_stats"
+required-features = ["pprof"]
+[[test]]
+name = "t10_snapshot_concurrency"
+required-features = ["pprof"]
+[[test]]
+name = "t11_enable"
+required-features = ["pprof"]
+[[test]]
+name = "t12_proto"
+required-features = ["pprof"]
+[[test]]
+name = "t14_modules"
+required-features = ["pprof"]
+[[test]]
+name = "t15_heap_stats"
+required-features = ["pprof"]
+[[test]]
+name = "t17_realloc_profiling"
+required-features = ["pprof"]
+
 [build-dependencies]
 cc = "1.2"
 

--- a/rust/mimalloc-pprof/README.md
+++ b/rust/mimalloc-pprof/README.md
@@ -25,6 +25,19 @@ debug = "line-tables-only"
 strip = false
 ```
 
+Profiling hooks are enabled by default, preserving the behavior of earlier
+releases. If an application only needs mimalloc and wants to compile the
+profiler out, opt out of the default feature:
+
+```toml
+[dependencies]
+mimalloc-pprof = { version = "0.9", default-features = false }
+```
+
+With `default-features = false`, the allocator remains available and the
+profiling API is retained for source compatibility, but profiling cannot be
+started (`prof::start` and `enable_heap_profiling` return `false`).
+
 ```rust
 use mimalloc_pprof::{prof, MiMalloc};
 use std::path::Path;

--- a/rust/mimalloc-pprof/build.rs
+++ b/rust/mimalloc-pprof/build.rs
@@ -17,9 +17,17 @@ fn main() {
         .include("vendor")
         .file("vendor/mimalloc-pprof-amalgamated.c")
         .define("MI_STATIC_LIB", None)
-        // This is a no-op until Phase 1; keeping the define here ensures the
-        // Rust build exercises profiling code as soon as it exists.
-        .define("MI_PPROF", "1");
+        // Preserve the crate's default profiler-enabled behavior, while
+        // allowing allocator-only consumers to compile hooks out with
+        // `default-features = false`.
+        .define(
+            "MI_PPROF",
+            if env::var_os("CARGO_FEATURE_PPROF").is_some() {
+                "1"
+            } else {
+                "0"
+            },
+        );
     if env::var("PROFILE").as_deref() == Ok("release") {
         build.define("NDEBUG", None);
     }

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -9,6 +9,10 @@
 //! # Ok(()) }
 //! ```
 //!
+//! Profiling is enabled by default. To build the allocator without profiler
+//! hooks, depend on this crate with `default-features = false`; in that mode the
+//! profiling API remains available but cannot start a profiler.
+//!
 //! See the README's Rust integration guide for frame-pointer and line-table
 //! build flags. Open the resulting profile with `pprof -http=: app.exe heap.prof`.
 
@@ -215,7 +219,8 @@ pub unsafe fn usable_size(p: *const u8) -> usize {
 /// as well, set `MIMALLOC_PROF=1` in the environment instead.
 ///
 /// Returns `false` if profiling was already enabled (the earlier session,
-/// and its sample rate, stay active).
+/// and its sample rate, stay active), or if the crate was built with
+/// `default-features = false`.
 pub fn enable_heap_profiling() -> bool {
     prof::start(0)
 }
@@ -299,7 +304,8 @@ pub struct ProfConfig {
 /// `include/mimalloc/profile.h`.
 ///
 /// Returns `false` if profiling was already enabled (the earlier session
-/// stays active), or if `config.dump_at_exit` is set but is not
+/// stays active), if the crate was built with `default-features = false`, or
+/// if `config.dump_at_exit` is set but is not
 /// representable as a NUL-free C string (non-UTF-8 or an embedded NUL byte)
 /// -- in that case `mi_prof_start_ex` is never called.
 pub fn enable_heap_profiling_with(config: &ProfConfig) -> bool {
@@ -678,14 +684,17 @@ pub mod prof {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "pprof")]
     use std::sync::Mutex;
 
     // The profiler is process-global state, and unit tests within this
     // binary may run concurrently by default, so serialize everything that
     // starts/stops it. `unwrap_or_else` rides through a poisoned lock rather
     // than cascading a single panicking test into every other one.
+    #[cfg(feature = "pprof")]
     static PROF_TEST_LOCK: Mutex<()> = Mutex::new(());
 
+    #[cfg(feature = "pprof")]
     fn reset_profiler() {
         if prof::is_enabled() {
             prof::stop();
@@ -693,6 +702,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pprof")]
     fn enable_heap_profiling_with_default_config_starts_profiler() {
         let _guard = PROF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_profiler();
@@ -705,6 +715,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "pprof")]
     fn enable_heap_profiling_with_override_mode_sets_sample_interval() {
         let _guard = PROF_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_profiler();
@@ -719,6 +730,13 @@ mod tests {
         assert_eq!(prof::stats().sample_rate, 4096);
 
         prof::stop();
+    }
+
+    #[test]
+    #[cfg(not(feature = "pprof"))]
+    fn heap_profiling_is_unavailable_when_compiled_out() {
+        assert!(!enable_heap_profiling_with(&ProfConfig::default()));
+        assert!(!prof::is_enabled());
     }
 
     #[test]

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -272,12 +272,11 @@ pub mod dhat {
 
     /// Serialize the current or stopped measurement window as a DHAT v2 JSON file.
     pub fn dump_file(path: &Path) -> io::Result<()> {
-        let path = path.to_str().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "DHAT path is not UTF-8")
-        })?;
-        let path = CString::new(path).map_err(|_| {
-            io::Error::new(io::ErrorKind::InvalidInput, "DHAT path contains NUL")
-        })?;
+        let path = path
+            .to_str()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "DHAT path is not UTF-8"))?;
+        let path = CString::new(path)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "DHAT path contains NUL"))?;
         if unsafe { sys::mi_dhat_dump(path.as_ptr()) } {
             Ok(())
         } else {
@@ -771,7 +770,6 @@ pub mod prof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "pprof")]
     use std::sync::Mutex;
 
     // The profiler is process-global state, and unit tests within this

--- a/rust/mimalloc-pprof/tests/feature_contract.rs
+++ b/rust/mimalloc-pprof/tests/feature_contract.rs
@@ -1,0 +1,41 @@
+use mimalloc_pprof::{dhat, prof, MiMalloc};
+
+#[global_allocator]
+static ALLOCATOR: MiMalloc = MiMalloc;
+
+#[test]
+fn published_feature_contract_keeps_dhat_and_selects_pprof() {
+    if dhat::is_enabled() {
+        dhat::stop();
+    }
+    assert!(
+        dhat::start(),
+        "exact DHAT must remain available in every build"
+    );
+
+    let allocation = vec![0x5au8; 64 * 1024];
+    std::hint::black_box(&allocation);
+    let stats = dhat::stats();
+    assert!(stats.enabled);
+    assert!(stats.total_blocks > 0);
+    assert!(stats.total_bytes >= allocation.len() as u64);
+
+    dhat::stop();
+    assert!(!dhat::is_enabled());
+
+    #[cfg(feature = "pprof")]
+    {
+        assert!(prof::start(4096), "default features must compile pprof in");
+        assert!(prof::is_enabled());
+        prof::stop();
+    }
+
+    #[cfg(not(feature = "pprof"))]
+    {
+        assert!(
+            !prof::start(4096),
+            "no-default-features must use pprof stubs"
+        );
+        assert!(!prof::is_enabled());
+    }
+}

--- a/rust/mimalloc-pprof/tests/t10_snapshot_concurrency.rs
+++ b/rust/mimalloc-pprof/tests/t10_snapshot_concurrency.rs
@@ -1,22 +1,37 @@
 mod common;
 use mimalloc_pprof::prof;
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
 
 #[test]
 fn snapshot_visit_is_safe_under_concurrent_alloc_free() {
     common::start(4096, 103);
-    let deadline = Instant::now() + Duration::from_millis(50);
+    let run_for = Duration::from_millis(50);
+    let ready = Arc::new(Barrier::new(9));
     let workers: Vec<_> = (0..8)
         .map(|_| {
+            let ready = Arc::clone(&ready);
             thread::spawn(move || {
-                while Instant::now() < deadline {
-                    let value = vec![0_u8; 4096];
-                    drop(value);
+                let mut live = Vec::with_capacity(64);
+                for _ in 0..64 {
+                    live.push(vec![0_u8; 4096]);
                 }
+                ready.wait();
+                let deadline = Instant::now() + run_for;
+                while Instant::now() < deadline {
+                    live.remove(0);
+                    live.push(vec![0_u8; 4096]);
+                }
+                std::hint::black_box(live);
             })
         })
         .collect();
+
+    // Do not race the first snapshot against worker startup. Every worker now
+    // retains a live allocation set while concurrent frees/replacements run.
+    ready.wait();
+    let deadline = Instant::now() + run_for;
 
     let mut saw_samples = false;
     for _ in 0..20 {

--- a/rust/mimalloc-pprof/tests/t16_rezalloc.rs
+++ b/rust/mimalloc-pprof/tests/t16_rezalloc.rs
@@ -16,9 +16,7 @@
 //! `mi_usable_size: invalid pointer`. The first draft of this test made exactly that
 //! mistake and crashed, which is why `rezalloc`'s safety docs now name the family.
 
-mod common;
-
-use mimalloc_pprof::{prof, sys};
+use mimalloc_pprof::sys;
 
 /// The zeroing contract, stated the way mimalloc actually implements it.
 ///

--- a/rust/mimalloc-pprof/tests/vendored_atomics.rs
+++ b/rust/mimalloc-pprof/tests/vendored_atomics.rs
@@ -36,8 +36,7 @@ fn msvc_wrapper_is_gated_on_missing_c11_atomics() {
          take it and fail on __ldar64/__stlr64 for ARM64"
     );
     assert!(
-        AMALGAMATION
-            .contains("|| !defined(_MSC_VER) || MI_HAS_C11_ATOMICS"),
+        AMALGAMATION.contains("|| !defined(_MSC_VER) || MI_HAS_C11_ATOMICS"),
         "the typed-ptr chain no longer tracks the backend selection; clang-cl \
          would get C11 atomics in one chain and Interlocked in the other"
     );


### PR DESCRIPTION
Closes #239. Implements the feature-gated code prerequisite for #243 and zackees/reld#94.

## Contract

- Preserve compatibility: `pprof` remains in the default feature set and builds `MI_PPROF=1`.
- `default-features = false` builds `MI_PPROF=0`; sampled APIs remain linkable no-op stubs.
- Internal exact DHAT remains available and functional in both modes.
- Publish and registry-download verification are tracked by #243.

## Validation

- focused feature contract in both default and no-default modes
- exact DHAT allocation accounting in both modes
- native Windows snapshot concurrency test repeated 10 times
- allocator crate suites in both modes
- clippy in both modes
- complete Rust workspace test suite
- vendored amalgamation drift check
- publish dry-run plus generated archive content verification

No allocator or linker performance claim is made by this PR.
