### PR TITLE
docs: render the star chart full width

### DIFF
--- a/.github/assets/star-history-dark.svg
+++ b/.github/assets/star-history-dark.svg
@@ -1,23 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400" role="img" aria-label="Star history for zackees/mimalloc-pprof">
-<rect width="800" height="400" fill="#0d1117"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-label="Star history for zackees/mimalloc-pprof">
+<rect width="1000" height="360" fill="#0d1117"/>
 <g font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
-<text x="64" y="28" font-size="16" font-weight="600" fill="#e6edf3">Star history</text>
-<text x="776" y="28" font-size="12" text-anchor="end" fill="#8b949e">zackees/mimalloc-pprof</text>
-<line x1="64" y1="352.00" x2="776" y2="352.00" stroke="#30363d" stroke-width="1"/>
-<text x="54" y="356.00" font-size="11" text-anchor="end" fill="#8b949e">0</text>
-<line x1="64" y1="291.20" x2="776" y2="291.20" stroke="#30363d" stroke-width="1"/>
-<text x="54" y="295.20" font-size="11" text-anchor="end" fill="#8b949e">5</text>
-<line x1="64" y1="230.40" x2="776" y2="230.40" stroke="#30363d" stroke-width="1"/>
-<text x="54" y="234.40" font-size="11" text-anchor="end" fill="#8b949e">10</text>
-<line x1="64" y1="169.60" x2="776" y2="169.60" stroke="#30363d" stroke-width="1"/>
-<text x="54" y="173.60" font-size="11" text-anchor="end" fill="#8b949e">15</text>
-<line x1="64" y1="108.80" x2="776" y2="108.80" stroke="#30363d" stroke-width="1"/>
-<text x="54" y="112.80" font-size="11" text-anchor="end" fill="#8b949e">20</text>
-<line x1="64" y1="48.00" x2="776" y2="48.00" stroke="#30363d" stroke-width="1"/>
-<text x="54" y="52.00" font-size="11" text-anchor="end" fill="#8b949e">25</text>
-<text x="64.00" y="374.00" font-size="11" text-anchor="start" fill="#8b949e">2026-07-25</text>
-<text x="776.00" y="374.00" font-size="11" text-anchor="end" fill="#8b949e">2026-09-01</text>
-<path d="M 64.00 339.84 L 64.00 327.68 L 64.00 315.52 L 82.74 303.36 L 101.47 291.20 L 101.47 279.04 L 120.21 266.88 L 120.21 254.72 L 138.95 242.56 L 157.68 230.40 L 157.68 218.24 L 213.89 206.08 L 232.63 193.92 L 251.37 181.76 L 251.37 169.60 L 345.05 157.44 L 363.79 145.28 L 382.53 133.12 L 494.95 120.96 L 776.00 108.80 L 776.00 96.64 L 776.00 84.48 L 776.00 72.32 L 776.00 352.00 L 64.00 352.00 Z" fill="rgba(88,166,255,0.15)" stroke="none"/>
-<path d="M 64.00 339.84 L 64.00 327.68 L 64.00 315.52 L 82.74 303.36 L 101.47 291.20 L 101.47 279.04 L 120.21 266.88 L 120.21 254.72 L 138.95 242.56 L 157.68 230.40 L 157.68 218.24 L 213.89 206.08 L 232.63 193.92 L 251.37 181.76 L 251.37 169.60 L 345.05 157.44 L 363.79 145.28 L 382.53 133.12 L 494.95 120.96 L 776.00 108.80 L 776.00 96.64 L 776.00 84.48 L 776.00 72.32" fill="none" stroke="#58a6ff" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
-<circle cx="776.00" cy="72.32" r="3.5" fill="#58a6ff"/>
+<text x="64" y="28" font-size="18" font-weight="600" fill="#e6edf3">Star history</text>
+<text x="976" y="28" font-size="13" text-anchor="end" fill="#8b949e">zackees/mimalloc-pprof</text>
+<line x1="64" y1="312.00" x2="976" y2="312.00" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="316.00" font-size="12" text-anchor="end" fill="#8b949e">0</text>
+<line x1="64" y1="259.20" x2="976" y2="259.20" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="263.20" font-size="12" text-anchor="end" fill="#8b949e">5</text>
+<line x1="64" y1="206.40" x2="976" y2="206.40" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="210.40" font-size="12" text-anchor="end" fill="#8b949e">10</text>
+<line x1="64" y1="153.60" x2="976" y2="153.60" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="157.60" font-size="12" text-anchor="end" fill="#8b949e">15</text>
+<line x1="64" y1="100.80" x2="976" y2="100.80" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="104.80" font-size="12" text-anchor="end" fill="#8b949e">20</text>
+<line x1="64" y1="48.00" x2="976" y2="48.00" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="52.00" font-size="12" text-anchor="end" fill="#8b949e">25</text>
+<text x="64.00" y="334.00" font-size="12" text-anchor="start" fill="#8b949e">2026-07-25</text>
+<text x="976.00" y="334.00" font-size="12" text-anchor="end" fill="#8b949e">2026-09-01</text>
+<path d="M 64.00 301.44 L 64.00 290.88 L 64.00 280.32 L 88.00 269.76 L 112.00 259.20 L 112.00 248.64 L 136.00 238.08 L 136.00 227.52 L 160.00 216.96 L 184.00 206.40 L 184.00 195.84 L 256.00 185.28 L 280.00 174.72 L 304.00 164.16 L 304.00 153.60 L 424.00 143.04 L 448.00 132.48 L 472.00 121.92 L 616.00 111.36 L 976.00 100.80 L 976.00 90.24 L 976.00 79.68 L 976.00 69.12 L 976.00 312.00 L 64.00 312.00 Z" fill="rgba(88,166,255,0.15)" stroke="none"/>
+<path d="M 64.00 301.44 L 64.00 290.88 L 64.00 280.32 L 88.00 269.76 L 112.00 259.20 L 112.00 248.64 L 136.00 238.08 L 136.00 227.52 L 160.00 216.96 L 184.00 206.40 L 184.00 195.84 L 256.00 185.28 L 280.00 174.72 L 304.00 164.16 L 304.00 153.60 L 424.00 143.04 L 448.00 132.48 L 472.00 121.92 L 616.00 111.36 L 976.00 100.80 L 976.00 90.24 L 976.00 79.68 L 976.00 69.12" fill="none" stroke="#58a6ff" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="976.00" cy="69.12" r="3.5" fill="#58a6ff"/>
 </g></svg>

