### PR TITLE
ci: cancel superseded workflow runs per ref (#277 phase 0)

### DIFF
--- a/.github/workflows/amalgamation-drift.yml
+++ b/.github/workflows/amalgamation-drift.yml
@@ -23,6 +23,11 @@ on:
     branches: [main, v4]
   pull_request:
 
+concurrency:
+  # Pure verification: a superseded push's answer is worthless.
+  group: amalgamation-drift-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: vendored C amalgamation matches src/

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -18,6 +18,11 @@ on:
       - 'CMakeLists.txt'
       - '.github/workflows/asan.yml'
 
+concurrency:
+  # Pure verification: a superseded push's answer is worthless.
+  group: asan-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   asan:
     name: address sanitizer

--- a/.github/workflows/benchmark-sentinel.yml
+++ b/.github/workflows/benchmark-sentinel.yml
@@ -17,6 +17,11 @@ on:
 env:
   SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
+concurrency:
+  # PR-tier sentinel; artifact-only, publishes nothing (see #171).
+  group: benchmark-sentinel-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sentinel:
     name: benchmark-sentinel (${{ matrix.os }})

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -12,6 +12,11 @@ on:
       - 'ci/**'
       - '.github/workflows/c-unit.yml'
 
+concurrency:
+  # The macOS/Windows queue hog (#277). A superseded push's ctest result is worthless.
+  group: c-unit-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ctest:
     strategy:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -18,6 +18,11 @@ on:
       - rust/**
       - .github/workflows/cross.yml
 
+concurrency:
+  # Measured ~4 h / ~5.5 h queue waits on the Apple rows (#277).
+  group: cross-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-linux:
     name: build (${{ matrix.target }})

--- a/.github/workflows/doc-snippets.yml
+++ b/.github/workflows/doc-snippets.yml
@@ -23,6 +23,11 @@ on:
       - 'ci/check_doc_snippets.py'
       - '.github/workflows/doc-snippets.yml'
 
+concurrency:
+  # Pure verification: a superseded push's answer is worthless.
+  group: doc-snippets-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,6 +20,13 @@ on:
   schedule:
     - cron: '0 4 * * *'   # nightly, longer budget
 
+concurrency:
+  # event_name is in the group on purpose: a scheduled run carries ref=refs/heads/main,
+  # so without it the nightly 2,000,000-iteration run and a main push would cancel each
+  # other. Same-event runs on the same ref still supersede.
+  group: fuzz-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -16,6 +16,11 @@ on:
       - '.github/workflows/python-lint.yml'
       - '.github/workflows/benchmark-*.yml'
 
+concurrency:
+  # Pure verification: a superseded push's answer is worthless.
+  group: python-lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,11 @@ on:
   workflow_dispatch:   # run the workflow manually 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true # Cancel any in-progress runs of this workflow when a new run is triggered on the same ref (branch or tag)
+  # Never cancel: this workflow uploads release assets to a GitHub Release, and a
+  # cancelled run leaves that release half-populated. Inherited from upstream as
+  # cancel-in-progress: true; flipped in #277 phase 0.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -9,6 +9,11 @@ on:
       - 'ci/check_crate_package.py'
       - '.github/workflows/rust-native.yml'
 
+concurrency:
+  # Its only publish-shaped step is `cargo publish --dry-run`, which uploads nothing.
+  group: rust-native-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,13 @@ on:
     - cron: "15 21 * * *"  # minute, hour, day (1-31), month (1-12), day of the week (0 - 6 or SUN-SAT)
 
 name: Close inactive issues
+
+concurrency:
+  # Never cancel: it closes/labels issues and PRs, so a half-run leaves the repo in a
+  # partially-swept state.
+  group: stale-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/zero-tracking.yml
+++ b/.github/workflows/zero-tracking.yml
@@ -17,6 +17,11 @@ on:
       - 'test/bench-zero-tracking.c'
       - '.github/workflows/zero-tracking.yml'
 
+concurrency:
+  # A/B timing report on a path-filtered PR; produces no artifact anyone waits on.
+  group: zero-tracking-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ab:
     strategy:

--- a/ci/ci_queue_wait.py
+++ b/ci/ci_queue_wait.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env -S uv run --script
+"""Measure GitHub Actions queue wait and execution time per runner label.
+
+Issue #277 phase 0. Every push spawns one fresh VM per job and nothing cancels the
+previous push's jobs, so a busy PR piles superseded runs onto the scarce macOS pool --
+`cross.yml` run 33055011757 shows an Apple row that waited hours after its build had
+already finished. `concurrency: cancel-in-progress` is supposed to fix that, and this
+script is how we tell whether it did: run it before the change, run it after, compare.
+
+Two numbers per job, both straight from the API:
+
+    queue wait  = started_at   - created_at
+    execution   = completed_at - started_at
+
+grouped by the job's `labels` (what `runs-on:` resolved to), because the whole point is
+that `macos-latest` behaves nothing like `ubuntu-latest`.
+
+CAVEAT, and it matters for `cross.yml`: a job that `needs:` another is *created* when the
+run is created, not when its dependency finishes. Its "queue wait" therefore includes the
+time its dependencies spent building. `c-unit.yml` and `rust-native.yml` have no `needs:`
+edges, so their rows are pure pool-wait; `cross.yml`'s `test (*)` rows are not. Rows are
+grouped per workflow, never pooled across workflows, so the two kinds never end up in one
+average -- but read a `cross.yml` row as "wait + upstream build", not as pool wait alone.
+
+Usage:
+
+    uv run ci/ci_queue_wait.py --limit 20 c-unit.yml cross.yml rust-native.yml
+    uv run ci/ci_queue_wait.py --branch main --limit 20 c-unit.yml
+
+Needs only `gh` (already authenticated in CI and on developer machines); no Python deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+REPO_DEFAULT = "zackees/mimalloc-pprof"
+
+# Conclusions whose timestamps describe something other than "a job ran to completion".
+# A cancelled job's completed_at is when the cancellation landed, and a skipped job never
+# started at all; averaging either into an execution time is how a measurement lies.
+_EXCLUDED_CONCLUSIONS = frozenset({"skipped", "cancelled", "neutral", "stale"})
+
+
+# --------------------------------------------------------------------------------------
+# JSON narrowing. The API responses are `object` as far as the type checker is concerned;
+# every field is proven before use rather than indexed on faith (docs/ci-gates.md).
+# --------------------------------------------------------------------------------------
+
+
+def _as_object(value: object) -> dict[str, object] | None:
+    # json.loads only ever produces str-keyed objects, so the cast restates a guarantee
+    # the parser already made; it is not a claim about the field's contents, which every
+    # accessor below re-checks.
+    return cast("dict[str, object]", value) if isinstance(value, dict) else None
+
+
+def _as_array(value: object) -> list[object]:
+    return cast("list[object]", value) if isinstance(value, list) else []
+
+
+def _as_str(obj: dict[str, object], key: str) -> str | None:
+    value = obj.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _as_int(obj: dict[str, object], key: str) -> int | None:
+    value = obj.get(key)
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def _as_str_list(obj: dict[str, object], key: str) -> list[str]:
+    return [item for item in _as_array(obj.get(key)) if isinstance(item, str)]
+
+
+def _parse_ts(text: str | None) -> datetime | None:
+    """Parse a GitHub ISO-8601 timestamp (`2026-09-01T12:34:56Z`)."""
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+# --------------------------------------------------------------------------------------
+# Model
+# --------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class JobRecord:
+    """One completed job with all three timestamps present."""
+
+    workflow: str
+    run_id: int
+    job_id: int
+    name: str
+    labels: tuple[str, ...]
+    created_at: datetime
+    started_at: datetime
+    completed_at: datetime
+
+    @property
+    def queue_seconds(self) -> float:
+        return max(0.0, (self.started_at - self.created_at).total_seconds())
+
+    @property
+    def exec_seconds(self) -> float:
+        return max(0.0, (self.completed_at - self.started_at).total_seconds())
+
+    @property
+    def runner(self) -> str:
+        return ",".join(self.labels) if self.labels else "(unlabelled)"
+
+
+@dataclass(frozen=True)
+class GroupSummary:
+    workflow: str
+    runner: str
+    count: int
+    queue_p50: float
+    queue_p90: float
+    queue_max: float
+    exec_p50: float
+    exec_p90: float
+    exec_max: float
+
+
+def parse_jobs(workflow: str, payload: object) -> list[JobRecord]:
+    """Convert one `/actions/runs/<id>/jobs` response into records.
+
+    Jobs missing any of the three timestamps, or whose conclusion says they never really
+    ran, are dropped -- silently by design, but `--verbose` reports the count.
+    """
+    root = _as_object(payload)
+    if root is None:
+        return []
+    records: list[JobRecord] = []
+    for raw in _as_array(root.get("jobs")):
+        job = _as_object(raw)
+        if job is None:
+            continue
+        if _as_str(job, "status") != "completed":
+            continue
+        conclusion = _as_str(job, "conclusion")
+        if conclusion is None or conclusion in _EXCLUDED_CONCLUSIONS:
+            continue
+        created = _parse_ts(_as_str(job, "created_at"))
+        started = _parse_ts(_as_str(job, "started_at"))
+        completed = _parse_ts(_as_str(job, "completed_at"))
+        if created is None or started is None or completed is None:
+            continue
+        run_id = _as_int(job, "run_id")
+        job_id = _as_int(job, "id")
+        name = _as_str(job, "name")
+        if run_id is None or job_id is None or name is None:
+            continue
+        records.append(
+            JobRecord(
+                workflow=workflow,
+                run_id=run_id,
+                job_id=job_id,
+                name=name,
+                labels=tuple(_as_str_list(job, "labels")),
+                created_at=created,
+                started_at=started,
+                completed_at=completed,
+            )
+        )
+    return records
+
+
+def percentile(values: Sequence[float], fraction: float) -> float:
+    """Nearest-rank percentile on an unsorted sequence. Empty input is 0.0.
+
+    Nearest-rank (rather than interpolated) because these samples are few and the
+    question is "how long did a real job actually wait", not a smoothed estimate.
+    """
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(1, min(len(ordered), int(-(-fraction * len(ordered) // 1))))
+    return ordered[rank - 1]
+
+
+def summarise(records: Sequence[JobRecord]) -> list[GroupSummary]:
+    """Group by (workflow, runner labels) and reduce to percentiles."""
+    buckets: dict[tuple[str, str], list[JobRecord]] = {}
+    for record in records:
+        buckets.setdefault((record.workflow, record.runner), []).append(record)
+    summaries: list[GroupSummary] = []
+    for (workflow, runner), group in buckets.items():
+        queue = [job.queue_seconds for job in group]
+        execs = [job.exec_seconds for job in group]
+        summaries.append(
+            GroupSummary(
+                workflow=workflow,
+                runner=runner,
+                count=len(group),
+                queue_p50=percentile(queue, 0.50),
+                queue_p90=percentile(queue, 0.90),
+                queue_max=max(queue),
+                exec_p50=percentile(execs, 0.50),
+                exec_p90=percentile(execs, 0.90),
+                exec_max=max(execs),
+            )
+        )
+    summaries.sort(key=lambda s: (s.workflow, s.runner))
+    return summaries
+
+
+def human_seconds(seconds: float) -> str:
+    """Compact duration: `12s`, `4m30s`, `5h29m`."""
+    total = round(seconds)
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        return f"{total // 60}m{total % 60:02d}s"
+    return f"{total // 3600}h{(total % 3600) // 60:02d}m"
+
+
+def format_table(summaries: Sequence[GroupSummary]) -> str:
+    """Render a fixed-width table. Markdown-pasteable inside a fenced block."""
+    header = (
+        "workflow",
+        "runs-on labels",
+        "n",
+        "queue p50",
+        "queue p90",
+        "queue max",
+        "exec p50",
+        "exec p90",
+        "exec max",
+    )
+    rows: list[tuple[str, ...]] = [header]
+    for s in summaries:
+        rows.append(
+            (
+                s.workflow,
+                s.runner,
+                str(s.count),
+                human_seconds(s.queue_p50),
+                human_seconds(s.queue_p90),
+                human_seconds(s.queue_max),
+                human_seconds(s.exec_p50),
+                human_seconds(s.exec_p90),
+                human_seconds(s.exec_max),
+            )
+        )
+    widths = [max(len(row[i]) for row in rows) for i in range(len(header))]
+    lines = ["  ".join(cell.ljust(widths[i]) for i, cell in enumerate(rows[0])).rstrip()]
+    lines.append("  ".join("-" * widths[i] for i in range(len(header))))
+    for row in rows[1:]:
+        lines.append("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)).rstrip())
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------------------
+# Fetching
+# --------------------------------------------------------------------------------------
+
+
+def gh_api(path: str) -> object:
+    """One `gh api` GET. Raises RuntimeError with gh's own stderr on failure."""
+    proc = subprocess.run(
+        ["gh", "api", "-H", "Accept: application/vnd.github+json", path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed ({proc.returncode}): {proc.stderr.strip()}")
+    return json.loads(proc.stdout)
+
+
+def fetch_run_ids(repo: str, workflow: str, limit: int, branch: str | None) -> list[int]:
+    query = f"per_page={min(limit, 100)}&status=completed"
+    if branch:
+        query += f"&branch={branch}"
+    payload = gh_api(f"/repos/{repo}/actions/workflows/{workflow}/runs?{query}")
+    root = _as_object(payload)
+    if root is None:
+        return []
+    ids: list[int] = []
+    for raw in _as_array(root.get("workflow_runs")):
+        run = _as_object(raw)
+        if run is None:
+            continue
+        run_id = _as_int(run, "id")
+        if run_id is not None:
+            ids.append(run_id)
+    return ids[:limit]
+
+
+def fetch_records(
+    repo: str, workflow: str, limit: int, branch: str | None, verbose: bool
+) -> list[JobRecord]:
+    records: list[JobRecord] = []
+    run_ids = fetch_run_ids(repo, workflow, limit, branch)
+    if verbose:
+        print(f"# {workflow}: {len(run_ids)} runs", file=sys.stderr)
+    for run_id in run_ids:
+        payload = gh_api(f"/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100")
+        records.extend(parse_jobs(workflow, payload))
+    return records
+
+
+# --------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("workflows", nargs="*", help="workflow file names, e.g. c-unit.yml")
+    parser.add_argument("--repo", default=REPO_DEFAULT)
+    parser.add_argument("--limit", type=int, default=20, help="runs per workflow (default 20)")
+    parser.add_argument("--branch", default=None, help="restrict to one branch (default: all)")
+    parser.add_argument(
+        "--jobs-json",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="read a saved [{workflow, jobs: [...]}, ...] payload instead of calling gh",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    records: list[JobRecord] = []
+    if args.jobs_json is not None:
+        saved = _as_array(json.loads(Path(args.jobs_json).read_text(encoding="utf-8")))
+        for raw in saved:
+            entry = _as_object(raw)
+            if entry is None:
+                continue
+            workflow = _as_str(entry, "workflow") or str(args.jobs_json.name)
+            records.extend(parse_jobs(workflow, entry))
+    else:
+        if not args.workflows:
+            parser.error("give at least one workflow file name (or --jobs-json)")
+        for workflow in args.workflows:
+            records.extend(
+                fetch_records(
+                    str(args.repo), str(workflow), int(args.limit), args.branch, bool(args.verbose)
+                )
+            )
+
+    if not records:
+        print("no completed jobs with usable timestamps", file=sys.stderr)
+        return 1
+
+    scope = f"branch {args.branch}" if args.branch else "all branches"
+    print(f"# {len(records)} jobs, last {args.limit} runs per workflow, {scope}")
+    print(format_table(summarise(records)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/fixtures/queue_wait/jobs.json
+++ b/ci/tests/fixtures/queue_wait/jobs.json
@@ -1,0 +1,96 @@
+[
+  {
+    "workflow": "cross.yml",
+    "total_count": 8,
+    "jobs": [
+      {
+        "id": 1,
+        "run_id": 900,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:01:00Z",
+        "completed_at": "2026-09-01T00:01:10Z",
+        "labels": ["macos-latest"]
+      },
+      {
+        "id": 2,
+        "run_id": 901,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:02:00Z",
+        "completed_at": "2026-09-01T00:02:20Z",
+        "labels": ["macos-latest"]
+      },
+      {
+        "id": 3,
+        "run_id": 902,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "failure",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:05:00Z",
+        "completed_at": "2026-09-01T00:05:30Z",
+        "labels": ["macos-latest"]
+      },
+      {
+        "id": 4,
+        "run_id": 903,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T05:26:00Z",
+        "completed_at": "2026-09-01T05:26:40Z",
+        "labels": ["macos-latest"]
+      },
+      {
+        "id": 5,
+        "run_id": 903,
+        "name": "build (x86_64-unknown-linux-gnu)",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:00:04Z",
+        "completed_at": "2026-09-01T00:00:50Z",
+        "labels": ["ubuntu-latest"]
+      },
+      {
+        "id": 6,
+        "run_id": 903,
+        "name": "test (x86_64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:00:01Z",
+        "completed_at": "2026-09-01T00:00:02Z",
+        "labels": ["macos-15-intel"]
+      },
+      {
+        "id": 7,
+        "run_id": 903,
+        "name": "test (x86_64-pc-windows-gnu)",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": null,
+        "completed_at": null,
+        "labels": ["windows-latest"]
+      },
+      {
+        "id": 8,
+        "run_id": 904,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "in_progress",
+        "conclusion": null,
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:00:30Z",
+        "completed_at": null,
+        "labels": ["macos-latest"]
+      }
+    ]
+  }
+]

--- a/ci/tests/test_ci_queue_wait.py
+++ b/ci/tests/test_ci_queue_wait.py
@@ -1,0 +1,161 @@
+"""Unit tests for ci/ci_queue_wait.py (issue #277 phase 0).
+
+The script decides whether `concurrency: cancel-in-progress` actually bought anything, so
+its arithmetic has to be checkable without hitting the API: everything below drives the
+pure functions from a fixture in the real `/actions/runs/<id>/jobs` shape.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from typing import cast
+
+import ci_queue_wait
+
+FIXTURE = Path(__file__).parent / "fixtures" / "queue_wait" / "jobs.json"
+SCRIPT = Path(__file__).resolve().parents[1] / "ci_queue_wait.py"
+
+
+def _fixture_payload() -> object:
+    payloads = cast("list[object]", json.loads(FIXTURE.read_text(encoding="utf-8")))
+    assert len(payloads) == 1
+    return payloads[0]
+
+
+class ParseJobsTest(unittest.TestCase):
+    def test_keeps_only_completed_jobs_with_all_three_timestamps(self) -> None:
+        records = ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())
+        # 8 jobs in the fixture; dropped: cancelled (6), skipped/null ts (7), in_progress (8).
+        self.assertEqual([r.job_id for r in records], [1, 2, 3, 4, 5])
+
+    def test_failed_jobs_are_kept(self) -> None:
+        records = ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())
+        failed = [r for r in records if r.job_id == 3]
+        self.assertEqual(len(failed), 1, "a red job still waited in the queue and still ran")
+
+    def test_queue_and_exec_split(self) -> None:
+        records = {r.job_id: r for r in ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())}
+        self.assertEqual(records[4].queue_seconds, 5 * 3600 + 26 * 60)
+        self.assertEqual(records[4].exec_seconds, 40.0)
+        self.assertEqual(records[5].queue_seconds, 4.0)
+
+    def test_runner_label_grouping_key(self) -> None:
+        records = {r.job_id: r for r in ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())}
+        self.assertEqual(records[1].runner, "macos-latest")
+        self.assertEqual(records[5].runner, "ubuntu-latest")
+
+    def test_multi_label_runs_on_joins_labels(self) -> None:
+        payload = {
+            "jobs": [
+                {
+                    "id": 11,
+                    "run_id": 1,
+                    "name": "j",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "created_at": "2026-09-01T00:00:00Z",
+                    "started_at": "2026-09-01T00:00:10Z",
+                    "completed_at": "2026-09-01T00:00:20Z",
+                    "labels": ["self-hosted", "macOS", "ARM64"],
+                }
+            ]
+        }
+        records = ci_queue_wait.parse_jobs("x.yml", payload)
+        self.assertEqual(records[0].runner, "self-hosted,macOS,ARM64")
+
+    def test_garbage_payloads_yield_no_records_rather_than_raising(self) -> None:
+        payloads: tuple[object, ...] = (None, [], {}, {"jobs": "nope"}, {"jobs": [None, 7, "x"]})
+        for payload in payloads:
+            self.assertEqual(ci_queue_wait.parse_jobs("x.yml", payload), [])
+
+
+class PercentileTest(unittest.TestCase):
+    def test_nearest_rank(self) -> None:
+        values = [10.0, 20.0, 30.0, 40.0]
+        self.assertEqual(ci_queue_wait.percentile(values, 0.50), 20.0)
+        self.assertEqual(ci_queue_wait.percentile(values, 0.90), 40.0)
+        self.assertEqual(ci_queue_wait.percentile(values, 0.25), 10.0)
+
+    def test_single_sample_and_empty(self) -> None:
+        self.assertEqual(ci_queue_wait.percentile([7.0], 0.9), 7.0)
+        self.assertEqual(ci_queue_wait.percentile([], 0.5), 0.0)
+
+    def test_unsorted_input(self) -> None:
+        self.assertEqual(ci_queue_wait.percentile([40.0, 10.0, 30.0, 20.0], 0.5), 20.0)
+
+
+class SummariseTest(unittest.TestCase):
+    def test_groups_by_workflow_and_runner(self) -> None:
+        records = ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())
+        summaries = {s.runner: s for s in ci_queue_wait.summarise(records)}
+        self.assertEqual(sorted(summaries), ["macos-latest", "ubuntu-latest"])
+        mac = summaries["macos-latest"]
+        self.assertEqual(mac.count, 4)
+        # queue waits 60, 120, 300, 19560 -> nearest-rank p50 = 120, p90 = 19560
+        self.assertEqual(mac.queue_p50, 120.0)
+        self.assertEqual(mac.queue_p90, 19560.0)
+        self.assertEqual(mac.queue_max, 19560.0)
+        self.assertEqual(mac.exec_p50, 20.0)
+        self.assertEqual(mac.exec_max, 40.0)
+
+    def test_same_runner_in_two_workflows_stays_separate(self) -> None:
+        """cross.yml rows include upstream `needs:` build time; c-unit rows do not."""
+        payload = _fixture_payload()
+        records = ci_queue_wait.parse_jobs("cross.yml", payload) + ci_queue_wait.parse_jobs(
+            "c-unit.yml", payload
+        )
+        summaries = ci_queue_wait.summarise(records)
+        self.assertEqual(
+            [(s.workflow, s.runner) for s in summaries],
+            [
+                ("c-unit.yml", "macos-latest"),
+                ("c-unit.yml", "ubuntu-latest"),
+                ("cross.yml", "macos-latest"),
+                ("cross.yml", "ubuntu-latest"),
+            ],
+        )
+
+
+class FormattingTest(unittest.TestCase):
+    def test_human_seconds(self) -> None:
+        self.assertEqual(ci_queue_wait.human_seconds(0), "0s")
+        self.assertEqual(ci_queue_wait.human_seconds(59.4), "59s")
+        self.assertEqual(ci_queue_wait.human_seconds(60), "1m00s")
+        self.assertEqual(ci_queue_wait.human_seconds(150), "2m30s")
+        self.assertEqual(ci_queue_wait.human_seconds(19560), "5h26m")
+
+    def test_table_has_one_row_per_group(self) -> None:
+        records = ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())
+        table = ci_queue_wait.format_table(ci_queue_wait.summarise(records))
+        lines = table.split("\n")
+        self.assertIn("runs-on labels", lines[0])
+        self.assertEqual(len(lines), 4, "header + rule + two groups")
+        self.assertIn("5h26m", table)
+
+
+class CliTest(unittest.TestCase):
+    def test_jobs_json_mode_needs_no_network(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--jobs-json", str(FIXTURE)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("cross.yml", proc.stdout)
+        self.assertIn("macos-latest", proc.stdout)
+        self.assertIn("5 jobs", proc.stdout)
+
+    def test_no_workflows_and_no_fixture_is_a_usage_error(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT)], capture_output=True, text=True, check=False
+        )
+        self.assertEqual(proc.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -33,6 +33,49 @@ verifying nothing**, each discovered by asking "has this ever actually failed?":
 | **python-lint** | the gate scripts themselves — `ruff` + `pyright --strict` | — |
 | **zero-tracking** | correctness and footprint of `mi_option_purge_zeroes`, reported as paired interleaved A/B medians with the within-arm spread alongside | — |
 
+## Concurrency: superseded runs are cancelled
+
+Every workflow now carries a `concurrency:` group. A second push to the same ref cancels
+the first push's still-queued jobs instead of letting both compete for a runner. This is
+issue #277 phase 0, and the reason it is worth a paragraph is that the cost it removes is
+not build time:
+
+| workflow | runner | jobs | queue p50 | queue p90 | queue max | exec p50 |
+|---|---|---|---|---|---|---|
+| `c-unit.yml` | `ubuntu-latest` | 160 | 4s | 19s | 1m10s | 45s |
+| `c-unit.yml` | `macos-latest` | 60 | 21s | 2m03s | 3m05s | 48s |
+| `cross.yml` | `macos-latest` | 20 | 9m25s | 1h29m | **5h26m** | 8s |
+| `cross.yml` | `macos-15-intel` | 20 | 9m23s | 2h32m | **6h13m** | 9s |
+
+Those Apple rows *execute* in under fifteen seconds and *wait* for hours. Cancelling a
+superseded push does not make any job faster; it stops a dead push from holding a macOS
+slot that a live one needs.
+
+Not every workflow may be cancelled. Anything that publishes keeps `cancel-in-progress:
+false`, because a half-finished publish is worse than a redundant one:
+
+- `auto-release.yml`, `release.yaml` — upload release assets / `cargo publish`
+- `benchmark-stats.yml`, `benchmark-latency.yml`, `benchmark-memory.yml`,
+  `benchmark-scaling.yml` — push the sealed `benchmark-stats` branch and deploy Pages;
+  these deliberately **share** one group (`benchmark-stats-production`) to serialise
+  against each other, so their group is not per-workflow
+- `star-history.yml` — commits a regenerated chart
+- `stale.yaml` — closes and labels issues; a half-run leaves the repo partly swept
+
+`fuzz.yml` is the one subtle case: it has a `schedule:` trigger, and a scheduled run
+carries `github.ref == refs/heads/main`. Its group therefore includes `github.event_name`,
+so the nightly long run and a `main` push cannot cancel each other.
+
+**Measuring it.** `uv run ci/ci_queue_wait.py --limit 20 c-unit.yml cross.yml
+rust-native.yml` reads the Actions API through `gh` and prints, per `runs-on` label,
+p50/p90/max of `started_at - created_at` (queue wait) and `completed_at - started_at`
+(execution), with the job count. One caveat is baked into the tool's output and repeated
+here: a job with `needs:` is *created* when the run is created, so a `cross.yml`
+`test (*)` row measures "pool wait + upstream build", while `c-unit.yml` and
+`rust-native.yml` have no `needs:` edges and measure pool wait alone. `--jobs-json` replays
+a saved payload, which is how `ci/tests/test_ci_queue_wait.py` checks the arithmetic
+without touching the network.
+
 Three details worth stating, because each was an assumption that measurement overturned:
 
 - **Peak memory is not a low-variance signal.** Repeated runs of the same unchanged


### PR DESCRIPTION
Phase 0 of #277. Two things: a `concurrency` group on every workflow, and the tool that
says whether it was worth it.

## Why

Nothing in `.github/workflows/` had a `concurrency` group, so a second push to a PR branch
left the first push's jobs queued and competing for the same runners. Measured over the
last 20 runs of each workflow, **all branches** (full table on #277):

| workflow | runner | n | queue p50 | queue p90 | queue max | exec p50 |
|---|---|---|---|---|---|---|
| `c-unit.yml` | `ubuntu-latest` | 160 | 4s | 19s | 1m10s | 45s |
| `c-unit.yml` | `windows-latest` | 140 | 4s | 24s | 1m14s | 1m46s |
| `c-unit.yml` | `macos-latest` | 60 | 21s | 2m03s | 3m05s | 48s |
| `rust-native.yml` | `macos-latest` | 20 | 27s | 1m32s | 2m07s | 2m31s |
| `cross.yml` | `macos-latest` | 20 | 9m25s | 1h29m | **5h26m** | 8s |
| `cross.yml` | `macos-15-intel` | 20 | 9m23s | 2h32m | **6h13m** | 9s |

The Apple rows on `cross.yml` **execute in 8–14 seconds** and **wait for hours**. macOS is
the motivation; every Linux and Windows row sits at a 4–5 s p50.

This change makes nothing faster. It stops a dead push from holding a macOS slot a live
push needs.

## Per-workflow decisions

**`cancel-in-progress: true`**, group `<stem>-${{ github.ref }}` — pure verification, so a
superseded run's answer is worthless:

| workflow | note |
|---|---|
| `amalgamation-drift.yml` | verification only |
| `asan.yml` | verification only |
| `benchmark-sentinel.yml` | PR-tier sentinel; artifact only, publishes nothing (#171) |
| `c-unit.yml` | the macOS/Windows queue hog |
| `cross.yml` | the 5–6 h Apple rows above |
| `doc-snippets.yml` | verification only |
| `python-lint.yml` | verification only |
| `rust-native.yml` | its only publish-shaped step is `cargo publish --dry-run`, which uploads nothing |
| `zero-tracking.yml` | A/B timing report on a path-filtered PR |
| `fuzz.yml` | **group is `fuzz-${{ github.event_name }}-${{ github.ref }}`** — see below |

**`cancel-in-progress: false`** — cancelling these leaves something half-done:

| workflow | why not cancelled | change |
|---|---|---|
| `auto-release.yml` | `cargo publish` + GitHub Release assets | none (already `false`) |
| `release.yaml` | uploads release assets | **flipped from `true`**; inherited from upstream. A cancelled run leaves the release half-populated. Group also renamed to the file stem for consistency. |
| `stale.yaml` | closes and labels issues and PRs; a half-run leaves the repo partly swept | **added** (`false`) |
| `star-history.yml` | commits a regenerated chart | none (already `false`) |
| `benchmark-stats.yml`, `benchmark-latency.yml`, `benchmark-memory.yml`, `benchmark-scaling.yml` | push the sealed `benchmark-stats` branch and deploy Pages | **none — deliberately left alone.** These four share one group, `benchmark-stats-production`, to serialise *against each other*. Renaming them per-stem would break that. |
| `test.yaml` | inherited upstream workflow, trigger is `push: branches: ['dev*']` — never fires on this fork's branches | none (already `true`, harmless) |

### The one subtle case: `fuzz.yml`

It has a `schedule:` trigger, and a scheduled run carries `github.ref == refs/heads/main`.
With a plain `fuzz-${{ github.ref }}` group, the nightly 2,000,000-iteration run and any
push to `main` would cancel each other — silently turning off the long fuzz run. The group
therefore includes `github.event_name`. Same-event runs on the same ref still supersede.

## `ci/ci_queue_wait.py`

The measurement instrument, so the "after" comparison is the same arithmetic on the same
API fields rather than a vibe:

```
uv run ci/ci_queue_wait.py --limit 20 c-unit.yml cross.yml rust-native.yml
```

Per job: `started_at − created_at` (queue wait) and `completed_at − started_at`
(execution), grouped by the job's `labels` — i.e. what `runs-on:` actually resolved to —
with p50/p90/max (nearest-rank) and the job count per row. Only `gh` is required; no
Python dependencies.

Two things it is deliberate about:

- **The `needs:` caveat is printed, not hidden.** A dependent job is *created* when the run
  is created, so `cross.yml`'s `test (*)` rows measure "pool wait + upstream build".
  `c-unit.yml` and `rust-native.yml` have no `needs:` edges, so their rows are pure pool
  wait. Rows are never pooled across workflows.
- **Cancelled/skipped jobs are excluded** (a cancelled job's `completed_at` is when the
  cancellation landed, not when work finished); **failed jobs are kept**, because a red job
  still occupied a runner for its whole execution.

Fetching is separated from arithmetic, so `ci/tests/test_ci_queue_wait.py` (15 tests)
drives `parse_jobs`/`percentile`/`summarise` from a fixture in the real
`/actions/runs/<id>/jobs` shape, and `--jobs-json` replays that fixture through the CLI.
Nothing in the test suite touches the network.

## Also in this PR

- `docs/ci-gates.md` gains a "Concurrency: superseded runs are cancelled" section with the
  policy, the publisher exclusions, the `fuzz.yml` reasoning, and the measurement command.

## Verification

- `ruff check ci/` and `ruff format --check ci/` clean (ruff 0.12.10, the CI pin).
- `pytest ci/tests` — 96 passed, 15 of them new, 0 failed. (Rebased onto `main` after #276
  merged, which brought `[tool.pytest.ini_options] pythonpath = ["ci"]` — so this PR no
  longer needs to add it — and fixed the stale README-anchor test that was making
  `python-lint` red on `main`.)
- All 19 workflow files re-parse as YAML and every one now has a `concurrency` block.
- **`pyright --strict` is clean.** It initially could not run here (no system Node); `uv run
  --with 'pyright[nodejs]==1.1.411' pyright` ships its own Node and works, which caught four
  real strict errors that are fixed in the last commit. That command is worth knowing for
  anyone else hacking on `ci/` from a Node-less box.

Refs #277. Does not merge anything; phase A (`ci/277-phase-a-test-bundles`) stacks on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
