### PR TITLE
ci: portable test bundles from ctest json-v1 + serial runner (#277 phase A)

### DIFF
--- a/.github/workflows/amalgamation-drift.yml
+++ b/.github/workflows/amalgamation-drift.yml
@@ -23,6 +23,11 @@ on:
     branches: [main, v4]
   pull_request:
 
+concurrency:
+  # Pure verification: a superseded push's answer is worthless.
+  group: amalgamation-drift-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: vendored C amalgamation matches src/

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -18,6 +18,11 @@ on:
       - 'CMakeLists.txt'
       - '.github/workflows/asan.yml'
 
+concurrency:
+  # Pure verification: a superseded push's answer is worthless.
+  group: asan-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   asan:
     name: address sanitizer

--- a/.github/workflows/benchmark-sentinel.yml
+++ b/.github/workflows/benchmark-sentinel.yml
@@ -17,6 +17,11 @@ on:
 env:
   SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
+concurrency:
+  # PR-tier sentinel; artifact-only, publishes nothing (see #171).
+  group: benchmark-sentinel-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sentinel:
     name: benchmark-sentinel (${{ matrix.os }})

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -12,6 +12,11 @@ on:
       - 'ci/**'
       - '.github/workflows/c-unit.yml'
 
+concurrency:
+  # The macOS/Windows queue hog (#277). A superseded push's ctest result is worthless.
+  group: c-unit-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ctest:
     strategy:

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -133,7 +133,10 @@ jobs:
       - run: cmake -B build -DMI_PPROF=ON -DMI_DEBUG_FULL=ON
       - run: cmake --build build --config Debug
       - name: ctest (the reference the bundle must reproduce)
-        run: ctest --test-dir build -C Debug --output-on-failure --output-junit ctest.xml
+        # --output-junit resolves relative to the *build* directory, not the working
+        # directory, so an absolute path is required here: a relative one would land in
+        # build/ and be carried off by the `mv` below.
+        run: ctest --test-dir build -C Debug --output-on-failure --output-junit "$GITHUB_WORKSPACE/ctest.xml"
       - name: Build the bundle
         run: python3 ci/bundle_tests.py build bundle --config Debug
       - name: Move the build tree out of the way

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -117,6 +117,41 @@ jobs:
       - uses: actions/checkout@v4
       - run: cmake -B build -DMI_PPROF=ON -DMI_DEBUG_FULL=ON && cmake --build build --config Debug && ctest --test-dir build -C Debug --output-on-failure
 
+  bundle-roundtrip:
+    # Issue #277 phase A. The plan in #277 is to build the macOS/Windows test binaries on
+    # Linux and ship them to one runner per OS as a portable *test bundle*. That is only
+    # credible if the bundle runs exactly the tests ctest runs and gets exactly the same
+    # results, so this job proves the equivalence on the config where every awkward
+    # command shape lives: MI_DEBUG_FULL emits 6 `cmake -P run-negative.cmake` negative
+    # controls and a `cmake -E env` LD_PRELOAD wrapper, none of which is a plain argv.
+    #
+    # The reference run and the bundle run are compared by name AND by pass/fail, so a
+    # bundle that silently drops a test fails here rather than reporting green on less.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cmake -B build -DMI_PPROF=ON -DMI_DEBUG_FULL=ON
+      - run: cmake --build build --config Debug
+      - name: ctest (the reference the bundle must reproduce)
+        run: ctest --test-dir build -C Debug --output-on-failure --output-junit ctest.xml
+      - name: Build the bundle
+        run: python3 ci/bundle_tests.py build bundle --config Debug
+      - name: Move the build tree out of the way
+        # The test executables carry an RPATH into the build tree. Without this the bundle
+        # would "pass" by loading the original libraries off disk, and the whole
+        # portability claim would be untested on the only machine that can check it.
+        run: mv build build.moved-away
+      - name: Replay the bundle and require identical results
+        run: python3 ci/run_test_bundle.py bundle --compare-junit ctest.xml --junit bundle.xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-bundle-ubuntu-debug-full
+          path: |
+            bundle
+            ctest.xml
+            bundle.xml
+          retention-days: 7
+
   ctest-debug-full-win-gnu:
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -18,6 +18,11 @@ on:
       - rust/**
       - .github/workflows/cross.yml
 
+concurrency:
+  # Measured ~4 h / ~5.5 h queue waits on the Apple rows (#277).
+  group: cross-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-linux:
     name: build (${{ matrix.target }})

--- a/.github/workflows/doc-snippets.yml
+++ b/.github/workflows/doc-snippets.yml
@@ -23,6 +23,11 @@ on:
       - 'ci/check_doc_snippets.py'
       - '.github/workflows/doc-snippets.yml'
 
+concurrency:
+  # Pure verification: a superseded push's answer is worthless.
+  group: doc-snippets-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,6 +20,13 @@ on:
   schedule:
     - cron: '0 4 * * *'   # nightly, longer budget
 
+concurrency:
+  # event_name is in the group on purpose: a scheduled run carries ref=refs/heads/main,
+  # so without it the nightly 2,000,000-iteration run and a main push would cancel each
+  # other. Same-event runs on the same ref still supersede.
+  group: fuzz-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -16,6 +16,11 @@ on:
       - '.github/workflows/python-lint.yml'
       - '.github/workflows/benchmark-*.yml'
 
+concurrency:
+  # Pure verification: a superseded push's answer is worthless.
+  group: python-lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,11 @@ on:
   workflow_dispatch:   # run the workflow manually 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true # Cancel any in-progress runs of this workflow when a new run is triggered on the same ref (branch or tag)
+  # Never cancel: this workflow uploads release assets to a GitHub Release, and a
+  # cancelled run leaves that release half-populated. Inherited from upstream as
+  # cancel-in-progress: true; flipped in #277 phase 0.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -9,6 +9,11 @@ on:
       - 'ci/check_crate_package.py'
       - '.github/workflows/rust-native.yml'
 
+concurrency:
+  # Its only publish-shaped step is `cargo publish --dry-run`, which uploads nothing.
+  group: rust-native-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,13 @@ on:
     - cron: "15 21 * * *"  # minute, hour, day (1-31), month (1-12), day of the week (0 - 6 or SUN-SAT)
 
 name: Close inactive issues
+
+concurrency:
+  # Never cancel: it closes/labels issues and PRs, so a half-run leaves the repo in a
+  # partially-swept state.
+  group: stale-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/zero-tracking.yml
+++ b/.github/workflows/zero-tracking.yml
@@ -17,6 +17,11 @@ on:
       - 'test/bench-zero-tracking.c'
       - '.github/workflows/zero-tracking.yml'
 
+concurrency:
+  # A/B timing report on a path-filtered PR; produces no artifact anyone waits on.
+  group: zero-tracking-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ab:
     strategy:

--- a/ci/bundle_tests.py
+++ b/ci/bundle_tests.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env -S uv run --script
+"""Turn a CMake build tree's ctest suite into a portable *test bundle*.
+
+Issue #277 phase A. The goal of #277 is to build once on Linux and execute once per OS,
+which means a macOS or Windows runner has to be able to run our whole ctest suite with
+neither CMake nor a repo checkout present. This script produces that: a directory holding
+every test executable, the mimalloc shared libraries they need, and a `tests.json`
+manifest that `ci/run_test_bundle.py` replays.
+
+The interesting part is that `ctest --show-only=json-v1` does *not* emit a list of plain
+executables. On the `MI_DEBUG_FULL` tree, 7 of 31 tests invoke `cmake` itself:
+
+  * `cmake -E env K=V ... <exe> [args]` -- a plain environment wrapper (test-stress-dynamic
+    uses it to set MIMALLOC_VERBOSE and LD_PRELOAD/DYLD_INSERT_LIBRARIES)
+  * `cmake -DTEST_EXE=... -DTEST_ARG=... -DEXPECTED_TEXT=... -P test/run-negative.cmake`
+    -- the negative-control harness: run the exe, require a *non-zero* exit, require an
+    expected substring in the combined stdout+stderr, and treat a 10 s timeout as a
+    failure ("timed out instead of failing fast", not "failed as expected")
+
+Both are *lowered* into manifest fields (`env`, `expect_nonzero`, `expect_text`,
+`timeout`), so the runner needs no CMake. Any other `cmake` argv shape is a hard error
+naming the test -- a bundle that silently drops a test is worse than no bundle, and
+issue #277's whole coverage argument depends on the count not going down.
+
+Absolute build-tree paths appear in argv *and* in env values, so both are rewritten to a
+`${BUNDLE}` placeholder that the runner expands. Files are flattened into the bundle root
+(so a Windows DLL sits next to its exe and a Linux .so is found via LD_LIBRARY_PATH rather
+than a build-tree RPATH); a basename collision is a hard error rather than a silent
+overwrite.
+
+Usage:
+
+    uv run ci/bundle_tests.py <build-dir> <out-dir> [--config Debug]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import cast
+
+MANIFEST_NAME = "tests.json"
+MANIFEST_VERSION = 1
+
+#: The runner substitutes this for the bundle's own absolute path. It is what "argv
+#: relative to the bundle root" means concretely: paths stay explicit and machine-readable
+#: instead of depending on the process's cwd, which `WORKING_DIRECTORY` is free to change.
+BUNDLE_PLACEHOLDER = "${BUNDLE}"
+
+#: ctest's own default when a test sets no TIMEOUT property.
+DEFAULT_TIMEOUT_SECONDS = 1500.0
+
+#: run-negative.cmake wraps its `execute_process` in `TIMEOUT 10`, and treats hitting it as
+#: a failure of the negative control rather than as the expected non-zero exit.
+NEGATIVE_TIMEOUT_SECONDS = 10.0
+
+#: Test properties this format understands. Anything else is a hard error: ctest semantics
+#: we do not implement (PASS_REGULAR_EXPRESSION, SKIP_RETURN_CODE, RESOURCE_LOCK, ...) must
+#: not be silently discarded into a bundle that then reports green.
+SUPPORTED_PROPERTIES = frozenset(
+    {"ENVIRONMENT", "TIMEOUT", "WORKING_DIRECTORY", "LABELS", "WILL_FAIL", "DISABLED"}
+)
+
+#: Shared/import libraries every bundle carries regardless of whether a test names them on
+#: its command line -- a dynamically linked test finds them through the loader, not argv.
+LIBRARY_GLOBS = (
+    "libmimalloc*",
+    "mimalloc*.dll",
+    "mimalloc*.so*",
+    "mimalloc*.dylib",
+    "mimalloc-redirect*.dll",
+)
+
+
+class BundleError(Exception):
+    """A shape this bundler will not guess at. Always names the test."""
+
+
+# --------------------------------------------------------------------------------------
+# JSON narrowing (see ci/ci_queue_wait.py for the same rationale: prove, don't index)
+# --------------------------------------------------------------------------------------
+
+
+def _as_object(value: object) -> dict[str, object] | None:
+    return cast("dict[str, object]", value) if isinstance(value, dict) else None
+
+
+def _as_array(value: object) -> list[object]:
+    return cast("list[object]", value) if isinstance(value, list) else []
+
+
+def _as_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _str_list(value: object) -> list[str]:
+    return [item for item in _as_array(value) if isinstance(item, str)]
+
+
+# --------------------------------------------------------------------------------------
+# Model
+# --------------------------------------------------------------------------------------
+
+
+@dataclass
+class BundledTest:
+    name: str
+    argv: list[str]
+    env: dict[str, str] = field(default_factory=dict)
+    cwd: str = BUNDLE_PLACEHOLDER
+    timeout: float = DEFAULT_TIMEOUT_SECONDS
+    expect_nonzero: bool = False
+    expect_text: str | None = None
+    labels: list[str] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "argv": list(self.argv),
+            "env": dict(self.env),
+            "cwd": self.cwd,
+            "timeout": self.timeout,
+            "expect_nonzero": self.expect_nonzero,
+            "expect_text": self.expect_text,
+            "labels": list(self.labels),
+        }
+
+
+@dataclass
+class _Lowered:
+    """Result of stripping any `cmake` wrapper off a ctest command."""
+
+    argv: list[str]
+    env: dict[str, str] = field(default_factory=dict)
+    timeout: float | None = None
+    expect_nonzero: bool = False
+    expect_text: str | None = None
+
+
+# --------------------------------------------------------------------------------------
+# Lowering
+# --------------------------------------------------------------------------------------
+
+
+def is_cmake(argv0: str) -> bool:
+    stem = PurePosixPath(argv0.replace("\\", "/")).name.lower()
+    return stem in {"cmake", "cmake.exe"}
+
+
+def _split_env_assignments(tokens: Sequence[str], test_name: str) -> tuple[dict[str, str], int]:
+    """Consume leading `K=V` tokens of `cmake -E env`.
+
+    Returns the assignments and the index of the first token that is not one. `--unset=`
+    and `--modify` are `cmake -E env` options we deliberately refuse rather than silently
+    ignore.
+    """
+    env: dict[str, str] = {}
+    for index, token in enumerate(tokens):
+        if token.startswith("-"):
+            raise BundleError(
+                f"{test_name}: `cmake -E env` option {token!r} is not supported by the "
+                f"bundle format (only plain K=V assignments are lowered)"
+            )
+        if "=" not in token:
+            return env, index
+        key, _, value = token.partition("=")
+        if not key:
+            return env, index
+        env[key] = value
+    raise BundleError(f"{test_name}: `cmake -E env` has no command after its assignments")
+
+
+def _lower_run_negative(tokens: Sequence[str], test_name: str) -> _Lowered:
+    """Lower `cmake -D... -P .../run-negative.cmake` into manifest fields.
+
+    Mirrors test/run-negative.cmake exactly: run TEST_EXE (with optional TEST_ARG) under a
+    10 s timeout, require a non-zero exit, and require EXPECTED_TEXT somewhere in the
+    combined stdout+stderr. A timeout is a *failure*, not a pass -- the script's own words
+    are "negative control timed out instead of failing fast".
+    """
+    defines: dict[str, str] = {}
+    script: str | None = None
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.startswith("-D"):
+            key, _, value = token[2:].partition("=")
+            defines[key] = value
+            index += 1
+        elif token == "-P":
+            if index + 1 >= len(tokens):
+                raise BundleError(f"{test_name}: `cmake -P` with no script path")
+            script = tokens[index + 1]
+            index += 2
+        else:
+            raise BundleError(
+                f"{test_name}: unsupported token {token!r} in a `cmake -P` command line"
+            )
+    if script is None or PurePosixPath(script.replace("\\", "/")).name != "run-negative.cmake":
+        raise BundleError(
+            f"{test_name}: only test/run-negative.cmake is understood as a `cmake -P` "
+            f"harness, got {script!r}"
+        )
+    exe = defines.get("TEST_EXE")
+    expected = defines.get("EXPECTED_TEXT")
+    if not exe or not expected:
+        raise BundleError(
+            f"{test_name}: run-negative.cmake needs TEST_EXE and EXPECTED_TEXT, got "
+            f"{sorted(defines)}"
+        )
+    unknown = sorted(set(defines) - {"TEST_EXE", "TEST_ARG", "EXPECTED_TEXT"})
+    if unknown:
+        raise BundleError(f"{test_name}: unrecognised run-negative.cmake variables {unknown}")
+    argv = [exe]
+    arg = defines.get("TEST_ARG")
+    if arg:
+        argv.append(arg)
+    return _Lowered(
+        argv=argv,
+        timeout=NEGATIVE_TIMEOUT_SECONDS,
+        expect_nonzero=True,
+        expect_text=expected,
+    )
+
+
+def lower_command(command: Sequence[str], test_name: str) -> _Lowered:
+    """Strip any `cmake` wrapper off a ctest command, or refuse loudly."""
+    if not command:
+        raise BundleError(f"{test_name}: empty command")
+    if not is_cmake(command[0]):
+        return _Lowered(argv=list(command))
+
+    rest = list(command[1:])
+    if rest[:2] == ["-E", "env"]:
+        env, offset = _split_env_assignments(rest[2:], test_name)
+        argv = rest[2 + offset :]
+        if not argv:
+            raise BundleError(f"{test_name}: `cmake -E env` has no command after its assignments")
+        if is_cmake(argv[0]):
+            raise BundleError(f"{test_name}: nested `cmake` invocations are not supported")
+        return _Lowered(argv=argv, env=env)
+    if rest[:1] == ["-E"]:
+        mode = rest[1] if len(rest) > 1 else "<none>"
+        raise BundleError(
+            f"{test_name}: `cmake -E {mode}` is not a shape this bundler lowers (only "
+            f"`cmake -E env`)"
+        )
+    return _lower_run_negative(rest, test_name)
+
+
+# --------------------------------------------------------------------------------------
+# Path rewriting
+# --------------------------------------------------------------------------------------
+
+
+def _normalise(path: str) -> str:
+    return os.path.normpath(path).replace("\\", "/")
+
+
+class PathRewriter:
+    """Rewrites absolute build-tree paths to `${BUNDLE}/<basename>` and records the files.
+
+    Flattening (rather than mirroring the build tree) is deliberate: on Windows a DLL has
+    to sit beside the exe that loads it, and on Linux/macOS a flat directory is what makes
+    `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` enough to override the build-tree RPATH baked
+    into the executable. Two different files with one basename would make that ambiguous,
+    so it is an error.
+    """
+
+    def __init__(self, build_dir: Path) -> None:
+        self._build_prefix = _normalise(str(build_dir.resolve())) + "/"
+        self.assets: dict[str, Path] = {}
+
+    def _register(self, source: Path) -> str:
+        name = source.name
+        existing = self.assets.get(name)
+        if existing is not None and _normalise(str(existing)) != _normalise(str(source)):
+            raise BundleError(
+                f"two different files would both land at {name!r} in the bundle: "
+                f"{existing} and {source}"
+            )
+        self.assets[name] = source
+        return f"{BUNDLE_PLACEHOLDER}/{name}"
+
+    def rewrite(self, value: str) -> str:
+        """Rewrite one argv element or env value. Non-build-tree text passes through."""
+        candidate = _normalise(value)
+        if candidate == self._build_prefix.rstrip("/"):
+            return BUNDLE_PLACEHOLDER
+        if not candidate.startswith(self._build_prefix):
+            return value
+        return self._register(Path(candidate))
+
+    def rewrite_all(self, values: Iterable[str]) -> list[str]:
+        return [self.rewrite(value) for value in values]
+
+
+# --------------------------------------------------------------------------------------
+# ctest
+# --------------------------------------------------------------------------------------
+
+
+def run_ctest_show_only(build_dir: Path, config: str | None) -> object:
+    argv = ["ctest", "--test-dir", str(build_dir), "--show-only=json-v1"]
+    if config:
+        argv += ["-C", config]
+    proc = subprocess.run(argv, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise BundleError(f"`{' '.join(argv)}` failed ({proc.returncode}): {proc.stderr.strip()}")
+    return json.loads(proc.stdout)
+
+
+def convert(payload: object, build_dir: Path) -> tuple[list[BundledTest], dict[str, Path]]:
+    """Convert a `ctest --show-only=json-v1` payload into manifest entries + asset list."""
+    root = _as_object(payload)
+    if root is None:
+        raise BundleError("ctest --show-only=json-v1 did not return a JSON object")
+    rewriter = PathRewriter(build_dir)
+    tests: list[BundledTest] = []
+    problems: list[str] = []
+
+    for raw in _as_array(root.get("tests")):
+        entry = _as_object(raw)
+        if entry is None:
+            problems.append("a `tests` element was not an object")
+            continue
+        name = _as_str(entry.get("name"))
+        if name is None:
+            problems.append("a test has no name")
+            continue
+        command = _str_list(entry.get("command"))
+
+        properties: dict[str, object] = {}
+        for raw_property in _as_array(entry.get("properties")):
+            prop = _as_object(raw_property)
+            if prop is None:
+                continue
+            key = _as_str(prop.get("name"))
+            if key is not None:
+                properties[key] = prop.get("value")
+        unsupported = sorted(set(properties) - SUPPORTED_PROPERTIES)
+        if unsupported:
+            problems.append(
+                f"{name}: test properties {unsupported} have no bundle equivalent; "
+                f"implement them or the bundle would silently change what is asserted"
+            )
+            continue
+        if properties.get("DISABLED") in (True, "TRUE", "ON", "1"):
+            continue
+
+        try:
+            lowered = lower_command(command, name)
+        except BundleError as exc:
+            problems.append(str(exc))
+            continue
+
+        env: dict[str, str] = {}
+        for assignment in _str_list(properties.get("ENVIRONMENT")):
+            key, _, value = assignment.partition("=")
+            if key:
+                env[key] = value
+        # `cmake -E env` assignments are applied by the wrapper, i.e. after (and therefore
+        # over) the ENVIRONMENT property, so they win on a conflict.
+        env.update(lowered.env)
+
+        timeout = lowered.timeout
+        if timeout is None:
+            raw_timeout = properties.get("TIMEOUT")
+            timeout = (
+                float(raw_timeout)
+                if isinstance(raw_timeout, (int, float)) and not isinstance(raw_timeout, bool)
+                else DEFAULT_TIMEOUT_SECONDS
+            )
+
+        working_directory = _as_str(properties.get("WORKING_DIRECTORY"))
+        expect_nonzero = lowered.expect_nonzero or properties.get("WILL_FAIL") in (
+            True,
+            "TRUE",
+            "ON",
+            "1",
+        )
+
+        try:
+            test = BundledTest(
+                name=name,
+                argv=rewriter.rewrite_all(lowered.argv),
+                env={key: rewriter.rewrite(value) for key, value in env.items()},
+                cwd=rewriter.rewrite(working_directory)
+                if working_directory
+                else BUNDLE_PLACEHOLDER,
+                timeout=timeout,
+                expect_nonzero=expect_nonzero,
+                expect_text=lowered.expect_text,
+                labels=_str_list(properties.get("LABELS")),
+            )
+        except BundleError as exc:
+            problems.append(f"{name}: {exc}")
+            continue
+
+        if not test.argv[0].startswith(BUNDLE_PLACEHOLDER):
+            problems.append(
+                f"{name}: argv[0] {test.argv[0]!r} is not inside the build tree, so the "
+                f"bundle cannot carry it"
+            )
+            continue
+        tests.append(test)
+
+    if problems:
+        raise BundleError(
+            "cannot lower "
+            + str(len(problems))
+            + " test(s) into a bundle:\n  - "
+            + "\n  - ".join(problems)
+        )
+    if not tests:
+        # An empty bundle would run cleanly and prove nothing -- exactly the "gate that
+        # verifies nothing" failure docs/ci-gates.md exists to prevent.
+        raise BundleError("ctest reported no tests; refusing to write an empty bundle")
+    tests.sort(key=lambda t: t.name)
+    return tests, dict(rewriter.assets)
+
+
+# --------------------------------------------------------------------------------------
+# Copying
+# --------------------------------------------------------------------------------------
+
+
+def library_files(build_dir: Path, config: str | None) -> list[Path]:
+    """Every mimalloc library in the build tree, whether or not a test names it."""
+    roots = [build_dir]
+    if config:
+        candidate = build_dir / config
+        if candidate.is_dir():
+            roots.append(candidate)
+    found: dict[str, Path] = {}
+    for root in roots:
+        for pattern in LIBRARY_GLOBS:
+            for path in sorted(root.glob(pattern)):
+                if path.is_file() or path.is_symlink():
+                    found.setdefault(path.name, path)
+    return list(found.values())
+
+
+def copy_into(out_dir: Path, sources: Iterable[Path]) -> list[str]:
+    """Copy files (and symlinks, as symlinks) flat into `out_dir`. Returns the names."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    copied: list[str] = []
+    for source in sources:
+        destination = out_dir / source.name
+        if destination.exists() or destination.is_symlink():
+            destination.unlink()
+        if source.is_symlink():
+            # `libmimalloc-debug.so -> libmimalloc-debug.so.3` and friends: keep the SONAME
+            # chain intact, otherwise the loader looks for a name the bundle does not have.
+            os.symlink(source.readlink(), destination)
+        else:
+            shutil.copy2(source, destination)
+        copied.append(source.name)
+    return copied
+
+
+def write_manifest(
+    out_dir: Path, tests: Sequence[BundledTest], build_dir: Path, config: str | None
+) -> Path:
+    manifest = {
+        "version": MANIFEST_VERSION,
+        "generated_from": {
+            "build_dir": str(build_dir),
+            "config": config,
+            "platform": sys.platform,
+        },
+        "tests": [test.to_json() for test in tests],
+    }
+    path = out_dir / MANIFEST_NAME
+    path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("build_dir", type=Path)
+    parser.add_argument("out_dir", type=Path)
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="build configuration for multi-config generators (passed to ctest as -C)",
+    )
+    args = parser.parse_args(argv)
+
+    build_dir = Path(cast("Path", args.build_dir)).resolve()
+    out_dir = Path(cast("Path", args.out_dir))
+    config = cast("str | None", args.config)
+
+    try:
+        payload = run_ctest_show_only(build_dir, config)
+        tests, assets = convert(payload, build_dir)
+        sources = list(assets.values()) + library_files(build_dir, config)
+        seen: dict[str, Path] = {}
+        unique: list[Path] = []
+        for source in sources:
+            if source.name not in seen:
+                seen[source.name] = source
+                unique.append(source)
+        copied = copy_into(out_dir, unique)
+        manifest_path = write_manifest(out_dir, tests, build_dir, config)
+    except BundleError as exc:
+        print(f"bundle_tests: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"bundled {len(tests)} tests and {len(copied)} files into {out_dir}")
+    print(f"manifest: {manifest_path}")
+    negatives = sum(1 for test in tests if test.expect_nonzero)
+    if negatives:
+        print(f"  {negatives} negative control(s) lowered from run-negative.cmake")
+    wrapped = sum(1 for test in tests if test.env)
+    if wrapped:
+        print(f"  {wrapped} test(s) carry environment overrides")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/bundle_tests.py
+++ b/ci/bundle_tests.py
@@ -113,12 +113,12 @@ def _str_list(value: object) -> list[str]:
 class BundledTest:
     name: str
     argv: list[str]
-    env: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = field(default_factory=dict[str, str])
     cwd: str = BUNDLE_PLACEHOLDER
     timeout: float = DEFAULT_TIMEOUT_SECONDS
     expect_nonzero: bool = False
     expect_text: str | None = None
-    labels: list[str] = field(default_factory=list)
+    labels: list[str] = field(default_factory=list[str])
 
     def to_json(self) -> dict[str, object]:
         return {
@@ -138,7 +138,7 @@ class _Lowered:
     """Result of stripping any `cmake` wrapper off a ctest command."""
 
     argv: list[str]
-    env: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = field(default_factory=dict[str, str])
     timeout: float | None = None
     expect_nonzero: bool = False
     expect_text: str | None = None

--- a/ci/ci_queue_wait.py
+++ b/ci/ci_queue_wait.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env -S uv run --script
+"""Measure GitHub Actions queue wait and execution time per runner label.
+
+Issue #277 phase 0. Every push spawns one fresh VM per job and nothing cancels the
+previous push's jobs, so a busy PR piles superseded runs onto the scarce macOS pool --
+`cross.yml` run 33055011757 shows an Apple row that waited hours after its build had
+already finished. `concurrency: cancel-in-progress` is supposed to fix that, and this
+script is how we tell whether it did: run it before the change, run it after, compare.
+
+Two numbers per job, both straight from the API:
+
+    queue wait  = started_at   - created_at
+    execution   = completed_at - started_at
+
+grouped by the job's `labels` (what `runs-on:` resolved to), because the whole point is
+that `macos-latest` behaves nothing like `ubuntu-latest`.
+
+CAVEAT, and it matters for `cross.yml`: a job that `needs:` another is *created* when the
+run is created, not when its dependency finishes. Its "queue wait" therefore includes the
+time its dependencies spent building. `c-unit.yml` and `rust-native.yml` have no `needs:`
+edges, so their rows are pure pool-wait; `cross.yml`'s `test (*)` rows are not. Rows are
+grouped per workflow, never pooled across workflows, so the two kinds never end up in one
+average -- but read a `cross.yml` row as "wait + upstream build", not as pool wait alone.
+
+Usage:
+
+    uv run ci/ci_queue_wait.py --limit 20 c-unit.yml cross.yml rust-native.yml
+    uv run ci/ci_queue_wait.py --branch main --limit 20 c-unit.yml
+
+Needs only `gh` (already authenticated in CI and on developer machines); no Python deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+REPO_DEFAULT = "zackees/mimalloc-pprof"
+
+# Conclusions whose timestamps describe something other than "a job ran to completion".
+# A cancelled job's completed_at is when the cancellation landed, and a skipped job never
+# started at all; averaging either into an execution time is how a measurement lies.
+_EXCLUDED_CONCLUSIONS = frozenset({"skipped", "cancelled", "neutral", "stale"})
+
+
+# --------------------------------------------------------------------------------------
+# JSON narrowing. The API responses are `object` as far as the type checker is concerned;
+# every field is proven before use rather than indexed on faith (docs/ci-gates.md).
+# --------------------------------------------------------------------------------------
+
+
+def _as_object(value: object) -> dict[str, object] | None:
+    # json.loads only ever produces str-keyed objects, so the cast restates a guarantee
+    # the parser already made; it is not a claim about the field's contents, which every
+    # accessor below re-checks.
+    return cast("dict[str, object]", value) if isinstance(value, dict) else None
+
+
+def _as_array(value: object) -> list[object]:
+    return cast("list[object]", value) if isinstance(value, list) else []
+
+
+def _as_str(obj: dict[str, object], key: str) -> str | None:
+    value = obj.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _as_int(obj: dict[str, object], key: str) -> int | None:
+    value = obj.get(key)
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def _as_str_list(obj: dict[str, object], key: str) -> list[str]:
+    return [item for item in _as_array(obj.get(key)) if isinstance(item, str)]
+
+
+def _parse_ts(text: str | None) -> datetime | None:
+    """Parse a GitHub ISO-8601 timestamp (`2026-09-01T12:34:56Z`)."""
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+# --------------------------------------------------------------------------------------
+# Model
+# --------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class JobRecord:
+    """One completed job with all three timestamps present."""
+
+    workflow: str
+    run_id: int
+    job_id: int
+    name: str
+    labels: tuple[str, ...]
+    created_at: datetime
+    started_at: datetime
+    completed_at: datetime
+
+    @property
+    def queue_seconds(self) -> float:
+        return max(0.0, (self.started_at - self.created_at).total_seconds())
+
+    @property
+    def exec_seconds(self) -> float:
+        return max(0.0, (self.completed_at - self.started_at).total_seconds())
+
+    @property
+    def runner(self) -> str:
+        return ",".join(self.labels) if self.labels else "(unlabelled)"
+
+
+@dataclass(frozen=True)
+class GroupSummary:
+    workflow: str
+    runner: str
+    count: int
+    queue_p50: float
+    queue_p90: float
+    queue_max: float
+    exec_p50: float
+    exec_p90: float
+    exec_max: float
+
+
+def parse_jobs(workflow: str, payload: object) -> list[JobRecord]:
+    """Convert one `/actions/runs/<id>/jobs` response into records.
+
+    Jobs missing any of the three timestamps, or whose conclusion says they never really
+    ran, are dropped -- silently by design, but `--verbose` reports the count.
+    """
+    root = _as_object(payload)
+    if root is None:
+        return []
+    records: list[JobRecord] = []
+    for raw in _as_array(root.get("jobs")):
+        job = _as_object(raw)
+        if job is None:
+            continue
+        if _as_str(job, "status") != "completed":
+            continue
+        conclusion = _as_str(job, "conclusion")
+        if conclusion is None or conclusion in _EXCLUDED_CONCLUSIONS:
+            continue
+        created = _parse_ts(_as_str(job, "created_at"))
+        started = _parse_ts(_as_str(job, "started_at"))
+        completed = _parse_ts(_as_str(job, "completed_at"))
+        if created is None or started is None or completed is None:
+            continue
+        run_id = _as_int(job, "run_id")
+        job_id = _as_int(job, "id")
+        name = _as_str(job, "name")
+        if run_id is None or job_id is None or name is None:
+            continue
+        records.append(
+            JobRecord(
+                workflow=workflow,
+                run_id=run_id,
+                job_id=job_id,
+                name=name,
+                labels=tuple(_as_str_list(job, "labels")),
+                created_at=created,
+                started_at=started,
+                completed_at=completed,
+            )
+        )
+    return records
+
+
+def percentile(values: Sequence[float], fraction: float) -> float:
+    """Nearest-rank percentile on an unsorted sequence. Empty input is 0.0.
+
+    Nearest-rank (rather than interpolated) because these samples are few and the
+    question is "how long did a real job actually wait", not a smoothed estimate.
+    """
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(1, min(len(ordered), int(-(-fraction * len(ordered) // 1))))
+    return ordered[rank - 1]
+
+
+def summarise(records: Sequence[JobRecord]) -> list[GroupSummary]:
+    """Group by (workflow, runner labels) and reduce to percentiles."""
+    buckets: dict[tuple[str, str], list[JobRecord]] = {}
+    for record in records:
+        buckets.setdefault((record.workflow, record.runner), []).append(record)
+    summaries: list[GroupSummary] = []
+    for (workflow, runner), group in buckets.items():
+        queue = [job.queue_seconds for job in group]
+        execs = [job.exec_seconds for job in group]
+        summaries.append(
+            GroupSummary(
+                workflow=workflow,
+                runner=runner,
+                count=len(group),
+                queue_p50=percentile(queue, 0.50),
+                queue_p90=percentile(queue, 0.90),
+                queue_max=max(queue),
+                exec_p50=percentile(execs, 0.50),
+                exec_p90=percentile(execs, 0.90),
+                exec_max=max(execs),
+            )
+        )
+    summaries.sort(key=lambda s: (s.workflow, s.runner))
+    return summaries
+
+
+def human_seconds(seconds: float) -> str:
+    """Compact duration: `12s`, `4m30s`, `5h29m`."""
+    total = round(seconds)
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        return f"{total // 60}m{total % 60:02d}s"
+    return f"{total // 3600}h{(total % 3600) // 60:02d}m"
+
+
+def format_table(summaries: Sequence[GroupSummary]) -> str:
+    """Render a fixed-width table. Markdown-pasteable inside a fenced block."""
+    header = (
+        "workflow",
+        "runs-on labels",
+        "n",
+        "queue p50",
+        "queue p90",
+        "queue max",
+        "exec p50",
+        "exec p90",
+        "exec max",
+    )
+    rows: list[tuple[str, ...]] = [header]
+    for s in summaries:
+        rows.append(
+            (
+                s.workflow,
+                s.runner,
+                str(s.count),
+                human_seconds(s.queue_p50),
+                human_seconds(s.queue_p90),
+                human_seconds(s.queue_max),
+                human_seconds(s.exec_p50),
+                human_seconds(s.exec_p90),
+                human_seconds(s.exec_max),
+            )
+        )
+    widths = [max(len(row[i]) for row in rows) for i in range(len(header))]
+    lines = ["  ".join(cell.ljust(widths[i]) for i, cell in enumerate(rows[0])).rstrip()]
+    lines.append("  ".join("-" * widths[i] for i in range(len(header))))
+    for row in rows[1:]:
+        lines.append("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)).rstrip())
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------------------
+# Fetching
+# --------------------------------------------------------------------------------------
+
+
+def gh_api(path: str) -> object:
+    """One `gh api` GET. Raises RuntimeError with gh's own stderr on failure."""
+    proc = subprocess.run(
+        ["gh", "api", "-H", "Accept: application/vnd.github+json", path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed ({proc.returncode}): {proc.stderr.strip()}")
+    return json.loads(proc.stdout)
+
+
+def fetch_run_ids(repo: str, workflow: str, limit: int, branch: str | None) -> list[int]:
+    query = f"per_page={min(limit, 100)}&status=completed"
+    if branch:
+        query += f"&branch={branch}"
+    payload = gh_api(f"/repos/{repo}/actions/workflows/{workflow}/runs?{query}")
+    root = _as_object(payload)
+    if root is None:
+        return []
+    ids: list[int] = []
+    for raw in _as_array(root.get("workflow_runs")):
+        run = _as_object(raw)
+        if run is None:
+            continue
+        run_id = _as_int(run, "id")
+        if run_id is not None:
+            ids.append(run_id)
+    return ids[:limit]
+
+
+def fetch_records(
+    repo: str, workflow: str, limit: int, branch: str | None, verbose: bool
+) -> list[JobRecord]:
+    records: list[JobRecord] = []
+    run_ids = fetch_run_ids(repo, workflow, limit, branch)
+    if verbose:
+        print(f"# {workflow}: {len(run_ids)} runs", file=sys.stderr)
+    for run_id in run_ids:
+        payload = gh_api(f"/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100")
+        records.extend(parse_jobs(workflow, payload))
+    return records
+
+
+# --------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("workflows", nargs="*", help="workflow file names, e.g. c-unit.yml")
+    parser.add_argument("--repo", default=REPO_DEFAULT)
+    parser.add_argument("--limit", type=int, default=20, help="runs per workflow (default 20)")
+    parser.add_argument("--branch", default=None, help="restrict to one branch (default: all)")
+    parser.add_argument(
+        "--jobs-json",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="read a saved [{workflow, jobs: [...]}, ...] payload instead of calling gh",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    records: list[JobRecord] = []
+    if args.jobs_json is not None:
+        saved = _as_array(json.loads(Path(args.jobs_json).read_text(encoding="utf-8")))
+        for raw in saved:
+            entry = _as_object(raw)
+            if entry is None:
+                continue
+            workflow = _as_str(entry, "workflow") or str(args.jobs_json.name)
+            records.extend(parse_jobs(workflow, entry))
+    else:
+        if not args.workflows:
+            parser.error("give at least one workflow file name (or --jobs-json)")
+        for workflow in args.workflows:
+            records.extend(
+                fetch_records(
+                    str(args.repo), str(workflow), int(args.limit), args.branch, bool(args.verbose)
+                )
+            )
+
+    if not records:
+        print("no completed jobs with usable timestamps", file=sys.stderr)
+        return 1
+
+    scope = f"branch {args.branch}" if args.branch else "all branches"
+    print(f"# {len(records)} jobs, last {args.limit} runs per workflow, {scope}")
+    print(format_table(summarise(records)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/run_test_bundle.py
+++ b/ci/run_test_bundle.py
@@ -247,6 +247,14 @@ def parse_junit(path: Path) -> dict[str, bool]:
     `status="fail"` with one; a `<skipped>` child means it never ran. Presence of a
     `<failure>`/`<error>` child is the authoritative signal, with `status` as the fallback.
     """
+    if not path.is_file():
+        # ctest resolves --output-junit against the build directory, not the working
+        # directory, so a relative path silently lands somewhere else. Say that, rather
+        # than raising a bare FileNotFoundError from deep inside ElementTree.
+        raise FileNotFoundError(
+            f"{path} does not exist. `ctest --output-junit` writes relative paths into the "
+            f"build directory -- pass it an absolute path."
+        )
     tree = ElementTree.parse(path)
     outcomes: dict[str, bool] = {}
     for case in tree.getroot().iter("testcase"):
@@ -361,7 +369,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     reference = cast("Path | None", args.compare_junit)
     if reference is not None:
-        problems = compare_with_junit(reference, results)
+        try:
+            problems = compare_with_junit(reference, results)
+        except (FileNotFoundError, ElementTree.ParseError) as exc:
+            print(f"cannot read the ctest reference: {exc}", file=sys.stderr)
+            return 1
         if problems:
             print()
             print(f"bundle/ctest mismatch ({len(problems)}):", file=sys.stderr)

--- a/ci/run_test_bundle.py
+++ b/ci/run_test_bundle.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env -S uv run --script
+"""Replay a test bundle produced by `ci/bundle_tests.py`, serially, with no CMake.
+
+Issue #277 phase A. This is the half that runs on the macOS or Windows runner: given only
+`uv` and the bundle directory -- no CMake, no repo checkout, no build tree -- it executes
+every test in `tests.json` and reports in ctest's own shape so the output is comparable at
+a glance.
+
+    uv run ci/run_test_bundle.py <bundle> [--only NAME ...] [--env K=V ...]
+                                          [--timeout-scale F] [--junit out.xml]
+                                          [--compare-junit ctest.xml]
+
+The three semantics that are not just "run it and check the exit code":
+
+  * `expect_nonzero` -- the negative controls lowered from test/run-negative.cmake must
+    fail. A zero exit is a test failure.
+  * `expect_text` -- with it, the expected substring must appear in the combined
+    stdout+stderr, so a control that fails for the *wrong* reason is still red.
+  * a timeout is always a failure, `expect_nonzero` included. run-negative.cmake says so
+    in as many words ("timed out instead of failing fast"), and a hung negative control
+    proves nothing.
+
+`--compare-junit` takes the JUnit XML that a normal `ctest --output-junit` run wrote and
+asserts the bundle ran the same set of test names with the same pass/fail per test. That
+comparison is the acceptance criterion for phase A, and it is what the `bundle-roundtrip`
+job in c-unit.yml runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ElementTree
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+from xml.sax.saxutils import escape, quoteattr
+
+MANIFEST_NAME = "tests.json"
+BUNDLE_PLACEHOLDER = "${BUNDLE}"
+
+#: Loader search paths, per platform. The bundle is prepended to all of them because the
+#: executables were linked in a build tree and carry an RPATH pointing at it; without this
+#: a bundle "passes" on the build machine by loading the original library and fails
+#: everywhere else, which would make the roundtrip test a lie.
+_LOADER_PATH_VARS = ("LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH", "PATH")
+
+
+@dataclass(frozen=True)
+class TestSpec:
+    name: str
+    argv: tuple[str, ...]
+    env: dict[str, str]
+    cwd: str
+    timeout: float
+    expect_nonzero: bool
+    expect_text: str | None
+    labels: tuple[str, ...]
+
+
+@dataclass
+class TestResult:
+    name: str
+    passed: bool
+    seconds: float
+    reason: str
+    output: str
+
+    @property
+    def status(self) -> str:
+        return "Passed" if self.passed else "Failed"
+
+
+def _as_object(value: object) -> dict[str, object] | None:
+    return cast("dict[str, object]", value) if isinstance(value, dict) else None
+
+
+def _as_array(value: object) -> list[object]:
+    return cast("list[object]", value) if isinstance(value, list) else []
+
+
+def _str_list(value: object) -> list[str]:
+    return [item for item in _as_array(value) if isinstance(item, str)]
+
+
+def load_manifest(bundle: Path) -> list[TestSpec]:
+    payload = json.loads((bundle / MANIFEST_NAME).read_text(encoding="utf-8"))
+    root = _as_object(payload)
+    if root is None:
+        raise ValueError(f"{bundle / MANIFEST_NAME} is not a JSON object")
+    specs: list[TestSpec] = []
+    for raw in _as_array(root.get("tests")):
+        entry = _as_object(raw)
+        if entry is None:
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        raw_env = _as_object(entry.get("env")) or {}
+        env = {key: value for key, value in raw_env.items() if isinstance(value, str)}
+        raw_timeout = entry.get("timeout")
+        timeout = (
+            float(raw_timeout)
+            if isinstance(raw_timeout, (int, float)) and not isinstance(raw_timeout, bool)
+            else 1500.0
+        )
+        cwd = entry.get("cwd")
+        expect_text = entry.get("expect_text")
+        specs.append(
+            TestSpec(
+                name=name,
+                argv=tuple(_str_list(entry.get("argv"))),
+                env=env,
+                cwd=cwd if isinstance(cwd, str) else BUNDLE_PLACEHOLDER,
+                timeout=timeout,
+                expect_nonzero=entry.get("expect_nonzero") is True,
+                expect_text=expect_text if isinstance(expect_text, str) else None,
+                labels=tuple(_str_list(entry.get("labels"))),
+            )
+        )
+    return specs
+
+
+def _decode(stream: object) -> str:
+    if isinstance(stream, bytes):
+        return stream.decode("utf-8", "replace")
+    return stream if isinstance(stream, str) else ""
+
+
+def expand(value: str, bundle: Path) -> str:
+    return value.replace(BUNDLE_PLACEHOLDER, str(bundle))
+
+
+def build_environment(
+    spec: TestSpec, bundle: Path, extra: dict[str, str], base: dict[str, str]
+) -> dict[str, str]:
+    env = dict(base)
+    for key, value in spec.env.items():
+        env[key] = expand(value, bundle)
+    env.update(extra)
+    for variable in _LOADER_PATH_VARS:
+        current = env.get(variable)
+        env[variable] = str(bundle) if not current else f"{bundle}{os.pathsep}{current}"
+    return env
+
+
+def run_one(
+    spec: TestSpec, bundle: Path, extra_env: dict[str, str], timeout_scale: float
+) -> TestResult:
+    argv = [expand(item, bundle) for item in spec.argv]
+    cwd = Path(expand(spec.cwd, bundle))
+    env = build_environment(spec, bundle, extra_env, dict(os.environ))
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=str(cwd),
+            env=env,
+            capture_output=True,
+            text=True,
+            errors="replace",
+            timeout=spec.timeout * timeout_scale,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        elapsed = time.monotonic() - started
+        # Keep whatever the hung process managed to say -- for a negative control that is
+        # usually the only clue to why it hung instead of aborting.
+        text = _decode(exc.stdout) + _decode(exc.stderr)
+        # Deliberately a failure even for a negative control: run-negative.cmake calls this
+        # out explicitly as "timed out instead of failing fast".
+        return TestResult(
+            spec.name, False, elapsed, f"timed out after {spec.timeout * timeout_scale:g}s", text
+        )
+    except OSError as exc:
+        return TestResult(
+            spec.name, False, time.monotonic() - started, f"cannot execute: {exc}", ""
+        )
+
+    elapsed = time.monotonic() - started
+    combined = proc.stdout + proc.stderr
+    if spec.expect_nonzero:
+        if proc.returncode == 0:
+            return TestResult(
+                spec.name, False, elapsed, "expected a non-zero exit, got 0", combined
+            )
+    elif proc.returncode != 0:
+        return TestResult(spec.name, False, elapsed, f"exit code {proc.returncode}", combined)
+    if spec.expect_text is not None and spec.expect_text not in combined:
+        return TestResult(
+            spec.name,
+            False,
+            elapsed,
+            f"expected text {spec.expect_text!r} not found in output",
+            combined,
+        )
+    return TestResult(spec.name, True, elapsed, "", combined)
+
+
+# --------------------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------------------
+
+
+def format_progress(index: int, total: int, result: TestResult, width: int) -> str:
+    """A line shaped like ctest's, so the two outputs can be read side by side."""
+    counter = f"{index}/{total}"
+    label = f"{result.name} "
+    dots = "." * max(3, width - len(result.name) + 3)
+    return (
+        f"{counter:>7} Test #{index}: {label}{dots} {result.status:>6}  {result.seconds:6.2f} sec"
+    )
+
+
+def write_junit(path: Path, results: Sequence[TestResult]) -> None:
+    failures = sum(1 for result in results if not result.passed)
+    total_time = sum(result.seconds for result in results)
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        f'<testsuite name={quoteattr("test-bundle")} tests="{len(results)}" '
+        f'failures="{failures}" disabled="0" skipped="0" time="{total_time:.6f}">',
+    ]
+    for result in results:
+        status = "run" if result.passed else "fail"
+        lines.append(
+            f"  <testcase name={quoteattr(result.name)} classname={quoteattr(result.name)} "
+            f'time="{result.seconds:.6f}" status="{status}">'
+        )
+        if not result.passed:
+            lines.append(f"    <failure message={quoteattr(result.reason)}/>")
+        lines.append(f"    <system-out>{escape(result.output)}</system-out>")
+        lines.append("  </testcase>")
+    lines.append("</testsuite>")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_junit(path: Path) -> dict[str, bool]:
+    """Read a ctest (or our own) JUnit file into {test name: passed}.
+
+    ctest marks a passing case `status="run"` with no `<failure>` child and a failing one
+    `status="fail"` with one; a `<skipped>` child means it never ran. Presence of a
+    `<failure>`/`<error>` child is the authoritative signal, with `status` as the fallback.
+    """
+    tree = ElementTree.parse(path)
+    outcomes: dict[str, bool] = {}
+    for case in tree.getroot().iter("testcase"):
+        name = case.get("name")
+        if name is None:
+            continue
+        status = case.get("status")
+        if case.find("skipped") is not None or status in ("disabled", "notrun"):
+            # ctest did not execute it, so there is nothing for the bundle to agree with.
+            continue
+        failed = case.find("failure") is not None or case.find("error") is not None
+        if not failed and status not in (None, "run"):
+            failed = True
+        outcomes[name] = not failed
+    return outcomes
+
+
+def compare_with_junit(reference: Path, results: Sequence[TestResult]) -> list[str]:
+    """Return the differences between a ctest run and this bundle run. Empty means equal."""
+    expected = parse_junit(reference)
+    actual = {result.name: result.passed for result in results}
+    problems: list[str] = []
+    for name in sorted(set(expected) - set(actual)):
+        problems.append(f"{name}: ctest ran it, the bundle does not contain it")
+    for name in sorted(set(actual) - set(expected)):
+        problems.append(f"{name}: the bundle ran it, ctest did not")
+    for name in sorted(set(expected) & set(actual)):
+        if expected[name] != actual[name]:
+            problems.append(
+                f"{name}: ctest says {'pass' if expected[name] else 'fail'}, "
+                f"the bundle says {'pass' if actual[name] else 'fail'}"
+            )
+    return problems
+
+
+# --------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("bundle", type=Path)
+    parser.add_argument("--only", nargs="+", default=None, metavar="NAME", help="run these tests")
+    parser.add_argument(
+        "--env", nargs="+", default=None, metavar="K=V", help="extra environment for every test"
+    )
+    parser.add_argument("--timeout-scale", type=float, default=1.0)
+    parser.add_argument("--junit", type=Path, default=None, metavar="FILE")
+    parser.add_argument(
+        "--compare-junit",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="assert the same test names and pass/fail as this ctest --output-junit file",
+    )
+    args = parser.parse_args(argv)
+
+    bundle = Path(cast("Path", args.bundle)).resolve()
+    specs = load_manifest(bundle)
+    only = cast("list[str] | None", args.only)
+    if only is not None:
+        wanted = set(only)
+        missing = sorted(wanted - {spec.name for spec in specs})
+        if missing:
+            print(f"no such test(s) in the bundle: {missing}", file=sys.stderr)
+            return 1
+        specs = [spec for spec in specs if spec.name in wanted]
+
+    extra_env: dict[str, str] = {}
+    for assignment in cast("list[str] | None", args.env) or []:
+        key, separator, value = assignment.partition("=")
+        if not separator or not key:
+            print(f"--env expects K=V, got {assignment!r}", file=sys.stderr)
+            return 1
+        extra_env[key] = value
+
+    scale = float(cast("float", args.timeout_scale))
+    width = max((len(spec.name) for spec in specs), default=10) + 6
+    print(f"Test bundle: {bundle}  ({platform.system()} {platform.machine()})")
+    results: list[TestResult] = []
+    started = time.monotonic()
+    for index, spec in enumerate(specs, start=1):
+        print(f"{'':>7} Start {index:>2}: {spec.name}", flush=True)
+        result = run_one(spec, bundle, extra_env, scale)
+        results.append(result)
+        print(format_progress(index, len(specs), result, width), flush=True)
+        if not result.passed:
+            print(f"          reason: {result.reason}")
+            tail = result.output.strip().splitlines()[-25:]
+            for line in tail:
+                print(f"          | {line}")
+    total = time.monotonic() - started
+
+    failed = [result for result in results if not result.passed]
+    percent = 100 if not results else round(100 * (len(results) - len(failed)) / len(results))
+    print()
+    print(f"{percent}% tests passed, {len(failed)} tests failed out of {len(results)}")
+    print(f"Total Test time (real) = {total:8.2f} sec")
+    if failed:
+        print()
+        print("The following tests FAILED:")
+        for result in failed:
+            print(f"\t{result.name} ({result.reason})")
+
+    junit = cast("Path | None", args.junit)
+    if junit is not None:
+        write_junit(junit, results)
+        print(f"JUnit written to {junit}")
+
+    reference = cast("Path | None", args.compare_junit)
+    if reference is not None:
+        problems = compare_with_junit(reference, results)
+        if problems:
+            print()
+            print(f"bundle/ctest mismatch ({len(problems)}):", file=sys.stderr)
+            for problem in problems:
+                print(f"  - {problem}", file=sys.stderr)
+            return 1
+        print(f"bundle matches {reference}: same {len(results)} test names, same results")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/fixtures/queue_wait/jobs.json
+++ b/ci/tests/fixtures/queue_wait/jobs.json
@@ -1,0 +1,96 @@
+[
+  {
+    "workflow": "cross.yml",
+    "total_count": 8,
+    "jobs": [
+      {
+        "id": 1,
+        "run_id": 900,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:01:00Z",
+        "completed_at": "2026-09-01T00:01:10Z",
+        "labels": ["macos-latest"]
+      },
+      {
+        "id": 2,
+        "run_id": 901,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:02:00Z",
+        "completed_at": "2026-09-01T00:02:20Z",
+        "labels": ["macos-latest"]
+      },
+      {
+        "id": 3,
+        "run_id": 902,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "failure",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:05:00Z",
+        "completed_at": "2026-09-01T00:05:30Z",
+        "labels": ["macos-latest"]
+      },
+      {
+        "id": 4,
+        "run_id": 903,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T05:26:00Z",
+        "completed_at": "2026-09-01T05:26:40Z",
+        "labels": ["macos-latest"]
+      },
+      {
+        "id": 5,
+        "run_id": 903,
+        "name": "build (x86_64-unknown-linux-gnu)",
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:00:04Z",
+        "completed_at": "2026-09-01T00:00:50Z",
+        "labels": ["ubuntu-latest"]
+      },
+      {
+        "id": 6,
+        "run_id": 903,
+        "name": "test (x86_64-apple-darwin)",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:00:01Z",
+        "completed_at": "2026-09-01T00:00:02Z",
+        "labels": ["macos-15-intel"]
+      },
+      {
+        "id": 7,
+        "run_id": 903,
+        "name": "test (x86_64-pc-windows-gnu)",
+        "status": "completed",
+        "conclusion": "skipped",
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": null,
+        "completed_at": null,
+        "labels": ["windows-latest"]
+      },
+      {
+        "id": 8,
+        "run_id": 904,
+        "name": "test (aarch64-apple-darwin)",
+        "status": "in_progress",
+        "conclusion": null,
+        "created_at": "2026-09-01T00:00:00Z",
+        "started_at": "2026-09-01T00:00:30Z",
+        "completed_at": null,
+        "labels": ["macos-latest"]
+      }
+    ]
+  }
+]

--- a/ci/tests/fixtures/test_bundles/ctest-show-only.json
+++ b/ci/tests/fixtures/test_bundles/ctest-show-only.json
@@ -1,0 +1,133 @@
+{
+ "kind": "ctestInfo",
+ "version": {
+  "major": 1,
+  "minor": 0
+ },
+ "tests": [
+  {
+   "name": "test-api",
+   "command": [
+    "/build/mimalloc-test-api"
+   ],
+   "properties": [
+    {
+     "name": "WORKING_DIRECTORY",
+     "value": "/build"
+    }
+   ]
+  },
+  {
+   "name": "test-profile-accum",
+   "command": [
+    "/build/mimalloc-test-profile"
+   ],
+   "properties": [
+    {
+     "name": "ENVIRONMENT",
+     "value": [
+      "MIMALLOC_PROF_ACCUM=1"
+     ]
+    },
+    {
+     "name": "WORKING_DIRECTORY",
+     "value": "/build"
+    }
+   ]
+  },
+  {
+   "name": "test-zero-tracking-enabled",
+   "command": [
+    "/build/mimalloc-test-zero-tracking"
+   ],
+   "properties": [
+    {
+     "name": "ENVIRONMENT",
+     "value": [
+      "MIMALLOC_PURGE_ZEROES=1",
+      "MIMALLOC_PURGE_DELAY=0"
+     ]
+    },
+    {
+     "name": "TIMEOUT",
+     "value": 900.0
+    },
+    {
+     "name": "WORKING_DIRECTORY",
+     "value": "/build"
+    }
+   ]
+  },
+  {
+   "name": "test-dhat",
+   "command": [
+    "/build/mimalloc-test-dhat"
+   ],
+   "properties": [
+    {
+     "name": "WORKING_DIRECTORY",
+     "value": "/build"
+    }
+   ]
+  },
+  {
+   "name": "test-lock-reentrancy",
+   "command": [
+    "/usr/bin/cmake",
+    "-DTEST_EXE=/build/mimalloc-test-lock-reentrancy",
+    "-DTEST_ARG=reentrant",
+    "-DEXPECTED_TEXT=reentrant_internal_lock_acquisition",
+    "-P",
+    "/src/test/run-negative.cmake"
+   ],
+   "properties": [
+    {
+     "name": "TIMEOUT",
+     "value": 15.0
+    },
+    {
+     "name": "WORKING_DIRECTORY",
+     "value": "/build"
+    }
+   ]
+  },
+  {
+   "name": "test-tls-control-zero",
+   "command": [
+    "/usr/bin/cmake",
+    "-DTEST_EXE=/build/mimalloc-test-tls-controls",
+    "-DTEST_ARG=zero",
+    "-DEXPECTED_TEXT=internal_tls_new_slots_not_zero",
+    "-P",
+    "/src/test/run-negative.cmake"
+   ],
+   "properties": [
+    {
+     "name": "TIMEOUT",
+     "value": 15.0
+    },
+    {
+     "name": "WORKING_DIRECTORY",
+     "value": "/build"
+    }
+   ]
+  },
+  {
+   "name": "test-stress-dynamic",
+   "command": [
+    "/usr/bin/cmake",
+    "-E",
+    "env",
+    "MIMALLOC_VERBOSE=1",
+    "LD_PRELOAD=/build/libmimalloc-debug.so.3.4",
+    "/build/mimalloc-test-stress-dynamic"
+   ],
+   "properties": [
+    {
+     "name": "WORKING_DIRECTORY",
+     "value": "/build"
+    }
+   ]
+  }
+ ]
+}

--- a/ci/tests/test_ci_queue_wait.py
+++ b/ci/tests/test_ci_queue_wait.py
@@ -1,0 +1,161 @@
+"""Unit tests for ci/ci_queue_wait.py (issue #277 phase 0).
+
+The script decides whether `concurrency: cancel-in-progress` actually bought anything, so
+its arithmetic has to be checkable without hitting the API: everything below drives the
+pure functions from a fixture in the real `/actions/runs/<id>/jobs` shape.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from typing import cast
+
+import ci_queue_wait
+
+FIXTURE = Path(__file__).parent / "fixtures" / "queue_wait" / "jobs.json"
+SCRIPT = Path(__file__).resolve().parents[1] / "ci_queue_wait.py"
+
+
+def _fixture_payload() -> object:
+    payloads = cast("list[object]", json.loads(FIXTURE.read_text(encoding="utf-8")))
+    assert len(payloads) == 1
+    return payloads[0]
+
+
+class ParseJobsTest(unittest.TestCase):
+    def test_keeps_only_completed_jobs_with_all_three_timestamps(self) -> None:
+        records = ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())
+        # 8 jobs in the fixture; dropped: cancelled (6), skipped/null ts (7), in_progress (8).
+        self.assertEqual([r.job_id for r in records], [1, 2, 3, 4, 5])
+
+    def test_failed_jobs_are_kept(self) -> None:
+        records = ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())
+        failed = [r for r in records if r.job_id == 3]
+        self.assertEqual(len(failed), 1, "a red job still waited in the queue and still ran")
+
+    def test_queue_and_exec_split(self) -> None:
+        records = {r.job_id: r for r in ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())}
+        self.assertEqual(records[4].queue_seconds, 5 * 3600 + 26 * 60)
+        self.assertEqual(records[4].exec_seconds, 40.0)
+        self.assertEqual(records[5].queue_seconds, 4.0)
+
+    def test_runner_label_grouping_key(self) -> None:
+        records = {r.job_id: r for r in ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())}
+        self.assertEqual(records[1].runner, "macos-latest")
+        self.assertEqual(records[5].runner, "ubuntu-latest")
+
+    def test_multi_label_runs_on_joins_labels(self) -> None:
+        payload = {
+            "jobs": [
+                {
+                    "id": 11,
+                    "run_id": 1,
+                    "name": "j",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "created_at": "2026-09-01T00:00:00Z",
+                    "started_at": "2026-09-01T00:00:10Z",
+                    "completed_at": "2026-09-01T00:00:20Z",
+                    "labels": ["self-hosted", "macOS", "ARM64"],
+                }
+            ]
+        }
+        records = ci_queue_wait.parse_jobs("x.yml", payload)
+        self.assertEqual(records[0].runner, "self-hosted,macOS,ARM64")
+
+    def test_garbage_payloads_yield_no_records_rather_than_raising(self) -> None:
+        payloads: tuple[object, ...] = (None, [], {}, {"jobs": "nope"}, {"jobs": [None, 7, "x"]})
+        for payload in payloads:
+            self.assertEqual(ci_queue_wait.parse_jobs("x.yml", payload), [])
+
+
+class PercentileTest(unittest.TestCase):
+    def test_nearest_rank(self) -> None:
+        values = [10.0, 20.0, 30.0, 40.0]
+        self.assertEqual(ci_queue_wait.percentile(values, 0.50), 20.0)
+        self.assertEqual(ci_queue_wait.percentile(values, 0.90), 40.0)
+        self.assertEqual(ci_queue_wait.percentile(values, 0.25), 10.0)
+
+    def test_single_sample_and_empty(self) -> None:
+        self.assertEqual(ci_queue_wait.percentile([7.0], 0.9), 7.0)
+        self.assertEqual(ci_queue_wait.percentile([], 0.5), 0.0)
+
+    def test_unsorted_input(self) -> None:
+        self.assertEqual(ci_queue_wait.percentile([40.0, 10.0, 30.0, 20.0], 0.5), 20.0)
+
+
+class SummariseTest(unittest.TestCase):
+    def test_groups_by_workflow_and_runner(self) -> None:
+        records = ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())
+        summaries = {s.runner: s for s in ci_queue_wait.summarise(records)}
+        self.assertEqual(sorted(summaries), ["macos-latest", "ubuntu-latest"])
+        mac = summaries["macos-latest"]
+        self.assertEqual(mac.count, 4)
+        # queue waits 60, 120, 300, 19560 -> nearest-rank p50 = 120, p90 = 19560
+        self.assertEqual(mac.queue_p50, 120.0)
+        self.assertEqual(mac.queue_p90, 19560.0)
+        self.assertEqual(mac.queue_max, 19560.0)
+        self.assertEqual(mac.exec_p50, 20.0)
+        self.assertEqual(mac.exec_max, 40.0)
+
+    def test_same_runner_in_two_workflows_stays_separate(self) -> None:
+        """cross.yml rows include upstream `needs:` build time; c-unit rows do not."""
+        payload = _fixture_payload()
+        records = ci_queue_wait.parse_jobs("cross.yml", payload) + ci_queue_wait.parse_jobs(
+            "c-unit.yml", payload
+        )
+        summaries = ci_queue_wait.summarise(records)
+        self.assertEqual(
+            [(s.workflow, s.runner) for s in summaries],
+            [
+                ("c-unit.yml", "macos-latest"),
+                ("c-unit.yml", "ubuntu-latest"),
+                ("cross.yml", "macos-latest"),
+                ("cross.yml", "ubuntu-latest"),
+            ],
+        )
+
+
+class FormattingTest(unittest.TestCase):
+    def test_human_seconds(self) -> None:
+        self.assertEqual(ci_queue_wait.human_seconds(0), "0s")
+        self.assertEqual(ci_queue_wait.human_seconds(59.4), "59s")
+        self.assertEqual(ci_queue_wait.human_seconds(60), "1m00s")
+        self.assertEqual(ci_queue_wait.human_seconds(150), "2m30s")
+        self.assertEqual(ci_queue_wait.human_seconds(19560), "5h26m")
+
+    def test_table_has_one_row_per_group(self) -> None:
+        records = ci_queue_wait.parse_jobs("cross.yml", _fixture_payload())
+        table = ci_queue_wait.format_table(ci_queue_wait.summarise(records))
+        lines = table.split("\n")
+        self.assertIn("runs-on labels", lines[0])
+        self.assertEqual(len(lines), 4, "header + rule + two groups")
+        self.assertIn("5h26m", table)
+
+
+class CliTest(unittest.TestCase):
+    def test_jobs_json_mode_needs_no_network(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--jobs-json", str(FIXTURE)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("cross.yml", proc.stdout)
+        self.assertIn("macos-latest", proc.stdout)
+        self.assertIn("5 jobs", proc.stdout)
+
+    def test_no_workflows_and_no_fixture_is_a_usage_error(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT)], capture_output=True, text=True, check=False
+        )
+        self.assertEqual(proc.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_test_bundles.py
+++ b/ci/tests/test_test_bundles.py
@@ -416,6 +416,12 @@ class RunnerTest(unittest.TestCase):
         outcomes = run_test_bundle.parse_junit(report)
         self.assertEqual(outcomes, {"t-ok": True, "t-bad": False})
 
+    def test_a_missing_reference_file_explains_the_ctest_gotcha(self) -> None:
+        self.write_manifest([self.spec("t-ok", "ok")])
+        proc = self.run_bundle("--compare-junit", str(self.bundle / "nope.xml"))
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("build directory", proc.stderr + proc.stdout)
+
     def test_compare_junit_detects_a_missing_test(self) -> None:
         reference = self.bundle / "ctest.xml"
         reference.write_text(

--- a/ci/tests/test_test_bundles.py
+++ b/ci/tests/test_test_bundles.py
@@ -1,0 +1,536 @@
+"""Unit tests for ci/bundle_tests.py and ci/run_test_bundle.py (issue #277 phase A).
+
+The bundle format's whole job is to carry a test suite to a machine that has no CMake and
+no checkout, without quietly changing what any test asserts. Two failure modes matter and
+both are covered here:
+
+  * a command shape the bundler cannot lower is *dropped*, so the bundle reports green on
+    fewer tests than ctest ran -- every unsupported shape must raise instead
+  * a negative control is lowered into something that passes for the wrong reason (a zero
+    exit, a timeout, or the wrong message) -- run-negative.cmake's exact semantics are
+    pinned below
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import bundle_tests
+import run_test_bundle
+
+FIXTURES = Path(__file__).parent / "fixtures" / "test_bundles"
+SHOW_ONLY = FIXTURES / "ctest-show-only.json"
+BUNDLE_TESTS = Path(__file__).resolve().parents[1] / "bundle_tests.py"
+RUN_BUNDLE = Path(__file__).resolve().parents[1] / "run_test_bundle.py"
+
+BUILD = Path("/build") if os.name != "nt" else Path("C:/build")
+
+
+def _payload() -> object:
+    text = SHOW_ONLY.read_text(encoding="utf-8")
+    if os.name == "nt":
+        text = text.replace('"/build', '"C:/build').replace('"/src', '"C:/src')
+    return json.loads(text)
+
+
+def _convert() -> dict[str, bundle_tests.BundledTest]:
+    tests, _ = bundle_tests.convert(_payload(), BUILD)
+    return {test.name: test for test in tests}
+
+
+def _test_entry(name: str, command: list[str], properties: object = None) -> dict[str, object]:
+    return {"name": name, "command": command, "properties": properties or []}
+
+
+def _wrap(*entries: dict[str, object]) -> dict[str, object]:
+    return {"kind": "ctestInfo", "version": {"major": 1, "minor": 0}, "tests": list(entries)}
+
+
+class LoweringTest(unittest.TestCase):
+    def test_plain_executable_passes_through(self) -> None:
+        test = _convert()["test-api"]
+        self.assertEqual(test.argv, ["${BUNDLE}/mimalloc-test-api"])
+        self.assertFalse(test.expect_nonzero)
+        self.assertIsNone(test.expect_text)
+        self.assertEqual(test.cwd, "${BUNDLE}")
+
+    def test_environment_property_becomes_env(self) -> None:
+        test = _convert()["test-zero-tracking-enabled"]
+        self.assertEqual(test.env, {"MIMALLOC_PURGE_ZEROES": "1", "MIMALLOC_PURGE_DELAY": "0"})
+        self.assertEqual(test.timeout, 900.0)
+
+    def test_default_timeout_is_ctests_own(self) -> None:
+        self.assertEqual(_convert()["test-api"].timeout, bundle_tests.DEFAULT_TIMEOUT_SECONDS)
+
+    def test_cmake_e_env_lowers_to_env_and_the_real_argv(self) -> None:
+        test = _convert()["test-stress-dynamic"]
+        self.assertEqual(test.argv, ["${BUNDLE}/mimalloc-test-stress-dynamic"])
+        self.assertEqual(test.env["MIMALLOC_VERBOSE"], "1")
+        # The absolute build-tree path inside an ENV VALUE must be relativised too.
+        self.assertEqual(test.env["LD_PRELOAD"], "${BUNDLE}/libmimalloc-debug.so.3.4")
+
+    def test_cmake_e_env_stops_at_the_first_non_assignment(self) -> None:
+        lowered = bundle_tests.lower_command(
+            ["/usr/bin/cmake", "-E", "env", "A=1", "/build/exe", "B=2"], "t"
+        )
+        self.assertEqual(lowered.env, {"A": "1"})
+        self.assertEqual(lowered.argv, ["/build/exe", "B=2"])
+
+    def test_cmake_e_env_options_are_refused_not_ignored(self) -> None:
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.lower_command(
+                ["/usr/bin/cmake", "-E", "env", "--unset=FOO", "/build/exe"], "t-unset"
+            )
+        self.assertIn("t-unset", str(caught.exception))
+        self.assertIn("--unset=FOO", str(caught.exception))
+
+    def test_other_cmake_e_modes_are_refused(self) -> None:
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.lower_command(["/usr/bin/cmake", "-E", "rm", "-f", "x"], "t-rm")
+        self.assertIn("cmake -E rm", str(caught.exception))
+
+
+class NegativeControlTest(unittest.TestCase):
+    """test/run-negative.cmake semantics, pinned field by field."""
+
+    def test_lowers_exe_arg_text_and_timeout(self) -> None:
+        test = _convert()["test-lock-reentrancy"]
+        self.assertEqual(test.argv, ["${BUNDLE}/mimalloc-test-lock-reentrancy", "reentrant"])
+        self.assertTrue(test.expect_nonzero)
+        self.assertEqual(test.expect_text, "reentrant_internal_lock_acquisition")
+        # The 10 s the cmake script wraps execute_process in, NOT the test's TIMEOUT 15.
+        self.assertEqual(test.timeout, bundle_tests.NEGATIVE_TIMEOUT_SECONDS)
+
+    def test_test_arg_is_optional(self) -> None:
+        lowered = bundle_tests.lower_command(
+            [
+                "/usr/bin/cmake",
+                "-DTEST_EXE=/build/exe",
+                "-DEXPECTED_TEXT=boom",
+                "-P",
+                "/src/test/run-negative.cmake",
+            ],
+            "t",
+        )
+        self.assertEqual(lowered.argv, ["/build/exe"])
+        self.assertEqual(lowered.expect_text, "boom")
+
+    def test_missing_expected_text_is_an_error(self) -> None:
+        with self.assertRaises(bundle_tests.BundleError):
+            bundle_tests.lower_command(
+                ["/usr/bin/cmake", "-DTEST_EXE=/build/exe", "-P", "/src/test/run-negative.cmake"],
+                "t",
+            )
+
+    def test_an_unknown_cmake_script_is_refused(self) -> None:
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.lower_command(
+                ["/usr/bin/cmake", "-DX=1", "-P", "/src/test/something-else.cmake"], "t-script"
+            )
+        self.assertIn("run-negative.cmake", str(caught.exception))
+
+    def test_unknown_define_is_refused(self) -> None:
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.lower_command(
+                [
+                    "/usr/bin/cmake",
+                    "-DTEST_EXE=/build/exe",
+                    "-DEXPECTED_TEXT=boom",
+                    "-DEXTRA=surprise",
+                    "-P",
+                    "/src/test/run-negative.cmake",
+                ],
+                "t",
+            )
+        self.assertIn("EXTRA", str(caught.exception))
+
+
+class PathRewritingTest(unittest.TestCase):
+    def test_build_tree_paths_become_placeholders_and_register_assets(self) -> None:
+        _, assets = bundle_tests.convert(_payload(), BUILD)
+        self.assertIn("mimalloc-test-api", assets)
+        self.assertIn("libmimalloc-debug.so.3.4", assets)
+
+    def test_paths_outside_the_build_tree_are_left_alone(self) -> None:
+        rewriter = bundle_tests.PathRewriter(BUILD)
+        self.assertEqual(rewriter.rewrite("MIMALLOC_VERBOSE=1"), "MIMALLOC_VERBOSE=1")
+        self.assertEqual(rewriter.rewrite("/usr/lib/libc.so"), "/usr/lib/libc.so")
+        self.assertEqual(rewriter.assets, {})
+
+    def test_dyld_insert_libraries_is_relativised_like_ld_preload(self) -> None:
+        """macOS's env var carries the same absolute build-tree path (#277 review, item 4)."""
+        payload = _wrap(
+            _test_entry(
+                "test-stress-dynamic",
+                [
+                    "/usr/bin/cmake",
+                    "-E",
+                    "env",
+                    "MIMALLOC_VERBOSE=1",
+                    f"DYLD_INSERT_LIBRARIES={BUILD.as_posix()}/libmimalloc-debug.dylib",
+                    f"{BUILD.as_posix()}/mimalloc-test-stress-dynamic",
+                ],
+            )
+        )
+        tests, assets = bundle_tests.convert(payload, BUILD)
+        self.assertEqual(tests[0].env["DYLD_INSERT_LIBRARIES"], "${BUNDLE}/libmimalloc-debug.dylib")
+        self.assertIn("libmimalloc-debug.dylib", assets)
+
+    def test_basename_collision_is_an_error_not_a_silent_overwrite(self) -> None:
+        payload = _wrap(
+            _test_entry("a", [f"{BUILD.as_posix()}/one/mimalloc-test-api"]),
+            _test_entry("b", [f"{BUILD.as_posix()}/two/mimalloc-test-api"]),
+        )
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.convert(payload, BUILD)
+        self.assertIn("mimalloc-test-api", str(caught.exception))
+
+    def test_an_executable_outside_the_build_tree_is_refused(self) -> None:
+        payload = _wrap(_test_entry("t-outside", ["/usr/bin/true"]))
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.convert(payload, BUILD)
+        self.assertIn("t-outside", str(caught.exception))
+
+
+class PropertyHandlingTest(unittest.TestCase):
+    def test_unsupported_property_is_refused(self) -> None:
+        payload = _wrap(
+            _test_entry(
+                "t-regex",
+                [f"{BUILD.as_posix()}/exe"],
+                [{"name": "PASS_REGULAR_EXPRESSION", "value": ["ok"]}],
+            )
+        )
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.convert(payload, BUILD)
+        self.assertIn("PASS_REGULAR_EXPRESSION", str(caught.exception))
+
+    def test_will_fail_lowers_to_expect_nonzero(self) -> None:
+        payload = _wrap(
+            _test_entry(
+                "t-willfail", [f"{BUILD.as_posix()}/exe"], [{"name": "WILL_FAIL", "value": True}]
+            )
+        )
+        tests, _ = bundle_tests.convert(payload, BUILD)
+        self.assertTrue(tests[0].expect_nonzero)
+
+    def test_labels_are_carried(self) -> None:
+        payload = _wrap(
+            _test_entry(
+                "t-lab", [f"{BUILD.as_posix()}/exe"], [{"name": "LABELS", "value": ["slow"]}]
+            )
+        )
+        tests, _ = bundle_tests.convert(payload, BUILD)
+        self.assertEqual(tests[0].labels, ["slow"])
+
+    def test_cmake_e_env_beats_the_environment_property_on_a_conflict(self) -> None:
+        payload = _wrap(
+            _test_entry(
+                "t-both",
+                ["/usr/bin/cmake", "-E", "env", "K=wrapper", f"{BUILD.as_posix()}/exe"],
+                [{"name": "ENVIRONMENT", "value": ["K=property"]}],
+            )
+        )
+        tests, _ = bundle_tests.convert(payload, BUILD)
+        self.assertEqual(tests[0].env["K"], "wrapper")
+
+    def test_every_problem_is_reported_at_once(self) -> None:
+        payload = _wrap(
+            _test_entry("t-one", ["/usr/bin/cmake", "-E", "rm", "x"]),
+            _test_entry("t-two", ["/usr/bin/cmake", "-E", "copy", "a", "b"]),
+        )
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.convert(payload, BUILD)
+        message = str(caught.exception)
+        self.assertIn("t-one", message)
+        self.assertIn("t-two", message)
+        self.assertIn("2 test(s)", message)
+
+
+# --------------------------------------------------------------------------------------
+# Runner
+# --------------------------------------------------------------------------------------
+
+PROBE = """
+import os, sys, time
+mode = sys.argv[1] if len(sys.argv) > 1 else "ok"
+if mode == "ok":
+    print("all good")
+elif mode == "boom":
+    print("expected_marker_here")
+    sys.exit(3)
+elif mode == "wrong-reason":
+    print("something else entirely")
+    sys.exit(3)
+elif mode == "hang":
+    print("hanging", flush=True)
+    time.sleep(30)
+elif mode == "env":
+    print("K=" + os.environ.get("K", "<unset>"))
+elif mode == "cwd":
+    print("CWD=" + os.getcwd())
+sys.exit(0)
+"""
+
+
+class RunnerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.bundle = Path(self._tmp.name)
+        (self.bundle / "probe.py").write_text(PROBE, encoding="utf-8")
+        self.addCleanup(self._tmp.cleanup)
+
+    def write_manifest(self, tests: list[dict[str, object]]) -> None:
+        (self.bundle / "tests.json").write_text(
+            json.dumps({"version": 1, "tests": tests}), encoding="utf-8"
+        )
+
+    def spec(self, name: str, mode: str, **overrides: object) -> dict[str, object]:
+        entry: dict[str, object] = {
+            "name": name,
+            "argv": [sys.executable, "${BUNDLE}/probe.py", mode],
+            "env": {},
+            "cwd": "${BUNDLE}",
+            "timeout": 30.0,
+            "expect_nonzero": False,
+            "expect_text": None,
+            "labels": [],
+        }
+        entry.update(overrides)
+        return entry
+
+    def run_bundle(self, *extra: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(RUN_BUNDLE), str(self.bundle), *extra],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_passing_and_failing_tests(self) -> None:
+        self.write_manifest([self.spec("t-ok", "ok"), self.spec("t-bad", "boom")])
+        proc = self.run_bundle()
+        self.assertEqual(proc.returncode, 1, proc.stdout)
+        self.assertIn("1 tests failed out of 2", proc.stdout)
+        self.assertIn("exit code 3", proc.stdout)
+
+    def test_expect_nonzero_and_expect_text(self) -> None:
+        self.write_manifest(
+            [self.spec("t-neg", "boom", expect_nonzero=True, expect_text="expected_marker_here")]
+        )
+        proc = self.run_bundle()
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("100% tests passed", proc.stdout)
+
+    def test_negative_control_that_fails_for_the_wrong_reason_is_red(self) -> None:
+        self.write_manifest(
+            [
+                self.spec(
+                    "t-neg", "wrong-reason", expect_nonzero=True, expect_text="expected_marker_here"
+                )
+            ]
+        )
+        proc = self.run_bundle()
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("not found in output", proc.stdout)
+
+    def test_negative_control_that_exits_zero_is_red(self) -> None:
+        self.write_manifest([self.spec("t-neg", "ok", expect_nonzero=True)])
+        proc = self.run_bundle()
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("expected a non-zero exit", proc.stdout)
+
+    def test_timeout_is_a_failure_even_for_a_negative_control(self) -> None:
+        """run-negative.cmake: 'timed out instead of failing fast' is a FATAL_ERROR."""
+        self.write_manifest(
+            [self.spec("t-hang", "hang", timeout=1.0, expect_nonzero=True, expect_text="hanging")]
+        )
+        proc = self.run_bundle()
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("timed out", proc.stdout)
+
+    def test_timeout_scale(self) -> None:
+        self.write_manifest([self.spec("t-hang", "hang", timeout=100.0)])
+        proc = self.run_bundle("--timeout-scale", "0.01")
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("timed out after 1s", proc.stdout)
+
+    def test_manifest_env_reaches_the_child(self) -> None:
+        self.write_manifest(
+            [self.spec("t-env", "env", env={"K": "from-manifest"}, expect_text="K=from-manifest")]
+        )
+        self.assertEqual(self.run_bundle().returncode, 0)
+
+    def test_cli_env_overrides_the_manifest(self) -> None:
+        self.write_manifest(
+            [self.spec("t-env", "env", env={"K": "from-manifest"}, expect_text="K=from-cli")]
+        )
+        self.assertEqual(self.run_bundle().returncode, 1, "manifest value alone must not match")
+        self.assertEqual(self.run_bundle("--env", "K=from-cli").returncode, 0)
+
+    def test_only_selects_a_subset(self) -> None:
+        self.write_manifest([self.spec("t-ok", "ok"), self.spec("t-bad", "boom")])
+        proc = self.run_bundle("--only", "t-ok")
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+        self.assertIn("out of 1", proc.stdout)
+
+    def test_only_with_an_unknown_name_is_an_error(self) -> None:
+        self.write_manifest([self.spec("t-ok", "ok")])
+        proc = self.run_bundle("--only", "t-nope")
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("no such test", proc.stderr)
+
+    def test_cwd_defaults_to_the_bundle_root(self) -> None:
+        self.write_manifest([self.spec("t-cwd", "cwd", expect_text=f"CWD={self.bundle.resolve()}")])
+        self.assertEqual(self.run_bundle().returncode, 0)
+
+    def test_bundle_is_prepended_to_the_loader_path(self) -> None:
+        """Otherwise a bundle 'passes' on the build machine via the build-tree RPATH."""
+        spec = run_test_bundle.TestSpec(
+            name="t",
+            argv=("x",),
+            env={},
+            cwd="${BUNDLE}",
+            timeout=1.0,
+            expect_nonzero=False,
+            expect_text=None,
+            labels=(),
+        )
+        env = run_test_bundle.build_environment(
+            spec, self.bundle, {}, {"LD_LIBRARY_PATH": "/existing"}
+        )
+        self.assertEqual(env["LD_LIBRARY_PATH"], f"{self.bundle}{os.pathsep}/existing")
+        self.assertEqual(env["DYLD_LIBRARY_PATH"], str(self.bundle))
+
+    def test_junit_roundtrips_through_compare(self) -> None:
+        self.write_manifest([self.spec("t-ok", "ok"), self.spec("t-bad", "boom")])
+        report = self.bundle / "out.xml"
+        self.run_bundle("--junit", str(report))
+        outcomes = run_test_bundle.parse_junit(report)
+        self.assertEqual(outcomes, {"t-ok": True, "t-bad": False})
+
+    def test_compare_junit_detects_a_missing_test(self) -> None:
+        reference = self.bundle / "ctest.xml"
+        reference.write_text(
+            '<?xml version="1.0"?><testsuite>'
+            '<testcase name="t-ok" status="run"/>'
+            '<testcase name="t-gone" status="run"/>'
+            "</testsuite>",
+            encoding="utf-8",
+        )
+        self.write_manifest([self.spec("t-ok", "ok")])
+        proc = self.run_bundle("--compare-junit", str(reference))
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("t-gone", proc.stderr)
+        self.assertIn("does not contain it", proc.stderr)
+
+    def test_compare_junit_detects_a_result_mismatch(self) -> None:
+        reference = self.bundle / "ctest.xml"
+        reference.write_text(
+            '<?xml version="1.0"?><testsuite><testcase name="t-bad" status="run"/></testsuite>',
+            encoding="utf-8",
+        )
+        self.write_manifest([self.spec("t-bad", "boom")])
+        proc = self.run_bundle("--compare-junit", str(reference))
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("ctest says pass", proc.stderr)
+
+    def test_compare_junit_accepts_an_identical_run(self) -> None:
+        reference = self.bundle / "ctest.xml"
+        reference.write_text(
+            '<?xml version="1.0"?><testsuite>'
+            '<testcase name="t-ok" status="run"/>'
+            '<testcase name="t-bad" status="fail"><failure message="x"/></testcase>'
+            "</testsuite>",
+            encoding="utf-8",
+        )
+        self.write_manifest([self.spec("t-ok", "ok"), self.spec("t-bad", "boom")])
+        proc = self.run_bundle("--compare-junit", str(reference))
+        self.assertIn("same 2 test names, same results", proc.stdout)
+        # Still exit 1: one test genuinely failed. The comparison only asserts agreement.
+        self.assertEqual(proc.returncode, 1)
+
+    def test_ctest_skipped_cases_are_ignored_by_the_comparison(self) -> None:
+        reference = self.bundle / "ctest.xml"
+        reference.write_text(
+            '<?xml version="1.0"?><testsuite>'
+            '<testcase name="t-ok" status="run"/>'
+            '<testcase name="t-skip" status="run"><skipped/></testcase>'
+            "</testsuite>",
+            encoding="utf-8",
+        )
+        self.write_manifest([self.spec("t-ok", "ok")])
+        proc = self.run_bundle("--compare-junit", str(reference))
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+
+class EndToEndBundleTest(unittest.TestCase):
+    """A tiny fake 'build tree' bundled by the real CLI and replayed by the real runner."""
+
+    def test_roundtrip_without_the_build_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            build = Path(root) / "build"
+            build.mkdir()
+            script = build / "fake-test"
+            script.write_text("#!/bin/sh\necho fake ok\n", encoding="utf-8")
+            script.chmod(script.stat().st_mode | stat.S_IEXEC)
+            library = build / "libmimalloc-fake.so"
+            library.write_bytes(b"not really a library")
+
+            payload = _wrap(
+                _test_entry(
+                    "fake-test",
+                    [str(script)],
+                    [{"name": "WORKING_DIRECTORY", "value": str(build)}],
+                )
+            )
+            tests, assets = bundle_tests.convert(payload, build)
+            out = Path(root) / "bundle"
+            bundle_tests.copy_into(
+                out, list(assets.values()) + bundle_tests.library_files(build, None)
+            )
+            bundle_tests.write_manifest(out, tests, build, None)
+
+            # The acceptance claim is "only uv and the bundle": prove the build tree is
+            # genuinely unnecessary by deleting it before replaying.
+            for path in sorted(build.iterdir()):
+                path.unlink()
+            build.rmdir()
+
+            self.assertTrue((out / "libmimalloc-fake.so").is_file())
+            if os.name != "nt":
+                proc = subprocess.run(
+                    [sys.executable, str(RUN_BUNDLE), str(out)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+                self.assertIn("100% tests passed", proc.stdout)
+
+    def test_an_empty_suite_is_an_error_not_an_empty_green_bundle(self) -> None:
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.convert(_wrap(), BUILD)
+        self.assertIn("no tests", str(caught.exception))
+
+    def test_cli_refuses_a_build_dir_with_no_ctest(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            proc = subprocess.run(
+                [sys.executable, str(BUNDLE_TESTS), root, str(Path(root) / "out")],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 1)
+            self.assertIn("bundle_tests:", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_verify_local.py
+++ b/ci/tests/test_verify_local.py
@@ -143,6 +143,7 @@ class VerifyLocalDriftTests(unittest.TestCase):
             "debug-full",
             "guarded",
             "shared",
+            "bundle",
             "memory-gate",
             "diag",
             "rust",

--- a/ci/verify_local.py
+++ b/ci/verify_local.py
@@ -223,6 +223,7 @@ def ctest_run(
     exclude_slow: bool = True,
     timeout: int = DEFAULT_CTEST_TIMEOUT,
     env: dict[str, str] | None = None,
+    junit: Path | None = None,
 ) -> int:
     cmd = [
         "ctest",
@@ -236,6 +237,9 @@ def ctest_run(
     ]
     if config:
         cmd += ["-C", config]
+    if junit:
+        # Must be absolute: ctest resolves a relative --output-junit against --test-dir.
+        cmd += ["--output-junit", str(junit.resolve())]
     if filter_regex:
         cmd += ["-R", filter_regex]
     excluded_now = False
@@ -289,6 +293,72 @@ def run_debug_full(ctx: RunCtx) -> bool:
     if cmake_build(ctx, build, config="Debug"):
         return False
     return ctest_run(ctx, build, config="Debug") == 0
+
+
+def run_bundle(ctx: RunCtx) -> bool:
+    """c-unit.yml job `bundle-roundtrip`: -DMI_PPROF=ON -DMI_DEBUG_FULL=ON, Debug.
+
+    Builds, records a reference `ctest --output-junit`, bundles with
+    `ci/bundle_tests.py`, moves the build tree away so the executables' RPATH cannot
+    rescue a broken bundle, then replays with `ci/run_test_bundle.py --compare-junit`
+    and requires the same test names with the same pass/fail (#277 phase A).
+
+    Note the absolute `--output-junit` path: ctest resolves a relative one against the
+    *build* directory, so a relative path would be carried off by the move.
+    """
+    build = ctx.dir / "build"
+    bundle = ctx.dir / "bundle"
+    junit = ctx.dir / "ctest.xml"
+    moved = ctx.dir / "build.moved-away"
+    for stale in (bundle, moved):
+        if stale.exists():
+            shutil.rmtree(stale)
+    rc, _ = cmake_configure(ctx, build, ["-DMI_PPROF=ON", "-DMI_DEBUG_FULL=ON"])
+    if rc:
+        return False
+    if cmake_build(ctx, build, config="Debug"):
+        return False
+    # The comparison is only meaningful if the reference ran the whole suite, so the
+    # slow tier is NOT excluded here regardless of --slow.
+    if ctest_run(
+        ctx,
+        build,
+        config="Debug",
+        exclude_slow=False,
+        timeout=DEFAULT_CTEST_TIMEOUT,
+        junit=junit,
+    ):
+        return False
+    rc, _ = run_logged(
+        [
+            sys.executable,
+            str(ROOT / "ci" / "bundle_tests.py"),
+            str(build),
+            str(bundle),
+            "--config",
+            "Debug",
+        ],
+        cwd=ROOT,
+        log=ctx.log,
+    )
+    if rc:
+        return False
+    build.rename(moved)
+    try:
+        rc, _ = run_logged(
+            [
+                sys.executable,
+                str(ROOT / "ci" / "run_test_bundle.py"),
+                str(bundle),
+                "--compare-junit",
+                str(junit),
+            ],
+            cwd=ROOT,
+            log=ctx.log,
+        )
+    finally:
+        moved.rename(build)
+    return rc == 0
 
 
 def run_guarded(ctx: RunCtx) -> bool:
@@ -684,6 +754,12 @@ CONFIGS: list[ConfigSpec] = [
     ),
     ConfigSpec(
         "shared", "c-unit.yml: ctest-shared", "shared lib only, no static/object", run_shared
+    ),
+    ConfigSpec(
+        "bundle",
+        "c-unit.yml: bundle-roundtrip",
+        "ctest vs. portable test bundle, build tree removed",
+        run_bundle,
     ),
     ConfigSpec(
         "memory-gate",

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -33,6 +33,49 @@ verifying nothing**, each discovered by asking "has this ever actually failed?":
 | **python-lint** | the gate scripts themselves — `ruff` + `pyright --strict` | — |
 | **zero-tracking** | correctness and footprint of `mi_option_purge_zeroes`, reported as paired interleaved A/B medians with the within-arm spread alongside | — |
 
+## Concurrency: superseded runs are cancelled
+
+Every workflow now carries a `concurrency:` group. A second push to the same ref cancels
+the first push's still-queued jobs instead of letting both compete for a runner. This is
+issue #277 phase 0, and the reason it is worth a paragraph is that the cost it removes is
+not build time:
+
+| workflow | runner | jobs | queue p50 | queue p90 | queue max | exec p50 |
+|---|---|---|---|---|---|---|
+| `c-unit.yml` | `ubuntu-latest` | 160 | 4s | 19s | 1m10s | 45s |
+| `c-unit.yml` | `macos-latest` | 60 | 21s | 2m03s | 3m05s | 48s |
+| `cross.yml` | `macos-latest` | 20 | 9m25s | 1h29m | **5h26m** | 8s |
+| `cross.yml` | `macos-15-intel` | 20 | 9m23s | 2h32m | **6h13m** | 9s |
+
+Those Apple rows *execute* in under fifteen seconds and *wait* for hours. Cancelling a
+superseded push does not make any job faster; it stops a dead push from holding a macOS
+slot that a live one needs.
+
+Not every workflow may be cancelled. Anything that publishes keeps `cancel-in-progress:
+false`, because a half-finished publish is worse than a redundant one:
+
+- `auto-release.yml`, `release.yaml` — upload release assets / `cargo publish`
+- `benchmark-stats.yml`, `benchmark-latency.yml`, `benchmark-memory.yml`,
+  `benchmark-scaling.yml` — push the sealed `benchmark-stats` branch and deploy Pages;
+  these deliberately **share** one group (`benchmark-stats-production`) to serialise
+  against each other, so their group is not per-workflow
+- `star-history.yml` — commits a regenerated chart
+- `stale.yaml` — closes and labels issues; a half-run leaves the repo partly swept
+
+`fuzz.yml` is the one subtle case: it has a `schedule:` trigger, and a scheduled run
+carries `github.ref == refs/heads/main`. Its group therefore includes `github.event_name`,
+so the nightly long run and a `main` push cannot cancel each other.
+
+**Measuring it.** `uv run ci/ci_queue_wait.py --limit 20 c-unit.yml cross.yml
+rust-native.yml` reads the Actions API through `gh` and prints, per `runs-on` label,
+p50/p90/max of `started_at - created_at` (queue wait) and `completed_at - started_at`
+(execution), with the job count. One caveat is baked into the tool's output and repeated
+here: a job with `needs:` is *created* when the run is created, so a `cross.yml`
+`test (*)` row measures "pool wait + upstream build", while `c-unit.yml` and
+`rust-native.yml` have no `needs:` edges and measure pool wait alone. `--jobs-json` replays
+a saved payload, which is how `ci/tests/test_ci_queue_wait.py` checks the arithmetic
+without touching the network.
+
 Three details worth stating, because each was an assumption that measurement overturned:
 
 - **Peak memory is not a low-variance signal.** Repeated runs of the same unchanged

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -33,6 +33,60 @@ verifying nothing**, each discovered by asking "has this ever actually failed?":
 | **python-lint** | the gate scripts themselves — `ruff` + `pyright --strict` | — |
 | **zero-tracking** | correctness and footprint of `mi_option_purge_zeroes`, reported as paired interleaved A/B medians with the within-arm spread alongside | — |
 
+## Test bundles
+
+Issue #277 wants the macOS and Windows test binaries built once on Linux (through the
+soldr lanes, #277 §2) and executed on one runner per OS, instead of one fresh VM per job.
+That needs a *test bundle*: a directory a runner can execute with **no CMake and no repo
+checkout**.
+
+`uv run ci/bundle_tests.py <build-dir> <out-dir> [--config Debug]` writes one.
+`uv run ci/run_test_bundle.py <bundle> [--only NAME…] [--env K=V…] [--timeout-scale F]
+[--junit out.xml] [--compare-junit ctest.xml]` replays it serially and prints a
+ctest-shaped summary.
+
+### `tests.json`
+
+One entry per test: `name`, `argv`, `env`, `cwd`, `timeout`, `expect_nonzero`,
+`expect_text`, `labels`. Paths inside `argv` and `env` values are written as
+`${BUNDLE}/<file>`, which the runner expands to the bundle's own absolute path; files are
+flattened into the bundle root so a Windows DLL sits beside its exe and a Linux `.so` is
+found through `LD_LIBRARY_PATH` rather than a build-tree RPATH. A basename collision is a
+hard error, never a silent overwrite.
+
+### Lowering rules
+
+`ctest --show-only=json-v1` does not emit a list of plain executables. On the
+`MI_DEBUG_FULL` tree, **7 of 31 tests invoke `cmake` itself**, and both shapes are lowered
+into manifest fields:
+
+| ctest command | lowered to |
+|---|---|
+| `cmake -E env K=V … <exe> [args]` | `env` entries plus the real `argv`; leading `K=V` tokens are consumed up to the first token that is not one |
+| `cmake -D TEST_EXE=… -D TEST_ARG=… -D EXPECTED_TEXT=… -P test/run-negative.cmake` | `argv = [TEST_EXE, TEST_ARG?]`, `expect_nonzero: true`, `expect_text: EXPECTED_TEXT`, `timeout: 10` |
+
+The negative-control semantics come from `test/run-negative.cmake` and are reproduced
+exactly, including the part that is easy to get backwards: **a timeout is a failure**, not
+the expected non-zero exit — the script's own words are "negative control timed out
+instead of failing fast" — and the expected substring is searched in the *combined*
+stdout+stderr, so a control that fails for the wrong reason stays red.
+
+Test properties are an **allowlist** (`ENVIRONMENT`, `TIMEOUT`, `WORKING_DIRECTORY`,
+`LABELS`, `WILL_FAIL`, `DISABLED`). Anything else — `PASS_REGULAR_EXPRESSION`,
+`SKIP_RETURN_CODE`, `RESOURCE_LOCK` — is a hard error naming the test, as is any `cmake`
+argv shape not in the table, and so is an empty suite. All of that is the same principle
+as the rest of this document: a bundle that quietly carries fewer tests than ctest ran
+would report green while verifying less, which is precisely the failure mode the seven
+dead gates above shared.
+
+### The gate
+
+`bundle-roundtrip` (in `c-unit.yml`, ubuntu, `MI_PPROF=ON MI_DEBUG_FULL=ON`) builds, runs
+`ctest --output-junit`, bundles, **moves the build tree away**, replays the bundle, and
+requires the same test names with the same pass/fail (`--compare-junit`). Moving the build
+tree is the load-bearing step: the executables carry an RPATH into it, so without that
+`mv` a broken bundle would pass on the build machine by loading the original libraries.
+
 ## Concurrency: superseded runs are cancelled
 
 Every workflow now carries a `concurrency:` group. A second push to the same ref cancels


### PR DESCRIPTION
Phase A of #277: the portable test-bundle format, the two scripts, and the gate that
proves a bundle runs exactly what ctest runs.

> **Stacked on #278.** Both branches are rebased onto `main` as of #276. Against `main` this
> PR's diff shows #278's two commits first; everything titled "(#277 phase A)" is this PR.
> Merge #278 first and this collapses to the phase-A commits alone.

## What a bundle is

A directory a macOS or Windows runner can execute with **no CMake and no repo checkout**:
every test executable, every `libmimalloc*` / `mimalloc*.dll` / `mimalloc-redirect*.dll`,
and a `tests.json` manifest.

```
uv run ci/bundle_tests.py <build-dir> <out-dir> [--config Debug]
uv run ci/run_test_bundle.py <bundle> [--only NAME…] [--env K=V…]
                                      [--timeout-scale F] [--junit out.xml]
                                      [--compare-junit ctest.xml]
```

One entry per test: `name`, `argv`, `env`, `cwd`, `timeout`, `expect_nonzero`,
`expect_text`, `labels`.

## Lowering rules

`ctest --show-only=json-v1` does not emit a list of plain executables. Both `cmake`
shapes are lowered into manifest fields so the runner needs no CMake:

| ctest command | lowered to |
|---|---|
| `cmake -E env K=V … <exe> [args]` | `env` + the real `argv`; `K=V` tokens consumed up to the first token that is not one |
| `cmake -D TEST_EXE=… -D TEST_ARG=… -D EXPECTED_TEXT=… -P test/run-negative.cmake` | `argv = [TEST_EXE, TEST_ARG?]`, `expect_nonzero: true`, `expect_text: EXPECTED_TEXT`, `timeout: 10` |

The negative-control semantics come straight from `test/run-negative.cmake`, including the
two that are easy to get backwards:

- **A timeout is a failure**, not the expected non-zero exit. The script's own words are
  *"negative control timed out instead of failing fast"*. A hung control proves nothing.
- The expected text is searched in the **combined stdout+stderr**, so a control that fails
  for the *wrong* reason stays red (`"failed for the wrong reason (result=…)"` upstream).

`TEST_ARG` is optional; the effective timeout is the cmake script's 10 s, not the test's
`TIMEOUT 15`.

## Failing loudly

Everything the bundler cannot lower is a hard error **naming the test**, and all problems
are reported in one message rather than one per run:

- an unknown `cmake` argv shape (`cmake -E rm`, an unrecognised `-P` script)
- a `cmake -E env` option (`--unset=`, `--modify`) rather than a plain assignment
- an unrecognised `run-negative.cmake` variable
- a test property outside the allowlist — `ENVIRONMENT`, `TIMEOUT`, `WORKING_DIRECTORY`,
  `LABELS`, `WILL_FAIL`, `DISABLED`. `PASS_REGULAR_EXPRESSION`, `SKIP_RETURN_CODE`,
  `RESOURCE_LOCK` and friends are refused, not silently dropped.
- an executable outside the build tree, a basename collision, or an empty suite

The reason is the one `docs/ci-gates.md` is built around: a bundle that quietly carries
fewer tests than ctest ran reports green while verifying less. That is precisely the shape
of all seven dead gates this repo has already found.

## Path handling

Absolute build-tree paths appear in **argv and in env values** (`LD_PRELOAD=/abs/build/…`,
`DYLD_INSERT_LIBRARIES=/abs/build/…`); both are rewritten to a `${BUNDLE}` placeholder the
runner expands. Files are **flattened** into the bundle root, because a Windows DLL must
sit beside the exe that loads it and a flat directory is what lets
`LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` override the build-tree RPATH baked into the
executables. Symlinks are recreated as symlinks so the `libmimalloc-debug.so →
.so.3 → .so.3.4` SONAME chain survives.

## The `bundle-roundtrip` job (c-unit.yml, ubuntu)

`MI_PPROF=ON MI_DEBUG_FULL=ON`, mirroring the existing `ctest-debug-full` ubuntu row:
configure → build → `ctest --output-junit ctest.xml` (the reference) → bundle → **`mv build
build.moved-away`** → replay with `--compare-junit`. The bundle and both JUnit files upload
as an artifact.

The `mv` is the load-bearing step. The executables carry an RPATH into the build tree, so
without it a broken bundle passes on the build machine by loading the original libraries
and the portability claim goes untested on the only machine that can check it.

`--compare-junit` compares against `ctest --output-junit` rather than parsing
`LastTest.log`: it is a stable documented format, so the comparison is deterministic and
testable from fixtures. It asserts the same name set **and** the same pass/fail per test.

## Local verification (this machine, Linux x86-64)

Both runs had the build tree renamed away before replaying:

```
# Debug, MI_PPROF=ON MI_DEBUG_FULL=ON
bundled 31 tests and 26 files into out/bundle-a-out
  6 negative control(s) lowered from run-negative.cmake
  5 test(s) carry environment overrides
100% tests passed, 0 tests failed out of 31
Total Test time (real) =    19.86 sec
bundle matches out/ctest-debug.xml: same 31 test names, same results

# Release, MI_PPROF=ON
bundled 24 tests and 24 files into out/bundle-rel-out
  5 test(s) carry environment overrides
100% tests passed, 0 tests failed out of 24
Total Test time (real) =    26.63 sec
bundle matches out/ctest-rel.xml: same 24 test names, same results
```

## Corrections to #277

- §1 says *"verified on the `MI_DEBUG_FULL` tree, 12 of 32 tests invoke `cmake`: 6 are
  `cmake -E env` and 6 are `cmake -P run-negative.cmake`"*. **Actual: 31 tests, 7 of which
  invoke `cmake` — 6 negative controls plus exactly one `cmake -E env`
  (`test-stress-dynamic`).** The Release tree has 24 tests and none. The lowering rules the
  issue asks for are all still needed; only the counts were off.
- The rest of §1 held up: no `WILL_FAIL` and no `PASS_REGULAR_EXPRESSION` in use; the live
  properties are `ENVIRONMENT`, `TIMEOUT`, `WORKING_DIRECTORY`; absolute paths really do
  appear in env values. `WILL_FAIL` and `DISABLED` are implemented anyway, since they are
  one line each and the alternative is a future `add_test` breaking the bundler.

## Tests and checks

- `ci/tests/test_test_bundles.py`, 42 tests: the two lowering rules, every refusal path,
  path relativisation in argv and in env (`LD_PRELOAD` and `DYLD_INSERT_LIBRARIES`),
  basename collisions, the negative-control semantics end to end (wrong reason → red, zero
  exit → red, timeout → red *even with* `expect_nonzero`), loader-path injection,
  `--only`/`--env`/`--timeout-scale`/`--junit`/`--compare-junit`, and a roundtrip on a tiny
  fake bundle whose build tree is **deleted** before replay.
- `pytest ci/tests`: 139 passed, 0 failed.
- `ruff check ci/` + `ruff format --check ci/` clean on the CI pin (0.12.10).
- **`pyright --strict` is clean.** It initially could not run here (no system Node); `uv run
  --with 'pyright[nodejs]==1.1.411' pyright` ships its own Node and works, which caught four
  real strict errors that are fixed in the last commit. That command is worth knowing for
  anyone else hacking on `ci/` from a Node-less box.
- `uv run ci/verify_local.py --list` — `ci/verify_local.py` did not exist on `main` when
  this work started; #276 landed it mid-flight, along with a drift gate that fails when a
  Linux CI job references a `ci/*.py` the local mirror does not. So `bundle-roundtrip` now
  has a matching `bundle` config, and the gate is reproducible locally:

```
$ uv run ci/verify_local.py --only bundle
[  103.6s] bundle       PASS
…
100% tests passed, 0 tests failed out of 32          # ctest reference
bundled 32 tests and 27 files into …/verify/bundle/bundle
100% tests passed, 0 tests failed out of 32          # the bundle, build tree removed
bundle matches …/verify/bundle/ctest.xml: same 32 test names, same results
```
- CI uses `python3`, matching every existing workflow here; the scripts are stdlib-only, so
  `uv run` behaves identically.

## One CI-only bug this caught

The first CI run failed and it was worth having: `ctest --output-junit` resolves a
**relative** path against the *build* directory, not the working directory, so the
reference `ctest.xml` landed in `build/` and the `mv` carried it away. Locally the roundtrip
had always been run with an absolute path, so it never showed. The workflow now passes
`$GITHUB_WORKSPACE/ctest.xml`, `run_test_bundle.py` names the gotcha instead of leaking an
ElementTree stack trace, `ctest_run()` in `verify_local.py` resolves the path so no caller
can repeat it, and there is a test. The bundle itself ran **31/31 green with the build tree
gone** on that failing run — the thing the job exists to prove.

## Not in scope

No toolchain work: the cross lanes are phase B/C/D (soldr lanes, #277 §2). Nothing outside
`ci/`, `.github/workflows/c-unit.yml` and `docs/ci-gates.md` is touched, so rule 2 holds.

Refs #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
