### PR TITLE
docs: add star history chart near the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ top reports, and profile diffs.
 Profiling is **opt-in at runtime**: a build with `MI_PPROF=ON` (the default) does
 not sample until you call a start API or set `MIMALLOC_PROF=1`.
 
+<a href="https://star-history.com/#zackees/mimalloc-pprof&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=zackees/mimalloc-pprof&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=zackees/mimalloc-pprof&type=Date" />
+    <img alt="Star history for zackees/mimalloc-pprof" src="https://api.star-history.com/svg?repos=zackees/mimalloc-pprof&type=Date" width="600" />
+  </picture>
+</a>
+
 **Contents**
 
 - [Why use this fork](#why-use-this-fork) — the most tested mimalloc fork in existence


### PR DESCRIPTION
Adds a GitHub star history chart from star-history.com, placed after the intro paragraphs and before the Contents TOC — visible on the first scroll without displacing the ASCII banner or tagline.

Uses a `<picture>` element so the chart follows the viewer's GitHub theme (light/dark); both variants verified to return `image/svg+xml` HTTP 200. Sized to 600px so it complements rather than dominates the top of the page, and links through to the interactive star-history page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WALJDJNg9GRwJyTRZF1kB