### PR TITLE
fix: make the cross-built windows-gnu override actually redirect (#277 phase C blocker)

### DIFF
--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -425,8 +425,9 @@ jobs:
         # The previous round's `head -30` cut that off before it appeared. Print
         # everything, under each env knob whose name is in the module's string table.
         if: ${{ !cancelled() }}
+        continue-on-error: true
         run: |
-          set -uo pipefail
+          set +e -u -o pipefail
           bundle=bundle/windows-gnu-x64-release
           exe="$bundle/mimalloc-test-stress-dynamic.exe"
           run_one() {
@@ -461,6 +462,15 @@ jobs:
           uv run ci/pe_imports.py "$exe"
           echo "--- mimalloc.dll ---"
           uv run ci/pe_imports.py "$bundle/mimalloc.dll"
+          echo "::endgroup::"
+
+          echo "::group::DIAG redirect-first: does it redirect now?"
+          ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1; timeout 60 "$exe" 2 5 1 ) > rf0.raw 2>&1
+          rc=$?
+          if [ "$rc" -ne 0 ]; then echo "VERDICT=FAILED(rc=$rc)";
+          elif grep -q 'malloc is redirected' rf0.raw; then echo "VERDICT=REDIRECTED";
+          else echo "VERDICT=NOT-REDIRECTED"; fi
+          grep -v "^option '" rf0.raw
           echo "::endgroup::"
 
           echo "::group::DIAG redirect-first plain run"

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -452,8 +452,9 @@ jobs:
         # layout crashed at load in run 33614876511 with no output at all; this step gets
         # the faulting instruction and a stack instead of an exit code.
         if: ${{ !cancelled() }}
+        continue-on-error: true
         run: |
-          set -uo pipefail
+          set +e -u -o pipefail
           bundle=bundle/windows-gnu-x64-redirect-first
           exe="$bundle/mimalloc-test-stress-dynamic.exe"
           echo "::group::DIAG redirect-first import tables"
@@ -466,6 +467,16 @@ jobs:
           ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1; timeout 60 "$exe" 2 5 1 ) > rf.raw 2>&1
           echo "rc=$?"
           grep -v "^option '" rf.raw
+          echo "::endgroup::"
+
+          echo "::group::DIAG redirect-first with MIMALLOC_DISABLE_REDIRECT=1"
+          # Separates the two candidate causes: if the image loads with redirection
+          # switched off, the import order itself is fine and the fault is in the window
+          # where a patched, still-uninitialised ucrtbase allocates through mimalloc.
+          ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1 MIMALLOC_DISABLE_REDIRECT=1
+            timeout 60 "$exe" 2 5 1 ) > rfd.raw 2>&1
+          echo "rc=$?"
+          grep -v "^option '" rfd.raw
           echo "::endgroup::"
 
           echo "::group::DIAG redirect-first NTSTATUS (cmd reports the real exit code)"

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -96,12 +96,6 @@ jobs:
             # has seen fire (docs/ci-gates.md). New on win-gnu: no native win-gnu job runs
             # the memory gate today -- see the coverage table in docs/ci-gates.md.
             cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BENCH_INJECT_LEAK=200000
-          - bundle: windows-gnu-x64-redirect-first
-            # TEMPORARY (#277 investigation). Identical to the release bundle except that
-            # `mimalloc.dll` imports `mimalloc-redirect.dll` before `api-ms-win-crt-*`,
-            # which is the only layout the redirection module accepts. It is not run as a
-            # test suite -- only the DIAG steps below touch it.
-            cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_MINGW_REDIRECT_FIRST=ON
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
@@ -193,6 +187,24 @@ jobs:
           # The Windows override goes through the redirection DLL, not through symbol
           # interposition; a mimalloc.dll that lost this import overrides nothing.
           grep -qi 'DLL Name: mimalloc-redirect.dll' private.txt
+          # #277, both halves of the override, asserted on the artifact rather than on the
+          # flags that produced it:
+          #  * the redirection module must be the FIRST import descriptor, or the loader
+          #    initialises `ucrtbase` first and the module refuses to patch it;
+          #  * `mimalloc.dll` must not import `__emutls_get_address`. This toolchain's
+          #    GCC has no native TLS, so a `__thread` on the allocation path becomes
+          #    emulated TLS, and libgcc allocates it with `malloc` -- which, once the
+          #    override is live, is mi_malloc: unbounded recursion, dead before `main`.
+          first_dll=$(grep -i 'DLL Name:' private.txt | head -1 | sed 's/.*DLL Name: *//' | tr -d '\r')
+          if [ "$first_dll" != "mimalloc-redirect.dll" ]; then
+            echo "::error::$lib imports '$first_dll' first, expected mimalloc-redirect.dll"
+            exit 1
+          fi
+          if grep -q '__emutls_get_address' private.txt; then
+            echo "::error::$lib imports __emutls_get_address: a thread-local on the allocation path will recurse through the redirected malloc (#277)"
+            grep -n '__emutls' private.txt
+            exit 1
+          fi
           {
             echo '```'
             grep -E '^Entry 9' private.txt
@@ -376,20 +388,23 @@ jobs:
         # the runtime -- so without this step the bundle could pass while overriding
         # nothing.
         #
-        # TODO(#277 phase C, added 2026-09-02): make this a HARD failure. It is not one
-        # today because no cross-built configuration has been found that redirects, and a
-        # permanently-red gate is worse than an absent one (docs/ci-gates.md). What was
-        # measured, in order:
-        #   * mimalloc.dll last in the exe's import table -> NOT-REDIRECTED (run …889444)
-        #   * `minject` (both postfixes, with and without --inplace) -> image will not
-        #     start, rc 127 (run …497360)
-        #   * MI_MINGW_UCRT64=OFF, same toolchain -> NOT-REDIRECTED (run …909837)
-        #   * mimalloc.dll FIRST in the exe (the CMakeLists fix) -> still NOT-REDIRECTED,
-        #     everything else green (run …889444)
-        #   * mimalloc-redirect.dll also first inside mimalloc.dll -> SEGFAULT before any
-        #     output (run …876511); reverted
-        # The msvcrt binary MSYS2 builds in this same job redirects, and IS gated below.
-        # Escalated on #277: this needs a Windows debugger, not another CI round.
+        # This is a HARD failure (#277). What used to make it impossible, in order:
+        #   1. `mimalloc-redirect.dll` refuses to patch a CRT whose DllMain has already
+        #      run -- it reads `ucrtbase.dll`'s LDR_DATA_TABLE_ENTRY.Flags and checks
+        #      LDRP_PROCESS_ATTACH_CALLED (0x00080000), then reports
+        #      "seems to be initialized after ucrtbase.dll" and gives up. The loader
+        #      initialises a module's dependencies in that module's own import order, so
+        #      `mimalloc.dll` must import the redirect module before `api-ms-win-crt-*`
+        #      (CMakeLists.txt, MI_MINGW_REDIRECT_FIRST) -- the exe importing
+        #      `mimalloc.dll` first is necessary but not sufficient.
+        #   2. With that fixed, the process died before `main`: soldr's mingw-w64 GCC has
+        #      no native TLS, so mimalloc's `__thread` variables became GCC *emulated*
+        #      TLS, and `__emutls_get_address` allocates with `malloc` -- which is now
+        #      mi_malloc. Fixed in src/threadlocal.c and src/options.c; asserted in the
+        #      build job (mimalloc.dll must not import `__emutls_get_address`).
+        # The module's own explanation only ever reaches the log through the `const char**`
+        # that `mi_allocator_init` returns (it imports no output API at all), which
+        # src/init.c prints AFTER the option dump -- so print the whole thing on failure.
         run: |
           set -uo pipefail
           probe() {
@@ -408,109 +423,15 @@ jobs:
             fi
             echo "$label: $(cat "$out")"
             if [ "$(cat "$out")" != "REDIRECTED" ]; then
-              echo "::warning::$exe did not redirect malloc ($(cat "$out")) -- known, tracked on #277 phase C"
-              head -30 "$out.raw" || true
+              echo "::error::$exe did not redirect malloc ($(cat "$out"))"
+              grep -v "^option '" "$out.raw" || true
+              failed=1
             fi
           }
+          failed=0
           probe "UCRT release bundle" bundle/windows-gnu-x64-release ucrt-release.txt
           probe "UCRT shared bundle " bundle/windows-gnu-x64-shared ucrt-shared.txt
-
-      - name: DIAG (temporary, #277) -- what does the redirection module actually say?
-        # TEMPORARY diagnostic for the ci/277-ucrt-redirect-investigation branch.
-        # `mimalloc-redirect.dll` imports only ntdll (LdrFindEntryForAddress,
-        # LdrGetDllHandle, NtProtectVirtualMemory, RtlQueryEnvironmentVariable,
-        # RtlGetCurrentPeb, RtlGetProcessHeaps) -- it has NO output API at all, so the
-        # ONLY channel it can report on is the `const char** message` that
-        # `mi_allocator_init` hands back, which src/init.c prints after the option dump.
-        # The previous round's `head -30` cut that off before it appeared. Print
-        # everything, under each env knob whose name is in the module's string table.
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        run: |
-          set +e -u -o pipefail
-          bundle=bundle/windows-gnu-x64-release
-          exe="$bundle/mimalloc-test-stress-dynamic.exe"
-          run_one() {
-            local label="$1"; shift
-            echo "::group::DIAG $label"
-            ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1 "$@"; timeout 45 "$exe" 2 5 1 ) > diag.raw 2>&1
-            echo "rc=$?"
-            grep -v "^option '" diag.raw
-            echo "::endgroup::"
-          }
-          run_one "baseline"                MIMALLOC_SHOW_STATS=1
-          run_one "FORCE_REDIRECT"          MIMALLOC_FORCE_REDIRECT=1
-          run_one "PATCH_IMPORTS"           MIMALLOC_PATCH_IMPORTS=1
-          run_one "PATCH_NTHEAP"            MIMALLOC_PATCH_NTHEAP=1
-          run_one "PRIORITIZE_LOAD_ORDER"   MIMALLOC_PRIORITIZE_LOAD_ORDER=1
-          run_one "ENABLE_REDIRECT"         MIMALLOC_ENABLE_REDIRECT=1
-          run_one "VERBOSE=9"               MIMALLOC_VERBOSE=9
-
-      - name: DIAG (temporary, #277) -- the redirect-first bundle, under a debugger
-        # `mimalloc-redirect.dll` refuses to patch a CRT whose DllMain has already run
-        # (LDRP_PROCESS_ATTACH_CALLED), so it must be the first import descriptor of
-        # `mimalloc.dll` -- which is what `windows-gnu-x64-redirect-first` builds. That
-        # layout crashed at load in run 33614876511 with no output at all; this step gets
-        # the faulting instruction and a stack instead of an exit code.
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        run: |
-          set +e -u -o pipefail
-          bundle=bundle/windows-gnu-x64-redirect-first
-          exe="$bundle/mimalloc-test-stress-dynamic.exe"
-          echo "::group::DIAG redirect-first import tables"
-          uv run ci/pe_imports.py "$exe"
-          echo "--- mimalloc.dll ---"
-          uv run ci/pe_imports.py "$bundle/mimalloc.dll"
-          echo "::endgroup::"
-
-          echo "::group::DIAG redirect-first: does it redirect now?"
-          ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1; timeout 60 "$exe" 2 5 1 ) > rf0.raw 2>&1
-          rc=$?
-          if [ "$rc" -ne 0 ]; then echo "VERDICT=FAILED(rc=$rc)";
-          elif grep -q 'malloc is redirected' rf0.raw; then echo "VERDICT=REDIRECTED";
-          else echo "VERDICT=NOT-REDIRECTED"; fi
-          grep -v "^option '" rf0.raw
-          echo "::endgroup::"
-
-          echo "::group::DIAG redirect-first plain run"
-          ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1; timeout 60 "$exe" 2 5 1 ) > rf.raw 2>&1
-          echo "rc=$?"
-          grep -v "^option '" rf.raw
-          echo "::endgroup::"
-
-          echo "::group::DIAG redirect-first with MIMALLOC_DISABLE_REDIRECT=1"
-          # Separates the two candidate causes: if the image loads with redirection
-          # switched off, the import order itself is fine and the fault is in the window
-          # where a patched, still-uninitialised ucrtbase allocates through mimalloc.
-          ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1 MIMALLOC_DISABLE_REDIRECT=1
-            timeout 60 "$exe" 2 5 1 ) > rfd.raw 2>&1
-          echo "rc=$?"
-          grep -v "^option '" rfd.raw
-          echo "::endgroup::"
-
-          echo "::group::DIAG redirect-first NTSTATUS (cmd reports the real exit code)"
-          PATH="$PWD/$bundle:$PATH" cmd //c "$(cygpath -w "$exe") 2 5 1 & echo EXITCODE=%ERRORLEVEL%" 2>&1 | tail -5
-          echo "::endgroup::"
-
-          cdb=""
-          for c in "/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/cdb.exe" \
-                   "/c/Program Files/Windows Kits/10/Debuggers/x64/cdb.exe"; do
-            [ -x "$c" ] && cdb="$c" && break
-          done
-          echo "cdb: ${cdb:-<not found>}"
-          if [ -n "$cdb" ]; then
-            echo "::group::DIAG redirect-first under cdb"
-            ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1
-              timeout 240 "$cdb" -g -G -c '.lines -e; g; .lastevent; r; kb; ub .; lm; q' \
-                "$(cygpath -w "$exe")" 2 5 1 ) 2>&1 | tail -120
-            echo "::endgroup::"
-          else
-            echo "::group::DIAG what debuggers exist"
-            ls "/c/Program Files (x86)/Windows Kits/10/Debuggers" 2>/dev/null || true
-            ls "/c/Program Files/Windows Kits/10/Debuggers" 2>/dev/null || true
-            echo "::endgroup::"
-          fi
+          exit $failed
 
       - name: ctest-win-gnu equivalent -- windows-gnu-x64-release
         run: |
