### PR TITLE
feat: add exact DHAT heap profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ set(mi_sources
     src/init.c
     src/libc.c
     src/memory-events.c
+    src/dhat.c
+    src/dhat-stack.c
     src/options.c
     src/os.c
     src/page.c
@@ -800,6 +802,7 @@ install(FILES include/mimalloc-new-delete.h DESTINATION ${mi_install_incdir})
 install(FILES include/mimalloc-stats.h DESTINATION ${mi_install_incdir})
 install(FILES include/mimalloc/profile.h DESTINATION ${mi_install_incdir}/mimalloc)
 install(FILES include/mimalloc/memory-events.h DESTINATION ${mi_install_incdir}/mimalloc)
+install(FILES include/mimalloc/dhat.h DESTINATION ${mi_install_incdir}/mimalloc)
 install(FILES cmake/mimalloc-config.cmake DESTINATION ${mi_install_cmakedir})
 install(FILES cmake/mimalloc-config-version.cmake DESTINATION ${mi_install_cmakedir})
 
@@ -1069,6 +1072,18 @@ if (MI_BUILD_TESTS)
   add_test(NAME test-memory-events COMMAND mimalloc-test-memory-events)
   add_test(NAME test-memory-events-env-enabled COMMAND mimalloc-test-memory-events --env-enabled-check)
   set_tests_properties(test-memory-events-env-enabled PROPERTIES ENVIRONMENT "MIMALLOC_MEMORY_EVENTS=1")
+
+  # Exact DHAT v2 observer (issue #238): intentionally independent of MI_PPROF.
+  add_executable(mimalloc-test-dhat test/test-dhat.c)
+  target_compile_definitions(mimalloc-test-dhat PRIVATE ${mi_defines})
+  target_compile_options(mimalloc-test-dhat PRIVATE ${mi_cflags})
+  target_include_directories(mimalloc-test-dhat PRIVATE include)
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    target_link_libraries(mimalloc-test-dhat PRIVATE mimalloc-static ${mi_libraries})
+  else()
+    target_link_libraries(mimalloc-test-dhat PRIVATE mimalloc ${mi_libraries})
+  endif()
+  add_test(NAME test-dhat COMMAND mimalloc-test-dhat)
 
   # thread-local slot array provenance (issue #128 B3): the array must not be
   # allocated from whatever heap the application happens to have set as its default,

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ versions](#bugs-fixed-in-older-versions) were found; upstream has no MinGW job.
 - [C and C++ integration](#c-and-c-integration)
 - [Rust integration](#rust-integration)
 - [Profiler reference](#profiler-reference)
+- [Exact DHAT profiling](#exact-dhat-profiling)
 - [Memory-events API](#memory-events-api)
 - [Performance](#performance) — continuous benchmarks vs. upstream mimalloc, TCMalloc, and jemalloc
 - [For maintainers](#for-maintainers)
@@ -824,6 +825,45 @@ Two counters carry caveats:
 - **`theap_count` excludes the main thread's statically-initialized theap**, so a
   single-threaded process reports 0. It also lags thread exit, since v3
   reference-counts theaps for cached thread-locals.
+
+---
+
+## Exact DHAT profiling
+
+`<mimalloc/dhat.h>` provides an **exact**, high-overhead heap/lifetime observer that
+writes [DHAT file-version 2](https://valgrind.org/docs/manual/dh-manual.html) JSON for
+`dh_view.html`. Unlike the production-oriented sampled pprof profiler, it retains one
+raw-OS-backed record for every observed live allocation. Use it for short tests and
+focused investigations, not a continuously running production workload.
+
+```c
+#include <mimalloc.h>
+#include <mimalloc/dhat.h>
+
+int main(void) {
+  if (!mi_dhat_start()) return 1;
+  void* p = mi_malloc(4096);
+  mi_free(p);
+  mi_dhat_stop();                 /* stop observing; retained report can still dump */
+  return mi_dhat_dump("heap.dhat.json") ? 0 : 2;
+}
+```
+
+DHAT is built independently of `MI_PPROF` and coexists with an application-installed
+`mi_memory_set_callbacks` table. It observes pointer identity before the application
+callback, suppresses callback-internal allocations just as memory-events does, and
+commits its ledger update after the callback returns. It records requested bytes,
+not allocator slack, and emits heap/lifetime metrics only (`bklt: true`, `bkacc: false`):
+it does **not** claim reads, writes, copy traffic, access histograms, or instruction
+counts.
+
+Set `MIMALLOC_DHAT=1` to start at process initialization and
+`MIMALLOC_DHAT_DUMP_AT_EXIT=heap.dhat.json` to write an exit report. The timestamps
+are monotonic wall-clock milliseconds (`tu: "ms"`), not Valgrind instruction counts.
+`MIMALLOC_DHAT_MAX_BYTES` bounds persistent raw-OS collector state (default 64 MiB).
+When the budget is exhausted the application allocation still succeeds; the collector
+marks the report partial (`mi_dhat_incomplete`) and exposes the drop count through
+`mi_dhat_stats_t`.
 
 ---
 

--- a/ci/internal-state-inventory.json
+++ b/ci/internal-state-inventory.json
@@ -476,6 +476,23 @@
       "cleanup": "negative control exits before publication; other modes use thread cleanup",
       "publication": "owner diagnostic runs before zeroing, count update, or mi_thread_locals_set",
       "locks": ["no explicit lock; table is thread-local", "test heap allocation may acquire allocator locks"]
+    },
+    {
+      "id": "dhat-collector-arena-chunk",
+      "path": "src/dhat.c",
+      "callee": "_mi_os_alloc",
+      "args": "_mi_subproc_main(),total,&memid",
+      "occurrence": 1,
+      "owner": "process-global exact DHAT collector arena",
+      "initial_owner": "unpublished process-main raw OS chunk",
+      "owner_transitions": "prepended to dhat_chunks only after its raw OS provenance and bump extent initialize",
+      "destroyable_by": "mi_dhat_start session reset or process teardown; never an application heap",
+      "lifetime": "one exact-DHAT session",
+      "logical_size": "max(DHAT_CHUNK_SIZE, dhat chunk header plus aligned requested object)",
+      "usable_size": "chunk->size and chunk->memid retain the exact raw OS cleanup extent",
+      "cleanup": "dhat_release_locked walks dhat_chunks and calls _mi_os_free",
+      "publication": "dhat_lock serializes publication into dhat_chunks after allocation succeeds",
+      "locks": ["dhat_lock protects the arena list and bump pointer", "raw OS layer may lock internally"]
     }
   ]
 }

--- a/include/mimalloc/dhat.h
+++ b/include/mimalloc/dhat.h
@@ -1,0 +1,50 @@
+/* Exact, opt-in DHAT v2 heap profiling. Unlike the sampled pprof profiler,
+   DHAT tracks every non-internal allocation and is intended for short diagnostic
+   runs/tests, not production profiling. It is independent of MI_PPROF and of
+   mi_memory_set_callbacks: both observers can run simultaneously.
+
+   Start explicitly with mi_dhat_start(), or set MIMALLOC_DHAT=1 before process
+   initialization. MIMALLOC_DHAT_DUMP_AT_EXIT=<path> writes a standard DHAT v2
+   JSON report at process exit. MIMALLOC_DHAT_MAX_BYTES bounds raw-OS-backed
+   collector state (default 64 MiB); exhaustion is fail-soft and is exposed via
+   incomplete/dropped in mi_dhat_stats_t and mi_dhat_incomplete in the JSON.
+   Time fields use monotonic milliseconds (tu="ms"), not instruction counts.
+   Memory-access profiling is not available: emitted reports always use bkacc=false. */
+#pragma once
+#ifndef MIMALLOC_DHAT_H
+#define MIMALLOC_DHAT_H
+
+#include "mimalloc.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MI_DHAT_STATS_VERSION 1
+typedef struct mi_dhat_stats_s {
+  size_t size; int version;
+  bool enabled;
+  bool incomplete;
+  uint64_t total_bytes, total_blocks;
+  uint64_t live_bytes, live_blocks;
+  uint64_t peak_bytes, peak_blocks;
+  uint64_t dropped, internal_bytes;
+} mi_dhat_stats_t;
+#define mi_dhat_stats_t_decl(name) mi_dhat_stats_t name = { 0 }; name.size = sizeof(mi_dhat_stats_t); name.version = MI_DHAT_STATS_VERSION
+
+/* Starts/stops exact tracking. Starting also activates the internal event path;
+   installed mi_memory_set_callbacks observers remain installed and independent. */
+mi_decl_export bool mi_dhat_start(void) mi_attr_noexcept;
+mi_decl_export void mi_dhat_stop(void) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_dhat_is_enabled(void) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_dhat_stats_get(mi_dhat_stats_t* out) mi_attr_noexcept;
+
+/* Writes a DHAT file-version-2 heap JSON document. `tu` is monotonic milliseconds,
+   not Valgrind instruction counts; bkacc is always false. */
+mi_decl_nodiscard mi_decl_export bool mi_dhat_dump(const char* path) mi_attr_noexcept;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -353,12 +353,24 @@ void        _mi_memevt_on_free(mi_page_t* page, void* p);
 void        _mi_memevt_on_realloc_in_place(mi_page_t* page, void* p, size_t request_size);
 // Called after _mi_memevt_suppress_end, with suppression already lifted, to emit the single
 // synthesized RESIZE event for a moving realloc (see alloc.c's _mi_theap_realloc_zero).
-void        _mi_memevt_on_resize(size_t usable_pre, size_t usable_post, size_t request_size);
+// oldp/newp retain the allocation identity needed by the internal DHAT observer.
+void        _mi_memevt_on_resize(void* oldp, void* newp, size_t usable_pre, size_t usable_post, size_t request_size);
 // Suppress accounting/dispatch for internal allocate+free pairs that are really one resize
 // (e.g. a moving realloc's internal mi_theap_umalloc+mi_free), and for reentrant calls made
 // from inside a memory-change callback itself.
 void        _mi_memevt_suppress_begin(void);
 void        _mi_memevt_suppress_end(void);
+
+// "dhat.c": exact heap/lifetime observer, independent of MI_PPROF. The event
+// bracketing deliberately captures before the public callback and commits after it.
+bool        _mi_dhat_is_active(void);
+void        _mi_dhat_begin_alloc(void* p, size_t request_size);
+void        _mi_dhat_begin_free(void* p);
+void        _mi_dhat_begin_resize(void* oldp, void* newp, size_t request_size);
+void        _mi_dhat_finish_event(void);
+void        _mi_dhat_process_init(void);
+void        _mi_dhat_process_done(void);
+size_t      _mi_dhat_stack_capture(void** pcs, size_t capacity);
 
 
 // ------------------------------------------------------

--- a/include/mimalloc/memory-events.h
+++ b/include/mimalloc/memory-events.h
@@ -31,6 +31,9 @@
      is suppressed: no accounting update and no nested callback invocation. This bounds
      stack depth and avoids double-counting/re-entrant surprises; it also means bytes
      allocated or freed *from inside* a callback are not reflected in the running totals.
+   - Callbacks must return normally. A C `longjmp` or C++ exception that escapes a
+     callback skips the recursion-guard cleanup and is unsupported; callback code that
+     needs non-local control flow must defer it until after the callback returns.
    - `arg` pointers in `mi_memory_callbacks_t` are caller-owned: the caller must keep
      them valid for as long as the callback might still be invoked (i.e. until a
      subsequent `mi_memory_set_callbacks` call replaces/clears them, or tracking is

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -195,6 +195,93 @@ pub unsafe fn usable_size(p: *const u8) -> usize {
     unsafe { sys::mi_usable_size(p.cast()) }
 }
 
+/// Exact DHAT v2 heap/lifetime profiling controls.
+///
+/// DHAT records every non-internal allocation from the moment [`start`] succeeds.
+/// It is intended for short diagnostic runs and tests rather than continuous production
+/// telemetry. The generated JSON opens in the standard Valgrind `dh_view.html` viewer.
+/// It is independent of sampled [`prof`] profiling and of `mi_memory_set_callbacks`.
+pub mod dhat {
+    use std::ffi::CString;
+    use std::io;
+    use std::path::Path;
+
+    use crate::sys;
+
+    /// Snapshot of exact DHAT collector state.
+    #[derive(Debug, Clone, Default, PartialEq, Eq)]
+    pub struct Stats {
+        pub enabled: bool,
+        /// True when raw-OS collector storage hit its configured budget or an internal
+        /// allocation failed. The application allocation still completed, but the
+        /// resulting profile is intentionally marked partial.
+        pub incomplete: bool,
+        pub total_bytes: u64,
+        pub total_blocks: u64,
+        pub live_bytes: u64,
+        pub live_blocks: u64,
+        pub peak_bytes: u64,
+        pub peak_blocks: u64,
+        pub dropped: u64,
+        pub internal_bytes: u64,
+    }
+
+    /// Start exact allocation/lifetime tracking. Returns `false` if it is already active.
+    pub fn start() -> bool {
+        unsafe { sys::mi_dhat_start() }
+    }
+
+    /// Stop observing allocation events. Retained records remain available to [`dump_file`]
+    /// so a caller can stop a measurement window before serializing its report.
+    pub fn stop() {
+        unsafe { sys::mi_dhat_stop() }
+    }
+
+    /// Whether exact DHAT tracking is currently active.
+    pub fn is_enabled() -> bool {
+        unsafe { sys::mi_dhat_is_enabled() }
+    }
+
+    /// Read the collector's exact counters. Returns a zero/default snapshot only if the
+    /// linked C library rejected the versioned ABI structure.
+    pub fn stats() -> Stats {
+        let mut raw: sys::mi_dhat_stats_t = unsafe { core::mem::zeroed() };
+        raw.size = core::mem::size_of::<sys::mi_dhat_stats_t>();
+        raw.version = sys::MI_DHAT_STATS_VERSION;
+        if unsafe { sys::mi_dhat_stats_get(&mut raw) } {
+            Stats {
+                enabled: raw.enabled,
+                incomplete: raw.incomplete,
+                total_bytes: raw.total_bytes,
+                total_blocks: raw.total_blocks,
+                live_bytes: raw.live_bytes,
+                live_blocks: raw.live_blocks,
+                peak_bytes: raw.peak_bytes,
+                peak_blocks: raw.peak_blocks,
+                dropped: raw.dropped,
+                internal_bytes: raw.internal_bytes,
+            }
+        } else {
+            Stats::default()
+        }
+    }
+
+    /// Serialize the current or stopped measurement window as a DHAT v2 JSON file.
+    pub fn dump_file(path: &Path) -> io::Result<()> {
+        let path = path.to_str().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "DHAT path is not UTF-8")
+        })?;
+        let path = CString::new(path).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "DHAT path contains NUL")
+        })?;
+        if unsafe { sys::mi_dhat_dump(path.as_ptr()) } {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}
+
 /// Turn on sampled heap profiling at the default sample rate.
 ///
 /// Convenience entry point for wiring profiling to a command-line flag:
@@ -685,6 +772,7 @@ mod tests {
     // starts/stops it. `unwrap_or_else` rides through a poisoned lock rather
     // than cascading a single panicking test into every other one.
     static PROF_TEST_LOCK: Mutex<()> = Mutex::new(());
+    static DHAT_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     fn reset_profiler() {
         if prof::is_enabled() {
@@ -776,5 +864,19 @@ mod tests {
             let p2 = unwrapped_realloc(p, 0, 0);
             assert!(p2.is_null());
         }
+    }
+
+    #[test]
+    fn dhat_controls_report_lifecycle() {
+        let _guard = DHAT_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        if dhat::is_enabled() {
+            dhat::stop();
+        }
+        assert!(dhat::start());
+        let active = dhat::stats();
+        assert!(active.enabled);
+        dhat::stop();
+        assert!(!dhat::is_enabled());
+        assert!(!dhat::stats().enabled);
     }
 }

--- a/rust/mimalloc-pprof/src/sys.rs
+++ b/rust/mimalloc-pprof/src/sys.rs
@@ -9,6 +9,27 @@ pub type MiProfWriteFun = unsafe extern "C" fn(*mut c_void, *const c_char, usize
 /// Mirrors `MI_PROF_STAT_VERSION` in `include/mimalloc/profile.h`.
 pub const MI_PROF_STAT_VERSION: c_int = 3;
 
+/// Mirrors `MI_DHAT_STATS_VERSION` in `include/mimalloc/dhat.h`.
+pub const MI_DHAT_STATS_VERSION: c_int = 1;
+
+/// Mirrors `mi_dhat_stats_t` (include/mimalloc/dhat.h) field-for-field.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct mi_dhat_stats_t {
+    pub size: usize,
+    pub version: c_int,
+    pub enabled: bool,
+    pub incomplete: bool,
+    pub total_bytes: u64,
+    pub total_blocks: u64,
+    pub live_bytes: u64,
+    pub live_blocks: u64,
+    pub peak_bytes: u64,
+    pub peak_blocks: u64,
+    pub dropped: u64,
+    pub internal_bytes: u64,
+}
+
 /// Mirrors `mi_prof_stats_t` (include/mimalloc/profile.h) field-for-field.
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -138,6 +159,11 @@ unsafe extern "C" {
     /// Grow in place only; returns NULL if the block cannot be extended without moving.
     pub fn mi_expand(p: *mut c_void, newsize: usize) -> *mut c_void;
     pub fn mi_usable_size(p: *const c_void) -> usize;
+    pub fn mi_dhat_start() -> bool;
+    pub fn mi_dhat_stop();
+    pub fn mi_dhat_is_enabled() -> bool;
+    pub fn mi_dhat_stats_get(stats: *mut mi_dhat_stats_t) -> bool;
+    pub fn mi_dhat_dump(path: *const c_char) -> bool;
     pub fn mi_prof_start(sample_rate: usize) -> bool;
     pub fn mi_prof_start_seeded(sample_rate: usize, seed: u64) -> bool;
     pub fn mi_prof_start_ex(config: *const mi_prof_config_t) -> bool;

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 766f35dc of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 00859e98 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -17000,9 +17000,19 @@ static void dhat_write_json_locked(FILE* f) {
 }
 bool mi_dhat_dump(const char* path) mi_attr_noexcept {
   if (path == NULL || dhat_observer_depth != 0) return false;
-  FILE* f = fopen(path, "wb"); if (f == NULL) return false;
-  mi_lock_acquire(&dhat_lock); dhat_write_json_locked(f); mi_lock_release(&dhat_lock);
-  const bool ok = (fclose(f) == 0); return ok;
+  /* stdio can allocate (and applications can override those calls with mimalloc).
+     Suppress this thread's dump-time traffic before fopen/fprintf while leaving the
+     report's actual live records untouched; otherwise a reentrant hook could attempt
+     to take dhat_lock while serialization already owns it. */
+  dhat_observer_depth++;
+  FILE* f = fopen(path, "wb");
+  if (f == NULL) { dhat_observer_depth--; return false; }
+  mi_lock_acquire(&dhat_lock);
+  dhat_write_json_locked(f);
+  mi_lock_release(&dhat_lock);
+  const bool ok = (fclose(f) == 0);
+  dhat_observer_depth--;
+  return ok;
 }
 void _mi_dhat_process_init(void) { dhat_resolve_env(); }
 void _mi_dhat_process_done(void) { if (dhat_dump_at_exit[0] != 0) { const bool dumped = mi_dhat_dump(dhat_dump_at_exit); MI_UNUSED(dumped); } }

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 68869a3a of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 766f35dc of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -4330,12 +4330,24 @@ void        _mi_memevt_on_free(mi_page_t* page, void* p);
 void        _mi_memevt_on_realloc_in_place(mi_page_t* page, void* p, size_t request_size);
 // Called after _mi_memevt_suppress_end, with suppression already lifted, to emit the single
 // synthesized RESIZE event for a moving realloc (see alloc.c's _mi_theap_realloc_zero).
-void        _mi_memevt_on_resize(size_t usable_pre, size_t usable_post, size_t request_size);
+// oldp/newp retain the allocation identity needed by the internal DHAT observer.
+void        _mi_memevt_on_resize(void* oldp, void* newp, size_t usable_pre, size_t usable_post, size_t request_size);
 // Suppress accounting/dispatch for internal allocate+free pairs that are really one resize
 // (e.g. a moving realloc's internal mi_theap_umalloc+mi_free), and for reentrant calls made
 // from inside a memory-change callback itself.
 void        _mi_memevt_suppress_begin(void);
 void        _mi_memevt_suppress_end(void);
+
+// "dhat.c": exact heap/lifetime observer, independent of MI_PPROF. The event
+// bracketing deliberately captures before the public callback and commits after it.
+bool        _mi_dhat_is_active(void);
+void        _mi_dhat_begin_alloc(void* p, size_t request_size);
+void        _mi_dhat_begin_free(void* p);
+void        _mi_dhat_begin_resize(void* oldp, void* newp, size_t request_size);
+void        _mi_dhat_finish_event(void);
+void        _mi_dhat_process_init(void);
+void        _mi_dhat_process_done(void);
+size_t      _mi_dhat_stack_capture(void** pcs, size_t capacity);
 
 
 // ------------------------------------------------------
@@ -7511,7 +7523,7 @@ void* _mi_theap_realloc_zero(mi_theap_t* theap, void* p, size_t newsize, bool ze
   }
   if (memevt_is_resize) {
     _mi_memevt_suppress_end();
-    if (newp != NULL) { _mi_memevt_on_resize(memevt_usable_pre, memevt_usable_post, newsize); }
+    if (newp != NULL) { _mi_memevt_on_resize(p, newp, memevt_usable_pre, memevt_usable_post, newsize); }
   }
   return newp;
 }
@@ -15578,6 +15590,7 @@ static void mi_process_init_once(void) mi_attr_noexcept {
   #if MI_PPROF
   _mi_prof_process_init();
   #endif
+  _mi_dhat_process_init();
   if (mi_option_is_enabled(mi_option_reserve_huge_os_pages)) {
     size_t pages = mi_option_get_clamp(mi_option_reserve_huge_os_pages, 0, 128*1024);
     int reserve_at  = (int)mi_option_get_clamp(mi_option_reserve_huge_os_pages_at, -1, INT_MAX);
@@ -15632,6 +15645,7 @@ static void mi_process_done_once(void) {
   #if MI_PPROF
   _mi_prof_process_done();
   #endif
+  _mi_dhat_process_done();
 
   // Forcefully release all retained memory; this can be dangerous in general if overriding regular malloc/free
   // since after process_done there might still be other code running that calls `free` (like at_exit routines,
@@ -16369,42 +16383,55 @@ static void memevt_dispatch(mi_memory_change_kind_t kind, int64_t delta_bytes, u
 // disabled path.
 // ---------------------------------------------------------------------------------------
 
+/* DHAT and the public callback table are independent observers.  The detailed
+   identity context is prepared before dispatch, while the allocator still has the
+   original pointers available; it is committed only after the user callback returns.
+   The shared suppression depth excludes callback-internal and moving-realloc internals
+   from both observers. */
 void _mi_memevt_on_alloc(mi_page_t* page, void* p, size_t request_size) {
-  MI_UNUSED(p);
+  if (memevt_suppress_depth > 0) return;
+  _mi_dhat_begin_alloc(p, request_size);
   size_t state = mi_atomic_load_relaxed(&memevt_state);
-  if mi_likely(state == MEMEVT_DISABLED) return;
   if (state == MEMEVT_UNINIT) { memevt_resolve_env(); state = mi_atomic_load_relaxed(&memevt_state); }
-  if (state != MEMEVT_ENABLED) return;
-  const size_t usable = mi_page_usable_block_size(page);
-  memevt_dispatch(MI_MEMORY_ALLOCATE, (int64_t)usable, (uint64_t)request_size);
+  if (state == MEMEVT_ENABLED) {
+    const size_t usable = mi_page_usable_block_size(page);
+    memevt_dispatch(MI_MEMORY_ALLOCATE, (int64_t)usable, (uint64_t)request_size);
+  }
+  _mi_dhat_finish_event();
 }
 
 void _mi_memevt_on_free(mi_page_t* page, void* p) {
-  MI_UNUSED(p);
+  if (memevt_suppress_depth > 0) return;
+  _mi_dhat_begin_free(p);
   const size_t state = mi_atomic_load_relaxed(&memevt_state);
-  if mi_likely(state == MEMEVT_DISABLED) return;
-  if (state != MEMEVT_ENABLED) return; // MEMEVT_UNINIT: nothing can have been counted yet, nothing to free-account.
-  const size_t usable = mi_page_usable_block_size(page);
-  memevt_dispatch(MI_MEMORY_FREE, -(int64_t)usable, 0);
+  if (state == MEMEVT_ENABLED) {
+    const size_t usable = mi_page_usable_block_size(page);
+    memevt_dispatch(MI_MEMORY_FREE, -(int64_t)usable, 0);
+  }
+  _mi_dhat_finish_event();
 }
 
 void _mi_memevt_on_realloc_in_place(mi_page_t* page, void* p, size_t request_size) {
-  MI_UNUSED(p);
+  if (memevt_suppress_depth > 0) return;
+  _mi_dhat_begin_resize(p, p, request_size);
   const size_t state = mi_atomic_load_relaxed(&memevt_state);
-  if mi_likely(state == MEMEVT_DISABLED) return;
-  if (state != MEMEVT_ENABLED) return;
-  // Same page => same block-size class => usable size is identical before and after;
-  // delta is always exactly 0 (still a real, dispatched RESIZE event, per spec).
-  MI_UNUSED(page);
-  memevt_dispatch(MI_MEMORY_RESIZE, 0, (uint64_t)request_size);
+  if (state == MEMEVT_ENABLED) {
+    // Same page => same block-size class => usable size is identical before and after.
+    MI_UNUSED(page);
+    memevt_dispatch(MI_MEMORY_RESIZE, 0, (uint64_t)request_size);
+  }
+  _mi_dhat_finish_event();
 }
 
-void _mi_memevt_on_resize(size_t usable_pre, size_t usable_post, size_t request_size) {
+void _mi_memevt_on_resize(void* oldp, void* newp, size_t usable_pre, size_t usable_post, size_t request_size) {
+  if (memevt_suppress_depth > 0) return;
+  _mi_dhat_begin_resize(oldp, newp, request_size);
   const size_t state = mi_atomic_load_relaxed(&memevt_state);
-  if mi_likely(state == MEMEVT_DISABLED) return;
-  if (state != MEMEVT_ENABLED) return;
-  const int64_t delta = (int64_t)usable_post - (int64_t)usable_pre;
-  memevt_dispatch(MI_MEMORY_RESIZE, delta, (uint64_t)request_size);
+  if (state == MEMEVT_ENABLED) {
+    const int64_t delta = (int64_t)usable_post - (int64_t)usable_pre;
+    memevt_dispatch(MI_MEMORY_RESIZE, delta, (uint64_t)request_size);
+  }
+  _mi_dhat_finish_event();
 }
 
 // ---------------------------------------------------------------------------------------
@@ -16576,6 +16603,452 @@ void* mi_unwrapped_realloc(void* p, size_t new_size, size_t alignment) mi_attr_n
   return newp;
 }
 /* ---- end inlined: src/memory-events.c ---- */
+/* ---- begin inlined: src/dhat.c ---- */
+/* Exact, opt-in DHAT v2 heap/lifetime profiler (issue #238).
+   All persistent collector state is bump allocated directly from the raw OS layer;
+   it never enters the normal mimalloc allocation paths. */
+/* ---- begin inlined: include/mimalloc/dhat.h ---- */
+/* Exact, opt-in DHAT v2 heap profiling. Unlike the sampled pprof profiler,
+   DHAT tracks every non-internal allocation and is intended for short diagnostic
+   runs/tests, not production profiling. It is independent of MI_PPROF and of
+   mi_memory_set_callbacks: both observers can run simultaneously.
+
+   Start explicitly with mi_dhat_start(), or set MIMALLOC_DHAT=1 before process
+   initialization. MIMALLOC_DHAT_DUMP_AT_EXIT=<path> writes a standard DHAT v2
+   JSON report at process exit. MIMALLOC_DHAT_MAX_BYTES bounds raw-OS-backed
+   collector state (default 64 MiB); exhaustion is fail-soft and is exposed via
+   incomplete/dropped in mi_dhat_stats_t and mi_dhat_incomplete in the JSON.
+   Time fields use monotonic milliseconds (tu="ms"), not instruction counts.
+   Memory-access profiling is not available: emitted reports always use bkacc=false. */
+#pragma once
+#ifndef MIMALLOC_DHAT_H
+#define MIMALLOC_DHAT_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MI_DHAT_STATS_VERSION 1
+typedef struct mi_dhat_stats_s {
+  size_t size; int version;
+  bool enabled;
+  bool incomplete;
+  uint64_t total_bytes, total_blocks;
+  uint64_t live_bytes, live_blocks;
+  uint64_t peak_bytes, peak_blocks;
+  uint64_t dropped, internal_bytes;
+} mi_dhat_stats_t;
+#define mi_dhat_stats_t_decl(name) mi_dhat_stats_t name = { 0 }; name.size = sizeof(mi_dhat_stats_t); name.version = MI_DHAT_STATS_VERSION
+
+/* Starts/stops exact tracking. Starting also activates the internal event path;
+   installed mi_memory_set_callbacks observers remain installed and independent. */
+mi_decl_export bool mi_dhat_start(void) mi_attr_noexcept;
+mi_decl_export void mi_dhat_stop(void) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_dhat_is_enabled(void) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_dhat_stats_get(mi_dhat_stats_t* out) mi_attr_noexcept;
+
+/* Writes a DHAT file-version-2 heap JSON document. `tu` is monotonic milliseconds,
+   not Valgrind instruction counts; bkacc is always false. */
+mi_decl_nodiscard mi_decl_export bool mi_dhat_dump(const char* path) mi_attr_noexcept;
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* ---- end inlined: include/mimalloc/dhat.h ---- */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <stddef.h>
+
+#define DHAT_UNINIT 0
+#define DHAT_DISABLED 1
+#define DHAT_ENABLED 2
+#define DHAT_STACK_MAX 64
+#define DHAT_CHUNK_SIZE (64*1024)
+#define DHAT_DEFAULT_BUDGET (64*1024*1024)
+#define DHAT_BUCKETS 4096
+
+typedef struct dhat_chunk_s {
+  struct dhat_chunk_s* next;
+  mi_memid_t memid;
+  size_t size;
+  size_t used;
+} dhat_chunk_t;
+
+typedef struct dhat_pp_s {
+  struct dhat_pp_s* next;
+  uint64_t hash;
+  uint32_t depth;
+  uint64_t tb, tbk, tl;
+  uint64_t live, livek, mb, mbk, gb, gbk;
+  void* pcs[];
+} dhat_pp_t;
+
+typedef struct dhat_record_s {
+  struct dhat_record_s* next;
+  void* ptr;
+  size_t size;
+  uint64_t born;
+  dhat_pp_t* pp;
+} dhat_record_t;
+
+typedef enum dhat_event_kind_e { DHAT_EVENT_NONE, DHAT_EVENT_ALLOC, DHAT_EVENT_FREE, DHAT_EVENT_RESIZE } dhat_event_kind_t;
+typedef struct dhat_event_s {
+  dhat_event_kind_t kind;
+  void* oldp;
+  void* newp;
+  size_t size;
+  uint64_t at;
+  dhat_pp_t* pp;
+  bool armed;
+} dhat_event_t;
+
+static mi_lock_t dhat_lock = MI_LOCK_INITIALIZER;
+static mi_atomic_once_t dhat_once = { MI_ATOMIC_VAR_INIT(0), MI_LOCK_INITIALIZER };
+static _Atomic(size_t) dhat_state;
+static dhat_chunk_t* dhat_chunks;
+static dhat_record_t** dhat_live_table;
+static dhat_pp_t** dhat_pp_table;
+static size_t dhat_budget;
+static _Atomic(size_t) dhat_internal_bytes;
+static _Atomic(size_t) dhat_dropped;
+static _Atomic(size_t) dhat_incomplete;
+static mi_msecs_t dhat_started;
+static uint64_t dhat_total_bytes, dhat_total_blocks;
+static uint64_t dhat_live_bytes, dhat_live_blocks, dhat_peak_bytes, dhat_peak_blocks, dhat_peak_at;
+static char dhat_dump_at_exit[1024];
+static mi_decl_thread int dhat_observer_depth;
+static mi_decl_thread dhat_event_t dhat_event;
+
+size_t _mi_dhat_stack_capture(void** pcs, size_t capacity);
+
+static uint64_t dhat_hash_ptr(const void* p) {
+  uintptr_t x = (uintptr_t)p;
+  x ^= x >> 33; x *= UINT64_C(0xff51afd7ed558ccd); x ^= x >> 33;
+  return (uint64_t)x;
+}
+static uint64_t dhat_hash_stack(void* const* pcs, size_t depth) {
+  uint64_t h = UINT64_C(1469598103934665603);
+  for (size_t i = 0; i < depth; i++) {
+    uintptr_t pc = (uintptr_t)pcs[i];
+    for (size_t b = 0; b < sizeof(pc); b++) { h ^= (uint8_t)(pc >> (b * 8)); h *= UINT64_C(1099511628211); }
+  }
+  return h;
+}
+static bool dhat_stack_equal(const dhat_pp_t* pp, uint64_t hash, void* const* pcs, size_t depth) {
+  if (pp->hash != hash || pp->depth != depth) return false;
+  for (size_t i = 0; i < depth; i++) if (pp->pcs[i] != pcs[i]) return false;
+  return true;
+}
+static size_t dhat_align(size_t n) { const size_t a = sizeof(void*) - 1; return (n + a) & ~a; }
+
+static void dhat_release_locked(void) {
+  for (dhat_chunk_t* chunk = dhat_chunks; chunk != NULL; ) {
+    dhat_chunk_t* next = chunk->next;
+    _mi_os_free(_mi_subproc_main(), chunk, chunk->size, chunk->memid);
+    chunk = next;
+  }
+  dhat_chunks = NULL; dhat_live_table = NULL; dhat_pp_table = NULL;
+  dhat_total_bytes = dhat_total_blocks = 0;
+  dhat_live_bytes = dhat_live_blocks = dhat_peak_bytes = dhat_peak_blocks = dhat_peak_at = 0;
+  mi_atomic_store_relaxed(&dhat_internal_bytes, (size_t)0);
+  mi_atomic_store_relaxed(&dhat_dropped, (size_t)0);
+  mi_atomic_store_relaxed(&dhat_incomplete, (size_t)0);
+}
+
+static void* dhat_arena_alloc(size_t size) {
+  size = dhat_align(size);
+  dhat_chunk_t* chunk = dhat_chunks;
+  if (chunk == NULL || chunk->used + size > chunk->size) {
+    if (size > SIZE_MAX - sizeof(dhat_chunk_t)) return NULL;
+    size_t total = DHAT_CHUNK_SIZE;
+    if (total < sizeof(dhat_chunk_t) + size) total = sizeof(dhat_chunk_t) + size;
+    const size_t committed = mi_atomic_load_relaxed(&dhat_internal_bytes);
+    if (dhat_budget != 0 && (committed > dhat_budget || total > dhat_budget - committed)) return NULL;
+    mi_memid_t memid;
+    chunk = (dhat_chunk_t*)_mi_os_alloc(_mi_subproc_main(), total, &memid);
+    if (chunk == NULL) return NULL;
+    chunk->next = dhat_chunks; chunk->memid = memid; chunk->size = total; chunk->used = sizeof(*chunk);
+    dhat_chunks = chunk;
+    mi_atomic_add_relaxed(&dhat_internal_bytes, total);
+  }
+  void* p = (uint8_t*)chunk + chunk->used;
+  chunk->used += size;
+  return p;
+}
+
+static void dhat_mark_dropped(void) { mi_atomic_increment_relaxed(&dhat_dropped); mi_atomic_store_relaxed(&dhat_incomplete, (size_t)1); }
+
+static bool dhat_init_tables_locked(void) {
+  if (dhat_live_table != NULL || dhat_pp_table != NULL) {
+    /* A partial first attempt cannot safely be completed: the budget may have
+       been exhausted after one table allocation. Keep the collector fail-soft
+       instead of dereferencing a missing sibling table. */
+    return (dhat_live_table != NULL && dhat_pp_table != NULL);
+  }
+  dhat_live_table = (dhat_record_t**)dhat_arena_alloc(DHAT_BUCKETS * sizeof(*dhat_live_table));
+  dhat_pp_table = (dhat_pp_t**)dhat_arena_alloc(DHAT_BUCKETS * sizeof(*dhat_pp_table));
+  if (dhat_live_table == NULL || dhat_pp_table == NULL) { dhat_mark_dropped(); return false; }
+  _mi_memzero(dhat_live_table, DHAT_BUCKETS * sizeof(*dhat_live_table));
+  _mi_memzero(dhat_pp_table, DHAT_BUCKETS * sizeof(*dhat_pp_table));
+  return true;
+}
+
+static dhat_pp_t* dhat_pp_intern_locked(void* const* pcs, size_t depth) {
+  if (!dhat_init_tables_locked()) return NULL;
+  const uint64_t hash = dhat_hash_stack(pcs, depth);
+  dhat_pp_t** bucket = &dhat_pp_table[(size_t)hash & (DHAT_BUCKETS - 1)];
+  for (dhat_pp_t* pp = *bucket; pp != NULL; pp = pp->next) if (dhat_stack_equal(pp, hash, pcs, depth)) return pp;
+  if (depth > (SIZE_MAX - sizeof(dhat_pp_t)) / sizeof(void*)) { dhat_mark_dropped(); return NULL; }
+  dhat_pp_t* pp = (dhat_pp_t*)dhat_arena_alloc(sizeof(*pp) + depth * sizeof(void*));
+  if (pp == NULL) { dhat_mark_dropped(); return NULL; }
+  _mi_memzero(pp, sizeof(*pp)); pp->hash = hash; pp->depth = (uint32_t)depth;
+  for (size_t i = 0; i < depth; i++) pp->pcs[i] = pcs[i];
+  pp->next = *bucket; *bucket = pp;
+  return pp;
+}
+
+static dhat_record_t** dhat_record_slot_locked(void* p) {
+  if (dhat_live_table == NULL) return NULL;
+  dhat_record_t** slot = &dhat_live_table[(size_t)dhat_hash_ptr(p) & (DHAT_BUCKETS - 1)];
+  while (*slot != NULL && (*slot)->ptr != p) slot = &(*slot)->next;
+  return slot;
+}
+static uint64_t dhat_elapsed_now(void) {
+  const mi_msecs_t now = _mi_clock_now();
+  return (now >= dhat_started ? (uint64_t)(now - dhat_started) : 0);
+}
+static void dhat_snapshot_global_peak_locked(void) {
+  if (dhat_live_bytes <= dhat_peak_bytes) return;
+  dhat_peak_bytes = dhat_live_bytes; dhat_peak_blocks = dhat_live_blocks;
+  dhat_peak_at = dhat_elapsed_now();
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) { pp->gb = pp->live; pp->gbk = pp->livek; }
+}
+static void dhat_commit_alloc_locked(dhat_event_t* ev) {
+  if (ev->pp == NULL || !dhat_init_tables_locked()) return;
+  dhat_record_t** slot = dhat_record_slot_locked(ev->newp);
+  if (slot == NULL) return;
+  if (*slot != NULL) { dhat_mark_dropped(); return; }
+  dhat_record_t* rec = (dhat_record_t*)dhat_arena_alloc(sizeof(*rec));
+  if (rec == NULL) { dhat_mark_dropped(); return; }
+  rec->next = NULL; rec->ptr = ev->newp; rec->size = ev->size; rec->born = ev->at; rec->pp = ev->pp; *slot = rec;
+  ev->pp->tb += ev->size; ev->pp->tbk++; ev->pp->live += ev->size; ev->pp->livek++;
+  if (ev->pp->live > ev->pp->mb) ev->pp->mb = ev->pp->live;
+  if (ev->pp->livek > ev->pp->mbk) ev->pp->mbk = ev->pp->livek;
+  dhat_total_bytes += ev->size; dhat_total_blocks++; dhat_live_bytes += ev->size; dhat_live_blocks++;
+  dhat_snapshot_global_peak_locked();
+}
+static void dhat_commit_free_locked(void* p, uint64_t at) {
+  dhat_record_t** slot = dhat_record_slot_locked(p);
+  if (slot == NULL || *slot == NULL) return;
+  dhat_record_t* rec = *slot; *slot = rec->next;
+  dhat_pp_t* pp = rec->pp;
+  if (pp->live >= rec->size) pp->live -= rec->size; else { pp->live = 0; dhat_mark_dropped(); }
+  if (pp->livek != 0) pp->livek--; else dhat_mark_dropped();
+  if (dhat_live_bytes >= rec->size) dhat_live_bytes -= rec->size; else { dhat_live_bytes = 0; dhat_mark_dropped(); }
+  if (dhat_live_blocks != 0) dhat_live_blocks--; else dhat_mark_dropped();
+  pp->tl += (at >= rec->born ? at - rec->born : 0);
+}
+static void dhat_commit_resize_locked(dhat_event_t* ev) {
+  dhat_record_t** slot = dhat_record_slot_locked(ev->oldp);
+  if (slot == NULL || *slot == NULL) return;
+  dhat_record_t* rec = *slot;
+  const size_t oldsize = rec->size;
+  if (ev->oldp != ev->newp) {
+    *slot = rec->next;
+    dhat_record_t** destination = dhat_record_slot_locked(ev->newp);
+    if (destination == NULL || *destination != NULL) { dhat_mark_dropped(); return; }
+    rec->ptr = ev->newp; rec->next = NULL; *destination = rec;
+  }
+  rec->size = ev->size;
+  dhat_pp_t* pp = rec->pp;
+  if (ev->size >= oldsize) { const size_t delta = ev->size - oldsize; pp->tb += delta; dhat_total_bytes += delta; pp->live += delta; dhat_live_bytes += delta; }
+  else { const size_t delta = oldsize - ev->size; pp->live -= delta; dhat_live_bytes -= delta; }
+  if (pp->live > pp->mb) pp->mb = pp->live;
+  dhat_snapshot_global_peak_locked();
+}
+
+static bool dhat_env_size(const char* name, size_t* out) {
+  char buf[64];
+  if (_mi_getenv(name, buf, sizeof(buf)) != 0 || buf[0] == 0) return false;
+  char* end = NULL;
+  const unsigned long long v = strtoull(buf, &end, 10);
+  if (end == buf || *end != 0 || v > SIZE_MAX) return false;
+  *out = (size_t)v;
+  return true;
+}
+static void dhat_resolve_env(void) {
+  if (_mi_atomic_once_enter(&dhat_once)) {
+    char value[8] = { 0 };
+    /* DHAT has its own opt-in switch; it must never inherit the unrelated
+       MIMALLOC_MEMORY_EVENTS activation state. */
+    const bool env_enabled = (_mi_getenv("MIMALLOC_DHAT", value, sizeof(value)) == 0 && value[0] != 0 && value[0] != '0');
+    (void)_mi_getenv("MIMALLOC_DHAT_DUMP_AT_EXIT", dhat_dump_at_exit, sizeof(dhat_dump_at_exit));
+    mi_atomic_store_release(&dhat_state, (size_t)(env_enabled ? DHAT_ENABLED : DHAT_DISABLED));
+    _mi_atomic_once_release(&dhat_once);
+    if (env_enabled) { mi_lock_acquire(&dhat_lock); dhat_budget = DHAT_DEFAULT_BUDGET; (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget); dhat_started = _mi_clock_now(); mi_lock_release(&dhat_lock); }
+  }
+}
+
+bool _mi_dhat_is_active(void) { return mi_atomic_load_relaxed(&dhat_state) == DHAT_ENABLED; }
+static void dhat_prepare(dhat_event_kind_t kind, void* oldp, void* newp, size_t size) {
+  dhat_event.armed = false;
+  size_t state = mi_atomic_load_relaxed(&dhat_state);
+  if (state == DHAT_UNINIT) { dhat_resolve_env(); state = mi_atomic_load_relaxed(&dhat_state); }
+  if (state != DHAT_ENABLED || dhat_observer_depth != 0) return;
+  dhat_observer_depth++;
+  dhat_event.kind = kind; dhat_event.oldp = oldp; dhat_event.newp = newp; dhat_event.size = size; dhat_event.at = _mi_clock_now(); dhat_event.pp = NULL;
+  if (kind == DHAT_EVENT_ALLOC) {
+    void* pcs[DHAT_STACK_MAX]; const size_t depth = _mi_dhat_stack_capture(pcs, DHAT_STACK_MAX);
+    if (depth == 0) { dhat_mark_dropped(); dhat_observer_depth--; return; }
+    mi_lock_acquire(&dhat_lock); dhat_event.pp = dhat_pp_intern_locked(pcs, depth); mi_lock_release(&dhat_lock);
+    if (dhat_event.pp == NULL) { dhat_observer_depth--; return; }
+  }
+  dhat_event.armed = true;
+}
+void _mi_dhat_begin_alloc(void* p, size_t request_size) { dhat_prepare(DHAT_EVENT_ALLOC, NULL, p, request_size); }
+void _mi_dhat_begin_free(void* p) { dhat_prepare(DHAT_EVENT_FREE, p, NULL, 0); }
+void _mi_dhat_begin_resize(void* oldp, void* newp, size_t request_size) { dhat_prepare(DHAT_EVENT_RESIZE, oldp, newp, request_size); }
+void _mi_dhat_finish_event(void) {
+  if (!dhat_event.armed) return;
+  dhat_event_t ev = dhat_event; dhat_event.armed = false; dhat_observer_depth--;
+  /* The observer guard is deliberately popped before mutating the ledger: a user memory
+     callback runs between begin and finish, and any allocations it makes are excluded. */
+  mi_lock_acquire(&dhat_lock);
+  if (_mi_dhat_is_active()) {
+    if (ev.kind == DHAT_EVENT_ALLOC) dhat_commit_alloc_locked(&ev);
+    else if (ev.kind == DHAT_EVENT_FREE) dhat_commit_free_locked(ev.oldp, ev.at);
+    else if (ev.kind == DHAT_EVENT_RESIZE) dhat_commit_resize_locked(&ev);
+  }
+  mi_lock_release(&dhat_lock);
+}
+
+bool mi_dhat_start(void) mi_attr_noexcept {
+  if (dhat_observer_depth != 0) return false;
+  if (_mi_atomic_once_enter(&dhat_once)) _mi_atomic_once_release(&dhat_once);
+  mi_lock_acquire(&dhat_lock);
+  if (_mi_dhat_is_active()) { mi_lock_release(&dhat_lock); return false; }
+  dhat_release_locked(); dhat_budget = DHAT_DEFAULT_BUDGET; (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget); dhat_started = _mi_clock_now();
+  mi_atomic_store_release(&dhat_state, DHAT_ENABLED);
+  mi_lock_release(&dhat_lock); return true;
+}
+void mi_dhat_stop(void) mi_attr_noexcept { if (dhat_observer_depth == 0) mi_atomic_store_release(&dhat_state, DHAT_DISABLED); }
+bool mi_dhat_is_enabled(void) mi_attr_noexcept { return _mi_dhat_is_active(); }
+bool mi_dhat_stats_get(mi_dhat_stats_t* out) mi_attr_noexcept {
+  if (out == NULL || out->size != sizeof(*out) || out->version != MI_DHAT_STATS_VERSION) return false;
+  mi_lock_acquire(&dhat_lock);
+  out->enabled = _mi_dhat_is_active(); out->incomplete = mi_atomic_load_relaxed(&dhat_incomplete) != 0;
+  out->total_bytes = dhat_total_bytes; out->total_blocks = dhat_total_blocks; out->live_bytes = dhat_live_bytes; out->live_blocks = dhat_live_blocks;
+  out->peak_bytes = dhat_peak_bytes; out->peak_blocks = dhat_peak_blocks; out->dropped = mi_atomic_load_relaxed(&dhat_dropped); out->internal_bytes = mi_atomic_load_relaxed(&dhat_internal_bytes);
+  mi_lock_release(&dhat_lock); return true;
+}
+
+/* Frame-table order is the order we visit program points below.  The dump is a
+   diagnostic operation, so this allocation-free O(frames^3) lookup is preferable to
+   adding a second persistent hash table solely for serialization. */
+static bool dhat_frame_seen_before_locked(const dhat_pp_t* stop_pp, size_t stop_frame, const void* pc) {
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) {
+    for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
+      const size_t limit = (pp == stop_pp ? stop_frame : pp->depth);
+      for (size_t frame = 0; frame < limit; frame++) if (pp->pcs[frame] == pc) return true;
+      if (pp == stop_pp) return false;
+    }
+  }
+  return false;
+}
+static size_t dhat_frame_index_locked(const dhat_pp_t* wanted, size_t wanted_frame) {
+  size_t index = 0;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
+    for (size_t frame = 0; frame < pp->depth; frame++) {
+      if (pp == wanted && frame == wanted_frame) {
+        if (!dhat_frame_seen_before_locked(pp, frame, pp->pcs[frame])) return index;
+        /* Locate the matching first occurrence, whose index is the count of unique
+           frames that preceded it. */
+        for (size_t j = 0; j < DHAT_BUCKETS; j++) for (dhat_pp_t* prior = dhat_pp_table[j]; prior != NULL; prior = prior->next) {
+          const size_t limit = (prior == pp ? frame : prior->depth);
+          for (size_t pf = 0; pf < limit; pf++) if (prior->pcs[pf] == pp->pcs[frame]) return dhat_frame_index_locked(prior, pf);
+        }
+      }
+      else if (!dhat_frame_seen_before_locked(pp, frame, pp->pcs[frame])) index++;
+    }
+  }
+  return 0;
+}
+static void dhat_write_json_locked(FILE* f) {
+  const uint64_t elapsed = dhat_elapsed_now();
+  /* The standard viewer accepts producer-specific mode strings and extra keys.
+     Keep the required v2 fields conventional; Mtu and tu truthfully say that
+     these are monotonic wall-clock milliseconds rather than Valgrind instructions. */
+  fprintf(f, "{\n  \"dhatFileVersion\": 2,\n  \"mode\": \"mimalloc-heap\",\n  \"verb\": \"Allocated\",\n  \"bklt\": true,\n  \"bkacc\": false,\n  \"tu\": \"ms\",\n  \"Mtu\": \"ms\",\n  \"tuth\": 1,\n  \"cmd\": \"\",\n  \"pid\": 0,\n  \"tg\": %llu,\n  \"te\": %llu,\n  \"mi_dhat_incomplete\": %s,\n  \"pps\": [\n", (unsigned long long)dhat_peak_at, (unsigned long long)elapsed, (mi_atomic_load_relaxed(&dhat_incomplete) ? "true" : "false"));
+  bool first_pp = true;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
+    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)pp->tl, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
+    for (size_t frame = 0; frame < pp->depth; frame++) fprintf(f, "%s%llu", frame == 0 ? "" : ", ", (unsigned long long)dhat_frame_index_locked(pp, frame));
+    fprintf(f, "]}"); first_pp = false;
+  }
+  fprintf(f, "\n  ],\n  \"ftbl\": [");
+  bool first_frame = true;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) for (size_t frame = 0; frame < pp->depth; frame++) {
+    bool seen = false; for (size_t j = 0; j <= i && !seen; j++) for (dhat_pp_t* prior = dhat_pp_table[j]; prior != NULL && !seen; prior = prior->next) { const size_t lim = (prior == pp ? frame : prior->depth); for (size_t pf = 0; pf < lim; pf++) if (prior->pcs[pf] == pp->pcs[frame]) { seen = true; break; } }
+    if (!seen) { fprintf(f, "%s\n    \"0x%llx\"", first_frame ? "" : ",", (unsigned long long)(uintptr_t)pp->pcs[frame]); first_frame = false; }
+  }
+  fprintf(f, "\n  ]\n}\n");
+}
+bool mi_dhat_dump(const char* path) mi_attr_noexcept {
+  if (path == NULL || dhat_observer_depth != 0) return false;
+  FILE* f = fopen(path, "wb"); if (f == NULL) return false;
+  mi_lock_acquire(&dhat_lock); dhat_write_json_locked(f); mi_lock_release(&dhat_lock);
+  const bool ok = (fclose(f) == 0); return ok;
+}
+void _mi_dhat_process_init(void) { dhat_resolve_env(); }
+void _mi_dhat_process_done(void) { if (dhat_dump_at_exit[0] != 0) { const bool dumped = mi_dhat_dump(dhat_dump_at_exit); MI_UNUSED(dumped); } }
+/* ---- end inlined: src/dhat.c ---- */
+/* ---- begin inlined: src/dhat-stack.c ---- */
+/* Allocation-free stack capture for the exact DHAT observer. Kept separate from
+   profile-stack.c because DHAT is deliberately available when MI_PPROF=OFF. */
+
+#define MI_DHAT_STACK_MAX 128
+
+#ifdef _WIN32
+#include <windows.h>
+size_t _mi_dhat_stack_capture(void** pcs, size_t capacity) {
+  if (capacity > MI_DHAT_STACK_MAX) capacity = MI_DHAT_STACK_MAX;
+  return (size_t)RtlCaptureStackBackTrace(2, (ULONG)capacity, pcs, NULL);
+}
+#elif defined(__APPLE__)
+#include <execinfo.h>
+size_t _mi_dhat_stack_capture(void** pcs, size_t capacity) {
+  if (capacity > MI_DHAT_STACK_MAX) capacity = MI_DHAT_STACK_MAX;
+  if (capacity == 0) return 0;
+  void* frames[MI_DHAT_STACK_MAX + 1];
+  const int count = backtrace(frames, (int)(capacity + 1));
+  if (count <= 1) return 0;
+  size_t n = (size_t)(count - 1);
+  if (n > capacity) n = capacity;
+  for (size_t i = 0; i < n; i++) pcs[i] = frames[i + 1];
+  return n;
+}
+#else
+size_t _mi_dhat_stack_capture(void** pcs, size_t capacity) {
+  void** fp = (void**)__builtin_frame_address(0);
+  size_t n = 0;
+  while (n < capacity && fp != NULL) {
+    void* ret = fp[1];
+    void** next = (void**)fp[0];
+    if (ret == NULL) break;
+    pcs[n++] = ret;
+    if (next <= fp || (uintptr_t)next - (uintptr_t)fp > (8u << 20) ||
+        (((uintptr_t)next & 0xF) != 0 && ((uintptr_t)next & 0x7) != 0)) break;
+    fp = next;
+  }
+  return n;
+}
+#endif
+/* ---- end inlined: src/dhat-stack.c ---- */
 /* ---- begin inlined: src/options.c ---- */
 /* ----------------------------------------------------------------------------
 Copyright (c) 2018-2026, Microsoft Research, Daan Leijen

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 3bc4b3e6 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 50ffb71b of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -17065,12 +17065,20 @@ bool mi_dhat_dump(const char* path) mi_attr_noexcept {
      report's actual live records untouched; otherwise a reentrant hook could attempt
      to take dhat_lock while serialization already owns it. */
   dhat_observer_depth++;
+  /* Suppress the public dispatcher too: a callback invoked by a lazy stdio
+     allocation could otherwise call a DHAT API while dhat_lock is held. */
+  _mi_memevt_suppress_begin();
   FILE* f = fopen(path, "wb");
-  if (f == NULL) { dhat_observer_depth--; return false; }
+  if (f == NULL) {
+    _mi_memevt_suppress_end();
+    dhat_observer_depth--;
+    return false;
+  }
   mi_lock_acquire(&dhat_lock);
   dhat_write_json_locked(f);
   mi_lock_release(&dhat_lock);
   const bool ok = (fclose(f) == 0);
+  _mi_memevt_suppress_end();
   dhat_observer_depth--;
   return ok;
 }

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 50ffb71b of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 833f5f1b of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -6442,6 +6442,12 @@ static inline void mi_free_block_mt(mi_page_t* page, mi_block_t* block, bool was
   }
   #endif
 
