### PR TITLE
docs: give the DHAT section Rust and C examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,15 +250,47 @@ two apart. Full field list and the rest of the caveats:
 
 When sampling isn't enough — you want **every** allocation's size and lifetime —
 run a short, focused session under the exact DHAT observer and open the result
-in Valgrind's `dh_view.html`:
+in Valgrind's [`dh_view.html`](https://valgrind.org/docs/manual/dh-manual.html).
+No code needed at all:
 
 ```sh
 MIMALLOC_DHAT=1 MIMALLOC_DHAT_DUMP_AT_EXIT=heap.dhat.json ./my_app
 ```
 
-Or from code: `mi_dhat_start()` … `mi_dhat_dump("heap.dhat.json")` from
-`<mimalloc/dhat.h>`. It's exact and high-overhead — for tests and
-investigations, not production. Budgeting, caveats, and the API:
+#### Rust
+
+```rust
+use mimalloc_pprof::dhat;
+use std::path::Path;
+
+assert!(dhat::start(), "DHAT already running");
+
+let retained = vec![0_u8; 1024 * 1024];
+std::hint::black_box(&retained);
+
+dhat::stop();  // stop observing; the retained records still dump
+dhat::dump_file(Path::new("heap.dhat.json")).expect("write DHAT report");
+```
+
+#### C
+
+```c
+#include <mimalloc.h>
+#include <mimalloc/dhat.h>
+
+if (!mi_dhat_start()) return 1;
+
+void* p = mi_malloc(4096);
+mi_free(p);
+
+mi_dhat_stop();                             /* stop observing; report still dumps */
+if (!mi_dhat_dump("heap.dhat.json")) return 2;
+```
+
+Unlike the sampled profiler this keeps a record for **every** live allocation, so
+it is exact but high-overhead — use it for tests and focused investigations, not a
+continuously running production workload. Memory budgeting
+(`MIMALLOC_DHAT_MAX_BYTES`), partial-report semantics, and the stats API:
 **[docs/dhat-and-memory-events.md](docs/dhat-and-memory-events.md)**.
 
 ### Going deeper


### PR DESCRIPTION
DHAT was the odd one out in Quick start: the pprof and allocator-stats sections each show **Rust** and **C**, while DHAT showed only an env-var invocation plus a prose mention of the C API. This brings it to the same level.

- **Rust** example using the `mimalloc_pprof::dhat` module (`start` / `stop` / `dump_file`), which mirrors the `prof` API.
- **C** example using `mi_dhat_start` / `mi_dhat_stop` / `mi_dhat_dump`, checking the `nodiscard` dump result.
- Keeps the zero-code env-var invocation up top, since that's the fastest path.
- States the tradeoff where the reader is deciding: it keeps a record for **every** live allocation, so it is exact but high-overhead — tests and focused investigations, not a running production workload. Links `MIMALLOC_DHAT_MAX_BYTES` budgeting and the stats API.

## Verification

- **C block**: compiled by the new `ci/check_doc_snippets.py` gate (#260) under gcc 15.2 and clang 21.1 with `-Wall -Wextra -Werror`. The gate picked the new block up automatically — 7 blocks now checked, up from 6, all passing. First real dividend from that gate.
- **Rust block**: type-checked against the actual crate with `cargo check` (built clean; the `#pragma once` warnings in the output are pre-existing, from the vendored amalgamated C). The scratch example used for that check was removed and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WALJDJNg9GRwJyTRZF1kB