@@ -700,18 +621,19 @@ jobs:
             | sed 's/^[[:space:]]*//' > native-imports.txt
           cat native-imports.txt
           set +e
-          MIMALLOC_VERBOSE=1 MIMALLOC_SHOW_STATS=1 ./native-release/mimalloc-test-stress-dynamic.exe 4 10 1 > msvcrt.raw 2>&1
+          MIMALLOC_VERBOSE=1 ./native-release/mimalloc-test-stress-dynamic.exe 4 10 1 > msvcrt.raw 2>&1
           rc=$?
           set -e
-          # DIAG (temporary, #277): the msvcrt lane is the control this PR gates against,
-          # so print what it actually reports -- including the stats, which say whether
-          # the process's mallocs really reached mimalloc or whether `ucrtbase.dll`
-          # merely happened to be loaded (by a system DLL) and got patched while
-          # `msvcrt.dll!malloc`, which is what this binary calls, stayed untouched.
-          echo "::group::DIAG msvcrt native"
+          # The msvcrt row is NOT a like-for-like control, and #277 records why: this
+          # binary's malloc comes from `msvcrt.dll`, and `mimalloc-redirect.dll` v1.3.3
+          # contains no reference to `msvcrt` at all -- its only CRT module names are
+          # `ucrtbase` and `ucrtbased`. It reports "redirected" because `ucrtbase.dll` is
+          # in the process (pulled in by system DLLs) and gets patched, not because this
+          # exe's allocations moved. Printed, not trusted.
+          echo "::group::msvcrt native, full output"
           grep -v "^option '" msvcrt.raw || true
           echo "::endgroup::"
-          echo "::group::DIAG msvcrt native imports of the exe and the dll"
+          echo "::group::msvcrt native: the DLL's own import table"
           objdump -p native-release/mimalloc.dll | grep -i 'DLL Name' || true
           echo "::endgroup::"
           if [ "$rc" -ne 0 ]; then

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -409,6 +409,35 @@ jobs:
           probe "UCRT release bundle" bundle/windows-gnu-x64-release ucrt-release.txt
           probe "UCRT shared bundle " bundle/windows-gnu-x64-shared ucrt-shared.txt
 
+      - name: DIAG (temporary, #277) -- what does the redirection module actually say?
+        # TEMPORARY diagnostic for the ci/277-ucrt-redirect-investigation branch.
+        # `mimalloc-redirect.dll` imports only ntdll (LdrFindEntryForAddress,
+        # LdrGetDllHandle, NtProtectVirtualMemory, RtlQueryEnvironmentVariable,
+        # RtlGetCurrentPeb, RtlGetProcessHeaps) -- it has NO output API at all, so the
+        # ONLY channel it can report on is the `const char** message` that
+        # `mi_allocator_init` hands back, which src/init.c prints after the option dump.
+        # The previous round's `head -30` cut that off before it appeared. Print
+        # everything, under each env knob whose name is in the module's string table.
+        if: ${{ !cancelled() }}
+        run: |
+          set -uo pipefail
+          bundle=bundle/windows-gnu-x64-release
+          exe="$bundle/mimalloc-test-stress-dynamic.exe"
+          run_one() {
+            local label="$1"; shift
+            echo "::group::DIAG $label"
+            ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1 "$@"; "$exe" 2 5 1 ) > diag.raw 2>&1
+            echo "rc=$?"
+            grep -v "^option '" diag.raw
+            echo "::endgroup::"
+          }
+          run_one "baseline"                MIMALLOC_SHOW_STATS=1
+          run_one "FORCE_REDIRECT"          MIMALLOC_FORCE_REDIRECT=1
+          run_one "PATCH_IMPORTS"           MIMALLOC_PATCH_IMPORTS=1
+          run_one "PATCH_NTHEAP"            MIMALLOC_PATCH_NTHEAP=1
+          run_one "PRIORITIZE_LOAD_ORDER"   MIMALLOC_PRIORITIZE_LOAD_ORDER=1
+          run_one "ENABLE_REDIRECT"         MIMALLOC_ENABLE_REDIRECT=1
+
       - name: ctest-win-gnu equivalent -- windows-gnu-x64-release
         run: |
           uv run ci/run_test_bundle.py bundle/windows-gnu-x64-release \
@@ -597,9 +626,20 @@ jobs:
             | sed 's/^[[:space:]]*//' > native-imports.txt
           cat native-imports.txt
           set +e
-          MIMALLOC_VERBOSE=1 ./native-release/mimalloc-test-stress-dynamic.exe 4 10 1 > msvcrt.raw 2>&1
+          MIMALLOC_VERBOSE=1 MIMALLOC_SHOW_STATS=1 ./native-release/mimalloc-test-stress-dynamic.exe 4 10 1 > msvcrt.raw 2>&1
           rc=$?
           set -e
+          # DIAG (temporary, #277): the msvcrt lane is the control this PR gates against,
+          # so print what it actually reports -- including the stats, which say whether
+          # the process's mallocs really reached mimalloc or whether `ucrtbase.dll`
+          # merely happened to be loaded (by a system DLL) and got patched while
+          # `msvcrt.dll!malloc`, which is what this binary calls, stayed untouched.
+          echo "::group::DIAG msvcrt native"
+          grep -v "^option '" msvcrt.raw || true
+          echo "::endgroup::"
+          echo "::group::DIAG msvcrt native imports of the exe and the dll"
+          objdump -p native-release/mimalloc.dll | grep -i 'DLL Name' || true
+          echo "::endgroup::"
           if [ "$rc" -ne 0 ]; then
             echo "FAILED(rc=$rc)" > msvcrt.txt
           elif grep -q 'malloc is redirected' msvcrt.raw; then

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -96,6 +96,12 @@ jobs:
             # has seen fire (docs/ci-gates.md). New on win-gnu: no native win-gnu job runs
             # the memory gate today -- see the coverage table in docs/ci-gates.md.
             cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BENCH_INJECT_LEAK=200000
+          - bundle: windows-gnu-x64-redirect-first
+            # TEMPORARY (#277 investigation). Identical to the release bundle except that
+            # `mimalloc.dll` imports `mimalloc-redirect.dll` before `api-ms-win-crt-*`,
+            # which is the only layout the redirection module accepts. It is not run as a
+            # test suite -- only the DIAG steps below touch it.
+            cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_MINGW_REDIRECT_FIRST=ON
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
@@ -426,7 +432,7 @@ jobs:
           run_one() {
             local label="$1"; shift
             echo "::group::DIAG $label"
-            ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1 "$@"; "$exe" 2 5 1 ) > diag.raw 2>&1
+            ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1 "$@"; timeout 45 "$exe" 2 5 1 ) > diag.raw 2>&1
             echo "rc=$?"
             grep -v "^option '" diag.raw
             echo "::endgroup::"
@@ -437,6 +443,53 @@ jobs:
           run_one "PATCH_NTHEAP"            MIMALLOC_PATCH_NTHEAP=1
           run_one "PRIORITIZE_LOAD_ORDER"   MIMALLOC_PRIORITIZE_LOAD_ORDER=1
           run_one "ENABLE_REDIRECT"         MIMALLOC_ENABLE_REDIRECT=1
+          run_one "VERBOSE=9"               MIMALLOC_VERBOSE=9
+
+      - name: DIAG (temporary, #277) -- the redirect-first bundle, under a debugger
+        # `mimalloc-redirect.dll` refuses to patch a CRT whose DllMain has already run
+        # (LDRP_PROCESS_ATTACH_CALLED), so it must be the first import descriptor of
+        # `mimalloc.dll` -- which is what `windows-gnu-x64-redirect-first` builds. That
+        # layout crashed at load in run 33614876511 with no output at all; this step gets
+        # the faulting instruction and a stack instead of an exit code.
+        if: ${{ !cancelled() }}
+        run: |
+          set -uo pipefail
+          bundle=bundle/windows-gnu-x64-redirect-first
+          exe="$bundle/mimalloc-test-stress-dynamic.exe"
+          echo "::group::DIAG redirect-first import tables"
+          uv run ci/pe_imports.py "$exe"
+          echo "--- mimalloc.dll ---"
+          uv run ci/pe_imports.py "$bundle/mimalloc.dll"
+          echo "::endgroup::"
+
+          echo "::group::DIAG redirect-first plain run"
+          ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1; timeout 60 "$exe" 2 5 1 ) > rf.raw 2>&1
+          echo "rc=$?"
+          grep -v "^option '" rf.raw
+          echo "::endgroup::"
+
+          echo "::group::DIAG redirect-first NTSTATUS (cmd reports the real exit code)"
+          PATH="$PWD/$bundle:$PATH" cmd //c "$(cygpath -w "$exe") 2 5 1 & echo EXITCODE=%ERRORLEVEL%" 2>&1 | tail -5
+          echo "::endgroup::"
+
+          cdb=""
+          for c in "/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/cdb.exe" \
+                   "/c/Program Files/Windows Kits/10/Debuggers/x64/cdb.exe"; do
+            [ -x "$c" ] && cdb="$c" && break
+          done
+          echo "cdb: ${cdb:-<not found>}"
+          if [ -n "$cdb" ]; then
+            echo "::group::DIAG redirect-first under cdb"
+            ( export PATH="$PWD/$bundle:$PATH" MIMALLOC_VERBOSE=1
+              timeout 240 "$cdb" -g -G -c '.lines -e; g; .lastevent; r; kb; ub .; lm; q' \
+                "$(cygpath -w "$exe")" 2 5 1 ) 2>&1 | tail -120
+            echo "::endgroup::"
+          else
+            echo "::group::DIAG what debuggers exist"
+            ls "/c/Program Files (x86)/Windows Kits/10/Debuggers" 2>/dev/null || true
+            ls "/c/Program Files/Windows Kits/10/Debuggers" 2>/dev/null || true
+            echo "::endgroup::"
+          fi
 
       - name: ctest-win-gnu equivalent -- windows-gnu-x64-release
         run: |

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -27,13 +27,14 @@ name: windows-bundles
 #   * mingw put the wrong thing first in TWO import tables -- `mimalloc.dll` last in
 #     `mimalloc-test-stress-dynamic.exe`, and `mimalloc-redirect.dll` after the CRT
 #     api-sets in `mimalloc.dll` itself -- so the redirection module was initialised after
-#     the runtime it patches and the override silently did nothing. Both are a
-#     path-spelling property of the link line, not a CRT property; see CMakeLists.txt.
+#     the runtime it patches and refused to do anything. Both are a path-spelling property
+#     of the link line, not a CRT property; see CMakeLists.txt (MI_MINGW_REDIRECT_FIRST).
 # `run-windows-gnu` asserts the import order on the BUNDLE'S OWN binaries
-# (`ci/pe_imports.py`) as a hard failure. Whether the bundle actually redirects is
-# measured and reported but NOT yet gated: no cross-built configuration has been found
-# that does, and the one that came closest segfaults -- see the TODO on that step and
-# #277. The msvcrt binary MSYS2 builds in this job does redirect and is gated.
+# (`ci/pe_imports.py`) as a hard failure, and gates the override itself on a BEHAVIOURAL
+# probe (`mimalloc-test-redirect-probe`: a CRT `malloc` pointer must land in a mimalloc
+# region) across all three bundles. Both halves of #277 -- the import order and the
+# emulated-TLS recursion it exposed -- are fixed; the bundle redirects.
+# The msvcrt row MSYS2 builds is printed but is NOT a control: see the step that says so.
 #
 # While this is being compared against the jobs it replaces, those jobs are
 # `continue-on-error: true`. They are the control arm, not decoration -- see the dated
@@ -371,24 +372,25 @@ jobs:
               echo "::error::$exe imports '$first' first, expected '$dll'"
               exit 1
             fi
-            # The DLL's own table is RECORDED, not asserted. Forcing
-            # `mimalloc-redirect.dll` ahead of the CRT api-sets here was tried and
-            # segfaults the process before it prints anything (run 33614876511) -- the
-            # redirection module then patches `ucrtbase` before `ucrtbase` has
-            # initialised. Upstream's supported MSVC layout has the api-sets first too.
+            # The DLL's own table is the half that decides whether the override engages
+            # at all, and it is asserted in the Linux build job that produced this bundle
+            # (mimalloc-redirect.dll first, and no __emutls_get_address import). Recorded
+            # again here so a bundle can be diagnosed from its own artifact.
             uv run ci/pe_imports.py "$bundle/$dll" | tee "$bundle/imports-dll.txt"
             echo "::endgroup::"
           done
 