--- a/.github/assets/star-history-light.svg
+++ b/.github/assets/star-history-light.svg
@@ -1,23 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400" role="img" aria-label="Star history for zackees/mimalloc-pprof">
-<rect width="800" height="400" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="1000" height="360" role="img" aria-label="Star history for zackees/mimalloc-pprof">
+<rect width="1000" height="360" fill="#ffffff"/>
 <g font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
-<text x="64" y="28" font-size="16" font-weight="600" fill="#1f2328">Star history</text>
-<text x="776" y="28" font-size="12" text-anchor="end" fill="#59636e">zackees/mimalloc-pprof</text>
-<line x1="64" y1="352.00" x2="776" y2="352.00" stroke="#d8dee4" stroke-width="1"/>
-<text x="54" y="356.00" font-size="11" text-anchor="end" fill="#59636e">0</text>
-<line x1="64" y1="291.20" x2="776" y2="291.20" stroke="#d8dee4" stroke-width="1"/>
-<text x="54" y="295.20" font-size="11" text-anchor="end" fill="#59636e">5</text>
-<line x1="64" y1="230.40" x2="776" y2="230.40" stroke="#d8dee4" stroke-width="1"/>
-<text x="54" y="234.40" font-size="11" text-anchor="end" fill="#59636e">10</text>
-<line x1="64" y1="169.60" x2="776" y2="169.60" stroke="#d8dee4" stroke-width="1"/>
-<text x="54" y="173.60" font-size="11" text-anchor="end" fill="#59636e">15</text>
-<line x1="64" y1="108.80" x2="776" y2="108.80" stroke="#d8dee4" stroke-width="1"/>
-<text x="54" y="112.80" font-size="11" text-anchor="end" fill="#59636e">20</text>
-<line x1="64" y1="48.00" x2="776" y2="48.00" stroke="#d8dee4" stroke-width="1"/>
-<text x="54" y="52.00" font-size="11" text-anchor="end" fill="#59636e">25</text>
-<text x="64.00" y="374.00" font-size="11" text-anchor="start" fill="#59636e">2026-07-25</text>
-<text x="776.00" y="374.00" font-size="11" text-anchor="end" fill="#59636e">2026-09-01</text>
-<path d="M 64.00 339.84 L 64.00 327.68 L 64.00 315.52 L 82.74 303.36 L 101.47 291.20 L 101.47 279.04 L 120.21 266.88 L 120.21 254.72 L 138.95 242.56 L 157.68 230.40 L 157.68 218.24 L 213.89 206.08 L 232.63 193.92 L 251.37 181.76 L 251.37 169.60 L 345.05 157.44 L 363.79 145.28 L 382.53 133.12 L 494.95 120.96 L 776.00 108.80 L 776.00 96.64 L 776.00 84.48 L 776.00 72.32 L 776.00 352.00 L 64.00 352.00 Z" fill="rgba(9,105,218,0.12)" stroke="none"/>
-<path d="M 64.00 339.84 L 64.00 327.68 L 64.00 315.52 L 82.74 303.36 L 101.47 291.20 L 101.47 279.04 L 120.21 266.88 L 120.21 254.72 L 138.95 242.56 L 157.68 230.40 L 157.68 218.24 L 213.89 206.08 L 232.63 193.92 L 251.37 181.76 L 251.37 169.60 L 345.05 157.44 L 363.79 145.28 L 382.53 133.12 L 494.95 120.96 L 776.00 108.80 L 776.00 96.64 L 776.00 84.48 L 776.00 72.32" fill="none" stroke="#0969da" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
-<circle cx="776.00" cy="72.32" r="3.5" fill="#0969da"/>
+<text x="64" y="28" font-size="18" font-weight="600" fill="#1f2328">Star history</text>
+<text x="976" y="28" font-size="13" text-anchor="end" fill="#59636e">zackees/mimalloc-pprof</text>
+<line x1="64" y1="312.00" x2="976" y2="312.00" stroke="#d8dee4" stroke-width="1"/>
+<text x="54" y="316.00" font-size="12" text-anchor="end" fill="#59636e">0</text>
+<line x1="64" y1="259.20" x2="976" y2="259.20" stroke="#d8dee4" stroke-width="1"/>
+<text x="54" y="263.20" font-size="12" text-anchor="end" fill="#59636e">5</text>
+<line x1="64" y1="206.40" x2="976" y2="206.40" stroke="#d8dee4" stroke-width="1"/>
+<text x="54" y="210.40" font-size="12" text-anchor="end" fill="#59636e">10</text>
+<line x1="64" y1="153.60" x2="976" y2="153.60" stroke="#d8dee4" stroke-width="1"/>
+<text x="54" y="157.60" font-size="12" text-anchor="end" fill="#59636e">15</text>
+<line x1="64" y1="100.80" x2="976" y2="100.80" stroke="#d8dee4" stroke-width="1"/>
+<text x="54" y="104.80" font-size="12" text-anchor="end" fill="#59636e">20</text>
+<line x1="64" y1="48.00" x2="976" y2="48.00" stroke="#d8dee4" stroke-width="1"/>
+<text x="54" y="52.00" font-size="12" text-anchor="end" fill="#59636e">25</text>
+<text x="64.00" y="334.00" font-size="12" text-anchor="start" fill="#59636e">2026-07-25</text>
+<text x="976.00" y="334.00" font-size="12" text-anchor="end" fill="#59636e">2026-09-01</text>
+<path d="M 64.00 301.44 L 64.00 290.88 L 64.00 280.32 L 88.00 269.76 L 112.00 259.20 L 112.00 248.64 L 136.00 238.08 L 136.00 227.52 L 160.00 216.96 L 184.00 206.40 L 184.00 195.84 L 256.00 185.28 L 280.00 174.72 L 304.00 164.16 L 304.00 153.60 L 424.00 143.04 L 448.00 132.48 L 472.00 121.92 L 616.00 111.36 L 976.00 100.80 L 976.00 90.24 L 976.00 79.68 L 976.00 69.12 L 976.00 312.00 L 64.00 312.00 Z" fill="rgba(9,105,218,0.12)" stroke="none"/>
+<path d="M 64.00 301.44 L 64.00 290.88 L 64.00 280.32 L 88.00 269.76 L 112.00 259.20 L 112.00 248.64 L 136.00 238.08 L 136.00 227.52 L 160.00 216.96 L 184.00 206.40 L 184.00 195.84 L 256.00 185.28 L 280.00 174.72 L 304.00 164.16 L 304.00 153.60 L 424.00 143.04 L 448.00 132.48 L 472.00 121.92 L 616.00 111.36 L 976.00 100.80 L 976.00 90.24 L 976.00 79.68 L 976.00 69.12" fill="none" stroke="#0969da" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="976.00" cy="69.12" r="3.5" fill="#0969da"/>
 </g></svg>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ not sample until you call a start API or set `MIMALLOC_PROF=1`.
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset=".github/assets/star-history-dark.svg" />
   <source media="(prefers-color-scheme: light)" srcset=".github/assets/star-history-light.svg" />
