### PR TITLE
ci: build macOS test bundles on Linux via soldr, run them on one macOS runner (#277 phase B)

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -24,6 +24,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # TODO(#277 phase B, added 2026-09-02): DELETE the macos-latest row after ten pushes
+    # have compared it against `run-macos` in macos-bundles.yml. Until then it is the
+    # control arm and is informational only -- a permanently-yellow job is worse than an
+    # absent one, so this comment carries its own expiry.
+    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     steps:
       - uses: actions/checkout@v4
       - run: cmake -B build -DMI_PPROF=ON
@@ -113,6 +118,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # TODO(#277 phase B, added 2026-09-02): DELETE the macos-latest row after ten pushes
+    # have compared it against `run-macos` in macos-bundles.yml. Until then it is the
+    # control arm and is informational only -- a permanently-yellow job is worse than an
+    # absent one, so this comment carries its own expiry.
+    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     steps:
       - uses: actions/checkout@v4
       - run: cmake -B build -DMI_PPROF=ON -DMI_DEBUG_FULL=ON && cmake --build build --config Debug && ctest --test-dir build -C Debug --output-on-failure
@@ -257,6 +267,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # TODO(#277 phase B, added 2026-09-02): DELETE the macos-latest row after ten pushes
+    # have compared it against `run-macos` in macos-bundles.yml. Until then it is the
+    # control arm and is informational only -- a permanently-yellow job is worse than an
+    # absent one, so this comment carries its own expiry.
+    # The macOS row keeps matching ci/memory-baselines/macos-pprof1.json, which is now
+    # annotated `compiler: apple-clang`: it declares no --arch/--compiler, so its baseline
+    # filename is unchanged. The soldr lane asks for its own file instead of borrowing
+    # this number (#277 phase B).
+    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     steps:
       - uses: actions/checkout@v4
       - run: cmake -B build -DMI_PPROF=ON

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -133,6 +133,47 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
         run: soldr prepare --target "$TARGET" --github-env "$GITHUB_ENV"
+      - name: Keep the Apple builds unwindable (frame pointers)
+        # #277 §4: build-linux sets RUSTFLAGS/CFLAGS at job level and this job set
+        # neither, so the Apple test binaries were built without frame pointers while the
+        # profiler walks frame pointers on every non-Windows platform. Copying
+        # build-linux's job-level `env:` here would be dead -- `soldr prepare` has already
+        # exported CARGO_ENCODED_RUSTFLAGS (which cargo lets shadow RUSTFLAGS entirely)
+        # and CFLAGS_<triple> (which cc-rs prefers over plain CFLAGS) -- so both are
+        # appended to. Apple targets only: the profiler does not walk frame pointers on
+        # Windows, and whether clang-cl accepts the flag is a #277 phase D question.
+        #
+        # Kept in step with macos-bundles.yml's build-rust-apple: while the Apple rows
+        # below are the informational control arm for #277 phase B, both arms must build
+        # the same way or a divergence has two possible causes instead of one.
+        if: contains(matrix.target, 'apple-darwin')
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          under="${TARGET//-/_}"
+          eval "existing=\${CFLAGS_${under}:-}"
+          echo "CFLAGS_${under}=${existing} -fno-omit-frame-pointer" >> "$GITHUB_ENV"
+          if [ -n "${CARGO_ENCODED_RUSTFLAGS:-}" ]; then
+            printf 'CARGO_ENCODED_RUSTFLAGS=%s\037-Cforce-frame-pointers=yes\n' \
+              "$CARGO_ENCODED_RUSTFLAGS" >> "$GITHUB_ENV"
+          else
+            echo 'CARGO_ENCODED_RUSTFLAGS=-Cforce-frame-pointers=yes' >> "$GITHUB_ENV"
+          fi
+      - name: The frame-pointer flags must actually be in the build's environment
+        # A flag that never reaches the compiler is this repository's most-repeated CI bug
+        # (MI_GUARDED, docs/ci-gates.md). Assert on the environment the next step runs
+        # with, not on what the previous step intended to write.
+        if: contains(matrix.target, 'apple-darwin')
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          eval "cflags=\${CFLAGS_${TARGET//-/_}:-}"
+          case "$cflags" in *-fno-omit-frame-pointer*) ;; *)
+            echo "::error::CFLAGS_${TARGET//-/_} lost -fno-omit-frame-pointer: '$cflags'"; exit 1;; esac
+          case "${CARGO_ENCODED_RUSTFLAGS:-}" in *force-frame-pointers*) ;; *)
+            echo "::error::CARGO_ENCODED_RUSTFLAGS lost -Cforce-frame-pointers"; exit 1;; esac
       - name: Build test binaries through Soldr
         env:
           TARGET: ${{ matrix.target }}

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -236,6 +236,12 @@ jobs:
     name: test (${{ matrix.target }})
     needs: [build-linux, build-cross, build-win-gnu]
     runs-on: ${{ matrix.runner }}
