### PR TITLE
docs: group Quick start by instrument

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,13 @@ lands, so quality is maintained by machinery, not just intent.
 
 ## Quick start
 
-### Rust
+Three instruments, each shown in Rust and C: **pprof** sampled profiling for
+production, **exact allocator stats** to check a sampled profile against, and
+**DHAT** exact profiling for focused investigations.
+
+### pprof: sampled heap profiling
+
+#### Rust
 
 ```toml
 [dependencies]
@@ -155,7 +161,7 @@ fn main() -> std::io::Result<()> {
 }
 ```
 
-### C
+#### C
 
 ```sh
 cmake -S . -B build -DMI_PPROF=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -181,20 +187,20 @@ int main(void) {
 `mi_prof_start` and `mi_prof_dump` are `nodiscard` — check their results or the
 compiler will warn.
 
-### Or without touching the code at all
+#### Or without touching the code at all
 
 ```sh
 MIMALLOC_PROF=1 MIMALLOC_PROF_DUMP_AT_EXIT=heap.prof ./my_app
 ```
 
-### Then read the profile
+#### Then read the profile
 
 ```sh
 pprof -http=:0 ./my_app heap.prof     # interactive
 pprof -top ./my_app heap.prof         # text summary
 ```
 
-### ⚠️ The flags your stacks depend on
+#### ⚠️ The flags your stacks depend on
 
 On Linux/macOS the profiler walks frame pointers, and **your** code must keep
 them — the failure mode is silently truncated stacks, not an error:


### PR DESCRIPTION
Quick start read as one long pprof walkthrough with allocator stats and DHAT bolted on the end, so the three instruments weren't visibly peers. This makes the hierarchy match the content:

```
## Quick start
### pprof: sampled heap profiling     <- new heading, groups what was already there
    #### Rust / #### C / #### Or without touching the code
    #### Then read the profile / #### ⚠️ The flags your stacks depend on
### Exact allocator stats
    #### Rust / #### C
### DHAT: exact heap profiling
    #### Rust / #### C
### Going deeper
```

The pprof and DHAT headings are deliberately parallel — *sampled* vs *exact* heap profiling — since that contrast is the actual choice a reader is making. Also adds a one-line orientation naming the three.

**Structural only:** no example code or prose was changed. Verified — the diff outside heading levels is just the three new intro lines, all 7 C blocks still compile under the doc-snippet gate, and every link/anchor still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WALJDJNg9GRwJyTRZF1kB