-      - name: Windows override probe -- does the bundle redirect malloc?
-        # `test-stress-dynamic` asserts nothing about redirection: it links `mi_version()`
-        # so the DLL loads and then allocates through the CRT. `MIMALLOC_VERBOSE=1` makes
-        # src/init.c:530 print "malloc is redirected." exactly when `_mi_is_redirected()`
-        # is true, which is the only direct evidence that the redirection module patched
-        # the runtime -- so without this step the bundle could pass while overriding
-        # nothing.
+      - name: Windows override gate -- the bundle's own malloc must reach mimalloc
+        # BEHAVIOURAL, deliberately. `mi_is_redirected()` -- what "mimalloc: malloc is
+        # redirected." reports -- only says the redirection module believed it patched
+        # something, and that flag lies: the MSYS2 msvcrt binary further down prints it
+        # while its `msvcrt.dll!malloc` was never touched (the module v1.3.3 knows only
+        # `ucrtbase`/`ucrtbased`; it had patched a `ucrtbase.dll` some system DLL dragged
+        # into the process). So gate on `mimalloc-test-redirect-probe`, which takes a
+        # pointer from the CRT's own `malloc` and asks `mi_is_in_heap_region`. Only a real
+        # override makes that 1.
         #
-        # This is a HARD failure (#277). What used to make it impossible, in order:
+        # A HARD failure, on all three bundles (#277). What used to make it impossible:
         #   1. `mimalloc-redirect.dll` refuses to patch a CRT whose DllMain has already
         #      run -- it reads `ucrtbase.dll`'s LDR_DATA_TABLE_ENTRY.Flags and checks
         #      LDRP_PROCESS_ATTACH_CALLED (0x00080000), then reports
@@ -404,33 +406,32 @@ jobs:
         #      build job (mimalloc.dll must not import `__emutls_get_address`).
         # The module's own explanation only ever reaches the log through the `const char**`
         # that `mi_allocator_init` returns (it imports no output API at all), which
-        # src/init.c prints AFTER the option dump -- so print the whole thing on failure.
+        # src/init.c prints AFTER the option dump -- so on failure print all of it.
         run: |
           set -uo pipefail
-          probe() {
-            local label="$1" bundle="$2" out="$3" rc=0
-            local exe="$bundle/mimalloc-test-stress-dynamic.exe"
-            # 4 threads / scale 10 / 1 iteration: a redirection probe, not the stress test
-            # (the bundle runs that in full below).
-            MIMALLOC_VERBOSE=1 PATH="$PWD/$bundle:$PATH" "$exe" 4 10 1 > "$out.raw" 2>&1 || rc=$?
-            if [ "$rc" -ne 0 ]; then
-              # 127 from this shell means the image did not start at all.
-              echo "FAILED(rc=$rc)" > "$out"
-            elif grep -q 'malloc is redirected' "$out.raw"; then
-              echo "REDIRECTED" > "$out"
-            else
-              echo "NOT-REDIRECTED" > "$out"
+          failed=0
+          gate() {
+            local label="$1" bundle="$2" rc=0
+            local probe="$bundle/mimalloc-test-redirect-probe.exe"
+            if [ ! -f "$probe" ]; then
+              echo "::error::$probe is missing from the bundle"
+              failed=1; return
             fi
-            echo "$label: $(cat "$out")"
-            if [ "$(cat "$out")" != "REDIRECTED" ]; then
-              echo "::error::$exe did not redirect malloc ($(cat "$out"))"
-              grep -v "^option '" "$out.raw" || true
+            PATH="$PWD/$bundle:$PATH" "$probe" > "$bundle/redirect-probe.txt" 2>&1 || rc=$?
+            echo "$label:"
+            sed 's/^/  /' "$bundle/redirect-probe.txt"
+            if [ "$rc" -ne 0 ] || ! grep -q '^REDIRECT_BEHAVIOURAL=1$' "$bundle/redirect-probe.txt"; then
+              echo "::error::$probe did not prove the override (rc=$rc)"
+              # test-stress-dynamic under MIMALLOC_VERBOSE is what carries the redirection
+              # module's own explanation; print it whole, options and all.
+              MIMALLOC_VERBOSE=1 PATH="$PWD/$bundle:$PATH" \
+                "$bundle/mimalloc-test-stress-dynamic.exe" 4 10 1 2>&1 | grep -v "^option '" || true
               failed=1
             fi
           }
-          failed=0
-          probe "UCRT release bundle" bundle/windows-gnu-x64-release ucrt-release.txt
-          probe "UCRT shared bundle " bundle/windows-gnu-x64-shared ucrt-shared.txt
+          gate "UCRT release bundle   " bundle/windows-gnu-x64-release
+          gate "UCRT shared bundle    " bundle/windows-gnu-x64-shared
+          gate "UCRT debug-full bundle" bundle/windows-gnu-x64-debug-full
           exit $failed
 
       - name: ctest-win-gnu equivalent -- windows-gnu-x64-release
@@ -643,7 +644,12 @@ jobs:
           else
             echo "NOT-REDIRECTED" > msvcrt.txt
           fi
-          echo "msvcrt (MSYS2 MINGW64, no minject): $(cat msvcrt.txt)"
+          echo "msvcrt (MSYS2 MINGW64): flag says $(cat msvcrt.txt)"
+          # ...and what the same binary does, which is the point. This row is expected to
+          # show the flag and the behaviour disagreeing: the probe's `malloc` comes from
+          # `msvcrt.dll`, which the redirection module cannot patch.
+          ./native-release/mimalloc-test-redirect-probe.exe > msvcrt-probe.txt 2>&1 || true
+          sed 's/^/  /' msvcrt-probe.txt
       - name: Coverage -- the bundles must run every test the native runner would
         if: ${{ !cancelled() }}
         run: |
@@ -652,27 +658,35 @@ jobs:
             --compare "ctest-debug-full-win-gnu" native-debug-full.json bundle/windows-gnu-x64-debug-full/tests.json \
             --compare "ctest-shared-win-gnu" native-shared.json bundle/windows-gnu-x64-shared/tests.json \
             --summary "$GITHUB_STEP_SUMMARY"
-      - name: The Windows override must not regress against the msvcrt lane
-        # The gate is comparative on purpose. `ctest-win-gnu` is what this lane replaces,
-        # and it runs test-stress-dynamic with no minject on a msvcrt runtime; requiring
-        # the UCRT bundle to do something the job it replaces never did would be a new
-        # gate smuggled in under the word "parity". So: if msvcrt redirects, UCRT must
-        # too (with or without minject). Anything else is recorded, loudly, and passes.
+      - name: Summary -- the flag, the behaviour, and why they differ
+        # `ctest-win-gnu` (what this lane replaces) only ever looked at
+        # `mi_is_redirected()`. That flag is kept here as a regression detector on the
+        # native row, but it is NOT the gate and it is not a control: on the msvcrt binary
+        # it reports success while the binary's own allocations never reach mimalloc.
+        # `mimalloc-redirect.dll` v1.3.3 names only `ucrtbase`/`ucrtbased` as CRT targets
+        # and contains no reference to `msvcrt` at all; what it patched in that process is
+        # a `ucrtbase.dll` a system DLL had loaded. The behavioural rows below show it.
+        # The cross-built bundle is gated hard, behaviourally, earlier in this job.
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
           read_result() { cat "$1" 2>/dev/null || echo "UNKNOWN"; }
+          behavioural() { grep -h '^REDIRECT_BEHAVIOURAL=' "$1" 2>/dev/null | tail -1 | cut -d= -f2 || echo "?"; }
+          flag()        { grep -h '^REDIRECT_FLAG=' "$1" 2>/dev/null | tail -1 | cut -d= -f2 || echo "?"; }
           msvcrt=$(read_result msvcrt.txt)
-          release=$(read_result ucrt-release.txt)
-          shared=$(read_result ucrt-shared.txt)
           {
-            echo "### test-stress-dynamic: does mimalloc override the CRT?"
+            echo "### Does mimalloc actually override the CRT?"
             echo
-            echo "| lane | result |"
-            echo "|---|---|"
-            echo "| MSYS2 MINGW64 (**msvcrt**), built by this job | $msvcrt |"
-            echo "| soldr mingw-w64 (**UCRT**) release bundle | $release |"
-            echo "| soldr mingw-w64 (**UCRT**) shared bundle | $shared |"
+            echo "\`REDIRECT_BEHAVIOURAL\` is a CRT \`malloc\` pointer landing in a mimalloc region."
+            echo "\`mi_is_redirected()\` is only what the redirection module believed it did."
+            echo
+            echo "| lane | behavioural | \`mi_is_redirected()\` |"
+            echo "|---|---|---|"
+            for b in release shared debug-full; do
+              f="bundle/windows-gnu-x64-$b/redirect-probe.txt"
+              echo "| soldr mingw-w64 (**UCRT**) $b bundle | $(behavioural "$f") | $(flag "$f") |"
+            done
+            echo "| MSYS2 MINGW64 (**msvcrt**), built by this job | $(behavioural msvcrt-probe.txt) | $(flag msvcrt-probe.txt) |"
             echo
             echo "First import of each \`test-stress-dynamic\`:"
             echo
@@ -681,12 +695,10 @@ jobs:
             echo "native (MSYS2): $(head -1 native-imports.txt)"
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
-          # The cross-built bundle is already gated hard, earlier in the job. This is the
-          # native row: it is recorded for the comparison window and gated too, because
-          # while it exists a regression there is still a regression -- but the bundle,
-          # not this, is what the product ships.
+          # Native row, flag only: while this MSYS2 build exists, losing even the flag
+          # there is a regression worth knowing about.
           if [ "$msvcrt" != "REDIRECTED" ]; then
-            echo "::error::the msvcrt win-gnu lane no longer redirects malloc in test-stress-dynamic (got: $msvcrt)"
+            echo "::error::the msvcrt win-gnu lane no longer sets mi_is_redirected() (got: $msvcrt)"
             cat msvcrt.raw || true
             exit 1
           fi
@@ -701,12 +713,12 @@ jobs:
             native-release.json
             native-debug-full.json
             native-shared.json
-            ucrt-release.txt
-            ucrt-release.txt.raw
-            ucrt-shared.txt
-            ucrt-shared.txt.raw
+            bundle/windows-gnu-x64-release/redirect-probe.txt
+            bundle/windows-gnu-x64-shared/redirect-probe.txt
+            bundle/windows-gnu-x64-debug-full/redirect-probe.txt
             msvcrt.txt
             msvcrt.raw
+            msvcrt-probe.txt
             native-imports.txt
             bundle/windows-gnu-x64-release/imports.txt
             bundle/windows-gnu-x64-release/imports-dll.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(MI_BUILD_TESTS       "Build test executables" ON)
 option(MI_OSX_INTERPOSE     "Use interpose to override standard malloc on macOS" ON)
 option(MI_OSX_ZONE          "Use malloc zone to override standard malloc on macOS" ON)
 option(MI_WIN_REDIRECT      "Use redirection module ('mimalloc-redirect') on Windows if compiling mimalloc as a DLL" ON)
-option(MI_MINGW_REDIRECT_FIRST "Emit 'mimalloc-redirect.dll' as the first import descriptor of mimalloc.dll (MinGW; see #277)" OFF)
+option(MI_MINGW_REDIRECT_FIRST "Emit 'mimalloc-redirect.dll' as the first import descriptor of mimalloc.dll (MinGW; see #277)" ON)
 option(MI_WIN_DIRECT_TLS    "Use only direct TLS slots on Windows to avoid extra tests in the malloc fast path (only works if the program uses less than 64 TlsAlloc'd slots in total)" OFF)
 option(MI_LOCAL_DYNAMIC_TLS "Use local-dynamic-tls, a slightly slower but dlopen-compatible thread local storage mechanism (Unix)" OFF)
 option(MI_LIBC_MUSL         "Enable this when linking with musl libc" OFF)
@@ -826,8 +826,9 @@ if(MI_BUILD_SHARED)
       # loses against the absolute sysroot path purely by where the checkout lives.
       # A copy spelled `./…` (0x2e) sorts ahead of every absolute path (0x2f).
       #
-      # #277: OFF by default while the crash this exposes is unresolved -- see
-      # .github/workflows/windows-bundles.yml.
+      # ON by default: this is the only layout in which the override works at all, and
+      # the load-time crash it used to expose (GCC emulated TLS re-entering the redirected
+      # `malloc`) is fixed in `src/threadlocal.c` and `src/options.c`. #277.
       configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib"
         "${CMAKE_CURRENT_BINARY_DIR}/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -833,8 +833,14 @@ if(MI_BUILD_SHARED)
         "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib"
         "${CMAKE_CURRENT_BINARY_DIR}/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib"
         COPYONLY)
+      # The link runs from CMAKE_BINARY_DIR, not from this project's binary dir, so under
+      # add_subdirectory()/FetchContent a bare `./` would name the wrong directory. Spell
+      # the relative path from the top of the build tree (empty for a standalone build,
+      # which gives plain `-L.`).
+      file(RELATIVE_PATH _mi_redirect_ldir "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+      set(_mi_redirect_ldir "-L./${_mi_redirect_ldir}")
       target_link_libraries(mimalloc PRIVATE
-        "-L." "-l:mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib")  # the DLL import library
+        "${_mi_redirect_ldir}" "-l:mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib")  # the DLL import library
     else()
       target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)  # the DLL import library
     endif()
@@ -1332,25 +1338,23 @@ if (MI_BUILD_TESTS)
         # before anything needs it contributes nothing -- hence a raw `-l:` here rather
         # than target_link_options(), with an explicit dependency since this is no longer
         # a target reference.