+  /* Commit the global memory observers before publishing this block to the
+     owner thread's reusable list. Otherwise the owner can collect and reuse the
+     address while DHAT still holds its old live record. This mirrors the local
+     free ordering: callbacks run without allocator locks, before list reuse. */
+  _mi_memevt_on_free(page, block);
+
   // push atomically on the page thread free list
   mi_thread_free_t tf_new;
   mi_thread_free_t tf_old = mi_atomic_load_relaxed(&page->xthread_free);
@@ -6450,14 +6456,6 @@ static inline void mi_free_block_mt(mi_page_t* page, mi_block_t* block, bool was
     const bool new_owned = (allow_collect ? true : mi_tf_is_owned(tf_old));    // if allow collection then always try to claim it if the page is abandoned 
     tf_new = mi_tf_create(block, new_owned);
   } while (!mi_atomic_cas_weak_acq_rel(&page->xthread_free, &tf_old, tf_new)); // todo: release is enough?
-
-  // memory-events (issue #20): this is a genuine remote (cross-thread) free that has just
-  // completed (the block is now pushed onto the page's thread-free list) -- hook here,
-  // mirroring mi_free_block_local's placement (definitely-freeing, page/block still valid).
-  // Deliberately NOT paired with _mi_prof_on_free here: the profiler's only remote-free
-  // counting point is inside the free-collect helper (mi_page_thread_collect_to_local),
-  // to avoid double counting.
-  _mi_memevt_on_free(page, block);
 
   // and atomically try to collect the page if it was abandoned
   if (allow_collect) {
@@ -8091,12 +8089,18 @@ static mi_decl_noinline mi_decl_restrict void* mi_theap_malloc_guarded_aligned(m
     return NULL;
   }
   const size_t oversize = size + alignment - 1;
+  /* The allocator needs oversize bytes internally, but observers describe the
+     caller's requested aligned block. Suppress the base allocation event and
+     publish one normalized event below keyed by the actual page block. */
+  _mi_memevt_suppress_begin();
   void* const base = _mi_theap_malloc_guarded(theap, oversize, zero, usable);
+  _mi_memevt_suppress_end();
   if (base==NULL) return NULL;
   void* const p = _mi_align_up_ptr(base, alignment);
   mi_track_align(base, p, (uint8_t*)p - (uint8_t*)base, size);
   mi_assert_internal(mi_usable_size(p) >= size);
   mi_assert_internal(_mi_is_aligned(p, alignment));
+  _mi_memevt_on_alloc(_mi_ptr_page(base), base, size);
   return p;
 }
 
