### PR TITLE
docs: make the MI_PROF_CONFIG_OVERRIDE snippet self-contained

### DIFF
--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -101,6 +101,9 @@ process-wide.
 do not rely on the variable names — use `MI_PROF_CONFIG_OVERRIDE`:**
 
 ```c
+#include <mimalloc.h>
+#include <mimalloc/profile.h>
+
 mi_prof_config_t_decl(cfg);           /* zeroed, with size + version filled in */
 cfg.mode = MI_PROF_CONFIG_OVERRIDE;   /* struct wins over env, field by field */
 cfg.sample_interval = 2048;


### PR DESCRIPTION
Now that C compilers are available in the dev environment, I compiled **every fenced ```c block in the README and docs/** against `include/` with gcc 15.2 and clang 21.1 under `-Wall -Wextra -Werror`.

Results: 7 blocks checked. The two README blocks pass — including the allocator-stats snippet added in #258, which was previously verified only by header inspection. One real defect found:

- **`docs/profiler.md`** — the `MI_PROF_CONFIG_OVERRIDE` example named no headers, so copying it verbatim yields implicit declarations of `mi_prof_config_t_decl` and `mi_prof_start_ex`. Every other C snippet in the docs includes what it uses. Fixed; it now compiles clean under both compilers.

The one remaining checker failure is **not** a defect: `docs/upstreaming.md` block 1 is an intentional patch excerpt showing part of an upstream `#if` block, so its unterminated `#if` is correct and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WALJDJNg9GRwJyTRZF1kB