### PR TITLE
docs: add long-term maintenance commitment to 'Why use this fork'

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ failed review stayed out, each with its reasoning recorded
 upstream mimalloc, TCMalloc, and jemalloc on every publication cycle, with sealed
 artifacts and reproduction commands — see [Performance](#performance).
 
+**Committed to for the long term.** [Zach Vorhies](https://github.com/zackees),
+the author, commits to maintaining this fork long-term.
+[Pull requests](https://github.com/zackees/mimalloc-pprof/pulls) are welcome and
+will be reviewed — and held to the same bar as everything else here: every
+contribution passes the full four-platform CI matrix and its gates before it
+lands, so quality is maintained by machinery, not just intent.
+
 ---
 
 ## Quick start


### PR DESCRIPTION
Adds a seventh pillar to the **Why use this fork** section: the author commits to long-term maintenance, pull requests are welcome and reviewed, and every contribution is held to the full four-platform CI matrix and its gates before landing — quality maintained by machinery, not just intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WALJDJNg9GRwJyTRZF1kB