@@ -8136,7 +8140,9 @@ static mi_decl_noinline void* mi_theap_malloc_zero_aligned_at_overalloc(mi_theap
     }
     oversize = (size <= MI_SMALL_SIZE_MAX ? MI_SMALL_SIZE_MAX + 1 /* ensure we use generic malloc path */ : size);
     // note: no guarded as alignment > 0
+    _mi_memevt_suppress_begin();
     p = _mi_theap_malloc_zero_ex(theap, oversize, zero, alignment, usable); // the page block size should be large enough to align in the single huge page block
+    _mi_memevt_suppress_end();
     if (p == NULL) return NULL;
   }
   else {
@@ -8144,7 +8150,9 @@ static mi_decl_noinline void* mi_theap_malloc_zero_aligned_at_overalloc(mi_theap
     mi_assert_internal(size <= (MI_MAX_ALLOC_SIZE - MI_PADDING_SIZE) && alignment <= MI_PAGE_MAX_OVERALLOC_ALIGN);
     mi_assert_internal(size < SIZE_MAX - alignment); // `oversize` cannot overflow
     oversize = (size < MI_MAX_ALIGN_SIZE ? MI_MAX_ALIGN_SIZE : size) + alignment - 1;  // adjust for size <= 16; with size 0 and alignment 64k, we would allocate a 64k block and pointing just beyond that.
+    _mi_memevt_suppress_begin();
     p = mi_theap_malloc_zero_no_guarded(theap, oversize, zero, usable);
+    _mi_memevt_suppress_end();
     if (p == NULL) return NULL;
   }
 
@@ -8203,6 +8211,9 @@ static mi_decl_noinline void* mi_theap_malloc_zero_aligned_at_overalloc(mi_theap
     mi_track_mem_defined(p, sizeof(mi_block_t));
     #endif
   }
+  /* `p` is the page's real allocation identity (and therefore what free hooks
+     receive), while `size` is the public requested size. */
+  _mi_memevt_on_alloc(page, p, size);
   return aligned_p;
 }
 
