### PR TITLE
docs: point Quick start readers at the other three instruments

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ stack-flag guidance, cross-compilation — is in
 **[docs/c-integration.md](docs/c-integration.md)** and
 **[docs/rust-integration.md](docs/rust-integration.md)**.
 
+The sampled profiler is one of four instruments here — exact allocator
+counters, DHAT-style exact heap/lifetime profiling, and a memory-events API
+are covered in [Profiling and observability](#profiling-and-observability).
+
 ---
 
 ## Performance


### PR DESCRIPTION
Quick start stays focused on the pprof path (the repo's name is a promise), but now ends with a three-line funnel into **Profiling and observability** for the exact allocator counters, DHAT profiling, and the memory-events API — no duplicated snippets, just discoverability at the moment of peak curiosity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WALJDJNg9GRwJyTRZF1kB