+        #
+        # Same relative-path caveat as the DLL's own redirect import above: the link runs
+        # from CMAKE_BINARY_DIR, so name this project's binary dir relative to that.
+        file(RELATIVE_PATH _mi_mimalloc_ldir "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+        set(_mi_mimalloc_ldir "-L./${_mi_mimalloc_ldir}")
         add_dependencies(mimalloc-test-stress-dynamic mimalloc)
         target_link_libraries(mimalloc-test-stress-dynamic PRIVATE
-          "-L." "-l:$<TARGET_LINKER_FILE_NAME:mimalloc>" ${mi_libraries})
+          "${_mi_mimalloc_ldir}" "-l:$<TARGET_LINKER_FILE_NAME:mimalloc>" ${mi_libraries})
       else()
         target_link_libraries(mimalloc-test-stress-dynamic PRIVATE mimalloc ${mi_libraries})  # link mi_version
       endif()
-      if(MI_MINGW_UCRT64 AND CMAKE_HOST_WIN32)
-        # mingw always links mimalloc after system libraries.
-        # post-process with `minject` to make sure mimalloc is the first dll in the load order.
-        add_custom_command(TARGET mimalloc-test-stress-dynamic POST_BUILD COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/minject${MINJECT_SUFFIX} --postfix=${mi_libsuffix} -f -i $<TARGET_FILE:mimalloc-test-stress-dynamic>)
-      elseif(MI_MINGW_UCRT64)
-        # `minject` is a Windows PE utility, so it cannot run on the host of a cross build.
-        # Say so loudly: without it mimalloc.dll is imported after the UCRT and the
-        # override this test exists to exercise may not take effect. Run
-        #   bin/minject${MINJECT_SUFFIX} --postfix=${mi_libsuffix} -f -i <the exe>
-        # on the target machine before running test-stress-dynamic (#277 phase C:
-        # .github/workflows/windows-bundles.yml does exactly that).
-        message(STATUS "Cross-compiling: run `bin/minject${MINJECT_SUFFIX} --postfix=${mi_libsuffix} -f -i mimalloc-test-stress-dynamic` on the target before running it")
-      endif()
+      # No `minject` step. Upstream runs one here because "mingw always links mimalloc
+      # after system libraries", but that is fixed at the link now -- above for the
+      # executable, and in MI_MINGW_REDIRECT_FIRST for `mimalloc.dll`'s own table, which
+      # is the half that actually decides whether the override engages. Running minject
+      # on top would only rewrite an import table that is already correct, and it is a
+      # Windows PE utility, so it cannot run on a cross build's host at all (#277).
       add_test(NAME test-stress-dynamic COMMAND ${CMAKE_COMMAND} -E env MIMALLOC_VERBOSE=1 $<TARGET_FILE:mimalloc-test-stress-dynamic>)
     else()
       target_link_libraries(mimalloc-test-stress-dynamic PRIVATE ${mi_libraries}) # pthreads, issue 1158
@@ -1361,6 +1365,30 @@ if (MI_BUILD_TESTS)
       endif()
       add_test(NAME test-stress-dynamic COMMAND ${CMAKE_COMMAND} -E env MIMALLOC_VERBOSE=1 ${LD_PRELOAD}=$<TARGET_FILE:mimalloc> $<TARGET_FILE:mimalloc-test-stress-dynamic>)
     endif()
+  endif()
+
+  # Behavioural override probe (mimalloc-pprof #277). `mi_is_redirected()` reports what
+  # the redirection module believed it did; this asks whether a CRT `malloc` pointer
+  # actually lands in a mimalloc region, which is the claim that matters and the one the
+  # msvcrt lane fails while reporting success. Windows + shared library only: everywhere
+  # else there is no redirection module to probe.
+  if(WIN32 AND MI_BUILD_SHARED AND MI_WIN_REDIRECT AND NOT (MI_CYGWIN OR MI_TRACK_ASAN OR MI_DEBUG_TSAN OR MI_DEBUG_UBSAN))
+    add_executable(mimalloc-test-redirect-probe test/test-redirect-probe.c)
+    target_compile_definitions(mimalloc-test-redirect-probe PRIVATE ${mi_defines})
+    target_compile_options(mimalloc-test-redirect-probe PRIVATE ${mi_cflags})
+    target_include_directories(mimalloc-test-redirect-probe PRIVATE include)
+    if(MINGW)
+      # `mimalloc.dll` must be this exe's first import descriptor, for the same reason and
+      # by the same means as `mimalloc-test-stress-dynamic` above.
+      file(RELATIVE_PATH _mi_probe_ldir "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+      set(_mi_probe_ldir "-L./${_mi_probe_ldir}")
+      add_dependencies(mimalloc-test-redirect-probe mimalloc)
+      target_link_libraries(mimalloc-test-redirect-probe PRIVATE
+        "${_mi_probe_ldir}" "-l:$<TARGET_LINKER_FILE_NAME:mimalloc>" ${mi_libraries})
+    else()
+      target_link_libraries(mimalloc-test-redirect-probe PRIVATE mimalloc ${mi_libraries})
+    endif()
+    add_test(NAME test-redirect-probe COMMAND mimalloc-test-redirect-probe)
   endif()
 
   # imported from oven-sh/mimalloc @ 942b8342 (commit 7ac561ab), MIT -- see #266.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(MI_BUILD_TESTS       "Build test executables" ON)
 option(MI_OSX_INTERPOSE     "Use interpose to override standard malloc on macOS" ON)
 option(MI_OSX_ZONE          "Use malloc zone to override standard malloc on macOS" ON)
 option(MI_WIN_REDIRECT      "Use redirection module ('mimalloc-redirect') on Windows if compiling mimalloc as a DLL" ON)
+option(MI_MINGW_REDIRECT_FIRST "Emit 'mimalloc-redirect.dll' as the first import descriptor of mimalloc.dll (MinGW; see #277)" OFF)
 option(MI_WIN_DIRECT_TLS    "Use only direct TLS slots on Windows to avoid extra tests in the malloc fast path (only works if the program uses less than 64 TlsAlloc'd slots in total)" OFF)
 option(MI_LOCAL_DYNAMIC_TLS "Use local-dynamic-tls, a slightly slower but dlopen-compatible thread local storage mechanism (Unix)" OFF)
 option(MI_LIBC_MUSL         "Enable this when linking with musl libc" OFF)
@@ -811,7 +812,31 @@ if(MI_BUILD_SHARED)
       set(MINJECT_SUFFIX "-${MI_ARCH}")
     endif()
 
-    target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)  # the DLL import library
+    if(MINGW AND MI_MINGW_REDIRECT_FIRST)
+      # `mimalloc-redirect.dll` only redirects if its DllMain runs BEFORE the C runtime's:
+      # it reads `ucrtbase.dll`'s LDR_DATA_TABLE_ENTRY.Flags and bails out with
+      #   "mimalloc-redirect.dll seems to be initialized after ucrtbase.dll"
+      # as soon as LDRP_PROCESS_ATTACH_CALLED (0x00080000) is set there. The loader
+      # initialises a module's dependencies in THAT module's import-descriptor order, so
+      # the redirect module has to precede `api-ms-win-crt-*` in *this DLL's* import
+      # table -- the executable importing `mimalloc.dll` first is necessary but not
+      # sufficient. MSVC gets this for free (explicit libs are emitted before
+      # /DEFAULTLIB ones); `ld` sorts `.idata$2` by the input file path as spelled on the
+      # link line, and CMake spells this one as an absolute source path, which wins or
+      # loses against the absolute sysroot path purely by where the checkout lives.
+      # A copy spelled `./…` (0x2e) sorts ahead of every absolute path (0x2f).
+      #
+      # #277: OFF by default while the crash this exposes is unresolved -- see
+      # .github/workflows/windows-bundles.yml.
+      configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib"
+        "${CMAKE_CURRENT_BINARY_DIR}/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib"
+        COPYONLY)
+      target_link_libraries(mimalloc PRIVATE
+        "-L." "-l:mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib")  # the DLL import library
+    else()
+      target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)  # the DLL import library
+    endif()
     add_custom_command(TARGET mimalloc POST_BUILD
       COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" $<TARGET_FILE_DIR:mimalloc>
       COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -271,53 +271,70 @@ contributes nothing — using `$<TARGET_LINKER_FILE_NAME:mimalloc>` so the Debug
 `mimalloc-debug.dll` is handled too. Verified cross-built for all three configs, and
 gated on every run.
 
-That fixes the import order. **It does not, on its own, make the override take effect**,
-and the same trick applied one level down makes things worse — see below.
+That fixes the import order in the *executable*. It is necessary but not sufficient: the
+same defect one level down, inside `mimalloc.dll`'s own table, is what actually decided
+the outcome. See below.
 
 ### The override is gated on the bundle's own binaries
 
-`run-windows-gnu` asserts both halves, as hard failures, on the artifacts it ships:
+`run-windows-gnu` asserts all of this, as hard failures, on the artifacts it ships:
 
-- **gated:** `mimalloc*.dll` is import #0 of `mimalloc-test-stress-dynamic.exe` in the
-  release, debug-full and shared bundles. Read with `ci/pe_imports.py`, a PE import-table
-  reader — `dumpbin` is MSVC-only and MSYS2 is not installed at that point in the job (and
-  depending on it would be wrong anyway: the bundle is meant to run with no toolchain).
-- **measured, not yet gated:** whether `malloc is redirected.` appears under
-  `MIMALLOC_VERBOSE=1` (`src/init.c:530`, printed only when `_mi_is_redirected()`).
-  `test-stress-dynamic` asserts nothing about redirection itself, so this probe is the
-  only thing anywhere in CI that looks at it.
+- **the exe's table:** `mimalloc*.dll` is import #0 of `mimalloc-test-stress-dynamic.exe`
+  in the release, debug-full and shared bundles. Read with `ci/pe_imports.py`, a PE
+  import-table reader — `dumpbin` is MSVC-only and MSYS2 is not installed at that point in
+  the job (and depending on it would be wrong anyway: the bundle is meant to run with no
+  toolchain).
+- **the DLL's table**, in the Linux build job that produces each bundle:
+  `mimalloc-redirect.dll` is import #0 of `mimalloc.dll`, and `mimalloc.dll` does **not**
+  import `__emutls_get_address`.
+- **the behaviour**, on all three bundles: `mimalloc-test-redirect-probe` must print
+  `REDIRECT_BEHAVIOURAL=1`.
 
-### What was tried, and what is still open
+That last one is deliberately *not* `mi_is_redirected()`. That flag only reports what the
+redirection module believed it did, and on the MSYS2 msvcrt binary it reports success
+while the binary's own `msvcrt.dll!malloc` was never touched — `mimalloc-redirect.dll`
+v1.3.3 names only `ucrtbase`/`ucrtbased` and contains no reference to `msvcrt`; what it
+patched there was a `ucrtbase.dll` some system DLL had loaded. So the gate takes a pointer
+from the CRT's own `malloc` and asks `mi_is_in_heap_region`. Only a real override makes
+that true. The flag is still printed, and the native row is still gated on it, because
+while that MSYS2 build exists a regression in it is a regression — but it is a witness,
+not a control.
 
-The cross-built binary does **not** redirect, and five measured attempts did not change
-that. In order:
+### Why it did not redirect, and what fixed it
 
-| attempt | result |
-|---|---|
-| as originally linked (`mimalloc.dll` last) | NOT-REDIRECTED |
-| `minject`, both postfixes, with and without `--inplace` | image will not start (rc 127) |
-| `MI_MINGW_UCRT64=OFF`, same toolchain | NOT-REDIRECTED |
-| `mimalloc.dll` first in the exe (the fix above) | NOT-REDIRECTED; everything else green |
-| `mimalloc-redirect.dll` also first inside `mimalloc.dll` | **SEGFAULT** before any output; reverted |
+Two bugs in series, both now fixed:
 
-The last row retires the "minject writes a corrupt PE" theory: minject produces exactly
-that layout, and so does the linker when asked to, and both crash the same way. Loading
-the redirection module before `ucrtbase` has initialised is what this binary cannot
-survive — and upstream's supported MSVC layout has the api-sets first too, so being
-*early* was never the requirement.
+1. **`mimalloc-redirect.dll` refuses to patch a CRT that has already initialised.** It
+   imports only `ntdll` and has no output API at all: its entire diagnostic channel is the
+   `const char**` returned by `mi_allocator_init`, which `src/init.c` prints *after* the
+   option dump. Printed, it says `mimalloc-redirect.dll seems to be initialized after
+   ucrtbase.dll`. The check (disassembled at `0x180003720` in the v1.3.3 module) is
+   `LdrGetDllHandle` followed by `LDR_DATA_TABLE_ENTRY.Flags & 0x00080000`
+   (`LDRP_PROCESS_ATTACH_CALLED`). The loader initialises a module's dependencies in *that
+   module's* import-descriptor order, so `mimalloc.dll` has to import the redirect module
+   before its own `api-ms-win-crt-*`. MSVC gets that for free (explicit libraries precede
+   `/DEFAULTLIB` ones); with `ld` it was decided by where the checkout happened to live.
+   `MI_MINGW_REDIRECT_FIRST` (default ON) spells it `./…`.
 
-So the probe reports and warns rather than failing, with a dated TODO, because a
-permanently-red gate is worse than an absent one. The MSYS2-built msvcrt binary in the
-same job **does** redirect and **is** gated — not as a substitute for the bundle, but
-because while that row exists a regression in it is still a regression. Escalated on #277:
-closing this needs a Windows debugger, not another CI round.
+2. **That layout then died at load — GCC emulated TLS.** soldr's conda-forge
+   `x86_64-w64-mingw32-gcc 15.3.0` has no native TLS: `__thread int x;` compiles to
+   `__emutls_v.x` plus a call to `__emutls_get_address`, and `__declspec(thread)` only
+   warns and emits a plain global. `__emutls_get_address` allocates its per-thread table
+   with `malloc` — which, once the override is live, is `mi_malloc`. cdb on the runner
+   showed the cycle, one `libgcc_s_seh_1!__emutls_get_address` frame per turn, until the
+   stack was gone. That is the "rc 139 / rc 127" recorded on earlier runs: a stack
+   overflow before `main`, **not** a corrupt PE. Fixed by moving the two thread-locals on
+   the allocation path — `src/threadlocal.c`'s `mi_thread_locals`/`mi_slot_fast` and
+   `src/options.c`'s output-recursion guard — onto dynamic Win32 TLS keys
+   (`_mi_prim_tls_key_*`, `MI_WIN_TLS_SLOTS`), which never allocate.
 
-`minject` is **not** used on the cross lane. It is a Windows PE utility, so it cannot run
-on the Linux builder at all; and when it was run on the Windows runner instead it produced
-an image that will not start (exit 127 — the loader refused it), for both an empty and a
-non-empty `--postfix`, with and without `--inplace`. That is a separate upstream bug,
-recorded with the facts in `docs/upstreaming.md` and deliberately not root-caused here,
-because the link-order fix removes the need for it.
+`minject` is **not** used on the cross lane, and is not needed on any lane. It is a
+Windows PE utility, so it cannot run on the Linux builder at all; and when it was run on
+the Windows runner instead it produced an image that would not start (exit 127). That is
+now understood: minject builds exactly the redirect-first layout, which was correct all
+along — the image died of the emulated-TLS recursion above, not of anything wrong with the
+PE minject wrote. Superseded by `MI_MINGW_REDIRECT_FIRST`, which does the same thing at
+link time and works on a cross build.
 
 ### The runtime DLL
 

--- a/docs/upstreaming.md
+++ b/docs/upstreaming.md
@@ -321,30 +321,47 @@ It is what upstream's own "try to link with the mimalloc library earlier on the 
 line" hint asks for, it applies to the native MSYS2 lane too, and it needs no `minject`.
 Upstreamable as-is; it touches one guarded block and no C.
 
-**It is necessary but not sufficient, and the remaining half is unsolved.** With the exe
-importing `mimalloc.dll` first, a cross-built UCRT binary still reports
-`_mi_is_redirected() == false`. Going one level further -- forcing `mimalloc-redirect.dll`
-ahead of the `api-ms-win-crt-*` imports inside `mimalloc.dll`, by the same path-spelling
-trick -- makes the process **segfault before it prints anything**, which is also exactly
-what `minject` produces (minject builds the same layout). So the redirection module cannot
-be initialised before `ucrtbase` here, and upstream's supported MSVC layout does not do
-that either: the MSVC linker sorts descriptors alphabetically, so `api-ms-win-crt-*`
-precedes `mimalloc-redirect.dll` there as well. Whatever makes redirection work on
-MSVC/UCRT and on mingw/msvcrt, but not on mingw/UCRT, is still unidentified; it needs a
-Windows debugger.
+**It is necessary but not sufficient — the other half is inside `mimalloc.dll`.** The
+loader initialises a module's dependencies in *that module's* import-descriptor order, so
+`mimalloc.dll` must import `mimalloc-redirect.dll` before its own `api-ms-win-crt-*`, or
+`ucrtbase.dll`'s DllMain has already run by the time the redirection module gets control.
+It then refuses outright: `LdrGetDllHandle("ucrtbase.dll")` followed by a test of
+`LDR_DATA_TABLE_ENTRY.Flags & 0x00080000` (`LDRP_PROCESS_ATTACH_CALLED`), disassembled at
+`0x180003720` in `bin/mimalloc-redirect.dll` v1.3.3, and it reports
+`mimalloc-redirect.dll seems to be initialized after ucrtbase.dll` through the
+`const char**` that `mi_allocator_init` hands back — the module imports no output API, so
+that message is the only channel it has. MSVC produces the accepted layout by
+construction, because link.exe emits descriptors for explicitly named libraries before the
+`/DEFAULTLIB` ones. **Fix we carry:** `MI_MINGW_REDIRECT_FIRST` (default ON), the same
+`./…` spelling applied to `bin/mimalloc-redirect.lib`.
 
-**Related, and probably the same defect: `minject` produces a non-starting image on a
-mingw-linked exe.** Facts from CI run 33609497360: `minject --verbose --postfix=<p>` reads
-the exe, reports `inject 'mimalloc-redirect.dll'`, prints a correct reordering
+**Second fix, and the one that is genuinely ours: GCC emulated TLS on the allocation
+path.** With the layout above, the process died at load. soldr's conda-forge
+`x86_64-w64-mingw32-gcc 15.3.0` has no native TLS — `__thread int x;` compiles to
+`__emutls_v.x` plus a call to `__emutls_get_address`, and `__declspec(thread)` draws
+"warning: 'thread' attribute directive ignored" and emits an ordinary global.
+`__emutls_get_address` allocates its per-thread table with `malloc`, which with the
+override live is `mi_malloc`, which reads the thread-local again: unbounded recursion, and
+cdb on a Windows runner shows exactly that cycle with one
+`libgcc_s_seh_1!__emutls_get_address` frame per turn. We move the two thread-locals
+reachable from the allocator onto dynamic Win32 TLS keys, which never allocate:
+`src/threadlocal.c` (`mi_thread_locals`, `mi_slot_fast`) and `src/options.c` (the
+output-recursion guard, reached via `mi_malloc` -> arena reservation ->
+`_mi_verbose_message` -> `_mi_fputs`), behind `MI_WIN_TLS_SLOTS` and
+`_mi_prim_tls_key_*` in the prim layer. MSVC is untouched. Upstreamable: it is a real
+defect on any `--disable-tls` mingw-w64, independent of this fork.
+
+**`minject` produces a non-starting image on a mingw-linked exe — same defect, now
+explained.** Facts from CI run 33609497360: `minject --verbose --postfix=<p>` reads the
+exe, reports `inject 'mimalloc-redirect.dll'`, prints a correct reordering
 (`mimalloc-redirect.dll` #0, `mimalloc*.dll` #1, then `KERNEL32.dll` and the
-`api-ms-win-crt-*` set), and writes the file. `minject --list` on the result shows the
-intended 13-entry table. The resulting executable then fails to start: exit **127** from
-the runner's bash, i.e. the loader refused the image (`ERROR_MOD_NOT_FOUND`-shaped), with
-`mimalloc-redirect.dll` present next to it and every other import satisfied. Reproduced
-for both an empty `--postfix=` and `--postfix=debug`, and with and without `--inplace`
-(the in-place form died the same way). Not investigated further — the link-order fix above
-removes the need for minject on this lane. Worth reporting upstream with these facts if
-anyone picks it up.
+`api-ms-win-crt-*` set), writes the file, and `minject --list` on the result shows the
+intended 13-entry table. The image then exits **127**. That is **not** a PE defect:
+minject had built the correct layout, the override engaged, and the process then
+stack-overflowed in the emulated-TLS recursion above, before `main`. Superseded by
+`MI_MINGW_REDIRECT_FIRST`, which achieves the same import order at link time and works on
+a cross build, where minject (a Windows PE utility) cannot run at all. Nothing to report
+upstream about minject.
 
 ## Local reproduction
 