@@ -8396,11 +8407,23 @@ static void* mi_theap_realloc_zero_aligned_at(mi_theap_t* theap, void* p, size_t
   if (alignment <= sizeof(uintptr_t) && offset==0) return _mi_theap_realloc_zero(theap,p,newsize,zero,NULL,NULL);
   if (p == NULL) return mi_theap_malloc_zero_aligned_at(theap,newsize,alignment,offset,zero,NULL);
   size_t size = mi_usable_size(p);
+  mi_page_t* const old_page = _mi_ptr_page(p);
+  void* const old_base = _mi_page_ptr_unalign(old_page, p);
+  const size_t old_usable = mi_page_usable_block_size(old_page);
   if (newsize <= size && newsize >= (size - (size / 2)) && (((uintptr_t)p + offset) & (alignment-1)) == 0) {
+    /* Aligned pointers can be interior to the actual page block. Memory-events
+       and DHAT use that stable block address so this in-place resize matches the
+       synthesized aligned-allocation event above. */
+    mi_page_t* const page = _mi_ptr_page(p);
+    void* const base = _mi_page_ptr_unalign(page, p);
+    _mi_memevt_on_realloc_in_place(page, base, newsize);
     return p;  // reallocation still fits, is aligned and not more than 50% waste
   }
   else {
     // note: we don't zero allocate upfront so we only zero initialize the expanded part
+    /* Hide the internal allocation/free pair and expose one identity-preserving
+       resize, exactly like _mi_theap_realloc_zero does for unaligned realloc. */
+    _mi_memevt_suppress_begin();
     void* newp = mi_theap_malloc_aligned_at(theap,newsize,alignment,offset);
     if (newp != NULL) {
       if (zero && newsize > size) {
@@ -8410,6 +8433,12 @@ static void* mi_theap_realloc_zero_aligned_at(mi_theap_t* theap, void* p, size_t
       }
       _mi_memcpy(newp, p, (newsize > size ? size : newsize)); // cannot be aligned due to abitrary offset... (todo: require offset to be a multiple of sizeof(void*)?)
       mi_free(p); // only free if successful
+    }
+    _mi_memevt_suppress_end();
+    if (newp != NULL) {
+      mi_page_t* const new_page = _mi_ptr_page(newp);
+      void* const new_base = _mi_page_ptr_unalign(new_page, newp);
+      _mi_memevt_on_resize(old_base, new_base, old_usable, mi_page_usable_block_size(new_page), newsize);
     }
     return newp;
   }
@@ -16751,7 +16780,9 @@ static bool dhat_stack_equal(const dhat_pp_t* pp, uint64_t hash, void* const* pc
   for (size_t i = 0; i < depth; i++) if (pp->pcs[i] != pcs[i]) return false;
   return true;
 }
-static size_t dhat_align(size_t n) { const size_t a = sizeof(void*) - 1; return (n + a) & ~a; }
+/* The raw arena holds uint64_t counters as well as pointers. Use the allocator's
+   max fundamental alignment rather than pointer width for 32-bit strict-alignment ABIs. */
+static size_t dhat_align(size_t n) { const size_t a = MI_MAX_ALIGN_SIZE - 1; return (n + a) & ~a; }
 
 static void dhat_release_locked(void) {
   for (dhat_chunk_t* chunk = dhat_chunks; chunk != NULL; ) {
@@ -16969,7 +17000,12 @@ void _mi_dhat_finish_event(void) {
 
 bool mi_dhat_start(void) mi_attr_noexcept {
   if (dhat_observer_depth != 0) return false;
-  if (_mi_atomic_once_enter(&dhat_once)) _mi_atomic_once_release(&dhat_once);
+  if (_mi_atomic_once_enter(&dhat_once)) {
+    /* Explicit start wins over MIMALLOC_DHAT, but it must still honor the
+       independently useful exit-dump configuration before sealing the once. */
+    (void)_mi_getenv("MIMALLOC_DHAT_DUMP_AT_EXIT", dhat_dump_at_exit, sizeof(dhat_dump_at_exit));
+    _mi_atomic_once_release(&dhat_once);
+  }
   mi_lock_acquire(&dhat_lock);
   if (_mi_dhat_is_active()) { mi_lock_release(&dhat_lock); return false; }
   dhat_release_locked();

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 833f5f1b of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit f1c47160 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -16716,6 +16716,9 @@ typedef struct dhat_pp_s {
   uint64_t hash;
   uint32_t depth;
   uint64_t tb, tbk, tl;
+  /* Scratch refreshed under dhat_lock for dump serialization; it folds still-live
+     record ages into tl without changing the ledger's completed-lifetime total. */
+  uint64_t dump_tl;
   uint64_t live, livek, mb, mbk, gb, gbk;
   void* pcs[];
 } dhat_pp_t;
@@ -17058,19 +17061,24 @@ static size_t dhat_frame_index_locked(const dhat_pp_t* wanted, size_t wanted_fra
   }
   return 0;
 }
-static uint64_t dhat_live_lifetime_locked(const dhat_pp_t* pp, uint64_t now) {
-  uint64_t total = 0;
-  if (dhat_live_table == NULL) return 0;
+/* Compute every live record's contribution once, rather than scanning the full
+   live table for each program point while the global collector lock is held. */
+static void dhat_prepare_dump_lifetimes_locked(uint64_t now) {
+  if (dhat_pp_table == NULL) return;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) {
+    for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) pp->dump_tl = pp->tl;
+  }
+  if (dhat_live_table == NULL) return;
   for (size_t i = 0; i < DHAT_BUCKETS; i++) {
     for (dhat_record_t* rec = dhat_live_table[i]; rec != NULL; rec = rec->next) {
-      if (rec->pp == pp && now >= rec->born) total += now - rec->born;
+      if (now >= rec->born) rec->pp->dump_tl += now - rec->born;
     }
   }
-  return total;
 }
 static void dhat_write_json_locked(FILE* f) {
   const uint64_t elapsed = dhat_elapsed_now();
   const uint64_t now = (uint64_t)_mi_clock_now();
+  dhat_prepare_dump_lifetimes_locked(now);
   /* The standard viewer accepts producer-specific mode strings and extra keys.
      Keep the required v2 fields conventional; Mtu and tu truthfully say that
      these are monotonic wall-clock milliseconds rather than Valgrind instructions. */
@@ -17081,8 +17089,7 @@ static void dhat_write_json_locked(FILE* f) {
   }
   bool first_pp = true;
   for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
-    const uint64_t total_lifetime = pp->tl + dhat_live_lifetime_locked(pp, now);
-    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)total_lifetime, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
+    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)pp->dump_tl, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
     for (size_t frame = 0; frame < pp->depth; frame++) fprintf(f, "%s%llu", frame == 0 ? "" : ", ", (unsigned long long)dhat_frame_index_locked(pp, frame));
     fprintf(f, "]}"); first_pp = false;
   }

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 00859e98 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 3bc4b3e6 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -825,6 +825,9 @@ mi_decl_nodiscard mi_decl_export bool mi_prof_modules_visit(mi_prof_module_visit
      is suppressed: no accounting update and no nested callback invocation. This bounds
      stack depth and avoids double-counting/re-entrant surprises; it also means bytes
      allocated or freed *from inside* a callback are not reflected in the running totals.
+   - Callbacks must return normally. A C `longjmp` or C++ exception that escapes a
+     callback skips the recursion-guard cleanup and is unsupported; callback code that
+     needs non-local control flow must defer it until after the callback returns.
    - `arg` pointers in `mi_memory_callbacks_t` are caller-owned: the caller must keep
      them valid for as long as the callback might still be invoked (i.e. until a
      subsequent `mi_memory_set_callbacks` call replaces/clears them, or tracking is
@@ -16703,6 +16706,7 @@ typedef struct dhat_event_s {
   void* newp;
   size_t size;
   uint64_t at;
+  uint64_t generation;
   dhat_pp_t* pp;
   bool armed;
 } dhat_event_t;
@@ -16718,6 +16722,9 @@ static _Atomic(size_t) dhat_internal_bytes;
 static _Atomic(size_t) dhat_dropped;
 static _Atomic(size_t) dhat_incomplete;
 static mi_msecs_t dhat_started;
+/* Every fresh start gets an epoch so an event prepared before a concurrent
+   stop/start can never commit stale pointers into the new collector arena. */
+static uint64_t dhat_generation;
 static uint64_t dhat_total_bytes, dhat_total_blocks;
 static uint64_t dhat_live_bytes, dhat_live_blocks, dhat_peak_bytes, dhat_peak_blocks, dhat_peak_at;
 static char dhat_dump_at_exit[1024];
@@ -16866,8 +16873,24 @@ static void dhat_commit_resize_locked(dhat_event_t* ev) {
   }
   rec->size = ev->size;
   dhat_pp_t* pp = rec->pp;
-  if (ev->size >= oldsize) { const size_t delta = ev->size - oldsize; pp->tb += delta; dhat_total_bytes += delta; pp->live += delta; dhat_live_bytes += delta; }
-  else { const size_t delta = oldsize - ev->size; pp->live -= delta; dhat_live_bytes -= delta; }
+  /* A successful realloc is another allocation call for DHAT's cumulative
+     totals, even though its allocation identity and birth time remain attached
+     to the original program point. */
+  pp->tb += ev->size; pp->tbk++;
+  dhat_total_bytes += ev->size; dhat_total_blocks++;
+  if (ev->size >= oldsize) {
+    const size_t delta = ev->size - oldsize;
+    pp->live += delta; dhat_live_bytes += delta;
+  }
+  else {
+    const size_t delta = oldsize - ev->size;
+    if (pp->live >= delta && dhat_live_bytes >= delta) {
+      pp->live -= delta; dhat_live_bytes -= delta;
+    }
+    else {
+      pp->live = dhat_live_bytes = 0; dhat_mark_dropped();
+    }
+  }
   if (pp->live > pp->mb) pp->mb = pp->live;
   dhat_snapshot_global_peak_locked();
 }
@@ -16888,9 +16911,16 @@ static void dhat_resolve_env(void) {
        MIMALLOC_MEMORY_EVENTS activation state. */
     const bool env_enabled = (_mi_getenv("MIMALLOC_DHAT", value, sizeof(value)) == 0 && value[0] != 0 && value[0] != '0');
     (void)_mi_getenv("MIMALLOC_DHAT_DUMP_AT_EXIT", dhat_dump_at_exit, sizeof(dhat_dump_at_exit));
+    if (env_enabled) {
+      mi_lock_acquire(&dhat_lock);
+      dhat_budget = DHAT_DEFAULT_BUDGET;
+      (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget);
+      dhat_started = _mi_clock_now();
+      dhat_generation++;
+      mi_lock_release(&dhat_lock);
+    }
     mi_atomic_store_release(&dhat_state, (size_t)(env_enabled ? DHAT_ENABLED : DHAT_DISABLED));
     _mi_atomic_once_release(&dhat_once);
-    if (env_enabled) { mi_lock_acquire(&dhat_lock); dhat_budget = DHAT_DEFAULT_BUDGET; (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget); dhat_started = _mi_clock_now(); mi_lock_release(&dhat_lock); }
   }
 }
 
@@ -16901,12 +16931,22 @@ static void dhat_prepare(dhat_event_kind_t kind, void* oldp, void* newp, size_t 
   if (state == DHAT_UNINIT) { dhat_resolve_env(); state = mi_atomic_load_relaxed(&dhat_state); }
   if (state != DHAT_ENABLED || dhat_observer_depth != 0) return;
   dhat_observer_depth++;
-  dhat_event.kind = kind; dhat_event.oldp = oldp; dhat_event.newp = newp; dhat_event.size = size; dhat_event.at = _mi_clock_now(); dhat_event.pp = NULL;
+  dhat_event.kind = kind; dhat_event.oldp = oldp; dhat_event.newp = newp;
+  dhat_event.size = size; dhat_event.at = _mi_clock_now();
+  dhat_event.generation = 0; dhat_event.pp = NULL;
   if (kind == DHAT_EVENT_ALLOC) {
     void* pcs[DHAT_STACK_MAX]; const size_t depth = _mi_dhat_stack_capture(pcs, DHAT_STACK_MAX);
     if (depth == 0) { dhat_mark_dropped(); dhat_observer_depth--; return; }
-    mi_lock_acquire(&dhat_lock); dhat_event.pp = dhat_pp_intern_locked(pcs, depth); mi_lock_release(&dhat_lock);
+    mi_lock_acquire(&dhat_lock);
+    dhat_event.pp = dhat_pp_intern_locked(pcs, depth);
+    dhat_event.generation = dhat_generation;
+    mi_lock_release(&dhat_lock);
     if (dhat_event.pp == NULL) { dhat_observer_depth--; return; }
+  }
+  else {
+    mi_lock_acquire(&dhat_lock);
+    dhat_event.generation = dhat_generation;
+    mi_lock_release(&dhat_lock);
   }
   dhat_event.armed = true;
 }
@@ -16919,7 +16959,7 @@ void _mi_dhat_finish_event(void) {
   /* The observer guard is deliberately popped before mutating the ledger: a user memory
      callback runs between begin and finish, and any allocations it makes are excluded. */
   mi_lock_acquire(&dhat_lock);
-  if (_mi_dhat_is_active()) {
+  if (_mi_dhat_is_active() && ev.generation == dhat_generation) {
     if (ev.kind == DHAT_EVENT_ALLOC) dhat_commit_alloc_locked(&ev);
     else if (ev.kind == DHAT_EVENT_FREE) dhat_commit_free_locked(ev.oldp, ev.at);
     else if (ev.kind == DHAT_EVENT_RESIZE) dhat_commit_resize_locked(&ev);
@@ -16932,7 +16972,11 @@ bool mi_dhat_start(void) mi_attr_noexcept {
   if (_mi_atomic_once_enter(&dhat_once)) _mi_atomic_once_release(&dhat_once);
   mi_lock_acquire(&dhat_lock);
   if (_mi_dhat_is_active()) { mi_lock_release(&dhat_lock); return false; }
-  dhat_release_locked(); dhat_budget = DHAT_DEFAULT_BUDGET; (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget); dhat_started = _mi_clock_now();
+  dhat_release_locked();
+  dhat_budget = DHAT_DEFAULT_BUDGET;
+  (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget);
+  dhat_started = _mi_clock_now();
+  dhat_generation++;
   mi_atomic_store_release(&dhat_state, DHAT_ENABLED);
   mi_lock_release(&dhat_lock); return true;
 }
@@ -16978,15 +17022,31 @@ static size_t dhat_frame_index_locked(const dhat_pp_t* wanted, size_t wanted_fra
   }
   return 0;
 }
+static uint64_t dhat_live_lifetime_locked(const dhat_pp_t* pp, uint64_t now) {
+  uint64_t total = 0;
+  if (dhat_live_table == NULL) return 0;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) {
+    for (dhat_record_t* rec = dhat_live_table[i]; rec != NULL; rec = rec->next) {
+      if (rec->pp == pp && now >= rec->born) total += now - rec->born;
+    }
+  }
+  return total;
+}
 static void dhat_write_json_locked(FILE* f) {
   const uint64_t elapsed = dhat_elapsed_now();
+  const uint64_t now = (uint64_t)_mi_clock_now();
   /* The standard viewer accepts producer-specific mode strings and extra keys.
      Keep the required v2 fields conventional; Mtu and tu truthfully say that
      these are monotonic wall-clock milliseconds rather than Valgrind instructions. */
   fprintf(f, "{\n  \"dhatFileVersion\": 2,\n  \"mode\": \"mimalloc-heap\",\n  \"verb\": \"Allocated\",\n  \"bklt\": true,\n  \"bkacc\": false,\n  \"tu\": \"ms\",\n  \"Mtu\": \"ms\",\n  \"tuth\": 1,\n  \"cmd\": \"\",\n  \"pid\": 0,\n  \"tg\": %llu,\n  \"te\": %llu,\n  \"mi_dhat_incomplete\": %s,\n  \"pps\": [\n", (unsigned long long)dhat_peak_at, (unsigned long long)elapsed, (mi_atomic_load_relaxed(&dhat_incomplete) ? "true" : "false"));
+  if (dhat_pp_table == NULL) {
+    fprintf(f, "\n  ],\n  \"ftbl\": []\n}\n");
+    return;
+  }
   bool first_pp = true;
   for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
-    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)pp->tl, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
+    const uint64_t total_lifetime = pp->tl + dhat_live_lifetime_locked(pp, now);
+    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)total_lifetime, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
     for (size_t frame = 0; frame < pp->depth; frame++) fprintf(f, "%s%llu", frame == 0 ? "" : ", ", (unsigned long long)dhat_frame_index_locked(pp, frame));
     fprintf(f, "]}"); first_pp = false;
   }

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 3bc4b3e6 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 50ffb71b of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 56e8f2de of the three public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 766f35dc of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------
@@ -1066,3 +1066,54 @@ template<class T1, class T2> bool operator!=(const mi_heap_destroy_stl_allocator
 
 #endif
 /* ---- end inlined: include/mimalloc.h ---- */
+/* ---- begin inlined: include/mimalloc/dhat.h ---- */
+/* Exact, opt-in DHAT v2 heap profiling. Unlike the sampled pprof profiler,
+   DHAT tracks every non-internal allocation and is intended for short diagnostic
+   runs/tests, not production profiling. It is independent of MI_PPROF and of
+   mi_memory_set_callbacks: both observers can run simultaneously.
+
+   Start explicitly with mi_dhat_start(), or set MIMALLOC_DHAT=1 before process
+   initialization. MIMALLOC_DHAT_DUMP_AT_EXIT=<path> writes a standard DHAT v2
+   JSON report at process exit. MIMALLOC_DHAT_MAX_BYTES bounds raw-OS-backed
+   collector state (default 64 MiB); exhaustion is fail-soft and is exposed via
+   incomplete/dropped in mi_dhat_stats_t and mi_dhat_incomplete in the JSON.
+   Time fields use monotonic milliseconds (tu="ms"), not instruction counts.
+   Memory-access profiling is not available: emitted reports always use bkacc=false. */
+#pragma once
+#ifndef MIMALLOC_DHAT_H
+#define MIMALLOC_DHAT_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MI_DHAT_STATS_VERSION 1
+typedef struct mi_dhat_stats_s {
+  size_t size; int version;
+  bool enabled;
+  bool incomplete;
+  uint64_t total_bytes, total_blocks;
+  uint64_t live_bytes, live_blocks;
+  uint64_t peak_bytes, peak_blocks;
+  uint64_t dropped, internal_bytes;
+} mi_dhat_stats_t;
+#define mi_dhat_stats_t_decl(name) mi_dhat_stats_t name = { 0 }; name.size = sizeof(mi_dhat_stats_t); name.version = MI_DHAT_STATS_VERSION
+
+/* Starts/stops exact tracking. Starting also activates the internal event path;
+   installed mi_memory_set_callbacks observers remain installed and independent. */
+mi_decl_export bool mi_dhat_start(void) mi_attr_noexcept;
+mi_decl_export void mi_dhat_stop(void) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_dhat_is_enabled(void) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_dhat_stats_get(mi_dhat_stats_t* out) mi_attr_noexcept;
+
+/* Writes a DHAT file-version-2 heap JSON document. `tu` is monotonic milliseconds,
+   not Valgrind instruction counts; bkacc is always false. */
+mi_decl_nodiscard mi_decl_export bool mi_dhat_dump(const char* path) mi_attr_noexcept;
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* ---- end inlined: include/mimalloc/dhat.h ---- */

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 833f5f1b of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit f1c47160 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 00859e98 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 3bc4b3e6 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------
@@ -809,6 +809,9 @@ mi_decl_nodiscard mi_decl_export bool mi_prof_modules_visit(mi_prof_module_visit
      is suppressed: no accounting update and no nested callback invocation. This bounds
      stack depth and avoids double-counting/re-entrant surprises; it also means bytes
      allocated or freed *from inside* a callback are not reflected in the running totals.
+   - Callbacks must return normally. A C `longjmp` or C++ exception that escapes a
+     callback skips the recursion-guard cleanup and is unsupported; callback code that
+     needs non-local control flow must defer it until after the callback returns.
    - `arg` pointers in `mi_memory_callbacks_t` are caller-owned: the caller must keep
      them valid for as long as the callback might still be invoked (i.e. until a
      subsequent `mi_memory_set_callbacks` call replaces/clears them, or tracking is

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 50ffb71b of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 833f5f1b of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 766f35dc of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 00859e98 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -151,10 +151,9 @@ fn amalgamate_c(paths: &Paths) -> String {
     format!("{header}{body}")
 }
 
-/// Amalgamate the three public headers (in this fixed order, sharing one
-/// dedup set so profile.h/memory-events.h's own `#include "mimalloc.h"`
-/// doesn't duplicate content already inlined for mimalloc.h) into one
-/// self-contained public header.
+/// Amalgamate the public headers (in this fixed order, sharing one dedup set
+/// so the extension headers' own `#include "mimalloc.h"` does not duplicate
+/// content already inlined for mimalloc.h) into one self-contained public header.
 fn amalgamate_h(paths: &Paths) -> String {
     let mut visited = HashSet::new();
     let mut body = String::new();
@@ -162,6 +161,7 @@ fn amalgamate_h(paths: &Paths) -> String {
         "mimalloc.h",
         "mimalloc/profile.h",
         "mimalloc/memory-events.h",
+        "mimalloc/dhat.h",
     ] {
         inline_file(
             &paths.include_root.join(rel),
@@ -172,7 +172,7 @@ fn amalgamate_h(paths: &Paths) -> String {
     }
     let header = generated_header(
         paths,
-        "the three public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h)",
+        "the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h)",
         "amalgamate-h",
     );
     format!("{header}{body}")

--- a/src/alloc-aligned.c
+++ b/src/alloc-aligned.c
@@ -39,12 +39,18 @@ static mi_decl_noinline mi_decl_restrict void* mi_theap_malloc_guarded_aligned(m
     return NULL;
   }
   const size_t oversize = size + alignment - 1;
+  /* The allocator needs oversize bytes internally, but observers describe the
+     caller's requested aligned block. Suppress the base allocation event and
+     publish one normalized event below keyed by the actual page block. */
+  _mi_memevt_suppress_begin();
   void* const base = _mi_theap_malloc_guarded(theap, oversize, zero, usable);
+  _mi_memevt_suppress_end();
   if (base==NULL) return NULL;
   void* const p = _mi_align_up_ptr(base, alignment);
   mi_track_align(base, p, (uint8_t*)p - (uint8_t*)base, size);
   mi_assert_internal(mi_usable_size(p) >= size);
   mi_assert_internal(_mi_is_aligned(p, alignment));
+  _mi_memevt_on_alloc(_mi_ptr_page(base), base, size);
   return p;
 }
 
@@ -84,7 +90,9 @@ static mi_decl_noinline void* mi_theap_malloc_zero_aligned_at_overalloc(mi_theap
     }
     oversize = (size <= MI_SMALL_SIZE_MAX ? MI_SMALL_SIZE_MAX + 1 /* ensure we use generic malloc path */ : size);
     // note: no guarded as alignment > 0
+    _mi_memevt_suppress_begin();
     p = _mi_theap_malloc_zero_ex(theap, oversize, zero, alignment, usable); // the page block size should be large enough to align in the single huge page block
+    _mi_memevt_suppress_end();
     if (p == NULL) return NULL;
   }
   else {
@@ -92,7 +100,9 @@ static mi_decl_noinline void* mi_theap_malloc_zero_aligned_at_overalloc(mi_theap
     mi_assert_internal(size <= (MI_MAX_ALLOC_SIZE - MI_PADDING_SIZE) && alignment <= MI_PAGE_MAX_OVERALLOC_ALIGN);
     mi_assert_internal(size < SIZE_MAX - alignment); // `oversize` cannot overflow
     oversize = (size < MI_MAX_ALIGN_SIZE ? MI_MAX_ALIGN_SIZE : size) + alignment - 1;  // adjust for size <= 16; with size 0 and alignment 64k, we would allocate a 64k block and pointing just beyond that.
+    _mi_memevt_suppress_begin();
     p = mi_theap_malloc_zero_no_guarded(theap, oversize, zero, usable);
+    _mi_memevt_suppress_end();
     if (p == NULL) return NULL;
   }
 
@@ -151,6 +161,9 @@ static mi_decl_noinline void* mi_theap_malloc_zero_aligned_at_overalloc(mi_theap
     mi_track_mem_defined(p, sizeof(mi_block_t));
     #endif
   }
+  /* `p` is the page's real allocation identity (and therefore what free hooks
+     receive), while `size` is the public requested size. */
+  _mi_memevt_on_alloc(page, p, size);
   return aligned_p;
 }
 
@@ -344,11 +357,23 @@ static void* mi_theap_realloc_zero_aligned_at(mi_theap_t* theap, void* p, size_t
   if (alignment <= sizeof(uintptr_t) && offset==0) return _mi_theap_realloc_zero(theap,p,newsize,zero,NULL,NULL);
   if (p == NULL) return mi_theap_malloc_zero_aligned_at(theap,newsize,alignment,offset,zero,NULL);
   size_t size = mi_usable_size(p);
+  mi_page_t* const old_page = _mi_ptr_page(p);
+  void* const old_base = _mi_page_ptr_unalign(old_page, p);
+  const size_t old_usable = mi_page_usable_block_size(old_page);
   if (newsize <= size && newsize >= (size - (size / 2)) && (((uintptr_t)p + offset) & (alignment-1)) == 0) {
+    /* Aligned pointers can be interior to the actual page block. Memory-events
+       and DHAT use that stable block address so this in-place resize matches the
+       synthesized aligned-allocation event above. */
+    mi_page_t* const page = _mi_ptr_page(p);
+    void* const base = _mi_page_ptr_unalign(page, p);
+    _mi_memevt_on_realloc_in_place(page, base, newsize);
     return p;  // reallocation still fits, is aligned and not more than 50% waste
   }
   else {
     // note: we don't zero allocate upfront so we only zero initialize the expanded part
+    /* Hide the internal allocation/free pair and expose one identity-preserving
+       resize, exactly like _mi_theap_realloc_zero does for unaligned realloc. */
+    _mi_memevt_suppress_begin();
     void* newp = mi_theap_malloc_aligned_at(theap,newsize,alignment,offset);
     if (newp != NULL) {
       if (zero && newsize > size) {
@@ -358,6 +383,12 @@ static void* mi_theap_realloc_zero_aligned_at(mi_theap_t* theap, void* p, size_t
       }
       _mi_memcpy(newp, p, (newsize > size ? size : newsize)); // cannot be aligned due to abitrary offset... (todo: require offset to be a multiple of sizeof(void*)?)
       mi_free(p); // only free if successful
+    }
+    _mi_memevt_suppress_end();
+    if (newp != NULL) {
+      mi_page_t* const new_page = _mi_ptr_page(newp);
+      void* const new_base = _mi_page_ptr_unalign(new_page, newp);
+      _mi_memevt_on_resize(old_base, new_base, old_usable, mi_page_usable_block_size(new_page), newsize);
     }
     return newp;
   }

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -441,7 +441,7 @@ void* _mi_theap_realloc_zero(mi_theap_t* theap, void* p, size_t newsize, bool ze
   }
   if (memevt_is_resize) {
     _mi_memevt_suppress_end();
-    if (newp != NULL) { _mi_memevt_on_resize(memevt_usable_pre, memevt_usable_post, newsize); }
+    if (newp != NULL) { _mi_memevt_on_resize(p, newp, memevt_usable_pre, memevt_usable_post, newsize); }
   }
   return newp;
 }

--- a/src/dhat-stack.c
+++ b/src/dhat-stack.c
@@ -1,0 +1,42 @@
+/* Allocation-free stack capture for the exact DHAT observer. Kept separate from
+   profile-stack.c because DHAT is deliberately available when MI_PPROF=OFF. */
+#include "mimalloc.h"
+#include "mimalloc/internal.h"
+
+#define MI_DHAT_STACK_MAX 128
+
+#ifdef _WIN32
+#include <windows.h>
+size_t _mi_dhat_stack_capture(void** pcs, size_t capacity) {
+  if (capacity > MI_DHAT_STACK_MAX) capacity = MI_DHAT_STACK_MAX;
+  return (size_t)RtlCaptureStackBackTrace(2, (ULONG)capacity, pcs, NULL);
+}
+#elif defined(__APPLE__)
+#include <execinfo.h>
+size_t _mi_dhat_stack_capture(void** pcs, size_t capacity) {
+  if (capacity > MI_DHAT_STACK_MAX) capacity = MI_DHAT_STACK_MAX;
+  if (capacity == 0) return 0;
+  void* frames[MI_DHAT_STACK_MAX + 1];
+  const int count = backtrace(frames, (int)(capacity + 1));
+  if (count <= 1) return 0;
+  size_t n = (size_t)(count - 1);
+  if (n > capacity) n = capacity;
+  for (size_t i = 0; i < n; i++) pcs[i] = frames[i + 1];
+  return n;
+}
+#else
+size_t _mi_dhat_stack_capture(void** pcs, size_t capacity) {
+  void** fp = (void**)__builtin_frame_address(0);
+  size_t n = 0;
+  while (n < capacity && fp != NULL) {
+    void* ret = fp[1];
+    void** next = (void**)fp[0];
+    if (ret == NULL) break;
+    pcs[n++] = ret;
+    if (next <= fp || (uintptr_t)next - (uintptr_t)fp > (8u << 20) ||
+        (((uintptr_t)next & 0xF) != 0 && ((uintptr_t)next & 0x7) != 0)) break;
+    fp = next;
+  }
+  return n;
+}
+#endif

--- a/src/dhat.c
+++ b/src/dhat.c
@@ -49,6 +49,7 @@ typedef struct dhat_event_s {
   void* newp;
   size_t size;
   uint64_t at;
+  uint64_t generation;
   dhat_pp_t* pp;
   bool armed;
 } dhat_event_t;
@@ -64,6 +65,9 @@ static _Atomic(size_t) dhat_internal_bytes;
 static _Atomic(size_t) dhat_dropped;
 static _Atomic(size_t) dhat_incomplete;
 static mi_msecs_t dhat_started;
+/* Every fresh start gets an epoch so an event prepared before a concurrent
+   stop/start can never commit stale pointers into the new collector arena. */
+static uint64_t dhat_generation;
 static uint64_t dhat_total_bytes, dhat_total_blocks;
 static uint64_t dhat_live_bytes, dhat_live_blocks, dhat_peak_bytes, dhat_peak_blocks, dhat_peak_at;
 static char dhat_dump_at_exit[1024];
@@ -212,8 +216,24 @@ static void dhat_commit_resize_locked(dhat_event_t* ev) {
   }
   rec->size = ev->size;
   dhat_pp_t* pp = rec->pp;
-  if (ev->size >= oldsize) { const size_t delta = ev->size - oldsize; pp->tb += delta; dhat_total_bytes += delta; pp->live += delta; dhat_live_bytes += delta; }
-  else { const size_t delta = oldsize - ev->size; pp->live -= delta; dhat_live_bytes -= delta; }
+  /* A successful realloc is another allocation call for DHAT's cumulative
+     totals, even though its allocation identity and birth time remain attached
+     to the original program point. */
+  pp->tb += ev->size; pp->tbk++;
+  dhat_total_bytes += ev->size; dhat_total_blocks++;
+  if (ev->size >= oldsize) {
+    const size_t delta = ev->size - oldsize;
+    pp->live += delta; dhat_live_bytes += delta;
+  }
+  else {
+    const size_t delta = oldsize - ev->size;
+    if (pp->live >= delta && dhat_live_bytes >= delta) {
+      pp->live -= delta; dhat_live_bytes -= delta;
+    }
+    else {
+      pp->live = dhat_live_bytes = 0; dhat_mark_dropped();
+    }
+  }
   if (pp->live > pp->mb) pp->mb = pp->live;
   dhat_snapshot_global_peak_locked();
 }
@@ -234,9 +254,16 @@ static void dhat_resolve_env(void) {
        MIMALLOC_MEMORY_EVENTS activation state. */
     const bool env_enabled = (_mi_getenv("MIMALLOC_DHAT", value, sizeof(value)) == 0 && value[0] != 0 && value[0] != '0');
     (void)_mi_getenv("MIMALLOC_DHAT_DUMP_AT_EXIT", dhat_dump_at_exit, sizeof(dhat_dump_at_exit));
+    if (env_enabled) {
+      mi_lock_acquire(&dhat_lock);
+      dhat_budget = DHAT_DEFAULT_BUDGET;
+      (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget);
+      dhat_started = _mi_clock_now();
+      dhat_generation++;
+      mi_lock_release(&dhat_lock);
+    }
     mi_atomic_store_release(&dhat_state, (size_t)(env_enabled ? DHAT_ENABLED : DHAT_DISABLED));
     _mi_atomic_once_release(&dhat_once);
-    if (env_enabled) { mi_lock_acquire(&dhat_lock); dhat_budget = DHAT_DEFAULT_BUDGET; (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget); dhat_started = _mi_clock_now(); mi_lock_release(&dhat_lock); }
   }
 }
 
@@ -247,12 +274,22 @@ static void dhat_prepare(dhat_event_kind_t kind, void* oldp, void* newp, size_t 
   if (state == DHAT_UNINIT) { dhat_resolve_env(); state = mi_atomic_load_relaxed(&dhat_state); }
   if (state != DHAT_ENABLED || dhat_observer_depth != 0) return;
   dhat_observer_depth++;
-  dhat_event.kind = kind; dhat_event.oldp = oldp; dhat_event.newp = newp; dhat_event.size = size; dhat_event.at = _mi_clock_now(); dhat_event.pp = NULL;
+  dhat_event.kind = kind; dhat_event.oldp = oldp; dhat_event.newp = newp;
+  dhat_event.size = size; dhat_event.at = _mi_clock_now();
+  dhat_event.generation = 0; dhat_event.pp = NULL;
   if (kind == DHAT_EVENT_ALLOC) {
     void* pcs[DHAT_STACK_MAX]; const size_t depth = _mi_dhat_stack_capture(pcs, DHAT_STACK_MAX);
     if (depth == 0) { dhat_mark_dropped(); dhat_observer_depth--; return; }
-    mi_lock_acquire(&dhat_lock); dhat_event.pp = dhat_pp_intern_locked(pcs, depth); mi_lock_release(&dhat_lock);
+    mi_lock_acquire(&dhat_lock);
+    dhat_event.pp = dhat_pp_intern_locked(pcs, depth);
+    dhat_event.generation = dhat_generation;
+    mi_lock_release(&dhat_lock);
     if (dhat_event.pp == NULL) { dhat_observer_depth--; return; }
+  }
+  else {
+    mi_lock_acquire(&dhat_lock);
+    dhat_event.generation = dhat_generation;
+    mi_lock_release(&dhat_lock);
   }
   dhat_event.armed = true;
 }
@@ -265,7 +302,7 @@ void _mi_dhat_finish_event(void) {
   /* The observer guard is deliberately popped before mutating the ledger: a user memory
      callback runs between begin and finish, and any allocations it makes are excluded. */
   mi_lock_acquire(&dhat_lock);
-  if (_mi_dhat_is_active()) {
+  if (_mi_dhat_is_active() && ev.generation == dhat_generation) {
     if (ev.kind == DHAT_EVENT_ALLOC) dhat_commit_alloc_locked(&ev);
     else if (ev.kind == DHAT_EVENT_FREE) dhat_commit_free_locked(ev.oldp, ev.at);
     else if (ev.kind == DHAT_EVENT_RESIZE) dhat_commit_resize_locked(&ev);
@@ -278,7 +315,11 @@ bool mi_dhat_start(void) mi_attr_noexcept {
   if (_mi_atomic_once_enter(&dhat_once)) _mi_atomic_once_release(&dhat_once);
   mi_lock_acquire(&dhat_lock);
   if (_mi_dhat_is_active()) { mi_lock_release(&dhat_lock); return false; }
-  dhat_release_locked(); dhat_budget = DHAT_DEFAULT_BUDGET; (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget); dhat_started = _mi_clock_now();
+  dhat_release_locked();
+  dhat_budget = DHAT_DEFAULT_BUDGET;
+  (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget);
+  dhat_started = _mi_clock_now();
+  dhat_generation++;
   mi_atomic_store_release(&dhat_state, DHAT_ENABLED);
   mi_lock_release(&dhat_lock); return true;
 }
@@ -324,15 +365,31 @@ static size_t dhat_frame_index_locked(const dhat_pp_t* wanted, size_t wanted_fra
   }
   return 0;
 }
+static uint64_t dhat_live_lifetime_locked(const dhat_pp_t* pp, uint64_t now) {
+  uint64_t total = 0;
+  if (dhat_live_table == NULL) return 0;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) {
+    for (dhat_record_t* rec = dhat_live_table[i]; rec != NULL; rec = rec->next) {
+      if (rec->pp == pp && now >= rec->born) total += now - rec->born;
+    }
+  }
+  return total;
+}
 static void dhat_write_json_locked(FILE* f) {
   const uint64_t elapsed = dhat_elapsed_now();
+  const uint64_t now = (uint64_t)_mi_clock_now();
   /* The standard viewer accepts producer-specific mode strings and extra keys.
      Keep the required v2 fields conventional; Mtu and tu truthfully say that
      these are monotonic wall-clock milliseconds rather than Valgrind instructions. */
   fprintf(f, "{\n  \"dhatFileVersion\": 2,\n  \"mode\": \"mimalloc-heap\",\n  \"verb\": \"Allocated\",\n  \"bklt\": true,\n  \"bkacc\": false,\n  \"tu\": \"ms\",\n  \"Mtu\": \"ms\",\n  \"tuth\": 1,\n  \"cmd\": \"\",\n  \"pid\": 0,\n  \"tg\": %llu,\n  \"te\": %llu,\n  \"mi_dhat_incomplete\": %s,\n  \"pps\": [\n", (unsigned long long)dhat_peak_at, (unsigned long long)elapsed, (mi_atomic_load_relaxed(&dhat_incomplete) ? "true" : "false"));
+  if (dhat_pp_table == NULL) {
+    fprintf(f, "\n  ],\n  \"ftbl\": []\n}\n");
+    return;
+  }
   bool first_pp = true;
   for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
-    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)pp->tl, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
+    const uint64_t total_lifetime = pp->tl + dhat_live_lifetime_locked(pp, now);
+    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)total_lifetime, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
     for (size_t frame = 0; frame < pp->depth; frame++) fprintf(f, "%s%llu", frame == 0 ? "" : ", ", (unsigned long long)dhat_frame_index_locked(pp, frame));
     fprintf(f, "]}"); first_pp = false;
   }

--- a/src/dhat.c
+++ b/src/dhat.c
@@ -94,7 +94,9 @@ static bool dhat_stack_equal(const dhat_pp_t* pp, uint64_t hash, void* const* pc
   for (size_t i = 0; i < depth; i++) if (pp->pcs[i] != pcs[i]) return false;
   return true;
 }
-static size_t dhat_align(size_t n) { const size_t a = sizeof(void*) - 1; return (n + a) & ~a; }
+/* The raw arena holds uint64_t counters as well as pointers. Use the allocator's
+   max fundamental alignment rather than pointer width for 32-bit strict-alignment ABIs. */
+static size_t dhat_align(size_t n) { const size_t a = MI_MAX_ALIGN_SIZE - 1; return (n + a) & ~a; }
 
 static void dhat_release_locked(void) {
   for (dhat_chunk_t* chunk = dhat_chunks; chunk != NULL; ) {
@@ -312,7 +314,12 @@ void _mi_dhat_finish_event(void) {
 
 bool mi_dhat_start(void) mi_attr_noexcept {
   if (dhat_observer_depth != 0) return false;
-  if (_mi_atomic_once_enter(&dhat_once)) _mi_atomic_once_release(&dhat_once);
+  if (_mi_atomic_once_enter(&dhat_once)) {
+    /* Explicit start wins over MIMALLOC_DHAT, but it must still honor the
+       independently useful exit-dump configuration before sealing the once. */
+    (void)_mi_getenv("MIMALLOC_DHAT_DUMP_AT_EXIT", dhat_dump_at_exit, sizeof(dhat_dump_at_exit));
+    _mi_atomic_once_release(&dhat_once);
+  }
   mi_lock_acquire(&dhat_lock);
   if (_mi_dhat_is_active()) { mi_lock_release(&dhat_lock); return false; }
   dhat_release_locked();

--- a/src/dhat.c
+++ b/src/dhat.c
@@ -30,6 +30,9 @@ typedef struct dhat_pp_s {
   uint64_t hash;
   uint32_t depth;
   uint64_t tb, tbk, tl;
+  /* Scratch refreshed under dhat_lock for dump serialization; it folds still-live
+     record ages into tl without changing the ledger's completed-lifetime total. */
+  uint64_t dump_tl;
   uint64_t live, livek, mb, mbk, gb, gbk;
   void* pcs[];
 } dhat_pp_t;
@@ -372,19 +375,24 @@ static size_t dhat_frame_index_locked(const dhat_pp_t* wanted, size_t wanted_fra
   }
   return 0;
 }
-static uint64_t dhat_live_lifetime_locked(const dhat_pp_t* pp, uint64_t now) {
-  uint64_t total = 0;
-  if (dhat_live_table == NULL) return 0;
+/* Compute every live record's contribution once, rather than scanning the full
+   live table for each program point while the global collector lock is held. */
+static void dhat_prepare_dump_lifetimes_locked(uint64_t now) {
+  if (dhat_pp_table == NULL) return;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) {
+    for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) pp->dump_tl = pp->tl;
+  }
+  if (dhat_live_table == NULL) return;
   for (size_t i = 0; i < DHAT_BUCKETS; i++) {
     for (dhat_record_t* rec = dhat_live_table[i]; rec != NULL; rec = rec->next) {
-      if (rec->pp == pp && now >= rec->born) total += now - rec->born;
+      if (now >= rec->born) rec->pp->dump_tl += now - rec->born;
     }
   }
-  return total;
 }
 static void dhat_write_json_locked(FILE* f) {
   const uint64_t elapsed = dhat_elapsed_now();
   const uint64_t now = (uint64_t)_mi_clock_now();
+  dhat_prepare_dump_lifetimes_locked(now);
   /* The standard viewer accepts producer-specific mode strings and extra keys.
      Keep the required v2 fields conventional; Mtu and tu truthfully say that
      these are monotonic wall-clock milliseconds rather than Valgrind instructions. */
@@ -395,8 +403,7 @@ static void dhat_write_json_locked(FILE* f) {
   }
   bool first_pp = true;
   for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
-    const uint64_t total_lifetime = pp->tl + dhat_live_lifetime_locked(pp, now);
-    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)total_lifetime, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
+    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)pp->dump_tl, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
     for (size_t frame = 0; frame < pp->depth; frame++) fprintf(f, "%s%llu", frame == 0 ? "" : ", ", (unsigned long long)dhat_frame_index_locked(pp, frame));
     fprintf(f, "]}"); first_pp = false;
   }

--- a/src/dhat.c
+++ b/src/dhat.c
@@ -408,12 +408,20 @@ bool mi_dhat_dump(const char* path) mi_attr_noexcept {
      report's actual live records untouched; otherwise a reentrant hook could attempt
      to take dhat_lock while serialization already owns it. */
   dhat_observer_depth++;
+  /* Suppress the public dispatcher too: a callback invoked by a lazy stdio
+     allocation could otherwise call a DHAT API while dhat_lock is held. */
+  _mi_memevt_suppress_begin();
   FILE* f = fopen(path, "wb");
-  if (f == NULL) { dhat_observer_depth--; return false; }
+  if (f == NULL) {
+    _mi_memevt_suppress_end();
+    dhat_observer_depth--;
+    return false;
+  }
   mi_lock_acquire(&dhat_lock);
   dhat_write_json_locked(f);
   mi_lock_release(&dhat_lock);
   const bool ok = (fclose(f) == 0);
+  _mi_memevt_suppress_end();
   dhat_observer_depth--;
   return ok;
 }

--- a/src/dhat.c
+++ b/src/dhat.c
@@ -63,7 +63,7 @@ static size_t dhat_budget;
 static _Atomic(size_t) dhat_internal_bytes;
 static _Atomic(size_t) dhat_dropped;
 static _Atomic(size_t) dhat_incomplete;
-static uint64_t dhat_started;
+static mi_msecs_t dhat_started;
 static uint64_t dhat_total_bytes, dhat_total_blocks;
 static uint64_t dhat_live_bytes, dhat_live_blocks, dhat_peak_bytes, dhat_peak_blocks, dhat_peak_at;
 static char dhat_dump_at_exit[1024];
@@ -164,10 +164,14 @@ static dhat_record_t** dhat_record_slot_locked(void* p) {
   while (*slot != NULL && (*slot)->ptr != p) slot = &(*slot)->next;
   return slot;
 }
+static uint64_t dhat_elapsed_now(void) {
+  const mi_msecs_t now = _mi_clock_now();
+  return (now >= dhat_started ? (uint64_t)(now - dhat_started) : 0);
+}
 static void dhat_snapshot_global_peak_locked(void) {
   if (dhat_live_bytes <= dhat_peak_bytes) return;
   dhat_peak_bytes = dhat_live_bytes; dhat_peak_blocks = dhat_live_blocks;
-  dhat_peak_at = _mi_clock_now() - dhat_started;
+  dhat_peak_at = dhat_elapsed_now();
   for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) { pp->gb = pp->live; pp->gbk = pp->livek; }
 }
 static void dhat_commit_alloc_locked(dhat_event_t* ev) {
@@ -215,9 +219,13 @@ static void dhat_commit_resize_locked(dhat_event_t* ev) {
 }
 
 static bool dhat_env_size(const char* name, size_t* out) {
-  char buf[64]; if (_mi_getenv(name, buf, sizeof(buf)) != 0 || buf[0] == 0) return false;
-  char* end = NULL; unsigned long long v = strtoull(buf, &end, 10);
-  if (end == buf || *end != 0 || v > SIZE_MAX) return false; *out = (size_t)v; return true;
+  char buf[64];
+  if (_mi_getenv(name, buf, sizeof(buf)) != 0 || buf[0] == 0) return false;
+  char* end = NULL;
+  const unsigned long long v = strtoull(buf, &end, 10);
+  if (end == buf || *end != 0 || v > SIZE_MAX) return false;
+  *out = (size_t)v;
+  return true;
 }
 static void dhat_resolve_env(void) {
   if (_mi_atomic_once_enter(&dhat_once)) {
@@ -317,7 +325,7 @@ static size_t dhat_frame_index_locked(const dhat_pp_t* wanted, size_t wanted_fra
   return 0;
 }
 static void dhat_write_json_locked(FILE* f) {
-  const uint64_t elapsed = (_mi_clock_now() >= dhat_started ? _mi_clock_now() - dhat_started : 0);
+  const uint64_t elapsed = dhat_elapsed_now();
   /* The standard viewer accepts producer-specific mode strings and extra keys.
      Keep the required v2 fields conventional; Mtu and tu truthfully say that
      these are monotonic wall-clock milliseconds rather than Valgrind instructions. */

--- a/src/dhat.c
+++ b/src/dhat.c
@@ -1,0 +1,346 @@
+/* Exact, opt-in DHAT v2 heap/lifetime profiler (issue #238).
+   All persistent collector state is bump allocated directly from the raw OS layer;
+   it never enters the normal mimalloc allocation paths. */
+#include "mimalloc.h"
+#include "mimalloc/internal.h"
+#include "mimalloc/dhat.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <stddef.h>
+
+#define DHAT_UNINIT 0
+#define DHAT_DISABLED 1
+#define DHAT_ENABLED 2
+#define DHAT_STACK_MAX 64
+#define DHAT_CHUNK_SIZE (64*1024)
+#define DHAT_DEFAULT_BUDGET (64*1024*1024)
+#define DHAT_BUCKETS 4096
+
+typedef struct dhat_chunk_s {
+  struct dhat_chunk_s* next;
+  mi_memid_t memid;
+  size_t size;
+  size_t used;
+} dhat_chunk_t;
+
+typedef struct dhat_pp_s {
+  struct dhat_pp_s* next;
+  uint64_t hash;
+  uint32_t depth;
+  uint64_t tb, tbk, tl;
+  uint64_t live, livek, mb, mbk, gb, gbk;
+  void* pcs[];
+} dhat_pp_t;
+
+typedef struct dhat_record_s {
+  struct dhat_record_s* next;
+  void* ptr;
+  size_t size;
+  uint64_t born;
+  dhat_pp_t* pp;
+} dhat_record_t;
+
+typedef enum dhat_event_kind_e { DHAT_EVENT_NONE, DHAT_EVENT_ALLOC, DHAT_EVENT_FREE, DHAT_EVENT_RESIZE } dhat_event_kind_t;
+typedef struct dhat_event_s {
+  dhat_event_kind_t kind;
+  void* oldp;
+  void* newp;
+  size_t size;
+  uint64_t at;
+  dhat_pp_t* pp;
+  bool armed;
+} dhat_event_t;
+
+static mi_lock_t dhat_lock = MI_LOCK_INITIALIZER;
+static mi_atomic_once_t dhat_once = { MI_ATOMIC_VAR_INIT(0), MI_LOCK_INITIALIZER };
+static _Atomic(size_t) dhat_state;
+static dhat_chunk_t* dhat_chunks;
+static dhat_record_t** dhat_live_table;
+static dhat_pp_t** dhat_pp_table;
+static size_t dhat_budget;
+static _Atomic(size_t) dhat_internal_bytes;
+static _Atomic(size_t) dhat_dropped;
+static _Atomic(size_t) dhat_incomplete;
+static uint64_t dhat_started;
+static uint64_t dhat_total_bytes, dhat_total_blocks;
+static uint64_t dhat_live_bytes, dhat_live_blocks, dhat_peak_bytes, dhat_peak_blocks, dhat_peak_at;
+static char dhat_dump_at_exit[1024];
+static mi_decl_thread int dhat_observer_depth;
+static mi_decl_thread dhat_event_t dhat_event;
+
+size_t _mi_dhat_stack_capture(void** pcs, size_t capacity);
+
+static uint64_t dhat_hash_ptr(const void* p) {
+  uintptr_t x = (uintptr_t)p;
+  x ^= x >> 33; x *= UINT64_C(0xff51afd7ed558ccd); x ^= x >> 33;
+  return (uint64_t)x;
+}
+static uint64_t dhat_hash_stack(void* const* pcs, size_t depth) {
+  uint64_t h = UINT64_C(1469598103934665603);
+  for (size_t i = 0; i < depth; i++) {
+    uintptr_t pc = (uintptr_t)pcs[i];
+    for (size_t b = 0; b < sizeof(pc); b++) { h ^= (uint8_t)(pc >> (b * 8)); h *= UINT64_C(1099511628211); }
+  }
+  return h;
+}
+static bool dhat_stack_equal(const dhat_pp_t* pp, uint64_t hash, void* const* pcs, size_t depth) {
+  if (pp->hash != hash || pp->depth != depth) return false;
+  for (size_t i = 0; i < depth; i++) if (pp->pcs[i] != pcs[i]) return false;
+  return true;
+}
+static size_t dhat_align(size_t n) { const size_t a = sizeof(void*) - 1; return (n + a) & ~a; }
+
+static void dhat_release_locked(void) {
+  for (dhat_chunk_t* chunk = dhat_chunks; chunk != NULL; ) {
+    dhat_chunk_t* next = chunk->next;
+    _mi_os_free(_mi_subproc_main(), chunk, chunk->size, chunk->memid);
+    chunk = next;
+  }
+  dhat_chunks = NULL; dhat_live_table = NULL; dhat_pp_table = NULL;
+  dhat_total_bytes = dhat_total_blocks = 0;
+  dhat_live_bytes = dhat_live_blocks = dhat_peak_bytes = dhat_peak_blocks = dhat_peak_at = 0;
+  mi_atomic_store_relaxed(&dhat_internal_bytes, (size_t)0);
+  mi_atomic_store_relaxed(&dhat_dropped, (size_t)0);
+  mi_atomic_store_relaxed(&dhat_incomplete, (size_t)0);
+}
+
+static void* dhat_arena_alloc(size_t size) {
+  size = dhat_align(size);
+  dhat_chunk_t* chunk = dhat_chunks;
+  if (chunk == NULL || chunk->used + size > chunk->size) {
+    if (size > SIZE_MAX - sizeof(dhat_chunk_t)) return NULL;
+    size_t total = DHAT_CHUNK_SIZE;
+    if (total < sizeof(dhat_chunk_t) + size) total = sizeof(dhat_chunk_t) + size;
+    const size_t committed = mi_atomic_load_relaxed(&dhat_internal_bytes);
+    if (dhat_budget != 0 && (committed > dhat_budget || total > dhat_budget - committed)) return NULL;
+    mi_memid_t memid;
+    chunk = (dhat_chunk_t*)_mi_os_alloc(_mi_subproc_main(), total, &memid);
+    if (chunk == NULL) return NULL;
+    chunk->next = dhat_chunks; chunk->memid = memid; chunk->size = total; chunk->used = sizeof(*chunk);
+    dhat_chunks = chunk;
+    mi_atomic_add_relaxed(&dhat_internal_bytes, total);
+  }
+  void* p = (uint8_t*)chunk + chunk->used;
+  chunk->used += size;
+  return p;
+}
+
+static void dhat_mark_dropped(void) { mi_atomic_increment_relaxed(&dhat_dropped); mi_atomic_store_relaxed(&dhat_incomplete, (size_t)1); }
+
+static bool dhat_init_tables_locked(void) {
+  if (dhat_live_table != NULL || dhat_pp_table != NULL) {
+    /* A partial first attempt cannot safely be completed: the budget may have
+       been exhausted after one table allocation. Keep the collector fail-soft
+       instead of dereferencing a missing sibling table. */
+    return (dhat_live_table != NULL && dhat_pp_table != NULL);
+  }
+  dhat_live_table = (dhat_record_t**)dhat_arena_alloc(DHAT_BUCKETS * sizeof(*dhat_live_table));
+  dhat_pp_table = (dhat_pp_t**)dhat_arena_alloc(DHAT_BUCKETS * sizeof(*dhat_pp_table));
+  if (dhat_live_table == NULL || dhat_pp_table == NULL) { dhat_mark_dropped(); return false; }
+  _mi_memzero(dhat_live_table, DHAT_BUCKETS * sizeof(*dhat_live_table));
+  _mi_memzero(dhat_pp_table, DHAT_BUCKETS * sizeof(*dhat_pp_table));
+  return true;
+}
+
+static dhat_pp_t* dhat_pp_intern_locked(void* const* pcs, size_t depth) {
+  if (!dhat_init_tables_locked()) return NULL;
+  const uint64_t hash = dhat_hash_stack(pcs, depth);
+  dhat_pp_t** bucket = &dhat_pp_table[(size_t)hash & (DHAT_BUCKETS - 1)];
+  for (dhat_pp_t* pp = *bucket; pp != NULL; pp = pp->next) if (dhat_stack_equal(pp, hash, pcs, depth)) return pp;
+  if (depth > (SIZE_MAX - sizeof(dhat_pp_t)) / sizeof(void*)) { dhat_mark_dropped(); return NULL; }
+  dhat_pp_t* pp = (dhat_pp_t*)dhat_arena_alloc(sizeof(*pp) + depth * sizeof(void*));
+  if (pp == NULL) { dhat_mark_dropped(); return NULL; }
+  _mi_memzero(pp, sizeof(*pp)); pp->hash = hash; pp->depth = (uint32_t)depth;
+  for (size_t i = 0; i < depth; i++) pp->pcs[i] = pcs[i];
+  pp->next = *bucket; *bucket = pp;
+  return pp;
+}
+
+static dhat_record_t** dhat_record_slot_locked(void* p) {
+  if (dhat_live_table == NULL) return NULL;
+  dhat_record_t** slot = &dhat_live_table[(size_t)dhat_hash_ptr(p) & (DHAT_BUCKETS - 1)];
+  while (*slot != NULL && (*slot)->ptr != p) slot = &(*slot)->next;
+  return slot;
+}
+static void dhat_snapshot_global_peak_locked(void) {
+  if (dhat_live_bytes <= dhat_peak_bytes) return;
+  dhat_peak_bytes = dhat_live_bytes; dhat_peak_blocks = dhat_live_blocks;
+  dhat_peak_at = _mi_clock_now() - dhat_started;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) { pp->gb = pp->live; pp->gbk = pp->livek; }
+}
+static void dhat_commit_alloc_locked(dhat_event_t* ev) {
+  if (ev->pp == NULL || !dhat_init_tables_locked()) return;
+  dhat_record_t** slot = dhat_record_slot_locked(ev->newp);
+  if (slot == NULL) return;
+  if (*slot != NULL) { dhat_mark_dropped(); return; }
+  dhat_record_t* rec = (dhat_record_t*)dhat_arena_alloc(sizeof(*rec));
+  if (rec == NULL) { dhat_mark_dropped(); return; }
+  rec->next = NULL; rec->ptr = ev->newp; rec->size = ev->size; rec->born = ev->at; rec->pp = ev->pp; *slot = rec;
+  ev->pp->tb += ev->size; ev->pp->tbk++; ev->pp->live += ev->size; ev->pp->livek++;
+  if (ev->pp->live > ev->pp->mb) ev->pp->mb = ev->pp->live;
+  if (ev->pp->livek > ev->pp->mbk) ev->pp->mbk = ev->pp->livek;
+  dhat_total_bytes += ev->size; dhat_total_blocks++; dhat_live_bytes += ev->size; dhat_live_blocks++;
+  dhat_snapshot_global_peak_locked();
+}
+static void dhat_commit_free_locked(void* p, uint64_t at) {
+  dhat_record_t** slot = dhat_record_slot_locked(p);
+  if (slot == NULL || *slot == NULL) return;
+  dhat_record_t* rec = *slot; *slot = rec->next;
+  dhat_pp_t* pp = rec->pp;
+  if (pp->live >= rec->size) pp->live -= rec->size; else { pp->live = 0; dhat_mark_dropped(); }
+  if (pp->livek != 0) pp->livek--; else dhat_mark_dropped();
+  if (dhat_live_bytes >= rec->size) dhat_live_bytes -= rec->size; else { dhat_live_bytes = 0; dhat_mark_dropped(); }
+  if (dhat_live_blocks != 0) dhat_live_blocks--; else dhat_mark_dropped();
+  pp->tl += (at >= rec->born ? at - rec->born : 0);
+}
+static void dhat_commit_resize_locked(dhat_event_t* ev) {
+  dhat_record_t** slot = dhat_record_slot_locked(ev->oldp);
+  if (slot == NULL || *slot == NULL) return;
+  dhat_record_t* rec = *slot;
+  const size_t oldsize = rec->size;
+  if (ev->oldp != ev->newp) {
+    *slot = rec->next;
+    dhat_record_t** destination = dhat_record_slot_locked(ev->newp);
+    if (destination == NULL || *destination != NULL) { dhat_mark_dropped(); return; }
+    rec->ptr = ev->newp; rec->next = NULL; *destination = rec;
+  }
+  rec->size = ev->size;
+  dhat_pp_t* pp = rec->pp;
+  if (ev->size >= oldsize) { const size_t delta = ev->size - oldsize; pp->tb += delta; dhat_total_bytes += delta; pp->live += delta; dhat_live_bytes += delta; }
+  else { const size_t delta = oldsize - ev->size; pp->live -= delta; dhat_live_bytes -= delta; }
+  if (pp->live > pp->mb) pp->mb = pp->live;
+  dhat_snapshot_global_peak_locked();
+}
+
+static bool dhat_env_size(const char* name, size_t* out) {
+  char buf[64]; if (_mi_getenv(name, buf, sizeof(buf)) != 0 || buf[0] == 0) return false;
+  char* end = NULL; unsigned long long v = strtoull(buf, &end, 10);
+  if (end == buf || *end != 0 || v > SIZE_MAX) return false; *out = (size_t)v; return true;
+}
+static void dhat_resolve_env(void) {
+  if (_mi_atomic_once_enter(&dhat_once)) {
+    char value[8] = { 0 };
+    /* DHAT has its own opt-in switch; it must never inherit the unrelated
+       MIMALLOC_MEMORY_EVENTS activation state. */
+    const bool env_enabled = (_mi_getenv("MIMALLOC_DHAT", value, sizeof(value)) == 0 && value[0] != 0 && value[0] != '0');
+    (void)_mi_getenv("MIMALLOC_DHAT_DUMP_AT_EXIT", dhat_dump_at_exit, sizeof(dhat_dump_at_exit));
+    mi_atomic_store_release(&dhat_state, (size_t)(env_enabled ? DHAT_ENABLED : DHAT_DISABLED));
+    _mi_atomic_once_release(&dhat_once);
+    if (env_enabled) { mi_lock_acquire(&dhat_lock); dhat_budget = DHAT_DEFAULT_BUDGET; (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget); dhat_started = _mi_clock_now(); mi_lock_release(&dhat_lock); }
+  }
+}
+
+bool _mi_dhat_is_active(void) { return mi_atomic_load_relaxed(&dhat_state) == DHAT_ENABLED; }
+static void dhat_prepare(dhat_event_kind_t kind, void* oldp, void* newp, size_t size) {
+  dhat_event.armed = false;
+  size_t state = mi_atomic_load_relaxed(&dhat_state);
+  if (state == DHAT_UNINIT) { dhat_resolve_env(); state = mi_atomic_load_relaxed(&dhat_state); }
+  if (state != DHAT_ENABLED || dhat_observer_depth != 0) return;
+  dhat_observer_depth++;
+  dhat_event.kind = kind; dhat_event.oldp = oldp; dhat_event.newp = newp; dhat_event.size = size; dhat_event.at = _mi_clock_now(); dhat_event.pp = NULL;
+  if (kind == DHAT_EVENT_ALLOC) {
+    void* pcs[DHAT_STACK_MAX]; const size_t depth = _mi_dhat_stack_capture(pcs, DHAT_STACK_MAX);
+    if (depth == 0) { dhat_mark_dropped(); dhat_observer_depth--; return; }
+    mi_lock_acquire(&dhat_lock); dhat_event.pp = dhat_pp_intern_locked(pcs, depth); mi_lock_release(&dhat_lock);
+    if (dhat_event.pp == NULL) { dhat_observer_depth--; return; }
+  }
+  dhat_event.armed = true;
+}
+void _mi_dhat_begin_alloc(void* p, size_t request_size) { dhat_prepare(DHAT_EVENT_ALLOC, NULL, p, request_size); }
+void _mi_dhat_begin_free(void* p) { dhat_prepare(DHAT_EVENT_FREE, p, NULL, 0); }
+void _mi_dhat_begin_resize(void* oldp, void* newp, size_t request_size) { dhat_prepare(DHAT_EVENT_RESIZE, oldp, newp, request_size); }
+void _mi_dhat_finish_event(void) {
+  if (!dhat_event.armed) return;
+  dhat_event_t ev = dhat_event; dhat_event.armed = false; dhat_observer_depth--;
+  /* The observer guard is deliberately popped before mutating the ledger: a user memory
+     callback runs between begin and finish, and any allocations it makes are excluded. */
+  mi_lock_acquire(&dhat_lock);
+  if (_mi_dhat_is_active()) {
+    if (ev.kind == DHAT_EVENT_ALLOC) dhat_commit_alloc_locked(&ev);
+    else if (ev.kind == DHAT_EVENT_FREE) dhat_commit_free_locked(ev.oldp, ev.at);
+    else if (ev.kind == DHAT_EVENT_RESIZE) dhat_commit_resize_locked(&ev);
+  }
+  mi_lock_release(&dhat_lock);
+}
+
+bool mi_dhat_start(void) mi_attr_noexcept {
+  if (dhat_observer_depth != 0) return false;
+  if (_mi_atomic_once_enter(&dhat_once)) _mi_atomic_once_release(&dhat_once);
+  mi_lock_acquire(&dhat_lock);
+  if (_mi_dhat_is_active()) { mi_lock_release(&dhat_lock); return false; }
+  dhat_release_locked(); dhat_budget = DHAT_DEFAULT_BUDGET; (void)dhat_env_size("MIMALLOC_DHAT_MAX_BYTES", &dhat_budget); dhat_started = _mi_clock_now();
+  mi_atomic_store_release(&dhat_state, DHAT_ENABLED);
+  mi_lock_release(&dhat_lock); return true;
+}
+void mi_dhat_stop(void) mi_attr_noexcept { if (dhat_observer_depth == 0) mi_atomic_store_release(&dhat_state, DHAT_DISABLED); }
+bool mi_dhat_is_enabled(void) mi_attr_noexcept { return _mi_dhat_is_active(); }
+bool mi_dhat_stats_get(mi_dhat_stats_t* out) mi_attr_noexcept {
+  if (out == NULL || out->size != sizeof(*out) || out->version != MI_DHAT_STATS_VERSION) return false;
+  mi_lock_acquire(&dhat_lock);
+  out->enabled = _mi_dhat_is_active(); out->incomplete = mi_atomic_load_relaxed(&dhat_incomplete) != 0;
+  out->total_bytes = dhat_total_bytes; out->total_blocks = dhat_total_blocks; out->live_bytes = dhat_live_bytes; out->live_blocks = dhat_live_blocks;
+  out->peak_bytes = dhat_peak_bytes; out->peak_blocks = dhat_peak_blocks; out->dropped = mi_atomic_load_relaxed(&dhat_dropped); out->internal_bytes = mi_atomic_load_relaxed(&dhat_internal_bytes);
+  mi_lock_release(&dhat_lock); return true;
+}
+
+/* Frame-table order is the order we visit program points below.  The dump is a
+   diagnostic operation, so this allocation-free O(frames^3) lookup is preferable to
+   adding a second persistent hash table solely for serialization. */
+static bool dhat_frame_seen_before_locked(const dhat_pp_t* stop_pp, size_t stop_frame, const void* pc) {
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) {
+    for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
+      const size_t limit = (pp == stop_pp ? stop_frame : pp->depth);
+      for (size_t frame = 0; frame < limit; frame++) if (pp->pcs[frame] == pc) return true;
+      if (pp == stop_pp) return false;
+    }
+  }
+  return false;
+}
+static size_t dhat_frame_index_locked(const dhat_pp_t* wanted, size_t wanted_frame) {
+  size_t index = 0;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
+    for (size_t frame = 0; frame < pp->depth; frame++) {
+      if (pp == wanted && frame == wanted_frame) {
+        if (!dhat_frame_seen_before_locked(pp, frame, pp->pcs[frame])) return index;
+        /* Locate the matching first occurrence, whose index is the count of unique
+           frames that preceded it. */
+        for (size_t j = 0; j < DHAT_BUCKETS; j++) for (dhat_pp_t* prior = dhat_pp_table[j]; prior != NULL; prior = prior->next) {
+          const size_t limit = (prior == pp ? frame : prior->depth);
+          for (size_t pf = 0; pf < limit; pf++) if (prior->pcs[pf] == pp->pcs[frame]) return dhat_frame_index_locked(prior, pf);
+        }
+      }
+      else if (!dhat_frame_seen_before_locked(pp, frame, pp->pcs[frame])) index++;
+    }
+  }
+  return 0;
+}
+static void dhat_write_json_locked(FILE* f) {
+  const uint64_t elapsed = (_mi_clock_now() >= dhat_started ? _mi_clock_now() - dhat_started : 0);
+  /* The standard viewer accepts producer-specific mode strings and extra keys.
+     Keep the required v2 fields conventional; Mtu and tu truthfully say that
+     these are monotonic wall-clock milliseconds rather than Valgrind instructions. */
+  fprintf(f, "{\n  \"dhatFileVersion\": 2,\n  \"mode\": \"mimalloc-heap\",\n  \"verb\": \"Allocated\",\n  \"bklt\": true,\n  \"bkacc\": false,\n  \"tu\": \"ms\",\n  \"Mtu\": \"ms\",\n  \"tuth\": 1,\n  \"cmd\": \"\",\n  \"pid\": 0,\n  \"tg\": %llu,\n  \"te\": %llu,\n  \"mi_dhat_incomplete\": %s,\n  \"pps\": [\n", (unsigned long long)dhat_peak_at, (unsigned long long)elapsed, (mi_atomic_load_relaxed(&dhat_incomplete) ? "true" : "false"));
+  bool first_pp = true;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) {
+    fprintf(f, "%s    {\"tb\": %llu, \"tbk\": %llu, \"tl\": %llu, \"mb\": %llu, \"mbk\": %llu, \"gb\": %llu, \"gbk\": %llu, \"eb\": %llu, \"ebk\": %llu, \"fs\": [", first_pp ? "" : ",\n", (unsigned long long)pp->tb, (unsigned long long)pp->tbk, (unsigned long long)pp->tl, (unsigned long long)pp->mb, (unsigned long long)pp->mbk, (unsigned long long)pp->gb, (unsigned long long)pp->gbk, (unsigned long long)pp->live, (unsigned long long)pp->livek);
+    for (size_t frame = 0; frame < pp->depth; frame++) fprintf(f, "%s%llu", frame == 0 ? "" : ", ", (unsigned long long)dhat_frame_index_locked(pp, frame));
+    fprintf(f, "]}"); first_pp = false;
+  }
+  fprintf(f, "\n  ],\n  \"ftbl\": [");
+  bool first_frame = true;
+  for (size_t i = 0; i < DHAT_BUCKETS; i++) for (dhat_pp_t* pp = dhat_pp_table[i]; pp != NULL; pp = pp->next) for (size_t frame = 0; frame < pp->depth; frame++) {
+    bool seen = false; for (size_t j = 0; j <= i && !seen; j++) for (dhat_pp_t* prior = dhat_pp_table[j]; prior != NULL && !seen; prior = prior->next) { const size_t lim = (prior == pp ? frame : prior->depth); for (size_t pf = 0; pf < lim; pf++) if (prior->pcs[pf] == pp->pcs[frame]) { seen = true; break; } }
+    if (!seen) { fprintf(f, "%s\n    \"0x%llx\"", first_frame ? "" : ",", (unsigned long long)(uintptr_t)pp->pcs[frame]); first_frame = false; }
+  }
+  fprintf(f, "\n  ]\n}\n");
+}
+bool mi_dhat_dump(const char* path) mi_attr_noexcept {
+  if (path == NULL || dhat_observer_depth != 0) return false;
+  FILE* f = fopen(path, "wb"); if (f == NULL) return false;
+  mi_lock_acquire(&dhat_lock); dhat_write_json_locked(f); mi_lock_release(&dhat_lock);
+  const bool ok = (fclose(f) == 0); return ok;
+}
+void _mi_dhat_process_init(void) { dhat_resolve_env(); }
+void _mi_dhat_process_done(void) { if (dhat_dump_at_exit[0] != 0) { const bool dumped = mi_dhat_dump(dhat_dump_at_exit); MI_UNUSED(dumped); } }

--- a/src/dhat.c
+++ b/src/dhat.c
@@ -346,9 +346,19 @@ static void dhat_write_json_locked(FILE* f) {
 }
 bool mi_dhat_dump(const char* path) mi_attr_noexcept {
   if (path == NULL || dhat_observer_depth != 0) return false;
-  FILE* f = fopen(path, "wb"); if (f == NULL) return false;
-  mi_lock_acquire(&dhat_lock); dhat_write_json_locked(f); mi_lock_release(&dhat_lock);
-  const bool ok = (fclose(f) == 0); return ok;
+  /* stdio can allocate (and applications can override those calls with mimalloc).
+     Suppress this thread's dump-time traffic before fopen/fprintf while leaving the
+     report's actual live records untouched; otherwise a reentrant hook could attempt
+     to take dhat_lock while serialization already owns it. */
+  dhat_observer_depth++;
+  FILE* f = fopen(path, "wb");
+  if (f == NULL) { dhat_observer_depth--; return false; }
+  mi_lock_acquire(&dhat_lock);
+  dhat_write_json_locked(f);
+  mi_lock_release(&dhat_lock);
+  const bool ok = (fclose(f) == 0);
+  dhat_observer_depth--;
+  return ok;
 }
 void _mi_dhat_process_init(void) { dhat_resolve_env(); }
 void _mi_dhat_process_done(void) { if (dhat_dump_at_exit[0] != 0) { const bool dumped = mi_dhat_dump(dhat_dump_at_exit); MI_UNUSED(dumped); } }

--- a/src/free.c
+++ b/src/free.c
@@ -82,6 +82,12 @@ static inline void mi_free_block_mt(mi_page_t* page, mi_block_t* block, bool was
   }
   #endif
 
+  /* Commit the global memory observers before publishing this block to the
+     owner thread's reusable list. Otherwise the owner can collect and reuse the
+     address while DHAT still holds its old live record. This mirrors the local
+     free ordering: callbacks run without allocator locks, before list reuse. */
+  _mi_memevt_on_free(page, block);
+
   // push atomically on the page thread free list
   mi_thread_free_t tf_new;
   mi_thread_free_t tf_old = mi_atomic_load_relaxed(&page->xthread_free);
@@ -90,14 +96,6 @@ static inline void mi_free_block_mt(mi_page_t* page, mi_block_t* block, bool was
     const bool new_owned = (allow_collect ? true : mi_tf_is_owned(tf_old));    // if allow collection then always try to claim it if the page is abandoned 
     tf_new = mi_tf_create(block, new_owned);
   } while (!mi_atomic_cas_weak_acq_rel(&page->xthread_free, &tf_old, tf_new)); // todo: release is enough?
-
-  // memory-events (issue #20): this is a genuine remote (cross-thread) free that has just
-  // completed (the block is now pushed onto the page's thread-free list) -- hook here,
-  // mirroring mi_free_block_local's placement (definitely-freeing, page/block still valid).
-  // Deliberately NOT paired with _mi_prof_on_free here: the profiler's only remote-free
-  // counting point is inside the free-collect helper (mi_page_thread_collect_to_local),
-  // to avoid double counting.
-  _mi_memevt_on_free(page, block);
 
   // and atomically try to collect the page if it was abandoned
   if (allow_collect) {

--- a/src/init.c
+++ b/src/init.c
@@ -1183,6 +1183,7 @@ static void mi_process_init_once(void) mi_attr_noexcept {
   #if MI_PPROF
   _mi_prof_process_init();
   #endif
+  _mi_dhat_process_init();
   if (mi_option_is_enabled(mi_option_reserve_huge_os_pages)) {
     size_t pages = mi_option_get_clamp(mi_option_reserve_huge_os_pages, 0, 128*1024);
     int reserve_at  = (int)mi_option_get_clamp(mi_option_reserve_huge_os_pages_at, -1, INT_MAX);
@@ -1237,6 +1238,7 @@ static void mi_process_done_once(void) {
   #if MI_PPROF
   _mi_prof_process_done();
   #endif
+  _mi_dhat_process_done();
 
   // Forcefully release all retained memory; this can be dangerous in general if overriding regular malloc/free
   // since after process_done there might still be other code running that calls `free` (like at_exit routines,

--- a/src/memory-events.c
+++ b/src/memory-events.c
@@ -200,42 +200,55 @@ static void memevt_dispatch(mi_memory_change_kind_t kind, int64_t delta_bytes, u
 // disabled path.
 // ---------------------------------------------------------------------------------------
 
+/* DHAT and the public callback table are independent observers.  The detailed
+   identity context is prepared before dispatch, while the allocator still has the
+   original pointers available; it is committed only after the user callback returns.
+   The shared suppression depth excludes callback-internal and moving-realloc internals
+   from both observers. */
 void _mi_memevt_on_alloc(mi_page_t* page, void* p, size_t request_size) {
-  MI_UNUSED(p);
+  if (memevt_suppress_depth > 0) return;
+  _mi_dhat_begin_alloc(p, request_size);
   size_t state = mi_atomic_load_relaxed(&memevt_state);
-  if mi_likely(state == MEMEVT_DISABLED) return;
   if (state == MEMEVT_UNINIT) { memevt_resolve_env(); state = mi_atomic_load_relaxed(&memevt_state); }
-  if (state != MEMEVT_ENABLED) return;
-  const size_t usable = mi_page_usable_block_size(page);
-  memevt_dispatch(MI_MEMORY_ALLOCATE, (int64_t)usable, (uint64_t)request_size);
+  if (state == MEMEVT_ENABLED) {
+    const size_t usable = mi_page_usable_block_size(page);
+    memevt_dispatch(MI_MEMORY_ALLOCATE, (int64_t)usable, (uint64_t)request_size);
+  }
+  _mi_dhat_finish_event();
 }
 
 void _mi_memevt_on_free(mi_page_t* page, void* p) {
-  MI_UNUSED(p);
+  if (memevt_suppress_depth > 0) return;
+  _mi_dhat_begin_free(p);
   const size_t state = mi_atomic_load_relaxed(&memevt_state);
-  if mi_likely(state == MEMEVT_DISABLED) return;
-  if (state != MEMEVT_ENABLED) return; // MEMEVT_UNINIT: nothing can have been counted yet, nothing to free-account.
-  const size_t usable = mi_page_usable_block_size(page);
-  memevt_dispatch(MI_MEMORY_FREE, -(int64_t)usable, 0);
+  if (state == MEMEVT_ENABLED) {
+    const size_t usable = mi_page_usable_block_size(page);
+    memevt_dispatch(MI_MEMORY_FREE, -(int64_t)usable, 0);
+  }
+  _mi_dhat_finish_event();
 }
 
 void _mi_memevt_on_realloc_in_place(mi_page_t* page, void* p, size_t request_size) {
-  MI_UNUSED(p);
+  if (memevt_suppress_depth > 0) return;
+  _mi_dhat_begin_resize(p, p, request_size);
   const size_t state = mi_atomic_load_relaxed(&memevt_state);
-  if mi_likely(state == MEMEVT_DISABLED) return;
-  if (state != MEMEVT_ENABLED) return;
-  // Same page => same block-size class => usable size is identical before and after;
-  // delta is always exactly 0 (still a real, dispatched RESIZE event, per spec).
-  MI_UNUSED(page);
-  memevt_dispatch(MI_MEMORY_RESIZE, 0, (uint64_t)request_size);
+  if (state == MEMEVT_ENABLED) {
+    // Same page => same block-size class => usable size is identical before and after.
+    MI_UNUSED(page);
+    memevt_dispatch(MI_MEMORY_RESIZE, 0, (uint64_t)request_size);
+  }
+  _mi_dhat_finish_event();
 }
 
-void _mi_memevt_on_resize(size_t usable_pre, size_t usable_post, size_t request_size) {
+void _mi_memevt_on_resize(void* oldp, void* newp, size_t usable_pre, size_t usable_post, size_t request_size) {
+  if (memevt_suppress_depth > 0) return;
+  _mi_dhat_begin_resize(oldp, newp, request_size);
   const size_t state = mi_atomic_load_relaxed(&memevt_state);
-  if mi_likely(state == MEMEVT_DISABLED) return;
-  if (state != MEMEVT_ENABLED) return;
-  const int64_t delta = (int64_t)usable_post - (int64_t)usable_pre;
-  memevt_dispatch(MI_MEMORY_RESIZE, delta, (uint64_t)request_size);
+  if (state == MEMEVT_ENABLED) {
+    const int64_t delta = (int64_t)usable_post - (int64_t)usable_pre;
+    memevt_dispatch(MI_MEMORY_RESIZE, delta, (uint64_t)request_size);
+  }
+  _mi_dhat_finish_event();
 }
 
 // ---------------------------------------------------------------------------------------

--- a/src/static.c
+++ b/src/static.c
@@ -33,6 +33,8 @@ terms of the MIT license. A copy of the license can be found in the file
 #include "init.c"
 #include "libc.c"
 #include "memory-events.c"
+#include "dhat.c"
+#include "dhat-stack.c"
 #include "options.c"
 #include "os.c"
 #include "page.c"           // includes page-queue.c

--- a/test/test-dhat.c
+++ b/test/test-dhat.c
@@ -32,7 +32,6 @@ int main(void) {
   assert(mi_dhat_start());
   /* Empty and budget-exhausted sessions still need a valid, fail-soft JSON dump. */
   assert(mi_dhat_dump("test-dhat-empty.json"));
-  assert(remove("test-dhat-empty.json") == 0);
 
   void* p = mi_malloc(16); assert(p != NULL);
   void* q = mi_malloc(32); assert(q != NULL);
@@ -69,6 +68,7 @@ int main(void) {
 
   mi_dhat_stop();
   assert(!mi_dhat_is_enabled());
+  assert(remove("test-dhat-empty.json") == 0);
   assert(mi_dhat_dump("test-dhat-output.json"));
   FILE* f = fopen("test-dhat-output.json", "rb"); assert(f != NULL);
   char json[8192]; const size_t n = fread(json, 1, sizeof(json) - 1, f); fclose(f); json[n] = 0;

--- a/test/test-dhat.c
+++ b/test/test-dhat.c
@@ -30,6 +30,9 @@ int main(void) {
   callback_counts_t callbacks = { 0, 0, 0 };
   install_callbacks(&callbacks);
   assert(mi_dhat_start());
+  /* Empty and budget-exhausted sessions still need a valid, fail-soft JSON dump. */
+  assert(mi_dhat_dump("test-dhat-empty.json"));
+  assert(remove("test-dhat-empty.json") == 0);
 
   void* p = mi_malloc(16); assert(p != NULL);
   void* q = mi_malloc(32); assert(q != NULL);
@@ -39,7 +42,9 @@ int main(void) {
   mi_dhat_stats_t_decl(mid);
   assert(mi_dhat_stats_get(&mid));
   assert(mid.enabled && !mid.incomplete);
-  assert(mid.total_blocks == 2 && mid.total_bytes == 52);
+  /* realloc is a second allocation call for DHAT totals while retaining p's
+     identity/lifetime, so the 20-byte request adds one block and 20 bytes. */
+  assert(mid.total_blocks == 3 && mid.total_bytes == 68);
   assert(mid.live_blocks == 1 && mid.live_bytes == 20);
   assert(mid.peak_bytes >= 48 && mid.peak_bytes >= mid.live_bytes);
   assert(callbacks.alloc == 2 && callbacks.free == 1 && callbacks.resize == 1);
@@ -51,7 +56,7 @@ int main(void) {
   mi_dhat_stats_t_decl(done);
   assert(mi_dhat_stats_get(&done));
   assert(done.live_blocks == 0 && done.live_bytes == 0);
-  assert(done.total_blocks == 2 && done.total_bytes == 52);
+  assert(done.total_blocks == 3 && done.total_bytes == 68);
 
   mi_dhat_stop();
   assert(!mi_dhat_is_enabled());

--- a/test/test-dhat.c
+++ b/test/test-dhat.c
@@ -1,0 +1,66 @@
+/* Focused exact-DHAT smoke and composition test (issue #238). */
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "mimalloc.h"
+#include "mimalloc/memory-events.h"
+#include "mimalloc/dhat.h"
+
+typedef struct callback_counts_s { int alloc, free, resize; } callback_counts_t;
+static void on_change(const mi_memory_change_t* change, void* arg) {
+  callback_counts_t* counts = (callback_counts_t*)arg;
+  if (change->kind == MI_MEMORY_ALLOCATE) counts->alloc++;
+  else if (change->kind == MI_MEMORY_FREE) counts->free++;
+  else if (change->kind == MI_MEMORY_RESIZE) counts->resize++;
+}
+static void install_callbacks(callback_counts_t* counts) {
+  mi_memory_callbacks_t callbacks;
+  memset(&callbacks, 0, sizeof(callbacks));
+  callbacks.handlers[MI_MEMORY_ALLOCATE] = on_change; callbacks.args[MI_MEMORY_ALLOCATE] = counts;
+  callbacks.handlers[MI_MEMORY_FREE] = on_change; callbacks.args[MI_MEMORY_FREE] = counts;
+  callbacks.handlers[MI_MEMORY_RESIZE] = on_change; callbacks.args[MI_MEMORY_RESIZE] = counts;
+  assert(mi_memory_set_callbacks(&callbacks));
+}
+
+int main(void) {
+  assert(mi_memory_tracking_set_enabled(true));
+  callback_counts_t callbacks = { 0, 0, 0 };
+  install_callbacks(&callbacks);
+  assert(mi_dhat_start());
+
+  void* p = mi_malloc(16); assert(p != NULL);
+  void* q = mi_malloc(32); assert(q != NULL);
+  p = mi_realloc(p, 20); assert(p != NULL); /* exact identity whether this stays put or moves */
+  mi_free(q);
+
+  mi_dhat_stats_t_decl(mid);
+  assert(mi_dhat_stats_get(&mid));
+  assert(mid.enabled && !mid.incomplete);
+  assert(mid.total_blocks == 2 && mid.total_bytes == 52);
+  assert(mid.live_blocks == 1 && mid.live_bytes == 20);
+  assert(mid.peak_bytes >= 48 && mid.peak_bytes >= mid.live_bytes);
+  assert(callbacks.alloc == 2 && callbacks.free == 1 && callbacks.resize == 1);
+
+  mi_free(p);
+  mi_dhat_stats_t_decl(done);
+  assert(mi_dhat_stats_get(&done));
+  assert(done.live_blocks == 0 && done.live_bytes == 0);
+  assert(done.total_blocks == 2 && done.total_bytes == 52);
+
+  mi_dhat_stop();
+  assert(!mi_dhat_is_enabled());
+  assert(mi_dhat_dump("test-dhat-output.json"));
+  FILE* f = fopen("test-dhat-output.json", "rb"); assert(f != NULL);
+  char json[8192]; const size_t n = fread(json, 1, sizeof(json) - 1, f); fclose(f); json[n] = 0;
+  assert(strstr(json, "\"dhatFileVersion\": 2") != NULL);
+  assert(strstr(json, "\"bklt\": true") != NULL);
+  assert(strstr(json, "\"bkacc\": false") != NULL);
+  assert(strstr(json, "\"pps\"") != NULL && strstr(json, "\"ftbl\"") != NULL);
+  assert(remove("test-dhat-output.json") == 0);
+  assert(mi_memory_set_callbacks(NULL));
+  puts("DHAT tests passed");
+  return 0;
+}

--- a/test/test-dhat.c
+++ b/test/test-dhat.c
@@ -43,6 +43,9 @@ int main(void) {
   assert(mid.live_blocks == 1 && mid.live_bytes == 20);
   assert(mid.peak_bytes >= 48 && mid.peak_bytes >= mid.live_bytes);
   assert(callbacks.alloc == 2 && callbacks.free == 1 && callbacks.resize == 1);
+  /* Dump while active: stdio itself may allocate, so this also verifies dump-time
+     recursion suppression and that serialization never re-enters its own lock. */
+  assert(mi_dhat_dump("test-dhat-output.json"));
 
   mi_free(p);
   mi_dhat_stats_t_decl(done);

--- a/test/test-dhat.c
+++ b/test/test-dhat.c
@@ -55,10 +55,17 @@ int main(void) {
   assert(memcmp(&callbacks, &callbacks_before_dump, sizeof(callbacks)) == 0);
 
   mi_free(p);
+
+  /* Force the over-aligned fallback, then exercise its in-place resize. DHAT
+     must report caller requests (16 and 12), never the internal over-allocation. */
+  void* aligned = mi_malloc_aligned(16, 64); assert(aligned != NULL);
+  aligned = mi_realloc_aligned(aligned, 12, 64); assert(aligned != NULL);
+  mi_free(aligned);
+
   mi_dhat_stats_t_decl(done);
   assert(mi_dhat_stats_get(&done));
   assert(done.live_blocks == 0 && done.live_bytes == 0);
-  assert(done.total_blocks == 3 && done.total_bytes == 68);
+  assert(done.total_blocks == 5 && done.total_bytes == 96);
 
   mi_dhat_stop();
   assert(!mi_dhat_is_enabled());

--- a/test/test-dhat.c
+++ b/test/test-dhat.c
@@ -50,7 +50,9 @@ int main(void) {
   assert(callbacks.alloc == 2 && callbacks.free == 1 && callbacks.resize == 1);
   /* Dump while active: stdio itself may allocate, so this also verifies dump-time
      recursion suppression and that serialization never re-enters its own lock. */
+  const callback_counts_t callbacks_before_dump = callbacks;
   assert(mi_dhat_dump("test-dhat-output.json"));
+  assert(memcmp(&callbacks, &callbacks_before_dump, sizeof(callbacks)) == 0);
 
   mi_free(p);
   mi_dhat_stats_t_decl(done);


### PR DESCRIPTION
## Summary
- add an exact, opt-in DHAT v2 heap/lifetime collector independent of sampled pprof
- compose pointer-aware DHAT observation with existing memory-event callbacks, including realloc identity and recursion suppression
- expose C and Rust lifecycle/stats/dump controls; regenerate the Rust amalgamation and document diagnostic usage

Closes #238

## Validation
- `ctest --test-dir build-dhat-on -C Debug --output-on-failure` (23/23)
- `ctest --test-dir build-dhat -C Debug --output-on-failure` (18/18)
- `cargo test --manifest-path rust/Cargo.toml -p mimalloc-pprof`
- `cargo run --manifest-path rust/Cargo.toml -p xtask -- check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)