-  <img alt="Star history for zackees/mimalloc-pprof" src=".github/assets/star-history-light.svg" width="600" />
+  <img alt="Star history for zackees/mimalloc-pprof" src=".github/assets/star-history-light.svg" width="100%" />
 </picture>
 
 **Contents**

--- a/ci/star_history.py
+++ b/ci/star_history.py
@@ -39,8 +39,8 @@ from typing import NamedTuple, Optional, cast
 DEFAULT_REPO = "zackees/mimalloc-pprof"
 
 # Chart geometry, in user units (the SVG scales to whatever width it is given).
-WIDTH = 800
-HEIGHT = 400
+WIDTH = 1000
+HEIGHT = 360
 PAD_LEFT = 64
 PAD_RIGHT = 24
 PAD_TOP = 48
@@ -250,9 +250,9 @@ def render_svg(series: list[Point], repo: str, theme: Theme) -> str:
         f'aria-label="Star history for {escape(repo)}">',
         f'<rect width="{WIDTH}" height="{HEIGHT}" fill="{theme.background}"/>',
         '<g font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">',
-        f'<text x="{PAD_LEFT}" y="28" font-size="16" font-weight="600" '
+        f'<text x="{PAD_LEFT}" y="28" font-size="18" font-weight="600" '
         f'fill="{theme.text}">Star history</text>',
