### PR TITLE
docs: restore ASCII-art banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ A fork of [microsoft/mimalloc](https://github.com/microsoft/mimalloc) that adds
 target alongside Linux and macOS.
 
 ```
+   __  __ ___ __  __    _    _     _     ___   ____
+  |  \/  |_ _|  \/  |  / \  | |   | |   / _ \ / ___|
+  | |\/| || || |\/| | / _ \ | |   | |  | | | | |
+  | |  | || || |  | |/ ___ \| |___| |__| |_| | |___
+  |_|  |_|___|_|  |_/_/   \_\_____|_____\___/ \____|
+
+   ____  ____  ____   ___  _____
+  |  _ \|  _ \|  _ \ / _ \|  ___|
+  | |_) | |_) | |_) | | | | |_
+  |  __/|  __/|  _ <| |_| |  _|
+  |_|   |_|   |_| \_\\___/|_|
+
+      PPROF-COMPATIBLE SAMPLED HEAP PROFILING
+      WINDOWS FIRST-CLASS | LINUX | MACOS
+
+
     malloc / free
           |
           v


### PR DESCRIPTION
Restores the MIMALLOC PPROF ASCII-art banner that was trimmed in the #245 README split, verbatim from the pre-split README, above the pipeline diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WALJDJNg9GRwJyTRZF1kB