### PR TITLE
docs: clarify that a mimalloc 'subprocess' is an in-process partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ so switching is a version bump, not a code change.
 | Lives on | `main` | the [`v2`](https://github.com/zackees/mimalloc-pprof/tree/v2) branch |
 | Upstream base | mimalloc v3 (`upstream/dev3`) | mimalloc v2 (`upstream/main`) |
 | Allocator design | arena-of-slices + page-map; `mi_heap_t`/`mi_theap_t` split | segment allocator |
-| Allocator statistics | **per-heap and per-subprocess** | process-wide totals only |
+| Allocator statistics | **per-heap and per-partition** (a "subproc" — mimalloc's in-process isolation domain, *not* an OS child process) | process-wide totals only |
 | Memory under thread churn (MinGW) | **flat** | leaked in published 0.8.0; fixed on the `v2` branch — [bug 1](docs/upstream-bugs.md#bug-1-thread-exit-cleanup-never-runs-on-mingw--unbounded-memory-leak) |
 
 **Use v3 (0.9.x)** unless you have a specific reason not to. It has strictly more

--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -117,9 +117,19 @@ through to env-then-default. It can force them on.
 
 ## Allocator statistics in the profile (v3 only)
 
-v3 exposes per-heap and per-subprocess counters (`mi_heap_stats_get`,
-`mi_subproc_stats_get`) that v2 had no API for. The profiler surfaces them in two
-places:
+v3 exposes per-heap and per-"subprocess" counters (`mi_heap_stats_get`,
+`mi_subproc_stats_get`) that v2 had no API for.
+
+> **"Subprocess" does not mean an OS child process.** Despite the name, a mimalloc
+> `mi_subproc_t` is an **in-process partition**: a walled-off set of arenas and heaps
+> inside one OS process, whose threads never share or reclaim pages across the wall.
+> Upstream added it so an embedder like CPython can quarantine each subinterpreter's
+> allocations within a single process. Nothing spans OS process boundaries — an
+> actual child process gets its own independent allocator, as always. Every process
+> starts with exactly one default partition, so unless you call `mi_subproc_new`,
+> "per-subprocess" totals and process-wide totals are the same numbers.
+
+The profiler surfaces these counters in two places:
 
 **1. `mi_prof_stats_t` v3 fields** (`MI_PROF_STAT_VERSION` 3) — `heap_committed`,
 `heap_reserved`, `heap_malloc_requested`, `heap_pages`, `heap_pages_abandoned`,


### PR DESCRIPTION
"Subprocess" universally means an OS child process, so the README's "per-subprocess statistics" reads as if the allocator somehow spans process boundaries — impossible, and not what `mi_subproc_t` is. It's an **in-process** partition: its own arenas and heaps inside one OS process, no page sharing across the wall, added upstream so embedders like CPython can quarantine subinterpreters.

- README v2/v3 table row now says **per-heap and per-partition** with the disclaimer inline.
- `docs/profiler.md` gains a callout explaining the term where the stats API is documented.
- Upstream API identifiers (`mi_subproc_*`) are untouched.

Link check: all relative links/anchors still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WALJDJNg9GRwJyTRZF1kB