-        f'<text x="{WIDTH - PAD_RIGHT}" y="28" font-size="12" text-anchor="end" '
+        f'<text x="{WIDTH - PAD_RIGHT}" y="28" font-size="13" text-anchor="end" '
         f'fill="{theme.muted}">{escape(repo)}</text>',
     ]
 
@@ -263,7 +263,7 @@ def render_svg(series: list[Point], repo: str, theme: Theme) -> str:
             f'stroke="{theme.grid}" stroke-width="1"/>'
         )
         parts.append(
-            f'<text x="{PAD_LEFT - 10}" y="{y + 4:.2f}" font-size="11" text-anchor="end" '
+            f'<text x="{PAD_LEFT - 10}" y="{y + 4:.2f}" font-size="12" text-anchor="end" '
             f'fill="{theme.muted}">{tick}</text>'
         )
 
@@ -271,7 +271,7 @@ def render_svg(series: list[Point], repo: str, theme: Theme) -> str:
         label = date.fromordinal(ordinal).isoformat()
         anchor = "start" if ordinal == first_day else "end"
         parts.append(
-            f'<text x="{x_of(ordinal):.2f}" y="{HEIGHT - PAD_BOTTOM + 22:.2f}" font-size="11" '
+            f'<text x="{x_of(ordinal):.2f}" y="{HEIGHT - PAD_BOTTOM + 22:.2f}" font-size="12" '
             f'text-anchor="{anchor}" fill="{theme.muted}">{label}</text>'
         )
 


### PR DESCRIPTION
The chart was pinned to `width="600"`, leaving dead space to the right of it in the README column.

- README `<img>` goes to `width="100%"`.
- SVG geometry reshaped from 800×400 to **1000×360**, because a 2:1 chart stretched to full width becomes a tall block. At the ~840px README column it now renders **840×302** — full width, and no taller than the old 600px version.
- Font sizes bumped proportionally (18/13/12) so they stay legible once the SVG scales down to the column width.

Verified by rendering the dark SVG at the target column width and inspecting it. `ruff check`, `ruff format --check`, `pyright` strict, and the generator's `--check` idempotence all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WALJDJNg9GRwJyTRZF1kB