--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -30,6 +30,25 @@ terms of the MIT license. A copy of the license can be found in the file
 
 #define mi_decl_cache_align     mi_decl_align(64)
 
+// Should thread-locals that sit on an allocation path use dynamic Win32 TLS keys
+// (`_mi_prim_tls_key_*`) instead of `mi_decl_thread`?
+//
+// Yes for every Windows compiler that is not MSVC. Many mingw-w64 GCCs -- notably the
+// conda-forge cross compilers, and any toolchain configured `--disable-tls` -- have no
+// native TLS, so `__thread` becomes GCC's *emulated* TLS and `__declspec(thread)` is
+// silently ignored (it only warns). `__emutls_get_address` allocates its per-thread table
+// with `malloc`, so with `mimalloc-redirect.dll` active a thread-local read from the
+// allocator re-enters the allocator, forever. Win32 TLS keys never allocate.
+// llvm-mingw is included deliberately: the hazard is the toolchain's TLS lowering, not
+// the compiler brand, and one rule beats two that can disagree. See mimalloc-pprof #277.
+#if !defined(MI_WIN_TLS_SLOTS)
+#if defined(_WIN32) && !defined(_MSC_VER)
+#define MI_WIN_TLS_SLOTS  1
+#else
+#define MI_WIN_TLS_SLOTS  0
+#endif
+#endif
+
 #if defined(_MSC_VER)
 #pragma warning(disable:4127)   // suppress constant conditional warning (due to MI_SECURE paths)
 #pragma warning(disable:26812)  // unscoped enum warning
@@ -144,6 +163,7 @@ void          _mi_verbose_message(const char* fmt, ...);
 void          _mi_trace_message(const char* fmt, ...);
 void          _mi_options_init(void);
 void          _mi_options_post_init(void);
+void          _mi_options_done(void);
 long          _mi_option_get_fast(mi_option_t option);
 void          _mi_error_message(int err, const char* fmt, ...);
 