+    # TODO(#277 phase B, added 2026-09-02): DELETE the two apple-darwin rows -- and the
+    # matching targets from build-cross -- after ten pushes have compared them against
+    # macos-bundles.yml's `run-macos`, which runs the same binaries on one runner instead
+    # of two. These are the rows that measured 8-14 s of execution behind up to 5h26m /
+    # 6h13m of queue wait. Informational until then.
+    continue-on-error: ${{ contains(matrix.target, 'apple-darwin') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos-bundles.yml
+++ b/.github/workflows/macos-bundles.yml
@@ -1,0 +1,411 @@
+name: macos-bundles
+
+# Issue #277 phase B: build the macOS test binaries on Linux, execute them on ONE macOS
+# runner.
+#
+# The motivation is not build time. Measured over 20 runs per workflow (#277 phase 0),
+# cross.yml's Apple rows EXECUTE in 8-14 seconds and WAIT up to 5h26m (arm64) / 6h13m
+# (Intel) for a runner, p90 1h29m / 2h32m, while every ubuntu row waits 4-5 s. Per push
+# there are 5-6 macOS jobs, each spinning up its own VM to check out, build and run a
+# slice of the suite. This workflow replaces all of that with two Linux build jobs and one
+# macOS job.
+#
+# The Linux side needs no Apple hardware and no Xcode: `soldr prepare --target
+# aarch64-apple-darwin` provisions clang 21 + ld64.lld + an Apple SDK, and
+# cmake/toolchains/soldr-aarch64-apple-darwin.cmake feeds CMake nothing but what soldr
+# exported. `ci/bundle_tests.py` then turns the build tree into a directory that runs with
+# no CMake and no checkout (see docs/ci-gates.md, "Test bundles").
+#
+# While this is being compared against the jobs it replaces, the native macOS entries of
+# c-unit.yml's `ctest`/`ctest-debug-full`/`memory-gate`, cross.yml's Apple `test (*)` rows
+# and rust-native.yml's macOS row are `continue-on-error: true`. They are the control arm,
+# not decoration -- see the dated TODO on each.
+
+env:
+  SOLDR_GITHUB_TOKEN: ${{ github.token }}
+
+on:
+  push:
+    branches: [main, v4]
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'test/**'
+      - 'rust/**'
+      - 'CMakeLists.txt'
+      - 'cmake/toolchains/**'
+      - 'ci/**'
+      - '.github/workflows/macos-bundles.yml'
+
+concurrency:
+  # The macOS pool is the scarce one this whole workflow exists to stop wasting (#277).
+  group: macos-bundles-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-macos:
+    name: build-macos (${{ matrix.bundle }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Exactly today's macOS C coverage, no more: `ctest (macos-latest)` and
+          # `ctest-debug-full (macos-latest)`. #277's review found the first draft
+          # smuggling ~8 new configs in under the word "parity"; adding shared/guarded/
+          # pprof-off/Intel configs is a separate, deliberate decision.
+          #
+          # CMAKE_BUILD_TYPE is Release in both because that is what the native jobs
+          # actually compile: they pass no CMAKE_BUILD_TYPE and CMakeLists.txt (~137-145)
+          # then defaults it to Release unless the *binary directory name* ends in
+          # "debug"/"asan"/... . MI_DEBUG_FULL sets MI_DEBUG=3 independently of the build
+          # type, and the registered test set is identical either way (verified: 32 tests
+          # both ways) -- so this is parity with the job being replaced, not a downgrade.
+          - bundle: macos-arm64-release
+            cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON
+          - bundle: macos-arm64-debug-full
+            cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_DEBUG_FULL=ON
+          # The memory gate's positive control. It is a separate *build*
+          # (MI_BENCH_INJECT_LEAK), not a separate run, so it cannot be an entry in
+          # another bundle's manifest; it gets its own bundle rather than being dropped
+          # on macOS, because a gate whose control never runs is a gate nobody has seen
+          # fire (docs/ci-gates.md).
+          - bundle: macos-arm64-leak
+            cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BENCH_INJECT_LEAK=200000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          # zccache wraps `soldr cargo`; this job drives CMake directly, so there is
+          # nothing for it to wrap. Only the toolchain provisioning is wanted here.
+          cache: false
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+      - name: Cache the prepared Darwin toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/soldr-aarch64-apple-darwin.tar.zst
+          key: soldr-prepare-aarch64-apple-darwin-${{ hashFiles('rust/rust-toolchain.toml') }}
+      - name: Prepare the soldr Darwin toolchain
+        # `soldr prepare` resolves rustc from a rust-toolchain.toml at or above the
+        # working directory, which is why this runs in rust/ like cross.yml does.
+        working-directory: rust
+        run: |
+          set -euo pipefail
+          archive="$HOME/soldr-aarch64-apple-darwin.tar.zst"
+          args=(--target aarch64-apple-darwin --github-env "$GITHUB_ENV" --save "$archive")
+          # --restore on a nonexistent archive is not a documented no-op, so only pass it
+          # on a cache hit.
+          if [ -f "$archive" ]; then
+            args=(--restore "$archive" "${args[@]}")
+          fi
+          soldr prepare "${args[@]}"
+      - name: Configure for aarch64-apple-darwin
+        run: |
+          set -euo pipefail
+          cmake -S . -B build -G Ninja ${{ matrix.cmake }} \
+            --toolchain cmake/toolchains/soldr-aarch64-apple-darwin.cmake \
+            --log-level=VERBOSE 2>&1 | tee configure.log
+          # The find-root fix in the toolchain file is the difference between linking
+          # `pthread` and silently handing the host's ELF librt.so to a Mach-O link.
+          # Assert on the resolved list, not on the option that was passed in -- the
+          # MI_GUARDED lesson from docs/ci-gates.md.
+          if ! grep -qE '^-- Link libraries *: *pthread$' configure.log; then
+            echo "::error::the Darwin link picked up host libraries; expected exactly 'pthread'"
+            grep -E 'Link libraries' configure.log || true
+            exit 1
+          fi
+      - run: cmake --build build --parallel
+      - name: Prove the output is arm64 Mach-O with the profiler's Darwin sections
+        run: |
+          set -euo pipefail
+          lib=$(ls build/libmimalloc*.dylib | head -1)
+          echo "## ${{ matrix.bundle }}" >> "$GITHUB_STEP_SUMMARY"
+          llvm-objdump --macho --private-headers "$lib" > headers.txt
+          grep -E 'MH_MAGIC_64 +ARM64' headers.txt
+          grep -A3 'cmd LC_BUILD_VERSION' headers.txt | tee -a "$GITHUB_STEP_SUMMARY"
+          # MI_OSX_INTERPOSE puts the malloc replacements in __DATA,__interpose. If a
+          # cross build silently dropped that section the dylib would load on the runner
+          # and override nothing, which no test failure would obviously explain.
+          llvm-objdump --macho --section-headers "$lib" | grep -q '__interpose'
+          llvm-objdump --macho --section-headers "$lib" | grep -q '__thread_vars'
+          # ld64.lld ad-hoc signs arm64 images. Without a signature every process is
+          # killed by the kernel on arm64 macOS before main(), with no diagnostic.
+          grep -q 'cmd LC_CODE_SIGNATURE' headers.txt
+      - name: Bundle the tests
+        run: python3 ci/bundle_tests.py build bundle
+      - name: The manifest must carry no absolute path
+        # bundle_tests.py already refuses these; this is the independent check, because
+        # the whole portability claim rests on it and this is the first phase where the
+        # bundle leaves the machine that built it.
+        run: |
+          set -euo pipefail
+          if grep -nE '"(/|[A-Za-z]:[\\/])' bundle/tests.json; then
+            echo "::error::the bundle manifest contains an absolute path"
+            exit 1
+          fi
+          python3 -c "import json,sys; d=json.load(open('bundle/tests.json')); print(len(d['tests']), 'tests')"
+          ls bundle | grep -q '\.dylib$'
+      - name: Pack the bundle
+        # tar, not a plain artifact upload: upload-artifact@v4 drops the executable bit
+        # and does not preserve symlinks, and this bundle needs both (every test exe, and
+        # the libmimalloc.dylib -> libmimalloc.3.dylib SONAME chain).
+        run: tar -C bundle -czf "${{ matrix.bundle }}.tar.gz" .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bundle-${{ matrix.bundle }}
+          path: ${{ matrix.bundle }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  build-rust-apple:
+    name: build-rust (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [aarch64-apple-darwin, x86_64-apple-darwin]
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+          build-cache-mode: full
+      - name: Prepare blessed cross toolchain
+        env:
+          TARGET: ${{ matrix.target }}
+        run: soldr prepare --target "$TARGET" --github-env "$GITHUB_ENV"
+      - name: Keep the cross-built code unwindable (frame pointers)
+        # Pre-existing gap #277 §4 asks phase B to close: build-linux sets RUSTFLAGS and
+        # CFLAGS at job level, build-cross sets neither, so the Apple test binaries are
+        # built without frame pointers while the profiler walks frame pointers on every
+        # non-Windows platform.
+        #
+        # Copying build-linux's job-level `env:` here would be dead: `soldr prepare` has
+        # already exported CARGO_ENCODED_RUSTFLAGS (which cargo lets shadow RUSTFLAGS
+        # entirely) and CFLAGS_<triple> (which cc-rs prefers over plain CFLAGS). So both
+        # have to be *appended to*, not set. CARGO_ENCODED_RUSTFLAGS is 0x1f-separated.
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          under="${TARGET//-/_}"
+          eval "existing=\${CFLAGS_${under}:-}"
+          echo "CFLAGS_${under}=${existing} -fno-omit-frame-pointer" >> "$GITHUB_ENV"
+          if [ -n "${CARGO_ENCODED_RUSTFLAGS:-}" ]; then
+            printf 'CARGO_ENCODED_RUSTFLAGS=%s\037-Cforce-frame-pointers=yes\n' \
+              "$CARGO_ENCODED_RUSTFLAGS" >> "$GITHUB_ENV"
+          else
+            echo 'CARGO_ENCODED_RUSTFLAGS=-Cforce-frame-pointers=yes' >> "$GITHUB_ENV"
+          fi
+      - name: The frame-pointer flags must actually be in the build's environment
+        # A flag that never reaches the compiler is this repository's most-repeated CI
+        # bug (MI_GUARDED, docs/ci-gates.md). Assert on the environment the next step
+        # runs with, not on what the previous step intended to write.
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          eval "cflags=\${CFLAGS_${TARGET//-/_}:-}"
+          case "$cflags" in *-fno-omit-frame-pointer*) ;; *)
+            echo "::error::CFLAGS_${TARGET//-/_} lost -fno-omit-frame-pointer: '$cflags'"; exit 1;; esac
+          case "${CARGO_ENCODED_RUSTFLAGS:-}" in *force-frame-pointers*) ;; *)
+            echo "::error::CARGO_ENCODED_RUSTFLAGS lost -Cforce-frame-pointers"; exit 1;; esac
+      - name: Build test binaries through Soldr
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          # Same shape as cross.yml's build-cross, and for the same measured reasons:
+          # pipefail is NOT on in GitHub's `bash -e`, so without it a failed cargo build
+          # reports jq's exit status and looks green; and the raw JSON is kept because
+          # piping cargo straight into jq discards every `compiler-message`, which is
+          # where the error text lives.
+          set -euo pipefail
+          run_build() {
+            local rc=0
+            eval "$1 --target $TARGET --release --message-format=json" > cargo.json || rc=$?
+            jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' cargo.json > bins.txt
+            if [ "$rc" -ne 0 ]; then
+              jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' cargo.json >&2
+            fi
+            return "$rc"
+          }
+          # Plain `cargo`, NOT `soldr cargo` -- see the long note in cross.yml's
+          # build-cross: the wrapper drops mi_prof_* symbols at link time on these targets.
+          cmd="cargo test -p mimalloc-pprof --no-run"
+          if ! run_build "$cmd"; then
+            echo "::warning::build failed; retrying with the soldr compile cache bypassed (soldr#1969)"
+            run_build "${cmd/soldr/soldr --no-cache}"
+          fi
+          test -s bins.txt
+          mkdir -p "dist/$TARGET"
+          xargs -r -a bins.txt -I{} cp {} "dist/$TARGET/"
+          if ! ls "dist/$TARGET"/t3_stats-* >/dev/null 2>&1; then
+            echo "::error::t3_stats was not built for $TARGET. Staged binaries:"
+            ls -1 "dist/$TARGET" || echo "  (none)"
+            exit 1
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rust-test-bins-${{ matrix.target }}
+          path: rust/dist/${{ matrix.target }}
+          if-no-files-found: error
+          retention-days: 7
+
+  run-macos:
+    # The point of the whole workflow: one macOS VM, one queue slot, everything serial.
+    needs: [build-macos, build-rust-apple]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: bundle-macos-*
+          path: artifacts
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: rust-test-bins-*
+          path: rust-bins
+      - name: Unpack the bundles
+        run: |
+          set -euo pipefail
+          for archive in artifacts/*/*.tar.gz; do
+            name=$(basename "$archive" .tar.gz)
+            mkdir -p "bundle/$name"
+            tar -C "bundle/$name" -xzf "$archive"
+          done
+          # A cross-built binary that will not even load is the failure this whole phase
+          # risks, so say what these files are before running anything.
+          file bundle/macos-arm64-release/mimalloc-test-api
+          ls -l bundle/macos-arm64-release | head -40
+
+      - name: ctest (macos-latest) equivalent -- macos-arm64-release
+        run: |
+          python3 ci/run_test_bundle.py bundle/macos-arm64-release \
+            --junit "$GITHUB_WORKSPACE/bundle-release.xml"
+      - name: ctest-debug-full (macos-latest) equivalent -- macos-arm64-debug-full
+        # Carries the six run-negative.cmake controls and the DYLD_INSERT_LIBRARIES
+        # interposition test; run serially after the release bundle, never alongside it.
+        run: |
+          python3 ci/run_test_bundle.py bundle/macos-arm64-debug-full \
+            --junit "$GITHUB_WORKSPACE/bundle-debug-full.xml"
+
+      - name: Install Rosetta if x86_64 binaries cannot run
+        run: |
+          if ! arch -x86_64 /usr/bin/true >/dev/null 2>&1; then
+            sudo softwareupdate --install-rosetta --agree-to-license
+          fi
+      - name: Run the cross-built Rust test binaries
+        # Replaces cross.yml's `test (aarch64-apple-darwin)` and
+        # `test (x86_64-apple-darwin)`. Those rows have `pprof: false`, so there is no
+        # pprof-parses-a-dump step here either -- parity, not a silent reduction.
+        # These link MI_STATIC_LIB, so Rosetta is translating an ordinary static binary;
+        # no dylib interposition is involved.
+        run: |
+          set -euo pipefail
+          for target_dir in rust-bins/rust-test-bins-*; do
+            target=${target_dir#rust-bins/rust-test-bins-}
+            echo "::group::$target"
+            chmod +x "$target_dir"/*
+            for test_binary in "$target_dir"/*; do
+              case "$target" in
+                x86_64-*) arch -x86_64 "$test_binary" --test-threads=4 ;;
+                *) "$test_binary" --test-threads=4 ;;
+              esac
+            done
+            echo "::endgroup::"
+          done
+
+      - name: Memory gate -- 8 runs from the release bundle
+        run: |
+          # GitHub invokes `bash -e`, so a plain `set -uo pipefail` does NOT disable
+          # errexit: `set +e` is required, not decorative, or the script dies on the
+          # gate's non-zero exit before the rc check runs.
+          set +e
+          set -uo pipefail
+          exe="$PWD/bundle/macos-arm64-release/mimalloc-test-memory-gate"
+          for i in 1 2 3 4 5 6 7 8; do
+            MI_BENCH_JSON="$PWD/result-$i.json" "$exe" > /dev/null
+          done
+          cat result-1.json
+          # --arch/--compiler give this lane its own baseline. Without them it would be
+          # compared against ci/memory-baselines/macos-pprof1.json, which Apple clang
+          # recorded on this same runner -- a cross-toolchain comparison dressed as a
+          # regression check (#277 phase B).
+          python3 ci/memory_gate.py check --arch arm64 --compiler soldr-clang-21 result-*.json
+          rc=$?
+          if [ $rc -eq 2 ]; then
+            echo "::warning::No committed baseline for the soldr arm64 lane yet -- bootstrap it from this run's memory-gate artifact."
+            exit 0
+          fi
+          exit $rc
+      - name: Positive control -- the gate must catch an injected leak
+        run: |
+          set -euo pipefail
+          exe="$PWD/bundle/macos-arm64-leak/mimalloc-test-memory-gate"
+          for i in 1 2 3 4 5 6 7 8; do
+            MI_BENCH_JSON="$PWD/leak-$i.json" "$exe" > /dev/null || true
+          done
+          # `control` requires `check` to FAIL. A missing baseline is not a failure, it is
+          # a bootstrap (exit 2), so before this lane's baseline is committed the control
+          # would go red for the wrong reason. Ask memory_gate.py where the baseline lives
+          # rather than hardcoding a name it computes.
+          if ! python3 ci/memory_gate.py where --arch arm64 --compiler soldr-clang-21 leak-1.json; then
+            echo "::warning::the soldr arm64 lane has no committed baseline yet, so its positive control cannot run. Commit the baseline, then this becomes a hard gate."
+            exit 0
+          fi
+          python3 ci/memory_gate.py control --arch arm64 --compiler soldr-clang-21 leak-*.json
+      - if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: memory-gate-macos-arm64-soldr
+          path: result-*.json
+          if-no-files-found: error
+
+      - name: Native compile-compat check (Xcode clang, no tests)
+        # The bundles are built by soldr's clang against soldr's SDK. This is the only
+        # thing on this runner that still uses Xcode's compiler and headers, and it
+        # catches compile-only breakage (an Apple-clang-specific rejection, an SDK
+        # header change) that a cross build would not. It deliberately runs NO tests --
+        # the bundles do that -- so it costs a configure and a build, not a VM.
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          cmake -B native-release -DMI_PPROF=ON -DCMAKE_BUILD_TYPE=Release
+          cmake --build native-release --config Release --parallel
+          cc --version
+      - name: Enumerate what the native runner's own ctest would run
+        # `--show-only` needs a configured tree, not a built one, so the debug-full side
+        # of the coverage comparison costs a configure and nothing more.
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          cmake -B native-debug-full -DMI_PPROF=ON -DMI_DEBUG_FULL=ON -DCMAKE_BUILD_TYPE=Release
+          ctest --test-dir native-release --show-only=json-v1 > native-release.json
+          ctest --test-dir native-debug-full --show-only=json-v1 > native-debug-full.json
+      - name: Coverage -- the bundles must run every test the native runner would
+        if: ${{ !cancelled() }}
+        run: |
+          python3 ci/bundle_coverage.py \
+            --compare "ctest (macos-latest)" native-release.json bundle/macos-arm64-release/tests.json \
+            --compare "ctest-debug-full (macos-latest)" native-debug-full.json bundle/macos-arm64-debug-full/tests.json \
+            --summary "$GITHUB_STEP_SUMMARY"
+      - if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-bundle-results
+          path: |
+            bundle-release.xml
+            bundle-debug-full.xml
+            native-release.json
+            native-debug-full.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/macos-bundles.yml
+++ b/.github/workflows/macos-bundles.yml
@@ -240,11 +240,14 @@ jobs:
           }
           # Plain `cargo`, NOT `soldr cargo` -- see the long note in cross.yml's
           # build-cross: the wrapper drops mi_prof_* symbols at link time on these targets.
-          cmd="cargo test -p mimalloc-pprof --no-run"
-          if ! run_build "$cmd"; then
-            echo "::warning::build failed; retrying with the soldr compile cache bypassed (soldr#1969)"
-            run_build "${cmd/soldr/soldr --no-cache}"
-          fi
+          #
+          # No soldr#1969 cache-bypass retry here, deliberately: that retry re-runs
+          # `${cmd/soldr/soldr --no-cache}`, and with `soldr` absent from cmd the
+          # substitution is a no-op, so the "retry" would just run the identical command
+          # a second time and report the same failure twice. (cross.yml carries the same
+          # dead retry; it is left alone here so this PR does not change the control arm
+          # of #277 phase B's comparison.)
+          run_build "cargo test -p mimalloc-pprof --no-run"
           test -s bins.txt
           mkdir -p "dist/$TARGET"
           xargs -r -a bins.txt -I{} cp {} "dist/$TARGET/"
@@ -264,6 +267,9 @@ jobs:
     # The point of the whole workflow: one macOS VM, one queue slot, everything serial.
     needs: [build-macos, build-rust-apple]
     runs-on: macos-latest
+    # Everything this job does is serial, so a hung test would otherwise hold the very
+    # macOS slot this workflow exists to stop wasting. Observed end-to-end: ~1m40s.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -326,27 +332,52 @@ jobs:
 
       - name: Memory gate -- 8 runs from the release bundle
         run: |
-          # GitHub invokes `bash -e`, so a plain `set -uo pipefail` does NOT disable
-          # errexit: `set +e` is required, not decorative, or the script dies on the
-          # gate's non-zero exit before the rc check runs.
-          set +e
-          set -uo pipefail
+          set -euo pipefail
           exe="$PWD/bundle/macos-arm64-release/mimalloc-test-memory-gate"
           for i in 1 2 3 4 5 6 7 8; do
             MI_BENCH_JSON="$PWD/result-$i.json" "$exe" > /dev/null
           done
+          # A gate binary that crashed writes no JSON, the glob stays unexpanded, and
+          # every downstream error would then be indistinguishable from "this lane has no
+          # baseline yet" -- i.e. a green step. Count first.
+          # Counted with a glob, not `ls | wc -l`: under `set -o pipefail` a pipeline
+          # whose `ls` finds nothing fails, and the failing assignment would then kill the
+          # step before it could say why.
+          count=0
+          for produced in result-*.json; do
+            if [ -e "$produced" ]; then count=$((count + 1)); fi
+          done
+          if [ "$count" -ne 8 ]; then
+            echo "::error::only $count of 8 memory-gate runs produced JSON"
+            exit 1
+          fi
           cat result-1.json
           # --arch/--compiler give this lane its own baseline. Without them it would be
           # compared against ci/memory-baselines/macos-pprof1.json, which Apple clang
           # recorded on this same runner -- a cross-toolchain comparison dressed as a
           # regression check (#277 phase B).
-          python3 ci/memory_gate.py check --arch arm64 --compiler soldr-clang-21 result-*.json
-          rc=$?
-          if [ $rc -eq 2 ]; then
-            echo "::warning::No committed baseline for the soldr arm64 lane yet -- bootstrap it from this run's memory-gate artifact."
-            exit 0
-          fi
-          exit $rc
+          #
+          # "Is this lane new?" is decided by `where`, which answers 3 for "no baseline"
+          # and 2 for "cannot read this run". `check` collapses both into 2, so gating the
+          # yellow bootstrap path on check's own status would report an unreadable or
+          # missing result as a bootstrap and exit green.
+          rc=0
+          python3 ci/memory_gate.py where --arch arm64 --compiler soldr-clang-21 result-1.json || rc=$?
+          case "$rc" in
+            0)
+              python3 ci/memory_gate.py check --arch arm64 --compiler soldr-clang-21 result-*.json
+              ;;
+            3)
+              echo "::warning::No committed baseline for the soldr arm64 lane yet -- bootstrap it from this run's memory-gate artifact."
+              # `check` exits 2 here by construction: the probe just proved the baseline is
+              # absent, so its status carries no information -- but its report does.
+              python3 ci/memory_gate.py check --arch arm64 --compiler soldr-clang-21 result-*.json || true
+              ;;
+            *)
+              echo "::error::memory_gate could not read this run's JSON (rc=$rc)"
+              exit 1
+              ;;
+          esac
       - name: Positive control -- the gate must catch an injected leak
         run: |
           set -euo pipefail
@@ -354,20 +385,44 @@ jobs:
           for i in 1 2 3 4 5 6 7 8; do
             MI_BENCH_JSON="$PWD/leak-$i.json" "$exe" > /dev/null || true
           done
-          # `control` requires `check` to FAIL. A missing baseline is not a failure, it is
-          # a bootstrap (exit 2), so before this lane's baseline is committed the control
-          # would go red for the wrong reason. Ask memory_gate.py where the baseline lives
-          # rather than hardcoding a name it computes.
-          if ! python3 ci/memory_gate.py where --arch arm64 --compiler soldr-clang-21 leak-1.json; then
-            echo "::warning::the soldr arm64 lane has no committed baseline yet, so its positive control cannot run. Commit the baseline, then this becomes a hard gate."
-            exit 0
+          # The leak build is *expected* to exit non-zero (hence `|| true` above), which
+          # makes the file count the only evidence that it ran at all.
+          count=0
+          for produced in leak-*.json; do
+            if [ -e "$produced" ]; then count=$((count + 1)); fi
+          done
+          if [ "$count" -ne 8 ]; then
+            echo "::error::only $count of 8 leak-control runs produced JSON"
+            exit 1
           fi
-          python3 ci/memory_gate.py control --arch arm64 --compiler soldr-clang-21 leak-*.json
+          # `control` requires `check` to FAIL. A missing baseline is not a failure, it is
+          # a bootstrap, so before this lane's baseline is committed the control would go
+          # red for the wrong reason. Ask memory_gate.py where the baseline lives rather
+          # than hardcoding a name it computes -- and distinguish "no baseline" (3) from
+          # "cannot read this run" (2), which must stay a hard failure.
+          rc=0
+          python3 ci/memory_gate.py where --arch arm64 --compiler soldr-clang-21 leak-1.json || rc=$?
+          case "$rc" in
+            0)
+              python3 ci/memory_gate.py control --arch arm64 --compiler soldr-clang-21 leak-*.json
+              ;;
+            3)
+              echo "::warning::the soldr arm64 lane has no committed baseline yet, so its positive control cannot run. Commit the baseline, then this becomes a hard gate."
+              ;;
+            *)
+              echo "::error::memory_gate could not read the leak control's JSON (rc=$rc)"
+              exit 1
+              ;;
+          esac
       - if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: memory-gate-macos-arm64-soldr
-          path: result-*.json
+          # The leak runs too: they are what a reader needs to see why the control did or
+          # did not fire, and the gate runs are what the baseline is bootstrapped from.
+          path: |
+            result-*.json
+            leak-*.json
           if-no-files-found: error
 
       - name: Native compile-compat check (Xcode clang, no tests)
@@ -379,6 +434,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
+          # Must stay in step with c-unit.yml's `ctest` job (`cmake -B build -DMI_PPROF=ON`,
+          # built `--config Release`): this tree is the native half of the coverage
+          # comparison below, so if that job's flags change and these do not, the
+          # comparison silently stops describing the job being replaced. CMAKE_BUILD_TYPE
+          # is spelled out because there it is implied -- CMakeLists.txt (~137-145)
+          # defaults it to Release from the binary directory's name.
           cmake -B native-release -DMI_PPROF=ON -DCMAKE_BUILD_TYPE=Release
           cmake --build native-release --config Release --parallel
           cc --version
@@ -388,6 +449,11 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
+          # Same pairing as above, against c-unit.yml's `ctest-debug-full` job
+          # (`cmake -B build -DMI_PPROF=ON -DMI_DEBUG_FULL=ON`, built `--config Debug`).
+          # Release is not a typo: that job passes no CMAKE_BUILD_TYPE, its binary
+          # directory is `build`, and MI_DEBUG_FULL sets MI_DEBUG=3 independently of the
+          # build type -- so Release+MI_DEBUG_FULL is what it actually compiles.
           cmake -B native-debug-full -DMI_PPROF=ON -DMI_DEBUG_FULL=ON -DCMAKE_BUILD_TYPE=Release
           ctest --test-dir native-release --show-only=json-v1 > native-release.json
           ctest --test-dir native-debug-full --show-only=json-v1 > native-debug-full.json

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -21,6 +21,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # TODO(#277 phase B, added 2026-09-02): DELETE the macos-latest row after ten pushes
+    # have compared it against macos-bundles.yml's `run-macos`. Its cross-built Rust test
+    # binaries cover this row's `cargo test`, with one stated exception: the 8 doctests in
+    # rust/mimalloc-pprof/src/lib.rs cannot run from a `--tests` binary and are Linux-only
+    # after this (#277 §4). Informational until then; do not leave it yellow forever.
+    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     defaults:
       run:
         working-directory: rust

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ if the sub-issue conflicts with older prose in #2, the sub-issue + #2's Decision
    `MI_PPROF=ON`, the `OFF` job green (profiler hooks disabled; upstream allocator behavior
    with independent memory-events tracking left runtime-disabled), `rust-native` green.
    MSVC **and** win-gnu are priority platforms — both, always.
+   (macOS gates run from Linux-built bundles on one runner; see #277.)
 4. **Profiler memory-safety invariant:** profiler-internal memory (sample records, intern table,
    dump buffers) comes ONLY from the raw-OS-layer arena (`_mi_os_alloc`), never from hooked
    allocation paths (`mi_malloc`/`operator new`/`GlobalAlloc`). Debug builds assert this.

--- a/ci/bundle_coverage.py
+++ b/ci/bundle_coverage.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env -S uv run --script
+"""Prove a test bundle runs every test the native runner's own ctest would have run.
+
+Issue #277 phase B. The whole argument for building the macOS test binaries on Linux and
+executing them from a bundle is that coverage does not go down. That claim is only worth
+anything if something checks it on every run, against the machine the jobs are being taken
+away from -- so `run-macos` configures the same CMake trees natively (configure only; a
+tree needs no build for `ctest --show-only=json-v1` to list its suite), and this script
+compares those name lists against the bundles it just executed.
+
+A name the native tree has and the bundle does not is a hard failure: it is precisely the
+"gate that reports green on less" failure mode docs/ci-gates.md exists to prevent, and it
+can arise silently -- a test that CMake registers only for AppleClang, or one whose
+`add_test` sits behind a check that a cross configure resolves differently.
+
+A name the bundle has and the native tree does not is reported but not fatal: the bundle
+covering more than the runner used to is the direction this issue wants.
+
+    uv run ci/bundle_coverage.py \
+        --compare "ctest (Release)" native-release.json bundle-release/tests.json \
+        --compare "ctest-debug-full" native-debug.json bundle-debug/tests.json \
+        --summary "$GITHUB_STEP_SUMMARY"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+
+class CoverageError(Exception):
+    """An input this script cannot read. Always names the file."""
+
+
+def _as_object(value: object) -> dict[str, object] | None:
+    return cast("dict[str, object]", value) if isinstance(value, dict) else None
+
+
+def _as_array(value: object) -> list[object]:
+    return cast("list[object]", value) if isinstance(value, list) else []
+
+
+def read_test_names(path: Path) -> set[str]:
+    """Test names from either shape: `ctest --show-only=json-v1` or a bundle manifest.
+
+    Both put a `tests` array of objects with a `name` at the top level, which is not a
+    coincidence -- `bundle_tests.py` derives one from the other -- so one reader covers
+    both and the comparison cannot drift by reading them differently.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CoverageError(f"{path}: {exc}") from exc
+    root = _as_object(payload)
+    if root is None:
+        raise CoverageError(f"{path}: not a JSON object")
+    names: set[str] = set()
+    for raw in _as_array(root.get("tests")):
+        entry = _as_object(raw)
+        name = entry.get("name") if entry else None
+        if isinstance(name, str):
+            names.add(name)
+    if not names:
+        # An empty side would make every comparison trivially pass, which is the same
+        # "verifies nothing" shape this script exists to catch.
+        raise CoverageError(f"{path}: contains no test names")
+    return names
+
+
+@dataclass(frozen=True)
+class Comparison:
+    label: str
+    native: set[str]
+    bundle: set[str]
+
+    @property
+    def missing(self) -> list[str]:
+        return sorted(self.native - self.bundle)
+
+    @property
+    def extra(self) -> list[str]:
+        return sorted(self.bundle - self.native)
+
+
+def render(comparisons: Sequence[Comparison]) -> str:
+    lines = [
+        "### macOS coverage: native ctest vs cross-built bundle",
+        "",
+        "| config | native | bundle | missing from bundle | extra in bundle |",
+        "|---|---:|---:|---|---|",
+    ]
+    for comparison in comparisons:
+        missing = ", ".join(f"`{name}`" for name in comparison.missing) or "—"
+        extra = ", ".join(f"`{name}`" for name in comparison.extra) or "—"
+        lines.append(
+            f"| {comparison.label} | {len(comparison.native)} | {len(comparison.bundle)} "
+            f"| {missing} | {extra} |"
+        )
+    lines.append("")
+    total_missing = sum(len(comparison.missing) for comparison in comparisons)
+    if total_missing:
+        lines.append(
+            f"**{total_missing} test(s) the native runner executes are absent from the "
+            f"bundles.** Coverage would go down; see issue #277 §4."
+        )
+    else:
+        lines.append("Every test the native runner executes is present in a bundle.")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--compare",
+        nargs=3,
+        action="append",
+        metavar=("LABEL", "NATIVE_JSON", "BUNDLE_MANIFEST"),
+        required=True,
+        help="a ctest --show-only=json-v1 file and the bundle tests.json that replaces it",
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="append the markdown table here (point at $GITHUB_STEP_SUMMARY)",
+    )
+    args = parser.parse_args(argv)
+
+    comparisons: list[Comparison] = []
+    try:
+        for label, native, bundle in cast("list[list[str]]", args.compare):
+            comparisons.append(
+                Comparison(
+                    label=label,
+                    native=read_test_names(Path(native)),
+                    bundle=read_test_names(Path(bundle)),
+                )
+            )
+    except CoverageError as exc:
+        print(f"bundle_coverage: {exc}", file=sys.stderr)
+        return 2
+
+    table = render(comparisons)
+    print(table, end="")
+    summary = cast("Path | None", args.summary)
+    if summary is not None:
+        with summary.open("a", encoding="utf-8") as handle:
+            handle.write(table)
+    return 1 if any(comparison.missing for comparison in comparisons) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/bundle_tests.py
+++ b/ci/bundle_tests.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -264,6 +265,47 @@ def _normalise(path: str) -> str:
     return os.path.normpath(path).replace("\\", "/")
 
 
+#: A Windows drive-qualified path (`C:\\build\\x`) or a UNC share. `os.path.isabs` does not
+#: recognise either when this script runs on Linux, which is exactly where every cross
+#: bundle is produced -- so the leak scan below cannot rely on `isabs` alone.
+_WINDOWS_ABSOLUTE = re.compile(r"^(?:[A-Za-z]:[\\/]|\\\\[^\\/])")
+
+
+def looks_absolute(value: str) -> bool:
+    return Path(value).is_absolute() or bool(_WINDOWS_ABSOLUTE.match(value))
+
+
+def leaked_paths(test: BundledTest) -> list[str]:
+    """Every absolute path in a lowered test that the bundle does not carry.
+
+    `PathRewriter` only rewrites paths under the *build* directory. An absolute path from
+    anywhere else -- the source tree, the toolchain, the runner's home -- is copied into
+    the manifest verbatim and then silently refers to a directory that does not exist on
+    the machine that replays the bundle. Phase A only checked `argv[0]`, which was enough
+    while the bundle never left the build host; phase B ships bundles to another machine,
+    so argv[1:], every env value and the working directory are checked too (review
+    follow-up on PR #279).
+
+    `os.pathsep`-joined values are split first, so a `PATH`-shaped variable is reported by
+    the element that leaked rather than as one unreadable blob.
+    """
+    leaked: list[str] = []
+
+    def scan(where: str, value: str) -> None:
+        for piece in value.split(os.pathsep) if os.pathsep in value else [value]:
+            if not piece or piece.startswith(BUNDLE_PLACEHOLDER):
+                continue
+            if looks_absolute(piece):
+                leaked.append(f"{where}: {piece}")
+
+    for index, argument in enumerate(test.argv):
+        scan(f"argv[{index}]", argument)
+    for key in sorted(test.env):
+        scan(f"env[{key}]", test.env[key])
+    scan("cwd", test.cwd)
+    return leaked
+
+
 class PathRewriter:
     """Rewrites absolute build-tree paths to `${BUNDLE}/<basename>` and records the files.
 
@@ -410,6 +452,13 @@ def convert(payload: object, build_dir: Path) -> tuple[list[BundledTest], dict[s
                 f"bundle cannot carry it"
             )
             continue
+        leaked = leaked_paths(test)
+        if leaked:
+            problems.append(
+                f"{name}: absolute path(s) that the bundle does not carry would be "
+                f"replayed verbatim on another machine: " + ", ".join(leaked)
+            )
+            continue
         tests.append(test)
 
     if problems:
@@ -472,7 +521,11 @@ def write_manifest(
     manifest = {
         "version": MANIFEST_VERSION,
         "generated_from": {
-            "build_dir": str(build_dir),
+            # The build directory's *name* only. Its absolute path was the one remaining
+            # host path in the manifest, which made "grep the manifest for absolute paths"
+            # -- the check phase B's bundles are shipped under -- impossible to state
+            # simply (review follow-up on PR #279).
+            "build_dir": build_dir.name,
             "config": config,
             "platform": sys.platform,
         },

--- a/ci/memory-baselines/macos-pprof1.json
+++ b/ci/memory-baselines/macos-pprof1.json
@@ -1,6 +1,8 @@
 {
+  "arch": "arm64",
   "baseline_runs": 4,
   "baseline_spread_pct": 0.7,
+  "compiler": "apple-clang",
   "counters": {
     "pages_end": 1,
     "pages_start": 0,

--- a/ci/memory_gate.py
+++ b/ci/memory_gate.py
@@ -21,7 +21,7 @@ Usage:
     memory_gate.py check   [<result.json> ...]   # no paths: build/run the binary itself
     memory_gate.py update  <result.json> [more.json ...]   # deliberate, reviewed act
     memory_gate.py control <result.json> [more.json ...]   # positive control: must FAIL
-    memory_gate.py where   <result.json>                   # print the baseline it matches
+    memory_gate.py where   <result.json>                   # 0 = baseline exists, 3 = none
 
 `--arch <name>` and `--compiler <name>` (accepted by every command) declare the
 toolchain identity the binary cannot know about itself, and become part of the baseline
@@ -35,7 +35,7 @@ With no JSON paths, `check` locates the built `mimalloc-test-memory-gate` binary
 runs it RUNS_EXPECTED times (see run_gate_binary), and checks those results -- this
 is what makes `python ci/memory_gate.py check` alone reproduce the CI job locally.
 
-Exit codes: 0 pass, 1 regression, 2 usage/IO error.
+Exit codes: 0 pass, 1 regression, 2 usage/IO error, 3 (`where` only) no baseline yet.
 """
 
 from __future__ import annotations
@@ -461,16 +461,23 @@ def _identity_flags(arch: str | None, compiler: str | None) -> str:
 def where(result_paths: list[str], *, arch: str | None = None, compiler: str | None = None) -> int:
     """Print the baseline file a run of this identity is compared against.
 
-    Exit 0 if it exists, 2 if it does not. This is what lets a workflow ask "does this
-    lane have a baseline yet?" without hardcoding a filename that this module computes --
-    #277 phase B needs it because the *positive control* cannot run before a baseline
-    exists (`control` requires `check` to fail, and a missing baseline is not a failure,
-    it is a bootstrap to be committed), and a hardcoded path in YAML would drift silently.
+    Exit 0 if it exists, **3** if it does not, 2 if this run's JSON could not be read.
+
+    The three-way split is the point. `check` also exits 2 for "no baseline", but it exits
+    2 for an unreadable or absent result file as well -- so a workflow that treats `check`
+    rc=2 as "bootstrap me" turns a *crashed gate binary* into a green run with a
+    reassuring warning. Gating on this probe instead keeps those two apart: 3 means the
+    lane is genuinely new, 2 means something is wrong with the run itself.
+
+    #277 phase B needs the probe anyway, because the positive control cannot run before a
+    baseline exists (`control` requires `check` to fail, and a missing baseline is not a
+    failure), and hardcoding the filename in YAML would drift from what this module
+    computes from platform/arch/compiler/MI_PPROF.
     """
     result, _, _ = load_runs(result_paths, arch, compiler)
     path = baseline_path(result)
     print(path)
-    return 0 if path.exists() else 2
+    return 0 if path.exists() else 3
 
 
 def update(result_paths: list[str], *, arch: str | None = None, compiler: str | None = None) -> int:

--- a/ci/memory_gate.py
+++ b/ci/memory_gate.py
@@ -23,7 +23,7 @@ Usage:
     memory_gate.py control <result.json> [more.json ...]   # positive control: must FAIL
     memory_gate.py where   <result.json>                   # print the baseline it matches
 
-`--arch <name>` and `--compiler <name>` (accepted by all three commands) declare the
+`--arch <name>` and `--compiler <name>` (accepted by every command) declare the
 toolchain identity the binary cannot know about itself, and become part of the baseline
 file's name. #277 phase B needs them: an arm64 macOS run from a soldr-cross-built bundle
 and an arm64 macOS run from an Xcode-built tree are the same `platform` on the same

--- a/ci/memory_gate.py
+++ b/ci/memory_gate.py
@@ -21,6 +21,7 @@ Usage:
     memory_gate.py check   [<result.json> ...]   # no paths: build/run the binary itself
     memory_gate.py update  <result.json> [more.json ...]   # deliberate, reviewed act
     memory_gate.py control <result.json> [more.json ...]   # positive control: must FAIL
+    memory_gate.py where   <result.json>                   # print the baseline it matches
 
 `--arch <name>` and `--compiler <name>` (accepted by all three commands) declare the
 toolchain identity the binary cannot know about itself, and become part of the baseline
@@ -457,6 +458,21 @@ def _identity_flags(arch: str | None, compiler: str | None) -> str:
     return (f" --arch {arch}" if arch else "") + (f" --compiler {compiler}" if compiler else "")
 
 
+def where(result_paths: list[str], *, arch: str | None = None, compiler: str | None = None) -> int:
+    """Print the baseline file a run of this identity is compared against.
+
+    Exit 0 if it exists, 2 if it does not. This is what lets a workflow ask "does this
+    lane have a baseline yet?" without hardcoding a filename that this module computes --
+    #277 phase B needs it because the *positive control* cannot run before a baseline
+    exists (`control` requires `check` to fail, and a missing baseline is not a failure,
+    it is a bootstrap to be committed), and a hardcoded path in YAML would drift silently.
+    """
+    result, _, _ = load_runs(result_paths, arch, compiler)
+    path = baseline_path(result)
+    print(path)
+    return 0 if path.exists() else 2
+
+
 def update(result_paths: list[str], *, arch: str | None = None, compiler: str | None = None) -> int:
     result, peaks, spread = load_runs(result_paths, arch, compiler)
     if result.get("inject_leak", 0):
@@ -513,7 +529,7 @@ def main(argv: list[str]) -> int:
     except ValueError as e:
         print(f"error: {e}")
         return 2
-    if len(argv) < 2 or argv[1] not in ("check", "update", "control"):
+    if len(argv) < 2 or argv[1] not in ("check", "update", "control", "where"):
         print(__doc__)
         return 2
     result_paths = argv[2:]
@@ -528,7 +544,7 @@ def main(argv: list[str]) -> int:
         print(__doc__)
         return 2
     try:
-        cmd = {"check": check, "update": update, "control": control}[argv[1]]
+        cmd = {"check": check, "update": update, "control": control, "where": where}[argv[1]]
         return cmd(result_paths, arch=arch, compiler=compiler)
     except (OSError, ValueError, KeyError) as e:
         print(f"error: {e}")

--- a/ci/memory_gate.py
+++ b/ci/memory_gate.py
@@ -22,6 +22,14 @@ Usage:
     memory_gate.py update  <result.json> [more.json ...]   # deliberate, reviewed act
     memory_gate.py control <result.json> [more.json ...]   # positive control: must FAIL
 
+`--arch <name>` and `--compiler <name>` (accepted by all three commands) declare the
+toolchain identity the binary cannot know about itself, and become part of the baseline
+file's name. #277 phase B needs them: an arm64 macOS run from a soldr-cross-built bundle
+and an arm64 macOS run from an Xcode-built tree are the same `platform` on the same
+`macos-latest` runner, and comparing one against the other's committed peak would be a
+cross-toolchain comparison dressed as a regression check. Omitting both keeps the legacy
+`<platform>-pprof<N>.json` name, so no existing baseline moves.
+
 With no JSON paths, `check` locates the built `mimalloc-test-memory-gate` binary,
 runs it RUNS_EXPECTED times (see run_gate_binary), and checks those results -- this
 is what makes `python ci/memory_gate.py check` alone reproduce the CI job locally.
@@ -55,6 +63,14 @@ class Counters(TypedDict):
 
 class Result(TypedDict):
     """One run of test-memory-gate. Mirrors the JSON that MI_BENCH_JSON writes.
+
+    Two optional keys are written by the *caller* rather than by test-memory-gate.c and
+    so are read through `identity()` instead of being declared here (this project pins
+    pyright to pythonVersion 3.9, where `NotRequired` does not exist): `arch` and
+    `compiler`. What they distinguish is invisible to the binary: an arm64 macOS run from
+    a soldr-cross-built bundle and an arm64 macOS run from an Xcode-built tree report the
+    same `platform` on the same runner while being different toolchains with legitimately
+    different peaks (#277 phase B).
 
     Declared rather than left as dict[str, Any] because every field here is indexed by
     string literal below. A typo in one of those keys would previously have been a
@@ -206,10 +222,29 @@ def run_gate_binary(binary: Path, runs: int = RUNS_EXPECTED) -> list[str]:
     return result_paths
 
 
+def baseline_key(result: Result) -> tuple[str, ...]:
+    """The identity a baseline file is matched on: platform, arch, compiler, MI_PPROF.
+
+    MI_PPROF changes the legitimate peak (rule 4 puts the profiler arena in process
+    memory), so ON and OFF get separate baselines rather than one padded threshold. Arch
+    and compiler joined in for #277 phase B: `macos` alone stopped being a sufficient key
+    the moment the same `macos-latest` runner started executing both an Xcode-built binary
+    and a soldr-cross-built one. They are optional, so every existing baseline
+    (`linux-pprof1.json`, `windows-pprof1.json`, `macos-pprof1.json`) keeps its name and
+    keeps matching the runs that produced it -- a new toolchain asks for its own file
+    rather than silently borrowing another compiler's number.
+    """
+    parts = [result["platform"]]
+    for field in IDENTITY_FIELDS:
+        value = identity(result, field)
+        if value:
+            parts.append(value)
+    parts.append("pprof{}".format(result["mi_pprof"]))
+    return tuple(parts)
+
+
 def baseline_path(result: Result) -> Path:
-    # MI_PPROF changes the legitimate peak (rule 4 puts the profiler arena in process
-    # memory), so ON and OFF get separate baselines rather than one padded threshold.
-    return BASELINE_DIR / "{}-pprof{}.json".format(result["platform"], result["mi_pprof"])
+    return BASELINE_DIR / ("-".join(baseline_key(result)) + ".json")
 
 
 def load(path: str | Path) -> Result:
@@ -219,14 +254,35 @@ def load(path: str | Path) -> Result:
         return cast(Result, json.load(f))
 
 
-def load_runs(paths: list[str]) -> tuple[Result, list[float], float]:
+#: Optional identity keys (see Result's docstring). Order fixes the baseline file name.
+IDENTITY_FIELDS = ("arch", "compiler")
+
+
+def identity(record: Result, field: str) -> str | None:
+    value = cast("dict[str, object]", record).get(field)
+    return value if isinstance(value, str) and value else None
+
+
+def stamp(result: Result, arch: str | None, compiler: str | None) -> Result:
+    """Record the toolchain identity the binary cannot know about itself."""
+    fields = cast("dict[str, object]", result)
+    if arch:
+        fields["arch"] = arch
+    if compiler:
+        fields["compiler"] = compiler
+    return result
+
+
+def load_runs(
+    paths: list[str], arch: str | None = None, compiler: str | None = None
+) -> tuple[Result, list[float], float]:
     """Load N runs of the same configuration and return (representative, peak_mb, spread%).
 
     The representative record is the run with the minimum gated peak; its counters are
     the ones checked, so the counter assertions and the peak refer to the same run.
     """
-    runs = [load(p) for p in paths]
-    keys = {(r["platform"], r["mi_pprof"], r["gated_metric"]) for r in runs}
+    runs = [stamp(load(p), arch, compiler) for p in paths]
+    keys = {(baseline_key(r), r["gated_metric"]) for r in runs}
     if len(keys) != 1:
         raise ValueError(f"runs are not from the same configuration: {sorted(keys)}")
     peaks = sorted(r["peak_mb"] for r in runs)
@@ -256,7 +312,9 @@ def report_runs(peaks: list[float], spread: float) -> None:
         )
 
 
-def control(result_paths: list[str]) -> int:
+def control(
+    result_paths: list[str], *, arch: str | None = None, compiler: str | None = None
+) -> int:
     """Positive control: require the gate to FAIL on a deliberately leaky build.
 
     A gate that has never been observed to fire proves nothing -- it can be silently
@@ -267,7 +325,7 @@ def control(result_paths: list[str]) -> int:
     Requiring inject_leak to be *set* is what keeps this from being usable as an escape
     hatch -- it cannot be pointed at a real regression to turn it green.
     """
-    result, _, _ = load_runs(result_paths)
+    result, _, _ = load_runs(result_paths, arch, compiler)
     if not result.get("inject_leak", 0):
         print(
             "REFUSING: positive control requires a build with MI_BENCH_INJECT_LEAK "
@@ -277,7 +335,7 @@ def control(result_paths: list[str]) -> int:
         return 2
 
     print("=== positive control: the gate is expected to FAIL below ===")
-    rc = check(result_paths, _control=True)
+    rc = check(result_paths, _control=True, arch=arch, compiler=compiler)
     if rc == 1:
         print("\nPASS (control): the gate detected the injected leak.")
         return 0
@@ -287,8 +345,14 @@ def control(result_paths: list[str]) -> int:
     return 1
 
 
-def check(result_paths: list[str], _control: bool = False) -> int:
-    result, peaks, spread = load_runs(result_paths)
+def check(
+    result_paths: list[str],
+    _control: bool = False,
+    *,
+    arch: str | None = None,
+    compiler: str | None = None,
+) -> int:
+    result, peaks, spread = load_runs(result_paths, arch, compiler)
 
     if result.get("inject_leak", 0) and not _control:
         # An injected-leak run is a positive control; it is expected to fail and must
@@ -303,8 +367,15 @@ def check(result_paths: list[str], _control: bool = False) -> int:
     if not bpath.exists():
         print(f"No baseline at {bpath}.")
         report_runs(peaks, spread)
-        print("This platform/config has never been recorded. Create it with:")
-        print("    python ci/memory_gate.py update {}".format(" ".join(result_paths)))
+        print(
+            "This platform/arch/compiler/config ({}) has never been recorded. "
+            "Create it with:".format("+".join(baseline_key(result)))
+        )
+        print(
+            "    python ci/memory_gate.py update{} {}".format(
+                _identity_flags(arch, compiler), " ".join(result_paths)
+            )
+        )
         return 2
     base = load(bpath)
 
@@ -313,9 +384,16 @@ def check(result_paths: list[str], _control: bool = False) -> int:
     peak, base_peak = peaks[0], base["peak_mb"]
     allowed = base_peak * (1.0 + PEAK_TOLERANCE)
 
-    print(
-        "platform={} metric={} mi_pprof={}".format(result["platform"], metric, result["mi_pprof"])
-    )
+    print("baseline={} metric={}  ({})".format("+".join(baseline_key(result)), metric, bpath.name))
+    base_compiler = identity(base, "compiler")
+    if base_compiler and not identity(result, "compiler"):
+        # Not fatal: the file still keys on `macos`, so this is the legacy match working
+        # as intended. Saying so keeps a reader from assuming the number was recorded
+        # with the toolchain that just produced it.
+        print(
+            f"  NOTE: this baseline was recorded with compiler={base_compiler!r}; this run "
+            f"declared none (pass --compiler to give a new toolchain its own baseline)."
+        )
     print(
         f"  {metric:<22} {peak:>9.1f} MB   baseline {base_peak:>9.1f} MB   allowed {allowed:>9.1f} MB"
     )
@@ -363,7 +441,11 @@ def check(result_paths: list[str], _control: bool = False) -> int:
         for f in failures:
             print(f"  - {f}")
         print("\nIf this growth is intentional, re-baseline deliberately:")
-        print("    python ci/memory_gate.py update {}".format(" ".join(result_paths)))
+        print(
+            "    python ci/memory_gate.py update{} {}".format(
+                _identity_flags(arch, compiler), " ".join(result_paths)
+            )
+        )
         print("and say why in the PR. Do not re-baseline to make a red gate green.")
         return 1
 
@@ -371,8 +453,12 @@ def check(result_paths: list[str], _control: bool = False) -> int:
     return 0
 
 
-def update(result_paths: list[str]) -> int:
-    result, peaks, spread = load_runs(result_paths)
+def _identity_flags(arch: str | None, compiler: str | None) -> str:
+    return (f" --arch {arch}" if arch else "") + (f" --compiler {compiler}" if compiler else "")
+
+
+def update(result_paths: list[str], *, arch: str | None = None, compiler: str | None = None) -> int:
+    result, peaks, spread = load_runs(result_paths, arch, compiler)
     if result.get("inject_leak", 0):
         print("REFUSING to baseline a run with MI_BENCH_INJECT_LEAK set.")
         return 2
@@ -392,7 +478,41 @@ def update(result_paths: list[str]) -> int:
     return 0
 
 
+def take_option(argv: list[str], name: str) -> tuple[list[str], str | None]:
+    """Pull `--name VALUE` (or `--name=VALUE`) out of argv, anywhere in it.
+
+    Hand-rolled rather than argparse so the positional shape this script has always had
+    (`memory_gate.py <command> <result.json>...`, with a glob expanding to any number of
+    paths) is untouched, and so the module-level `check`/`update`/`control` functions that
+    ci/verify_local.py calls directly keep the same signature.
+    """
+    rest: list[str] = []
+    value: str | None = None
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == f"--{name}":
+            if index + 1 >= len(argv):
+                raise ValueError(f"--{name} needs a value")
+            value = argv[index + 1]
+            index += 2
+            continue
+        if token.startswith(f"--{name}="):
+            value = token.split("=", 1)[1]
+            index += 1
+            continue
+        rest.append(token)
+        index += 1
+    return rest, value
+
+
 def main(argv: list[str]) -> int:
+    try:
+        argv, arch = take_option(list(argv), "arch")
+        argv, compiler = take_option(argv, "compiler")
+    except ValueError as e:
+        print(f"error: {e}")
+        return 2
     if len(argv) < 2 or argv[1] not in ("check", "update", "control"):
         print(__doc__)
         return 2
@@ -409,7 +529,7 @@ def main(argv: list[str]) -> int:
         return 2
     try:
         cmd = {"check": check, "update": update, "control": control}[argv[1]]
-        return cmd(result_paths)
+        return cmd(result_paths, arch=arch, compiler=compiler)
     except (OSError, ValueError, KeyError) as e:
         print(f"error: {e}")
         return 2

--- a/ci/tests/test_bundle_coverage.py
+++ b/ci/tests/test_bundle_coverage.py
@@ -1,0 +1,80 @@
+"""Unit tests for ci/bundle_coverage.py (issue #277 phase B).
+
+The script's only job is to fail when a bundle runs fewer tests than the runner's own
+ctest would have. So the tests that matter are: it does fail then, it does not fail when
+the bundle runs *more*, and it refuses an input that would make every comparison
+trivially pass.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import bundle_coverage
+
+
+def _write(directory: Path, name: str, test_names: list[str]) -> str:
+    path = directory / name
+    path.write_text(json.dumps({"tests": [{"name": n} for n in test_names]}), encoding="utf-8")
+    return str(path)
+
+
+class CoverageTest(unittest.TestCase):
+    def test_identical_suites_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            native = _write(Path(tmp), "native.json", ["test-api", "test-stress"])
+            bundle = _write(Path(tmp), "bundle.json", ["test-stress", "test-api"])
+            self.assertEqual(bundle_coverage.main(["--compare", "release", native, bundle]), 0)
+
+    def test_a_test_only_the_native_runner_has_is_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            native = _write(Path(tmp), "native.json", ["test-api", "test-osx-zone"])
+            bundle = _write(Path(tmp), "bundle.json", ["test-api"])
+            self.assertEqual(bundle_coverage.main(["--compare", "release", native, bundle]), 1)
+
+    def test_a_test_only_the_bundle_has_is_not_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            native = _write(Path(tmp), "native.json", ["test-api"])
+            bundle = _write(Path(tmp), "bundle.json", ["test-api", "test-extra"])
+            self.assertEqual(bundle_coverage.main(["--compare", "release", native, bundle]), 0)
+
+    def test_an_empty_side_is_refused_rather_than_passing_vacuously(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            native = _write(Path(tmp), "native.json", [])
+            bundle = _write(Path(tmp), "bundle.json", ["test-api"])
+            self.assertEqual(bundle_coverage.main(["--compare", "release", native, bundle]), 2)
+
+    def test_a_missing_file_is_reported_not_raised(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = _write(Path(tmp), "bundle.json", ["test-api"])
+            self.assertEqual(
+                bundle_coverage.main(
+                    ["--compare", "release", str(Path(tmp) / "nope.json"), bundle]
+                ),
+                2,
+            )
+
+    def test_the_table_names_the_missing_tests(self) -> None:
+        comparison = bundle_coverage.Comparison(
+            label="ctest-debug-full", native={"a", "b"}, bundle={"a", "c"}
+        )
+        table = bundle_coverage.render([comparison])
+        self.assertIn("`b`", table)
+        self.assertIn("`c`", table)
+        self.assertIn("1 test(s) the native runner executes are absent", table)
+
+    def test_a_ctest_show_only_payload_reads_the_same_as_a_manifest(self) -> None:
+        # bundle_tests.py derives one from the other, so one reader covers both shapes.
+        show_only = Path(__file__).parent / "fixtures" / "test_bundles" / "ctest-show-only.json"
+        with tempfile.TemporaryDirectory() as tmp:
+            names = bundle_coverage.read_test_names(show_only)
+            bundle = _write(Path(tmp), "bundle.json", sorted(names))
+            self.assertEqual(bundle_coverage.main(["--compare", "x", str(show_only), bundle]), 0)
+        self.assertIn("test-api", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_memory_gate.py
+++ b/ci/tests/test_memory_gate.py
@@ -1,0 +1,140 @@
+"""Unit tests for ci/memory_gate.py's baseline identity (issue #277 phase B).
+
+Before phase B a baseline was keyed on platform + MI_PPROF alone. That was sufficient
+while `macos-latest` only ever ran binaries built by Xcode on that same machine. Phase B
+puts a second, differently-built arm64 binary on the same runner -- cross-compiled on
+Linux by soldr's clang -- and comparing its peak against a number recorded by Apple clang
+would be a cross-toolchain comparison presented as a regression check. So the identity a
+baseline is matched on gained two optional parts, and these tests pin both halves of that:
+a run that declares nothing still matches the file it always matched (no existing
+baseline moves, the ubuntu one least of all), and a run that declares a toolchain asks for
+its own file instead of silently borrowing another's.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import cast
+
+import memory_gate
+
+BASELINES = Path(memory_gate.__file__).resolve().parent / "memory-baselines"
+
+
+def _result(**overrides: object) -> memory_gate.Result:
+    base: dict[str, object] = {
+        "schema": 1,
+        "platform": "macos",
+        "gated_metric": "peak_rss",
+        "mi_pprof": 1,
+        "inject_leak": 0,
+        "peak_mb": 13.4,
+        "peak_rss_mb": 13.4,
+        "peak_commit_mb": 58.7,
+        "profiler_arena_mb": 0.0,
+        "peak_minus_profiler_mb": 13.4,
+        "purged_gb": 0.07,
+        "counters": {
+            "threads_start": 1,
+            "threads_end": 1,
+            "theaps_start": 0,
+            "theaps_end": 1,
+            "pages_start": 0,
+            "pages_end": 1,
+        },
+    }
+    base.update(overrides)
+    return cast("memory_gate.Result", base)
+
+
+class BaselineIdentityTest(unittest.TestCase):
+    def test_an_undeclared_run_keeps_the_legacy_filename(self) -> None:
+        self.assertEqual(memory_gate.baseline_path(_result()).name, "macos-pprof1.json")
+
+    def test_the_committed_baselines_still_match_undeclared_runs(self) -> None:
+        # The point of making arch/compiler optional: no committed file moves, so the
+        # ubuntu and windows gates are untouched by phase B.
+        for platform, pprof in (("linux", 1), ("macos", 1), ("windows", 1)):
+            path = memory_gate.baseline_path(_result(platform=platform, mi_pprof=pprof))
+            self.assertTrue(path.is_file(), f"{path} should be the committed baseline")
+
+    def test_a_declared_toolchain_gets_its_own_filename(self) -> None:
+        result = memory_gate.stamp(_result(), "arm64", "soldr-clang-21")
+        self.assertEqual(
+            memory_gate.baseline_path(result).name, "macos-arm64-soldr-clang-21-pprof1.json"
+        )
+
+    def test_the_soldr_lane_has_no_committed_baseline_yet(self) -> None:
+        # Phase B's first run is deliberately yellow, not red: memory_gate exits 2 and the
+        # workflow turns that into a ::warning:: telling the reader to bootstrap it.
+        result = memory_gate.stamp(_result(), "arm64", "soldr-clang-21")
+        self.assertFalse(memory_gate.baseline_path(result).exists())
+
+    def test_the_existing_macos_baseline_records_the_native_toolchain(self) -> None:
+        record = json.loads((BASELINES / "macos-pprof1.json").read_text(encoding="utf-8"))
+        self.assertEqual(record["arch"], "arm64")
+        self.assertEqual(record["compiler"], "apple-clang")
+
+    def test_arch_alone_is_a_valid_partial_identity(self) -> None:
+        self.assertEqual(
+            memory_gate.baseline_path(memory_gate.stamp(_result(), "x86_64", None)).name,
+            "macos-x86_64-pprof1.json",
+        )
+
+
+class LoadRunsTest(unittest.TestCase):
+    def _write(self, directory: Path, name: str, result: memory_gate.Result) -> str:
+        path = directory / name
+        path.write_text(json.dumps(result), encoding="utf-8")
+        return str(path)
+
+    def test_stamping_is_applied_to_every_loaded_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = [
+                self._write(Path(tmp), f"r{i}.json", _result(peak_mb=13.0 + i)) for i in range(3)
+            ]
+            best, peaks, _ = memory_gate.load_runs(paths, "arm64", "soldr-clang-21")
+        self.assertEqual(peaks[0], 13.0)
+        self.assertEqual(memory_gate.identity(best, "compiler"), "soldr-clang-21")
+
+    def test_runs_from_different_platforms_are_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = [
+                self._write(Path(tmp), "a.json", _result()),
+                self._write(Path(tmp), "b.json", _result(platform="linux")),
+            ]
+            with self.assertRaises(ValueError):
+                memory_gate.load_runs(paths)
+
+
+class OptionParsingTest(unittest.TestCase):
+    """`--arch`/`--compiler` are pulled out of argv wherever they appear, so the existing
+    `memory_gate.py check result-*.json` shape (a glob of any length) is unchanged."""
+
+    def test_separate_value_form(self) -> None:
+        rest, value = memory_gate.take_option(
+            ["memory_gate.py", "check", "--arch", "arm64", "a.json"], "arch"
+        )
+        self.assertEqual(rest, ["memory_gate.py", "check", "a.json"])
+        self.assertEqual(value, "arm64")
+
+    def test_equals_form(self) -> None:
+        rest, value = memory_gate.take_option(["check", "--compiler=apple-clang"], "compiler")
+        self.assertEqual(rest, ["check"])
+        self.assertEqual(value, "apple-clang")
+
+    def test_absent_option_is_none_and_argv_is_untouched(self) -> None:
+        rest, value = memory_gate.take_option(["check", "a.json", "b.json"], "arch")
+        self.assertEqual(rest, ["check", "a.json", "b.json"])
+        self.assertIsNone(value)
+
+    def test_a_dangling_option_is_an_error(self) -> None:
+        with self.assertRaises(ValueError):
+            memory_gate.take_option(["check", "--arch"], "arch")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_memory_gate.py
+++ b/ci/tests/test_memory_gate.py
@@ -110,6 +110,26 @@ class LoadRunsTest(unittest.TestCase):
                 memory_gate.load_runs(paths)
 
 
+class WhereTest(unittest.TestCase):
+    """`where` is how a workflow asks "does this lane have a baseline yet?" without
+    hardcoding a filename that memory_gate.py computes."""
+
+    def _write(self, directory: Path, result: memory_gate.Result) -> str:
+        path = directory / "r.json"
+        path.write_text(json.dumps(result), encoding="utf-8")
+        return str(path)
+
+    def test_exit_zero_and_the_path_for_a_committed_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(Path(tmp), _result())
+            self.assertEqual(memory_gate.where([path]), 0)
+
+    def test_exit_two_for_a_lane_with_no_baseline_yet(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(Path(tmp), _result())
+            self.assertEqual(memory_gate.where([path], arch="arm64", compiler="soldr-clang-21"), 2)
+
+
 class OptionParsingTest(unittest.TestCase):
     """`--arch`/`--compiler` are pulled out of argv wherever they appear, so the existing
     `memory_gate.py check result-*.json` shape (a glob of any length) is unchanged."""

--- a/ci/tests/test_memory_gate.py
+++ b/ci/tests/test_memory_gate.py
@@ -124,10 +124,18 @@ class WhereTest(unittest.TestCase):
             path = self._write(Path(tmp), _result())
             self.assertEqual(memory_gate.where([path]), 0)
 
-    def test_exit_two_for_a_lane_with_no_baseline_yet(self) -> None:
+    def test_exit_three_for_a_lane_with_no_baseline_yet(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = self._write(Path(tmp), _result())
-            self.assertEqual(memory_gate.where([path], arch="arm64", compiler="soldr-clang-21"), 2)
+            self.assertEqual(memory_gate.where([path], arch="arm64", compiler="soldr-clang-21"), 3)
+
+    def test_an_unreadable_run_is_exit_two_not_three(self) -> None:
+        # The distinction run-macos gates on: 3 is "this lane is new", 2 is "something is
+        # wrong with this run". Collapsing them would let a crashed gate binary be
+        # reported as a missing baseline and exit the step green.
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = str(Path(tmp) / "nope.json")
+            self.assertEqual(memory_gate.main(["memory_gate.py", "where", missing]), 2)
 
 
 class OptionParsingTest(unittest.TestCase):

--- a/ci/tests/test_test_bundles.py
+++ b/ci/tests/test_test_bundles.py
@@ -31,6 +31,7 @@ BUNDLE_TESTS = Path(__file__).resolve().parents[1] / "bundle_tests.py"
 RUN_BUNDLE = Path(__file__).resolve().parents[1] / "run_test_bundle.py"
 
 BUILD = Path("/build") if os.name != "nt" else Path("C:/build")
+BUNDLE = bundle_tests.BUNDLE_PLACEHOLDER
 
 
 def _payload() -> object:
@@ -197,6 +198,83 @@ class PathRewritingTest(unittest.TestCase):
         with self.assertRaises(bundle_tests.BundleError) as caught:
             bundle_tests.convert(payload, BUILD)
         self.assertIn("t-outside", str(caught.exception))
+
+
+class LeakedAbsolutePathTest(unittest.TestCase):
+    """Phase A only validated argv[0]; phase B ships bundles to another machine.
+
+    A path outside the build tree is not rewritten (PathRewriter only knows the build
+    prefix), so before this scan it was copied into the manifest verbatim and pointed at a
+    directory the macOS/Windows runner does not have. Review follow-up on PR #279.
+    """
+
+    def test_an_absolute_path_in_a_later_argv_element_is_refused(self) -> None:
+        payload = _wrap(
+            _test_entry(
+                "t-argv", [f"{BUILD.as_posix()}/mimalloc-test-api", "/home/runner/work/src/x.txt"]
+            )
+        )
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.convert(payload, BUILD)
+        self.assertIn("t-argv", str(caught.exception))
+        self.assertIn("argv[1]", str(caught.exception))
+
+    def test_an_absolute_path_in_an_env_value_is_refused(self) -> None:
+        payload = _wrap(
+            _test_entry(
+                "t-env",
+                [f"{BUILD.as_posix()}/mimalloc-test-api"],
+                [{"name": "ENVIRONMENT", "value": ["SOME_DIR=/opt/toolchain/lib"]}],
+            )
+        )
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.convert(payload, BUILD)
+        self.assertIn("env[SOME_DIR]", str(caught.exception))
+
+    def test_an_absolute_working_directory_is_refused(self) -> None:
+        payload = _wrap(
+            _test_entry(
+                "t-cwd",
+                [f"{BUILD.as_posix()}/mimalloc-test-api"],
+                [{"name": "WORKING_DIRECTORY", "value": "/some/source/tree"}],
+            )
+        )
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            bundle_tests.convert(payload, BUILD)
+        self.assertIn("cwd", str(caught.exception))
+
+    def test_a_pathsep_joined_value_reports_the_leaking_element(self) -> None:
+        joined = os.pathsep.join([f"{BUNDLE}/lib", "/opt/toolchain/lib"])
+        test = bundle_tests.BundledTest(name="t", argv=[f"{BUNDLE}/exe"], env={"MY_PATH": joined})
+        self.assertEqual(bundle_tests.leaked_paths(test), ["env[MY_PATH]: /opt/toolchain/lib"])
+
+    def test_a_windows_drive_path_is_absolute_even_on_linux(self) -> None:
+        # Every cross bundle is produced on Linux, where os.path.isabs("C:/build/x") is
+        # False -- so a Windows bundle's leak would pass unnoticed without this.
+        self.assertTrue(bundle_tests.looks_absolute("C:/build/x"))
+        self.assertTrue(bundle_tests.looks_absolute("C:\\build\\x"))
+        self.assertTrue(bundle_tests.looks_absolute("\\\\server\\share"))
+        self.assertFalse(bundle_tests.looks_absolute("relative/path"))
+        self.assertFalse(bundle_tests.looks_absolute("MIMALLOC_VERBOSE=1"))
+
+    def test_relative_and_placeholder_values_are_accepted(self) -> None:
+        test = bundle_tests.BundledTest(
+            name="t",
+            argv=[f"{BUNDLE}/exe", "reentrant"],
+            env={"A": "1", "B": f"{BUNDLE}/libmimalloc.dylib"},
+            cwd=BUNDLE,
+        )
+        self.assertEqual(bundle_tests.leaked_paths(test), [])
+
+    def test_the_manifest_records_no_absolute_build_directory(self) -> None:
+        # `generated_from.build_dir` used to be the one host path left in tests.json,
+        # which made "the manifest contains zero absolute paths" untrue as stated.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "bundle"
+            out.mkdir()
+            bundle_tests.write_manifest(out, [], Path(tmp) / "build-debug-full", "Debug")
+            manifest = json.loads((out / "tests.json").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["generated_from"]["build_dir"], "build-debug-full")
 
 
 class PropertyHandlingTest(unittest.TestCase):

--- a/cmake/toolchains/soldr-aarch64-apple-darwin.cmake
+++ b/cmake/toolchains/soldr-aarch64-apple-darwin.cmake
@@ -1,0 +1,91 @@
+# CMake toolchain: build this repository for arm64 macOS, on Linux, through soldr.
+#
+# Issue #277 phase B. The macOS gates are cross-compiled on a Linux runner into a portable
+# test bundle (ci/bundle_tests.py) and executed on one macOS runner, instead of one fresh
+# macOS VM per job -- the Apple rows in cross.yml execute in 8-14 s and were measured
+# waiting up to 5h26m for a runner.
+#
+# This file consumes ONLY the environment `soldr prepare --target aarch64-apple-darwin`
+# exports; it hardcodes no path, no SDK version and no compiler version, so a soldr
+# upgrade that moves the SDK (14.5 here, 15.5 in the #277 review) changes nothing here.
+#
+#   soldr prepare --target aarch64-apple-darwin --github-env "$GITHUB_ENV"
+#   cmake -B build-macos-arm64 -G Ninja -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON \
+#         --toolchain cmake/toolchains/soldr-aarch64-apple-darwin.cmake
+#
+# soldr exports (verified with soldr 0.9.11):
+#   SDKROOT                        the Apple SDK it materialised
+#   CC_aarch64_apple_darwin        "clang --target=arm64-apple-darwin -isysroot <sdk> -mmacosx-version-min=11.0"
+#   CXX_aarch64_apple_darwin       the same plus -stdlib=libc++
+#   CFLAGS_aarch64_apple_darwin    those flags without the driver, plus -fuse-ld=lld
+#   CXXFLAGS_aarch64_apple_darwin  likewise
+#   AR_aarch64_apple_darwin        llvm-ar
+#   RANLIB_aarch64_apple_darwin    llvm-ranlib
+# and prepends its LLVM 21 bin directory to PATH, which is where `clang` comes from.
+
+set(CMAKE_SYSTEM_NAME Darwin)
+set(CMAKE_SYSTEM_PROCESSOR arm64)
+
+set(_soldr_triple "aarch64_apple_darwin")
+
+# Refuse to guess. Without `soldr prepare` in the same shell this would otherwise
+# configure against the *host* clang and produce ELF objects that fail much later, in the
+# link or (worse) on the macOS runner.
+foreach(_required SDKROOT CC_${_soldr_triple} CXX_${_soldr_triple} CFLAGS_${_soldr_triple})
+  if(NOT DEFINED ENV{${_required}})
+    message(FATAL_ERROR
+      "$ENV{${_required}} is not set: run `soldr prepare --target aarch64-apple-darwin` "
+      "(with --github-env \"$GITHUB_ENV\" on CI) before configuring with this toolchain.")
+  endif()
+endforeach()
+
+# soldr's CC_/CXX_ are full driver command lines. CMake wants the program in
+# CMAKE_<LANG>_COMPILER and the flags in CMAKE_<LANG>_FLAGS, and the CFLAGS_/CXXFLAGS_
+# exports are exactly "the same command line minus the driver, plus -fuse-ld=lld", so the
+# driver is taken from the first token of CC_/CXX_ and everything else from CFLAGS_/CXXFLAGS_.
+separate_arguments(_soldr_cc NATIVE_COMMAND "$ENV{CC_${_soldr_triple}}")
+separate_arguments(_soldr_cxx NATIVE_COMMAND "$ENV{CXX_${_soldr_triple}}")
+list(GET _soldr_cc 0 CMAKE_C_COMPILER)
+list(GET _soldr_cxx 0 CMAKE_CXX_COMPILER)
+
+set(CMAKE_C_FLAGS_INIT "$ENV{CFLAGS_${_soldr_triple}}")
+set(CMAKE_CXX_FLAGS_INIT "$ENV{CXXFLAGS_${_soldr_triple}}")
+# -fuse-ld=lld lives in those flags and is what selects ld64.lld; a link driven without
+# them would look for Apple's `ld`, which does not exist on the Linux runner.
+set(CMAKE_EXE_LINKER_FLAGS_INIT "$ENV{CFLAGS_${_soldr_triple}}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "$ENV{CFLAGS_${_soldr_triple}}")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "$ENV{CFLAGS_${_soldr_triple}}")
+
+if(DEFINED ENV{AR_${_soldr_triple}})
+  find_program(CMAKE_AR NAMES "$ENV{AR_${_soldr_triple}}" REQUIRED)
+endif()
+if(DEFINED ENV{RANLIB_${_soldr_triple}})
+  find_program(CMAKE_RANLIB NAMES "$ENV{RANLIB_${_soldr_triple}}" REQUIRED)
+endif()
+
+# Naming the sysroot and the deployment target explicitly keeps CMake's Darwin platform
+# module from shelling out to `xcrun`/`sw_vers`, neither of which exists here. The minimum
+# version is read back out of soldr's own flags rather than repeated, so the two can never
+# disagree.
+set(CMAKE_OSX_SYSROOT "$ENV{SDKROOT}" CACHE PATH "Apple SDK provisioned by soldr")
+if("$ENV{CFLAGS_${_soldr_triple}}" MATCHES "-mmacosx-version-min=([0-9][0-9.]*)")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "${CMAKE_MATCH_1}" CACHE STRING "macOS deployment target")
+endif()
+# Deliberately NOT setting CMAKE_OSX_ARCHITECTURES: it is the switch CMakeLists.txt reads
+# to decide between a universal-binary `-Xarch_arm64 -march=armv8.1-a` and the plain
+# `-march=armv8.1-a` this single-architecture build wants (CMakeLists.txt ~601-615).
+
+# The load-bearing line. CMakeLists.txt's find_link_library() falls back to find_library()
+# when check_linker_flag() rejects `-l<name>`, and on a Darwin link `-lrt` and `-latomic`
+# are both rejected -- so without this the host's /usr/lib/x86_64-linux-gnu/librt.so and
+# libatomic.so are found and handed to a Mach-O link. Confining library and header lookup
+# to the SDK leaves Darwin linking `pthread` only, which is correct.
+set(CMAKE_FIND_ROOT_PATH "$ENV{SDKROOT}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+unset(_soldr_cc)
+unset(_soldr_cxx)
+unset(_soldr_triple)

--- a/cmake/toolchains/soldr-aarch64-apple-darwin.cmake
+++ b/cmake/toolchains/soldr-aarch64-apple-darwin.cmake
@@ -34,7 +34,7 @@ set(_soldr_triple "aarch64_apple_darwin")
 foreach(_required SDKROOT CC_${_soldr_triple} CXX_${_soldr_triple} CFLAGS_${_soldr_triple})
   if(NOT DEFINED ENV{${_required}})
     message(FATAL_ERROR
-      "$ENV{${_required}} is not set: run `soldr prepare --target aarch64-apple-darwin` "
+      "${_required} is not set: run `soldr prepare --target aarch64-apple-darwin` "
       "(with --github-env \"$GITHUB_ENV\" on CI) before configuring with this toolchain.")
   endif()
 endforeach()

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -171,10 +171,17 @@ Two coverage facts are stated rather than gated, because nothing can gate them:
 absent by default, so `linux-pprof1.json`, `windows-pprof1.json` and `macos-pprof1.json`
 keep their names and keep matching the runs that produced them — the ubuntu baseline is
 untouched. The soldr lane asks for `macos-arm64-soldr-clang-21-pprof1.json`, which does
-not exist yet, so its first run takes the existing "no baseline → bootstrap it" path
-(exit 2, a `::warning::`) and uploads its JSON. Its positive control is skipped with a
-warning until that baseline is committed, because `control` requires `check` to *fail* and
-a missing baseline is not a failure.
+not exist yet, so its first run takes the existing "no baseline → bootstrap it" path and
+uploads its JSON. Its positive control is skipped with a warning until that baseline is
+committed, because `control` requires `check` to *fail* and a missing baseline is not a
+failure.
+
+Which of those two states a run is in is decided by `memory_gate.py where`, not by
+`check`'s status. `check` exits 2 both for "no baseline" and for "this run's JSON could
+not be read", so a step that treated its 2 as "bootstrap me" would turn a **crashed gate
+binary** into a green run with a reassuring warning. `where` answers **3** for "no
+baseline" and keeps **2** for "cannot read this run", and `run-macos` additionally
+requires all eight result files to exist before it calls the gate at all.
 
 ### Rollout
 

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -71,6 +71,14 @@ the expected non-zero exit — the script's own words are "negative control time
 instead of failing fast" — and the expected substring is searched in the *combined*
 stdout+stderr, so a control that fails for the wrong reason stays red.
 
+Every lowered test is then scanned for absolute paths that the bundle does not carry --
+across `argv`, every `env` value (split on `os.pathsep`) and `cwd`, not just `argv[0]` --
+and any hit is a hard error naming the test and the field. `PathRewriter` only rewrites
+paths under the *build* directory, so a source-tree, toolchain or runner-home path would
+otherwise be replayed verbatim on a machine that does not have it. Windows drive-qualified
+and UNC paths count as absolute even though `os.path.isabs` says otherwise on Linux, which
+is where every cross bundle is built.
+
 Test properties are an **allowlist** (`ENVIRONMENT`, `TIMEOUT`, `WORKING_DIRECTORY`,
 `LABELS`, `WILL_FAIL`, `DISABLED`). Anything else — `PASS_REGULAR_EXPRESSION`,
 `SKIP_RETURN_CODE`, `RESOURCE_LOCK` — is a hard error naming the test, as is any `cmake`

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -24,7 +24,7 @@ verifying nothing**, each discovered by asking "has this ever actually failed?":
 |---|---|---|
 | **memory-gate** (`ci/memory_gate.py`) | peak memory or thread-count regressions vs a committed per-platform baseline | builds a copy with an injected leak; the gate must fail — verified at +212% / +98% / +27% on linux/windows/macos |
 | **isa-baseline** (`ci/check_isa_baseline.py`) | binaries containing instructions above the CPU baseline, which SIGILL on older hardware | builds with `MI_OPT_ARCH=ON`; the scanner must fire. The parser also self-tests against x86 and arm64 fixtures on every run |
-| **ctest matrix** | correctness on ubuntu / windows-MSVC / windows-MinGW / macos, `MI_PPROF` on and off, `MI_DEBUG_FULL`, and shared-library builds on all three of ubuntu, MSVC and MinGW | — |
+| **ctest matrix** | correctness on ubuntu / windows-MSVC / windows-MinGW / macos, `MI_PPROF` on and off, `MI_DEBUG_FULL`, and shared-library builds on all three of ubuntu, MSVC and MinGW. **macOS is gated from Linux-built bundles run on one runner** (`macos-bundles.yml`, #277 phase B); the native macOS jobs are informational during the comparison window | `ci/bundle_coverage.py` fails if any test the native macOS `ctest` would run is missing from a bundle |
 | **ctest-guarded** | the `MI_GUARDED` guard-page path, run twice: at the default sample rate and again with `MIMALLOC_GUARDED_SAMPLE_RATE=1` so every eligible allocation is guarded | configure step greps the resolved compiler defines for `MI_GUARDED=1`, since the original bug was the flag never reaching the compiler |
 | **asan** | use-after-free, overflow and leaks under AddressSanitizer | — |
 | **fuzz** (`test/fuzz/`) | crashes from structured random allocator-API sequences, with ASan as the oracle | builds with a planted use-after-free and requires an anchored `(ERROR\|SUMMARY): AddressSanitizer:` report naming it |
@@ -94,6 +94,95 @@ dead gates above shared.
 requires the same test names with the same pass/fail (`--compare-junit`). Moving the build
 tree is the load-bearing step: the executables carry an RPATH into it, so without that
 `mv` a broken bundle would pass on the build machine by loading the original libraries.
+
+## macOS via cross-built bundles
+
+Issue #277 phase B. The macOS gates no longer build on macOS. `macos-bundles.yml` builds
+the arm64 test binaries on **ubuntu-latest** through soldr's Darwin toolchain, packs them
+with `ci/bundle_tests.py`, and one `macos-latest` job runs everything serially.
+
+The reason is queue wait, not build time. Over 20 runs per workflow, `cross.yml`'s Apple
+rows executed in 8–14 s and waited up to 5h26m (arm64) / 6h13m (Intel), p90 1h29m / 2h32m,
+while every ubuntu row waited 4–5 s. Six macOS jobs per push become one.
+
+| Linux job | produces | replaces |
+|---|---|---|
+| `build-macos (macos-arm64-release)` | `bundle-macos-arm64-release` | `ctest (macos-latest)` |
+| `build-macos (macos-arm64-debug-full)` | `bundle-macos-arm64-debug-full` | `ctest-debug-full (macos-latest)` |
+| `build-macos (macos-arm64-leak)` | `bundle-macos-arm64-leak` | the `memory-gate` positive control |
+| `build-rust (aarch64-apple-darwin)` | `rust-test-bins-…` | `cross.yml` `test (aarch64-apple-darwin)` |
+| `build-rust (x86_64-apple-darwin)` | `rust-test-bins-…` | `cross.yml` `test (x86_64-apple-darwin)`, run under Rosetta 2 |
+
+### The toolchain
+
+`cmake/toolchains/soldr-aarch64-apple-darwin.cmake` consumes only what `soldr prepare
+--target aarch64-apple-darwin` exports (`CC_`/`CXX_`/`CFLAGS_`/`CXXFLAGS_`/`AR_`/`RANLIB_`
+per triple, plus `SDKROOT`), so no path, SDK version or compiler version is written down
+in the repository. One line in it is load-bearing:
+
+```cmake
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+```
+
+`CMakeLists.txt`'s `find_link_library()` falls back to `find_library()` when
+`check_linker_flag()` rejects `-l<name>`, and a Darwin link rejects both `-lrt` and
+`-latomic` — so without confining the search to the SDK, the host's ELF `librt.so` and
+`libatomic.so` are found and handed to a Mach-O link. `build-macos` asserts on the
+resolved list (`Link libraries : pthread`, exactly), not on the flag that was passed in.
+
+### What the build job proves before shipping a bundle
+
+Cross-compilation can produce a plausible-looking file that does nothing on the target, so
+the artifact is inspected rather than trusted:
+
+- arm64 Mach-O with `LC_BUILD_VERSION` (platform, `minos`, `sdk` printed into the job
+  summary — soldr's SDK moves, so it is recorded, never asserted against a constant)
+- `__DATA,__interpose` and `__DATA,__thread_vars` present: `MI_OSX_INTERPOSE` puts the
+  malloc replacements in the first, and a dylib that quietly lost the section would load
+  on the runner and override nothing
+- `LC_CODE_SIGNATURE` present (ad-hoc, from `ld64.lld`) — arm64 macOS kills an unsigned
+  image before `main()` with no diagnostic
+- `tests.json` contains no absolute path, and the bundle carries a `.dylib`
+
+The bundle is shipped as a **tar**, not as a plain artifact upload: `upload-artifact@v4`
+drops the executable bit and does not preserve symlinks, and the bundle needs both (every
+test executable, and the `libmimalloc.dylib → libmimalloc.3.dylib` chain).
+
+### Coverage accounting
+
+`ci/bundle_coverage.py` runs on every `run-macos`. The runner configures the same two
+CMake trees with **Xcode's** clang (`--show-only=json-v1` needs a configured tree, not a
+built one) and the script fails if any test name the native `ctest` would run is absent
+from the bundles. A name only the bundle has is reported, not fatal.
+
+Two coverage facts are stated rather than gated, because nothing can gate them:
+
+- the **8 doctests** in `rust/mimalloc-pprof/src/lib.rs` run under `cargo test` and cannot
+  run from a `--tests` binary; after phase B they are Linux-only (#277 §4)
+- the native compile-compat build uses Xcode clang and runs **no tests**: it catches
+  compile-only breakage, not codegen or runtime differences between Apple clang and
+  soldr's clang
+
+### Memory-gate baselines are per toolchain now
+
+`macos-latest` now executes two differently-built arm64 binaries, and they report the same
+`platform` and the same `platform.machine()`. `ci/memory_gate.py` therefore accepts
+`--arch` and `--compiler`, which join the baseline file's name. Both are optional and
+absent by default, so `linux-pprof1.json`, `windows-pprof1.json` and `macos-pprof1.json`
+keep their names and keep matching the runs that produced them — the ubuntu baseline is
+untouched. The soldr lane asks for `macos-arm64-soldr-clang-21-pprof1.json`, which does
+not exist yet, so its first run takes the existing "no baseline → bootstrap it" path
+(exit 2, a `::warning::`) and uploads its JSON. Its positive control is skipped with a
+warning until that baseline is committed, because `control` requires `check` to *fail* and
+a missing baseline is not a failure.
+
+### Rollout
+
+The native jobs stay as a control arm, `continue-on-error: true`, for at least ten pushes:
+`c-unit.yml`'s `ctest`, `ctest-debug-full` and `memory-gate` macOS rows, `cross.yml`'s two
+Apple `test` rows, and `rust-native.yml`'s macOS row. Each carries a dated TODO naming
+what deletes it. A permanently-yellow job is worse than an absent one, so the comparison
+window is meant to end.
 
 ## Concurrency: superseded runs are cancelled
 


### PR DESCRIPTION
Closes the macOS half of #277. Six macOS jobs per push become one.

The motivation is queue wait, not build time: over 20 runs per workflow (#277 phase 0),
`cross.yml`'s Apple rows **executed in 8-14 s and waited up to 5h26m / 6h13m**, p90
1h29m / 2h32m, while every ubuntu row waited 4-5 s.

## What lands

| new job | runner | replaces |
|---|---|---|
| `build-macos (macos-arm64-release)` | ubuntu-latest | — (produces the bundle) |
| `build-macos (macos-arm64-debug-full)` | ubuntu-latest | — |
| `build-macos (macos-arm64-leak)` | ubuntu-latest | — (memory-gate positive control) |
| `build-rust (aarch64-apple-darwin)` | ubuntu-latest | — |
| `build-rust (x86_64-apple-darwin)` | ubuntu-latest | — |
| `run-macos` | **macos-latest (one VM)** | `ctest (macos-latest)`, `ctest-debug-full (macos-latest)`, `memory-gate (macos-latest)`, `cross` `test (aarch64-apple-darwin)`, `cross` `test (x86_64-apple-darwin)`, `rust-native` `test (macos-latest)` |

Those six are now **`continue-on-error: true`** — the control arm, for at least ten
pushes — each with a dated TODO naming what deletes it.

## Toolchain spike (run locally on Linux, soldr 0.9.11, clang 21.1.5)

`cmake/toolchains/soldr-aarch64-apple-darwin.cmake` consumes only soldr's exported env
(`CC_`/`CXX_`/`CFLAGS_`/`CXXFLAGS_`/`AR_`/`RANLIB_` per triple, `SDKROOT`). Both configs
built clean:

```
-- Architecture: arm64
-- Architecture specific optimization is enabled (with -march=armv8.1-a) (MI_OPT_ARCH=ON)
-- Compiler defines : ...;MI_OSX_ZONE=1;MI_OSX_INTERPOSE=1;MI_PPROF=1;...
-- Link libraries   : pthread
```

`-march=armv8.1-a` is accepted by soldr's clang 21 (the #277 review's zig lane rejected
it). `Link libraries : pthread` is the `CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY` fix
working: without it `find_link_library()` falls through to `find_library()` and hands the
host's ELF `librt.so`/`libatomic.so` to a Mach-O link.

`llvm-objdump --macho` on the produced dylib (no `llvm-otool` exists in soldr's toolchain):

```
MH_MAGIC_64   ARM64  ALL  0x00  DYLIB  ... MH_HAS_TLV_DESCRIPTORS
  cmd LC_BUILD_VERSION       platform macos   sdk 15.5   minos 11.0
  cmd LC_ID_DYLIB            name @rpath/libmimalloc.3.dylib
  cmd LC_CODE_SIGNATURE      dataoff 267808  datasize 2256
sections:  __DATA_CONST,__mod_init_func   __DATA,__interpose   __DATA,__thread_vars
```

`LC_CODE_SIGNATURE` (ad-hoc, from `ld64.lld`) matters: arm64 macOS kills an unsigned image
before `main()` with no diagnostic. All test executables link only `/usr/lib/libSystem.B.dylib`
(static mimalloc); `test-stress-dynamic` is the one that loads the dylib, via
`DYLD_INSERT_LIBRARIES`.

Bundling both trees with `ci/bundle_tests.py`:

```
bundled 25 tests and 25 files      (release)
bundled 32 tests and 27 files      (debug-full)
  6 negative control(s) lowered from run-negative.cmake
  10 test(s) carry environment overrides
"DYLD_INSERT_LIBRARIES": "${BUNDLE}/libmimalloc.3.5.dylib"
```

Zero absolute paths in either `tests.json`; `.dylib` entries present with the
`libmimalloc.dylib -> libmimalloc.3.dylib` symlink chain intact through a tar round-trip
(exec bits and symlinks both survive — which is why the bundle is tarred: `upload-artifact@v4`
preserves neither).

**I cannot execute Mach-O on this host.** `run-macos` on this PR is the proof.

## Coverage

`ci/bundle_coverage.py` runs on every `run-macos` and fails if a test the native `ctest`
would run is missing. Run locally against the cross trees (CI compares against
**Xcode-clang-configured** trees, which is the part only CI can do):

| config | native | bundle | missing from bundle | extra in bundle |
|---|---:|---:|---|---|
| ctest (macos-latest) | 25 | 25 | — | — |
| ctest-debug-full (macos-latest) | 32 | 32 | — | — |

Stated, not gated, because nothing can gate them:

- the **8 doctests** in `rust/mimalloc-pprof/src/lib.rs` run under `cargo test` and cannot
  run from a `--tests` binary — Linux-only after this (#277 §4)
- the native compile-compat step uses Xcode clang and runs **no tests**: it catches
  compile-only breakage, not codegen/runtime differences
- `cross.yml`'s Apple rows have `pprof: false`, so `run-macos` has no
  pprof-parses-a-dump step either — parity, not a reduction

## Memory gate

`memory_gate.py` gained `--arch`/`--compiler`, which join the baseline file's **name**.
Both optional, so `linux-pprof1.json`, `windows-pprof1.json` and `macos-pprof1.json` keep
their names and keep matching the runs that produced them — **the ubuntu baseline is
untouched**. `macos-pprof1.json` is annotated `arch: arm64`, `compiler: apple-clang` so a
reader can tell which toolchain recorded 13.4 MB.

The soldr lane asks for `macos-arm64-soldr-clang-21-pprof1.json`, which does not exist, so
its **first run is deliberately yellow**: `::warning:: No committed baseline` and exit 0,
with the per-run JSON uploaded as `memory-gate-macos-arm64-soldr`. Its positive control is
skipped with a warning until that baseline is committed (`control` requires `check` to
*fail*, and a missing baseline is not a failure). Baselining it is a deliberate follow-up
with the numbers, not something this PR does silently.

## Also in here

- **Phase A review follow-up (medium):** `bundle_tests.py` validated only `argv[0]`.
  Every lowered test is now scanned across argv, env values (split on `os.pathsep`) and
  cwd; Windows drive/UNC paths count as absolute regardless of host, because every cross
  bundle is built on Linux where `os.path.isabs("C:/build/x")` is False.
  `generated_from.build_dir` is reduced to a basename — it was the one host path left in
  the manifest.
- **#277 §4's pre-existing gap:** `build-cross` had none of the frame-pointer flags
  `build-linux` sets, while the profiler walks frame pointers off Windows. Fixed in both
  `cross.yml` and the new workflow — by *appending* to `CFLAGS_<triple>` and
  `CARGO_ENCODED_RUSTFLAGS`, since `soldr prepare` exports both and they shadow the plain
  names, with an assertion step because a flag that never reaches the compiler is this
  repo's most-repeated CI bug.

## Local verification

`uv run ci/verify_local.py --keep-going`:

```
release     PASS    off        PASS    debug-full PASS    guarded  PASS
shared      PASS    bundle     PASS    memory-gate PASS   diag     PASS
rust        PASS    lint       FAIL*   asan       FAIL*
```

\* both environmental on this host, not from this branch: `asan` has no
`sanitizer/asan_interface.h` installed, and `lint` runs `uv run --with pyright==1.1.411`,
whose `nodeenv` download fails with an SSL cert error here. Run with the packaged node
(`--with 'pyright[nodejs]==1.1.411'`) pyright reports **0 errors**; `ruff check`,
`ruff format --check` and `pytest ci/tests` (167 passed) are clean.

## Things #277's body got wrong (load-bearing for phases C/D)

1. **The Rust Apple builds were already on Linux** (`cross.yml` `build-cross`), so "move
   the build side to Linux" was a no-op. Artifacts do not cross workflows without run-id
   plumbing, so they are duplicated into `macos-bundles.yml` for the comparison window and
   the TODO on `build-cross` says to drop the Apple targets with the test rows.
2. **The memory-gate key needs `compiler`, not just `arch`.** Native and soldr binaries
   both report `platform: macos` on the same arm64 runner; arch alone cannot separate them.
3. **Native `ctest-debug-full` compiles Release + `MI_DEBUG=3`**, not Debug: it passes no
   `CMAKE_BUILD_TYPE` and CMakeLists.txt defaults it from the *binary directory name*. The
   bundle matches that (verified: identical 32-test set either way).
4. **soldr's SDK directory is 14.5 but `LC_BUILD_VERSION` records sdk 15.5** (the review
   saw 15.5). The job records it into the step summary and asserts nothing against a constant.
5. **No `llvm-otool`** in soldr's toolchain; `llvm-objdump --macho` covers everything needed.
6. `NotRequired` is unavailable under this repo's pyright `pythonVersion = "3.9"`, so the
   two optional result keys are read through a narrowing accessor instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S


---

## Review round 2 (cfcec424)

**Medium fixed.** `run-macos`'s gate steps read `memory_gate.py check`'s exit 2 as "no
baseline yet, warn and pass", but `check` exits 2 for any caught `OSError`/`ValueError`/
`KeyError` as well, and the eight runs sat under `set +e` — so a crashed
`mimalloc-test-memory-gate` would leave the glob unexpanded and produce a **green** step
with a reassuring `::warning::No committed baseline`. Same shape on the leak-control path,
which also uploaded nothing. Now: `where` exits **3** for "no baseline" and keeps **2** for
"cannot read this run", both steps branch on that probe (any other rc is a hard failure),
both require all eight JSON files before calling the gate at all (counted with a glob —
under `set -o pipefail`, `ls … | wc -l` fails when it finds nothing and would kill the step
before it could say why), and `leak-*.json` is uploaded alongside `result-*.json`.

Lows in the same commit: the toolchain's `FATAL_ERROR` expanded the missing variable's
empty value instead of naming it (now `SDKROOT is not set: run soldr prepare …`, verified
by configuring with the variables unset); `run-macos` gains `timeout-minutes: 30`; the two
native coverage configures now name the `c-unit.yml` job each mirrors, including why
`Release` is not a typo for the debug-full one.

**Dead retry removed from the new job only.** `${cmd/soldr/soldr --no-cache}` substitutes
nothing when `cmd` is `cargo test …` with no `soldr` in it, so the soldr#1969 "retry" re-ran
the identical command and reported the same failure twice. Removed in
`macos-bundles.yml`; **`cross.yml` carries the same dead retry and is deliberately left
alone**, so this PR does not change the control arm of the comparison window. Worth a
follow-up issue.

**Untested configuration, stated:** `-DCMAKE_BUILD_TYPE=Debug` with this toolchain builds
and bundles cleanly *locally* (32 tests, identical name set to Release+`MI_DEBUG_FULL`),
but no CI job configures it — all three bundles are `Release` because that is what the
native jobs compile. A literal Debug lane is unexercised on CI.

**Deferred to phase C, recorded here so it is not lost:** `ci/bundle_tests.py`'s
leaked-absolute-path scan matches a bare absolute path, so it misses flag-prefixed ones
(`--out=/abs`, `-I/abs`) and a `C:\…` element inside a value that Linux's `os.pathsep`
(`:`) splits apart. Neither shape occurs in today's manifests; both become reachable when
phase C starts producing Windows bundles on Linux.