--- a/include/mimalloc/prim-tls.h
+++ b/include/mimalloc/prim-tls.h
@@ -231,16 +231,6 @@ This incurs an extra check in the fast path (but can often be combined in an exi
 #if !defined(MI_TLS_RECURSE_GUARD) && MI_TLS_MODEL_LOCAL && defined(__APPLE__)
 #define MI_TLS_RECURSE_GUARD 1     // macOS can allocate on thread-local initialization
 #endif
-#if !defined(MI_TLS_RECURSE_GUARD) && defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
-// Same hazard as macOS's `_tlv_bootstrap`, for the same reason: many mingw-w64 GCCs (the
-// conda-forge cross compilers among them) are built without native TLS, so `__thread`
-// becomes GCC's *emulated* TLS and `__emutls_get_address` allocates its per-thread table
-// with `malloc` -- which, with `mimalloc-redirect.dll` active, is mimalloc. The remaining
-// `mi_decl_thread` on an allocation-reachable path is `recurse` in `src/options.c`, and
-// this is exactly the guard that keeps it from being touched while preloading.
-// (mimalloc-pprof #277; `src/threadlocal.c` avoids `__thread` here altogether.)
-#define MI_TLS_RECURSE_GUARD 1
-#endif
 
 // Declared this way to optimize register spills and branches
 mi_decl_cold mi_decl_noinline mi_theap_t* _mi_theap_empty_get(void);

--- a/include/mimalloc/prim-tls.h
+++ b/include/mimalloc/prim-tls.h
@@ -231,6 +231,16 @@ This incurs an extra check in the fast path (but can often be combined in an exi
 #if !defined(MI_TLS_RECURSE_GUARD) && MI_TLS_MODEL_LOCAL && defined(__APPLE__)
 #define MI_TLS_RECURSE_GUARD 1     // macOS can allocate on thread-local initialization
 #endif
+#if !defined(MI_TLS_RECURSE_GUARD) && defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
+// Same hazard as macOS's `_tlv_bootstrap`, for the same reason: many mingw-w64 GCCs (the
+// conda-forge cross compilers among them) are built without native TLS, so `__thread`
+// becomes GCC's *emulated* TLS and `__emutls_get_address` allocates its per-thread table
+// with `malloc` -- which, with `mimalloc-redirect.dll` active, is mimalloc. The remaining
+// `mi_decl_thread` on an allocation-reachable path is `recurse` in `src/options.c`, and
+// this is exactly the guard that keeps it from being touched while preloading.
+// (mimalloc-pprof #277; `src/threadlocal.c` avoids `__thread` here altogether.)
+#define MI_TLS_RECURSE_GUARD 1
+#endif
 
 // Declared this way to optimize register spills and branches
 mi_decl_cold mi_decl_noinline mi_theap_t* _mi_theap_empty_get(void);

--- a/include/mimalloc/prim.h
+++ b/include/mimalloc/prim.h
@@ -133,4 +133,32 @@ bool _mi_prim_thread_is_in_threadpool(void);
 // Is called only in rare situations and does not have to be lightning fast.
 void _mi_prim_thread_yield(void);
 
+
+#if MI_WIN_TLS_SLOTS
+/* ----------------------------------------------------------------------------------
+  Dynamic Win32 TLS keys (mimalloc-pprof #277).
+
+  A `mi_prim_tls_key_t` holds a `TlsAlloc` index biased by one, so that a zeroed
+  (statically initialised) key means "not allocated yet" without needing a constructor.
+  `_mi_prim_tls_key_alloc` allocates on first use under a CAS and is safe to call
+  concurrently; it returns 0 -- and the caller must then *fail closed* -- only when the
+  process has exhausted its TLS indices.
+
+  None of these allocate, which is the whole point: they replace `mi_decl_thread` on
+  paths reachable from `mi_malloc`, where a toolchain that lowers `__thread` to GCC's
+  emulated TLS would otherwise call `malloc` to materialise the variable.
+---------------------------------------------------------------------------------- */
+typedef _Atomic(size_t) mi_prim_tls_key_t;   // 0 == unallocated, otherwise a TLS index + 1
+
+// Return the (biased) key, allocating it on first use. Returns 0 if none is available.
+size_t _mi_prim_tls_key_alloc(mi_prim_tls_key_t* key);
+
+// Read/write this thread's value for a biased key. The caller's last error is preserved.
+void*  _mi_prim_tls_key_get(size_t key);
+bool   _mi_prim_tls_key_set(size_t key, void* value);
+
+// Release a key (process teardown). Safe on an unallocated key.
+void   _mi_prim_tls_key_free(mi_prim_tls_key_t* key);
+#endif
+
 #endif  // MI_PRIM_H

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit cc6cc2a3 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 892e15cb of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -4094,6 +4094,25 @@ _mcgen_PASTE2(McTemplateU0xx_, MCGEN_EVENTWRITETRANSFER)(
 
 #define mi_decl_cache_align     mi_decl_align(64)
 
+// Should thread-locals that sit on an allocation path use dynamic Win32 TLS keys
+// (`_mi_prim_tls_key_*`) instead of `mi_decl_thread`?
+//
+// Yes for every Windows compiler that is not MSVC. Many mingw-w64 GCCs -- notably the
+// conda-forge cross compilers, and any toolchain configured `--disable-tls` -- have no
+// native TLS, so `__thread` becomes GCC's *emulated* TLS and `__declspec(thread)` is
+// silently ignored (it only warns). `__emutls_get_address` allocates its per-thread table
+// with `malloc`, so with `mimalloc-redirect.dll` active a thread-local read from the
+// allocator re-enters the allocator, forever. Win32 TLS keys never allocate.
+// llvm-mingw is included deliberately: the hazard is the toolchain's TLS lowering, not
+// the compiler brand, and one rule beats two that can disagree. See mimalloc-pprof #277.
+#if !defined(MI_WIN_TLS_SLOTS)
+#if defined(_WIN32) && !defined(_MSC_VER)
+#define MI_WIN_TLS_SLOTS  1
+#else
+#define MI_WIN_TLS_SLOTS  0
+#endif
+#endif
+
 #if defined(_MSC_VER)
 #pragma warning(disable:4127)   // suppress constant conditional warning (due to MI_SECURE paths)
 #pragma warning(disable:26812)  // unscoped enum warning
@@ -4208,6 +4227,7 @@ void          _mi_verbose_message(const char* fmt, ...);
 void          _mi_trace_message(const char* fmt, ...);
 void          _mi_options_init(void);
 void          _mi_options_post_init(void);
+void          _mi_options_done(void);
 long          _mi_option_get_fast(mi_option_t option);
 void          _mi_error_message(int err, const char* fmt, ...);
 
@@ -12084,6 +12104,34 @@ bool _mi_prim_thread_is_in_threadpool(void);
 // Is called only in rare situations and does not have to be lightning fast.
 void _mi_prim_thread_yield(void);
 
+
+#if MI_WIN_TLS_SLOTS
+/* ----------------------------------------------------------------------------------
+  Dynamic Win32 TLS keys (mimalloc-pprof #277).
+
+  A `mi_prim_tls_key_t` holds a `TlsAlloc` index biased by one, so that a zeroed
+  (statically initialised) key means "not allocated yet" without needing a constructor.
+  `_mi_prim_tls_key_alloc` allocates on first use under a CAS and is safe to call
+  concurrently; it returns 0 -- and the caller must then *fail closed* -- only when the
+  process has exhausted its TLS indices.
+
+  None of these allocate, which is the whole point: they replace `mi_decl_thread` on
+  paths reachable from `mi_malloc`, where a toolchain that lowers `__thread` to GCC's
+  emulated TLS would otherwise call `malloc` to materialise the variable.
+---------------------------------------------------------------------------------- */
+typedef _Atomic(size_t) mi_prim_tls_key_t;   // 0 == unallocated, otherwise a TLS index + 1
+
+// Return the (biased) key, allocating it on first use. Returns 0 if none is available.
+size_t _mi_prim_tls_key_alloc(mi_prim_tls_key_t* key);
+
+// Read/write this thread's value for a biased key. The caller's last error is preserved.
+void*  _mi_prim_tls_key_get(size_t key);
+bool   _mi_prim_tls_key_set(size_t key, void* value);
+
+// Release a key (process teardown). Safe on an unallocated key.
+void   _mi_prim_tls_key_free(mi_prim_tls_key_t* key);
+#endif
+
 #endif  // MI_PRIM_H
 /* ---- end inlined: include/mimalloc/prim.h ---- */
 
@@ -15253,6 +15301,7 @@ static void mi_process_done_once(void) {
   }
 
   _mi_tls_slots_done();
+  _mi_options_done();       // releases the Win32 TLS key behind the output recursion guard
   _mi_subproc_main_done();
   _mi_allocator_done();
   _mi_verbose_message("process done\n"); // : 0x%zx\n", mi_process_tld_main.thread_id);
@@ -17536,6 +17585,37 @@ static _Atomic(size_t) warning_count; // = 0;  // when >= max_warning_count stop
 // variables on demand. This is why we use a _mi_preloading test on such
 // platforms. However, C code generator may move the initial thread local address
 // load before the `if` and we therefore split it out in a separate function.
+//
+// mimalloc-pprof #277: on Windows with a non-MSVC compiler this guard must not be a
+// `mi_decl_thread` either, and for a sharper version of the same reason. `__thread` may
+// be GCC's emulated TLS there, and `__emutls_get_address` allocates with `malloc` --
+// which, with `mimalloc-redirect.dll` active, is `mi_malloc`. This guard sits directly on
+// `mi_malloc`'s own verbose-output path (`_mi_verbose_message` -> `_mi_fputs` -> here),
+// so touching it there recurses until the stack is gone. Win32 TLS keys never allocate.
+#if MI_WIN_TLS_SLOTS
+static mi_prim_tls_key_t mi_recurse_key;   // 0 == not allocated yet
+
+// Note this FAILS CLOSED: if the process has exhausted its TLS indices,
+// `_mi_prim_tls_key_alloc` returns 0 and we report "already inside", so the message is
+// dropped rather than risking unbounded recursion. Silence is the safe answer here.
+static mi_decl_noinline bool mi_recurse_enter_prim(void) {
+  const size_t key = _mi_prim_tls_key_alloc(&mi_recurse_key);
+  if (key == 0) return false;
+  if (_mi_prim_tls_key_get(key) != NULL) return false;   // already inside on this thread
+  _mi_prim_tls_key_set(key, (void*)1);
+  return true;
+}
+
+static mi_decl_noinline void mi_recurse_exit_prim(void) {
+  _mi_prim_tls_key_set(mi_atomic_load_relaxed(&mi_recurse_key), NULL);
+}
+
+// Called once from `mi_process_done_once` (init.c).
+void _mi_options_done(void) {
+  _mi_prim_tls_key_free(&mi_recurse_key);
+}
+
+#else
 static mi_decl_thread bool recurse = false;
 
 static mi_decl_noinline bool mi_recurse_enter_prim(void) {
@@ -17547,6 +17627,11 @@ static mi_decl_noinline bool mi_recurse_enter_prim(void) {
 static mi_decl_noinline void mi_recurse_exit_prim(void) {
   recurse = false;
 }
+
+void _mi_options_done(void) {
+  // nothing to release
+}
+#endif
 
 static bool mi_recurse_enter(void) {
   #if defined(__APPLE__) || defined(__ANDROID__) || defined(MI_TLS_RECURSE_GUARD)
@@ -24774,6 +24859,20 @@ static mi_thread_locals_t mi_thread_locals_empty = mi_init_struct_zero;
   static inline bool name##_set(tp val)   { return mi_pthread_key_set(&__##name##_key,val); } \
   static inline void name##_delete(void)  { mi_pthread_key_delete(&__##name##_key); }
 
+#elif MI_WIN_TLS_SLOTS
+// Windows, non-MSVC: dynamic Win32 TLS keys instead of `__thread`. This toolchain may
+// lower `__thread` to GCC's *emulated* TLS, whose `__emutls_get_address` allocates with
+// `malloc` -- which is `mi_malloc` once `mimalloc-redirect.dll` is live, so a
+// thread-local read from the allocator would re-enter the allocator forever
+// (mimalloc-pprof #277). See `MI_WIN_TLS_SLOTS` in `mimalloc/internal.h` and
+// `_mi_prim_tls_key_*` in `mimalloc/prim.h`; none of them allocate.
+#define mi_define_thread_local(tp,name,initval) \
+  static mi_prim_tls_key_t __##name##_key;  /* 0 == not allocated yet */ \
+  static inline tp   name##_peek(void)    { return (tp)_mi_prim_tls_key_get(mi_atomic_load_relaxed(&__##name##_key)); } \
+  static inline tp   name##_get(void)     { tp result = name##_peek(); return (result!=NULL ? result : initval); } \
+  static inline bool name##_set(tp val)   { return _mi_prim_tls_key_set(_mi_prim_tls_key_alloc(&__##name##_key), (void*)val); } \
+  static inline void name##_delete(void)  { _mi_prim_tls_key_free(&__##name##_key); }
+
 #else
 // Direct thread locals
 #define mi_define_thread_local(tp,name,initval) \
@@ -25852,6 +25951,56 @@ bool _mi_prim_random_buf(void* buf, size_t buf_len) {
 //----------------------------------------------------------------
 // Thread pool?
 //----------------------------------------------------------------
+
+/* ----------------------------------------------------------------------------------
+  Dynamic Win32 TLS keys -- see `include/mimalloc/prim.h` (mimalloc-pprof #277).
+  `TlsAlloc` takes an index from a bitmap in the PEB; none of this touches the C heap,
+  which is exactly why these exist. `TlsGetValue`/`TlsSetValue` reset the calling
+  thread's last error on success, and an allocator must not do that to its caller, so it
+  is saved and restored around them.
+---------------------------------------------------------------------------------- */
+#if MI_WIN_TLS_SLOTS
+size_t _mi_prim_tls_key_alloc(mi_prim_tls_key_t* key) {
+  size_t biased = mi_atomic_load_acquire(key);
+  if mi_unlikely(biased == 0) {
+    const DWORD index = TlsAlloc();
+    if (index == TLS_OUT_OF_INDEXES) {
+      return mi_atomic_load_acquire(key);   // another thread may have installed one meanwhile
+    }
+    size_t expected = 0;
+    if (mi_atomic_cas_strong_acq_rel(key, &expected, (size_t)index + 1)) {
+      biased = (size_t)index + 1;
+    }
+    else {
+      TlsFree(index);                       // lost the race; keep the winner's key
+      biased = expected;
+    }
+  }
+  return biased;
+}
+
+void* _mi_prim_tls_key_get(size_t key) {
+  if (key == 0) return NULL;
+  const DWORD err = GetLastError();
+  void* const value = TlsGetValue((DWORD)(key - 1));
+  SetLastError(err);
+  return value;
+}
+
+bool _mi_prim_tls_key_set(size_t key, void* value) {
+  if (key == 0) return false;
+  const DWORD err = GetLastError();
+  const BOOL ok = TlsSetValue((DWORD)(key - 1), value);
+  SetLastError(err);
+  return (ok != 0);
+}
+
+void _mi_prim_tls_key_free(mi_prim_tls_key_t* key) {
+  const size_t biased = mi_atomic_exchange_acq_rel(key, (size_t)0);
+  if (biased != 0) { TlsFree((DWORD)(biased - 1)); }
+}
+#endif
+
 
 bool _mi_prim_thread_is_in_threadpool(void) {
 #if (MI_ARCH_X64 || MI_ARCH_X86 || MI_ARCH_ARM64)

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit cc6cc2a3 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 892e15cb of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/src/init.c
+++ b/src/init.c
@@ -663,6 +663,7 @@ static void mi_process_done_once(void) {
   }
 
   _mi_tls_slots_done();
+  _mi_options_done();       // releases the Win32 TLS key behind the output recursion guard
   _mi_subproc_main_done();
   _mi_allocator_done();
   _mi_verbose_message("process done\n"); // : 0x%zx\n", mi_process_tld_main.thread_id);

--- a/src/options.c
+++ b/src/options.c
@@ -477,6 +477,51 @@ static _Atomic(size_t) warning_count; // = 0;  // when >= max_warning_count stop
 // variables on demand. This is why we use a _mi_preloading test on such
 // platforms. However, C code generator may move the initial thread local address
 // load before the `if` and we therefore split it out in a separate function.
+//
+// mimalloc-pprof #277: on Windows with a GCC-family compiler this guard must not be a
+// `mi_decl_thread` either, and for a sharper version of the same reason. Many mingw-w64
+// GCCs have no native TLS, so `__thread` becomes GCC's emulated TLS and
+// `__emutls_get_address` allocates with `malloc` -- which, with `mimalloc-redirect.dll`
+// active, is `mi_malloc`. This guard sits directly on `mi_malloc`'s own verbose-output
+// path (`_mi_verbose_message` -> `_mi_fputs` -> here), so touching it there recurses
+// until the stack is gone. A Win32 TLS slot never allocates. See `src/threadlocal.c`.
+#if defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
+#include <windows.h>
+static _Atomic(size_t) mi_recurse_key;   // 0 == not allocated yet, else TLS index + 1
+
+static size_t mi_recurse_key_get(void) {
+  size_t key = mi_atomic_load_acquire(&mi_recurse_key);
+  if mi_unlikely(key == 0) {
+    const DWORD index = TlsAlloc();      // does not allocate from the C heap
+    if (index == TLS_OUT_OF_INDEXES) return 0;
+    size_t expected = 0;
+    if (mi_atomic_cas_strong_acq_rel(&mi_recurse_key, &expected, (size_t)index + 1)) {
+      key = (size_t)index + 1;
+    }
+    else { TlsFree(index); key = expected; }   // lost the race
+  }
+  return key;
+}
+
+static mi_decl_noinline bool mi_recurse_enter_prim(void) {
+  const size_t key = mi_recurse_key_get();
+  if (key == 0) return false;
+  const DWORD err = GetLastError();     // an allocator must not clobber the caller's last error
+  const bool inside = (TlsGetValue((DWORD)(key - 1)) != NULL);
+  if (!inside) { TlsSetValue((DWORD)(key - 1), (void*)1); }
+  SetLastError(err);
+  return !inside;
+}
+
+static mi_decl_noinline void mi_recurse_exit_prim(void) {
+  const size_t key = mi_atomic_load_relaxed(&mi_recurse_key);
+  if (key == 0) return;
+  const DWORD err = GetLastError();
+  TlsSetValue((DWORD)(key - 1), NULL);
+  SetLastError(err);
+}
+
+#else
 static mi_decl_thread bool recurse = false;
 
 static mi_decl_noinline bool mi_recurse_enter_prim(void) {
@@ -488,6 +533,7 @@ static mi_decl_noinline bool mi_recurse_enter_prim(void) {
 static mi_decl_noinline void mi_recurse_exit_prim(void) {
   recurse = false;
 }
+#endif
 
 static bool mi_recurse_enter(void) {
   #if defined(__APPLE__) || defined(__ANDROID__) || defined(MI_TLS_RECURSE_GUARD)

--- a/src/options.c
+++ b/src/options.c
@@ -478,47 +478,33 @@ static _Atomic(size_t) warning_count; // = 0;  // when >= max_warning_count stop
 // platforms. However, C code generator may move the initial thread local address
 // load before the `if` and we therefore split it out in a separate function.
 //
-// mimalloc-pprof #277: on Windows with a GCC-family compiler this guard must not be a
-// `mi_decl_thread` either, and for a sharper version of the same reason. Many mingw-w64
-// GCCs have no native TLS, so `__thread` becomes GCC's emulated TLS and
-// `__emutls_get_address` allocates with `malloc` -- which, with `mimalloc-redirect.dll`
-// active, is `mi_malloc`. This guard sits directly on `mi_malloc`'s own verbose-output
-// path (`_mi_verbose_message` -> `_mi_fputs` -> here), so touching it there recurses
-// until the stack is gone. A Win32 TLS slot never allocates. See `src/threadlocal.c`.
-#if defined(_WIN32) && defined(__GNUC__) && !defined(__clang__)
-#include <windows.h>
-static _Atomic(size_t) mi_recurse_key;   // 0 == not allocated yet, else TLS index + 1
+// mimalloc-pprof #277: on Windows with a non-MSVC compiler this guard must not be a
+// `mi_decl_thread` either, and for a sharper version of the same reason. `__thread` may
+// be GCC's emulated TLS there, and `__emutls_get_address` allocates with `malloc` --
+// which, with `mimalloc-redirect.dll` active, is `mi_malloc`. This guard sits directly on
+// `mi_malloc`'s own verbose-output path (`_mi_verbose_message` -> `_mi_fputs` -> here),
+// so touching it there recurses until the stack is gone. Win32 TLS keys never allocate.
+#if MI_WIN_TLS_SLOTS
+static mi_prim_tls_key_t mi_recurse_key;   // 0 == not allocated yet
 
-static size_t mi_recurse_key_get(void) {
-  size_t key = mi_atomic_load_acquire(&mi_recurse_key);
-  if mi_unlikely(key == 0) {
-    const DWORD index = TlsAlloc();      // does not allocate from the C heap
-    if (index == TLS_OUT_OF_INDEXES) return mi_atomic_load_acquire(&mi_recurse_key);  // another thread may have won
-    size_t expected = 0;
-    if (mi_atomic_cas_strong_acq_rel(&mi_recurse_key, &expected, (size_t)index + 1)) {
-      key = (size_t)index + 1;
-    }
-    else { TlsFree(index); key = expected; }   // lost the race
-  }
-  return key;
-}
-
+// Note this FAILS CLOSED: if the process has exhausted its TLS indices,
+// `_mi_prim_tls_key_alloc` returns 0 and we report "already inside", so the message is
+// dropped rather than risking unbounded recursion. Silence is the safe answer here.
 static mi_decl_noinline bool mi_recurse_enter_prim(void) {
-  const size_t key = mi_recurse_key_get();
+  const size_t key = _mi_prim_tls_key_alloc(&mi_recurse_key);
   if (key == 0) return false;
-  const DWORD err = GetLastError();     // an allocator must not clobber the caller's last error
-  const bool inside = (TlsGetValue((DWORD)(key - 1)) != NULL);
-  if (!inside) { TlsSetValue((DWORD)(key - 1), (void*)1); }
-  SetLastError(err);
-  return !inside;
+  if (_mi_prim_tls_key_get(key) != NULL) return false;   // already inside on this thread
+  _mi_prim_tls_key_set(key, (void*)1);
+  return true;
 }
 
 static mi_decl_noinline void mi_recurse_exit_prim(void) {
-  const size_t key = mi_atomic_load_relaxed(&mi_recurse_key);
-  if (key == 0) return;
-  const DWORD err = GetLastError();
-  TlsSetValue((DWORD)(key - 1), NULL);
-  SetLastError(err);
+  _mi_prim_tls_key_set(mi_atomic_load_relaxed(&mi_recurse_key), NULL);
+}
+
+// Called once from `mi_process_done_once` (init.c).
+void _mi_options_done(void) {
+  _mi_prim_tls_key_free(&mi_recurse_key);
 }
 
 #else
@@ -532,6 +518,10 @@ static mi_decl_noinline bool mi_recurse_enter_prim(void) {
 
 static mi_decl_noinline void mi_recurse_exit_prim(void) {
   recurse = false;
+}
+
+void _mi_options_done(void) {
+  // nothing to release
 }
 #endif
 

--- a/src/options.c
+++ b/src/options.c
@@ -493,7 +493,7 @@ static size_t mi_recurse_key_get(void) {
   size_t key = mi_atomic_load_acquire(&mi_recurse_key);
   if mi_unlikely(key == 0) {
     const DWORD index = TlsAlloc();      // does not allocate from the C heap
-    if (index == TLS_OUT_OF_INDEXES) return 0;
+    if (index == TLS_OUT_OF_INDEXES) return mi_atomic_load_acquire(&mi_recurse_key);  // another thread may have won
     size_t expected = 0;
     if (mi_atomic_cas_strong_acq_rel(&mi_recurse_key, &expected, (size_t)index + 1)) {
       key = (size_t)index + 1;

--- a/src/prim/windows/prim.c
+++ b/src/prim/windows/prim.c
@@ -736,6 +736,56 @@ bool _mi_prim_random_buf(void* buf, size_t buf_len) {
 // Thread pool?
 //----------------------------------------------------------------
 
+/* ----------------------------------------------------------------------------------
+  Dynamic Win32 TLS keys -- see `include/mimalloc/prim.h` (mimalloc-pprof #277).
+  `TlsAlloc` takes an index from a bitmap in the PEB; none of this touches the C heap,
+  which is exactly why these exist. `TlsGetValue`/`TlsSetValue` reset the calling
+  thread's last error on success, and an allocator must not do that to its caller, so it
+  is saved and restored around them.
+---------------------------------------------------------------------------------- */
+#if MI_WIN_TLS_SLOTS
+size_t _mi_prim_tls_key_alloc(mi_prim_tls_key_t* key) {
+  size_t biased = mi_atomic_load_acquire(key);
+  if mi_unlikely(biased == 0) {
+    const DWORD index = TlsAlloc();
+    if (index == TLS_OUT_OF_INDEXES) {
+      return mi_atomic_load_acquire(key);   // another thread may have installed one meanwhile
+    }
+    size_t expected = 0;
+    if (mi_atomic_cas_strong_acq_rel(key, &expected, (size_t)index + 1)) {
+      biased = (size_t)index + 1;
+    }
+    else {
+      TlsFree(index);                       // lost the race; keep the winner's key
+      biased = expected;
+    }
+  }
+  return biased;
+}
+
+void* _mi_prim_tls_key_get(size_t key) {
+  if (key == 0) return NULL;
+  const DWORD err = GetLastError();
+  void* const value = TlsGetValue((DWORD)(key - 1));
+  SetLastError(err);
+  return value;
+}
+
+bool _mi_prim_tls_key_set(size_t key, void* value) {
+  if (key == 0) return false;
+  const DWORD err = GetLastError();
+  const BOOL ok = TlsSetValue((DWORD)(key - 1), value);
+  SetLastError(err);
+  return (ok != 0);
+}
+
+void _mi_prim_tls_key_free(mi_prim_tls_key_t* key) {
+  const size_t biased = mi_atomic_exchange_acq_rel(key, (size_t)0);
+  if (biased != 0) { TlsFree((DWORD)(biased - 1)); }
+}
+#endif
+
+
 bool _mi_prim_thread_is_in_threadpool(void) {
 #if (MI_ARCH_X64 || MI_ARCH_X86 || MI_ARCH_ARM64)
   if (win_major_version >= 6) {

--- a/src/threadlocal.c
+++ b/src/threadlocal.c
@@ -50,6 +50,54 @@ static mi_thread_locals_t mi_thread_locals_empty = mi_init_struct_zero;
   static inline bool name##_set(tp val)   { return mi_pthread_key_set(&__##name##_key,val); } \
   static inline void name##_delete(void)  { mi_pthread_key_delete(&__##name##_key); }
 
+#elif defined(_WIN32) && !defined(_MSC_VER)
+// Windows with a GCC-family compiler: use Win32 TLS slots, not `__thread`.
+//
+// Many mingw-w64 GCCs -- notably the conda-forge cross compilers a Linux host builds
+// Windows binaries with -- are configured without native TLS, so `__thread` compiles to
+// GCC's *emulated* TLS (`__emutls_v.<name>` + a call to `__emutls_get_address`) and
+// `__declspec(thread)` is silently ignored. `__emutls_get_address` allocates its
+// per-thread table with `malloc`; once `mimalloc-redirect.dll` has patched the C runtime
+// that `malloc` IS `mi_malloc`, so every thread-local read on an allocation path
+// re-enters the allocator and the process dies of a stack overflow before `main`
+// (mimalloc-pprof #277). Win32 TLS slots never allocate, so this is immune, and it is
+// correct on native-TLS MinGW too.
+//
+// `TlsGetValue`/`TlsSetValue` reset the thread's last error, which an allocator must not
+// do to its caller, so it is saved and restored. (A direct TEB read as in
+// `src/prim/prim-tls.c` would avoid both the call and the save; that is a possible
+// optimisation, not a correctness matter.)
+#include <windows.h>
+
+#define mi_define_thread_local(tp,name,initval) \
+  static _Atomic(size_t) __##name##_key;  /* 0 == not allocated yet, else TLS index + 1 */ \
+  static size_t name##_key_get(void) { \
+    size_t key = mi_atomic_load_acquire(&__##name##_key); \
+    if mi_unlikely(key == 0) { \
+      const DWORD index = TlsAlloc(); \
+      if (index == TLS_OUT_OF_INDEXES) return 0; \
+      size_t expected = 0; \
+      if (mi_atomic_cas_strong_acq_rel(&__##name##_key, &expected, (size_t)index + 1)) { \
+        key = (size_t)index + 1; \
+      } \
+      else { TlsFree(index); key = expected; }  /* lost the race */ \
+    } \
+    return key; \
+  } \
+  static inline tp   name##_peek(void)    { const size_t key = mi_atomic_load_relaxed(&__##name##_key); \
+                                            if (key == 0) return (tp)NULL; \
+                                            const DWORD err = GetLastError(); \
+                                            const tp val = (tp)TlsGetValue((DWORD)(key - 1)); \
+                                            SetLastError(err); return val; } \
+  static inline tp   name##_get(void)     { tp result = name##_peek(); return (result!=NULL ? result : initval); } \
+  static inline bool name##_set(tp val)   { const size_t key = name##_key_get(); \
+                                            if (key == 0) return false; \
+                                            const DWORD err = GetLastError(); \
+                                            const BOOL ok = TlsSetValue((DWORD)(key - 1), (void*)val); \
+                                            SetLastError(err); return (ok != 0); } \
+  static inline void name##_delete(void)  { const size_t key = mi_atomic_exchange_acq_rel(&__##name##_key, (size_t)0); \
+                                            if (key != 0) { TlsFree((DWORD)(key - 1)); } }
+
 #else
 // Direct thread locals
 #define mi_define_thread_local(tp,name,initval) \

--- a/src/threadlocal.c
+++ b/src/threadlocal.c
@@ -75,7 +75,7 @@ static mi_thread_locals_t mi_thread_locals_empty = mi_init_struct_zero;
     size_t key = mi_atomic_load_acquire(&__##name##_key); \
     if mi_unlikely(key == 0) { \
       const DWORD index = TlsAlloc(); \
-      if (index == TLS_OUT_OF_INDEXES) return 0; \
+      if (index == TLS_OUT_OF_INDEXES) return mi_atomic_load_acquire(&__##name##_key); /* another thread may have won */ \
       size_t expected = 0; \
       if (mi_atomic_cas_strong_acq_rel(&__##name##_key, &expected, (size_t)index + 1)) { \
         key = (size_t)index + 1; \

--- a/src/threadlocal.c
+++ b/src/threadlocal.c
@@ -50,53 +50,19 @@ static mi_thread_locals_t mi_thread_locals_empty = mi_init_struct_zero;
   static inline bool name##_set(tp val)   { return mi_pthread_key_set(&__##name##_key,val); } \
   static inline void name##_delete(void)  { mi_pthread_key_delete(&__##name##_key); }
 
-#elif defined(_WIN32) && !defined(_MSC_VER)
-// Windows with a GCC-family compiler: use Win32 TLS slots, not `__thread`.
-//
-// Many mingw-w64 GCCs -- notably the conda-forge cross compilers a Linux host builds
-// Windows binaries with -- are configured without native TLS, so `__thread` compiles to
-// GCC's *emulated* TLS (`__emutls_v.<name>` + a call to `__emutls_get_address`) and
-// `__declspec(thread)` is silently ignored. `__emutls_get_address` allocates its
-// per-thread table with `malloc`; once `mimalloc-redirect.dll` has patched the C runtime
-// that `malloc` IS `mi_malloc`, so every thread-local read on an allocation path
-// re-enters the allocator and the process dies of a stack overflow before `main`
-// (mimalloc-pprof #277). Win32 TLS slots never allocate, so this is immune, and it is
-// correct on native-TLS MinGW too.
-//
-// `TlsGetValue`/`TlsSetValue` reset the thread's last error, which an allocator must not
-// do to its caller, so it is saved and restored. (A direct TEB read as in
-// `src/prim/prim-tls.c` would avoid both the call and the save; that is a possible
-// optimisation, not a correctness matter.)
-#include <windows.h>
-
+#elif MI_WIN_TLS_SLOTS
+// Windows, non-MSVC: dynamic Win32 TLS keys instead of `__thread`. This toolchain may
+// lower `__thread` to GCC's *emulated* TLS, whose `__emutls_get_address` allocates with
+// `malloc` -- which is `mi_malloc` once `mimalloc-redirect.dll` is live, so a
+// thread-local read from the allocator would re-enter the allocator forever
+// (mimalloc-pprof #277). See `MI_WIN_TLS_SLOTS` in `mimalloc/internal.h` and
+// `_mi_prim_tls_key_*` in `mimalloc/prim.h`; none of them allocate.
 #define mi_define_thread_local(tp,name,initval) \
-  static _Atomic(size_t) __##name##_key;  /* 0 == not allocated yet, else TLS index + 1 */ \
-  static size_t name##_key_get(void) { \
-    size_t key = mi_atomic_load_acquire(&__##name##_key); \
-    if mi_unlikely(key == 0) { \
-      const DWORD index = TlsAlloc(); \
-      if (index == TLS_OUT_OF_INDEXES) return mi_atomic_load_acquire(&__##name##_key); /* another thread may have won */ \
-      size_t expected = 0; \
-      if (mi_atomic_cas_strong_acq_rel(&__##name##_key, &expected, (size_t)index + 1)) { \
-        key = (size_t)index + 1; \
-      } \
-      else { TlsFree(index); key = expected; }  /* lost the race */ \
-    } \
-    return key; \
-  } \
-  static inline tp   name##_peek(void)    { const size_t key = mi_atomic_load_relaxed(&__##name##_key); \
-                                            if (key == 0) return (tp)NULL; \
-                                            const DWORD err = GetLastError(); \
-                                            const tp val = (tp)TlsGetValue((DWORD)(key - 1)); \
-                                            SetLastError(err); return val; } \
+  static mi_prim_tls_key_t __##name##_key;  /* 0 == not allocated yet */ \
+  static inline tp   name##_peek(void)    { return (tp)_mi_prim_tls_key_get(mi_atomic_load_relaxed(&__##name##_key)); } \
   static inline tp   name##_get(void)     { tp result = name##_peek(); return (result!=NULL ? result : initval); } \
-  static inline bool name##_set(tp val)   { const size_t key = name##_key_get(); \
-                                            if (key == 0) return false; \
-                                            const DWORD err = GetLastError(); \
-                                            const BOOL ok = TlsSetValue((DWORD)(key - 1), (void*)val); \
-                                            SetLastError(err); return (ok != 0); } \
-  static inline void name##_delete(void)  { const size_t key = mi_atomic_exchange_acq_rel(&__##name##_key, (size_t)0); \
-                                            if (key != 0) { TlsFree((DWORD)(key - 1)); } }
+  static inline bool name##_set(tp val)   { return _mi_prim_tls_key_set(_mi_prim_tls_key_alloc(&__##name##_key), (void*)val); } \
+  static inline void name##_delete(void)  { _mi_prim_tls_key_free(&__##name##_key); }
 
 #else
 // Direct thread locals

--- a/test/test-redirect-probe.c
+++ b/test/test-redirect-probe.c
@@ -1,0 +1,48 @@
+/* ----------------------------------------------------------------------------
+Copyright (c) 2026, Microsoft Research, Daan Leijen
+This is free software; you can redistribute it and/or modify it under the
+terms of the MIT license. A copy of the license can be found in the file
+"LICENSE" at the root of this distribution.
+-----------------------------------------------------------------------------*/
+
+/* A *behavioural* check that the Windows override is engaged (mimalloc-pprof #277).
+
+   `mi_is_redirected()` -- which is what "mimalloc: malloc is redirected." in verbose
+   output reports -- only says that `mimalloc-redirect.dll` believed it patched something.
+   That is not the same claim as "this program's allocations reach mimalloc", and the
+   difference is not academic: a MinGW/msvcrt binary whose malloc comes from `msvcrt.dll`
+   reports `true`, because the redirection module (v1.3.3 knows only `ucrtbase` and
+   `ucrtbased`) patched a `ucrtbase.dll` that some system DLL had dragged into the
+   process, while the binary's own `msvcrt.dll!malloc` stayed untouched.
+
+   So ask the allocator instead: take a pointer from the *C runtime's* `malloc` and ask
+   mimalloc whether it came out of one of its regions. Only a real override can make that
+   true.
+
+   This always exits 0 and reports on stdout. Whether a given configuration is *required*
+   to redirect is a property of that configuration, not of this program, so the gate lives
+   where that is known (`.github/workflows/windows-bundles.yml`), and this test stays
+   runnable -- and informative -- everywhere.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <mimalloc.h>
+
+int main(void) {
+  // Touch the mimalloc API so the DLL is imported and loaded even if nothing else in this
+  // translation unit needs it (the same reason `test-stress-dynamic` links `mi_version`).
+  const int version = mi_version();
+
+  // `p` escapes into `mi_is_in_heap_region`, an external call, so the compiler cannot
+  // elide the allocation.
+  void* p = malloc(1);
+  const int served_by_mimalloc = ((p != NULL && mi_is_in_heap_region(p)) ? 1 : 0);
+  const int module_reports_redirected = (mi_is_redirected() ? 1 : 0);
+  free(p);
+
+  printf("REDIRECT_BEHAVIOURAL=%d\n", served_by_mimalloc);
+  printf("REDIRECT_FLAG=%d\n", module_reports_redirected);
+  printf("mi_version=%d\n", version);
+  fflush(stdout);
+  return 0;
+}


### PR DESCRIPTION
Fixes the #277 phase C blocker: the Linux-cross-built windows-gnu (UCRT) bundle now
**redirects malloc**, gated, on the cross-built binary.

```
UCRT release bundle   :  REDIRECT_BEHAVIOURAL=1   REDIRECT_FLAG=1
UCRT shared bundle    :  REDIRECT_BEHAVIOURAL=1   REDIRECT_FLAG=1
UCRT debug-full bundle:  REDIRECT_BEHAVIOURAL=1   REDIRECT_FLAG=1
MSYS2 native (msvcrt) :  REDIRECT_BEHAVIOURAL=0   REDIRECT_FLAG=1   <- the false control
```
(run 33629396176, `run-windows-gnu` green with the behavioural gate as a hard failure)

`REDIRECT_BEHAVIOURAL` is a CRT `malloc` pointer landing in a mimalloc region
(`mimalloc-test-redirect-probe`). `REDIRECT_FLAG` is `mi_is_redirected()`. The last row is
the two disagreeing, measured rather than argued: `mimalloc-redirect.dll` v1.3.3 names only
`ucrtbase`/`ucrtbased` and never mentions `msvcrt`, so on that binary it had patched a
`ucrtbase.dll` some system DLL dragged in while `msvcrt.dll!malloc` -- the only malloc that
binary calls -- was never touched.

## Two bugs, in series

**1. `mimalloc-redirect.dll` refuses to patch a CRT that has already initialised.**
The module imports only `ntdll` and has *no output API at all* — its entire diagnostic
channel is the `const char** message` returned by `mi_allocator_init`, which `src/init.c`
prints *after* the option dump, which is exactly what PR #285's `head -30` cut off. Print
it and it says:

```
mimalloc-redirect: error: mimalloc-redirect.dll seems to be initialized after ucrtbase.dll
  (hint: try to link with the mimalloc library earlier on the command line?)
```

Disassembled (`bin/mimalloc-redirect.dll` v1.3.3, `0x180003720`): `LdrGetDllHandle`
followed by `LDR_DATA_TABLE_ENTRY.Flags & 0x00080000` (`LDRP_PROCESS_ATTACH_CALLED`).
The loader initialises a module's dependencies in *that module's* import-descriptor order,
so `mimalloc.dll` must import the redirect module **before** its own `api-ms-win-crt-*` —
the exe importing `mimalloc.dll` first (PR #285's fix) is necessary but not sufficient.
MSVC gets this free; `ld` sorts `.idata$2` by the path as spelled, so today it is decided
by where the checkout lives. `MI_MINGW_REDIRECT_FIRST` (default ON) spells it `./…`.

**2. That layout then died before `main` — GCC emulated TLS.**
`soldr`'s conda-forge `x86_64-w64-mingw32-gcc 15.3.0` has **no native TLS**: `__thread int x;`
compiles to `__emutls_v.x` + `__emutls_get_address`, and `__declspec(thread)` draws
*"warning: 'thread' attribute directive ignored"* and emits a plain global.
`__emutls_get_address` allocates with `malloc` — which, with the override live, **is
`mi_malloc`**. cdb on the runner shows the cycle verbatim, one
`libgcc_s_seh_1!__emutls_get_address` frame per turn, until the stack is gone. That is the
"segfault (139) / image will not start (127)" recorded on PR #285 — not a corrupt PE.

Two thread-locals were on that path, both now Win32 TLS slots (which never allocate),
Windows+GCC only, MSVC untouched:
* `src/threadlocal.c` — `mi_thread_locals`, `mi_slot_fast`
* `src/options.c` — `recurse`, the output-recursion guard, reached from
  `mi_malloc` → arena reservation → `_mi_verbose_message` → `_mi_fputs`

The thread's last error is saved/restored around the slot access. Result: `mimalloc.dll`
imports exactly one libgcc symbol, `__popcountdi2`; `__emutls_get_address` is gone.

## The msvcrt row is not a control

`mimalloc-redirect.dll` v1.3.3 names only `ucrtbase`/`ucrtbased` and never mentions
`msvcrt`, yet the MSYS2 exe — whose malloc comes from `msvcrt.dll` — reports "redirected".
It is reporting that `ucrtbase.dll`, present via system DLLs, got patched; that binary's
own allocations were never touched. PR #285's "if msvcrt redirects, UCRT must too" gate was
comparing against a false positive. Kept and relabelled.

## Review follow-ups (second round)

* **vendored amalgamation regenerated** -- `xtask check` reported DRIFT, so the win-gnu
  sys-crate jobs were green against stale vendored C and never compiled the Win32-TLS
  code. Own rust-only commit.
* **one TLS rule, one helper** -- the two guards disagreed (`!_MSC_VER` vs
  `__GNUC__ && !__clang__`), and ~15 lines of `TlsAlloc`-under-a-CAS were duplicated in
  two upstream files, each pulling `<windows.h>` into a core TU. Now `MI_WIN_TLS_SLOTS`
  (internal.h) plus `_mi_prim_tls_key_alloc/_get/_set/_free` in the prim layer; neither
  core file includes `<windows.h>`. The recursion guard's key is freed at process done,
  and its fail-closed behaviour under TLS exhaustion is documented.
* **`-L.` → `-L./<rel from CMAKE_BINARY_DIR>`** at all three link sites: the link runs
  from the top of the build tree, so a bare `./` was wrong under
  `add_subdirectory()`/FetchContent.
* the `minject` `POST_BUILD` and its cross-build warning are removed.

## Gates added

* the override gate is **behavioural** and a **hard failure** on the release, shared and
  debug-full bundles (debug-full was not probed at all before);
* the Linux build job asserts on the artifact that `mimalloc-redirect.dll` is import #0 of
  `mimalloc.dll`, and that `mimalloc.dll` does **not** import `__emutls_get_address`.

Base is `ci/277-phase-c-windows-gnu` so it lands with phase C rather than ahead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S

