### PR TITLE
fix(benchmark-suite): keep harness allocations out of the measured interval (#236)

### DIFF
--- a/rust/benchmark-suite/Cargo.toml
+++ b/rust/benchmark-suite/Cargo.toml
@@ -46,6 +46,18 @@ path = "src/bin/benchmark-scaling-run.rs"
 name = "benchmark-scaling-validate"
 path = "src/bin/benchmark-scaling-validate.rs"
 
+[[test]]
+name = "timed_allocation_audit"
+path = "tests/timed_allocation_audit.rs"
+# Custom `fn main` (no libtest harness): libtest runs `#[test]` fns
+# concurrently on their own OS threads by default, and it initializes
+# per-thread output capture on each test's thread the moment that thread
+# starts -- an allocation with no ordering relative to this file's
+# `MEASURED` gate. That stray allocation from the *sibling* test's thread
+# landed inside this test's measured interval and was misattributed to
+# the code under audit. See #236 / #206.
+harness = false
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["float_roundtrip"] }

--- a/rust/benchmark-suite/tests/timed_allocation_audit.rs
+++ b/rust/benchmark-suite/tests/timed_allocation_audit.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Mutex, PoisonError};
+use std::sync::Mutex;
 
 use benchmark_suite::execution::{
     execute_cell, execute_latency_cell, set_measured_region_hook, AllocatorAdapter,
@@ -12,17 +12,11 @@ use benchmark_suite::scenarios::{cards, CardId, ScenarioCell, Topology};
 
 static MEASURED: AtomicBool = AtomicBool::new(false);
 static HARNESS_ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
-// Serializes the two audits: they share `MEASURED`, `HARNESS_ALLOCATIONS`, and the
-// process-wide measured-region hook, so they cannot overlap.
-//
-// Acquired with `unwrap_or_else(PoisonError::into_inner)`, never `unwrap()`. These
-// tests assert, and an assertion panic while holding the guard poisons the mutex --
-// so a plain `unwrap()` made the *other* test panic on `PoisonError` at its lock
-// line. One real failure was reported as two, the second pointing at a lock
-// acquisition that has nothing to do with allocations. Recovering is correct rather
-// than a workaround: the guard provides mutual exclusion only, and a `()` payload
-// cannot be left in an inconsistent state. See #236.
-static TEST_GATE: Mutex<()> = Mutex::new(());
+// Size in bytes of the first allocation that tripped `HARNESS_ALLOCATIONS` in
+// the current measured interval, `u64::MAX` when none has. Recorded so a
+// failure names *something* about the culprit without the audit hook itself
+// allocating (a `Backtrace` capture here would recurse into this allocator).
+static FIRST_OFFENDING_SIZE: AtomicU64 = AtomicU64::new(u64::MAX);
 
 thread_local! {
     static INSIDE_ADAPTER: Cell<bool> = const { Cell::new(false) };
@@ -30,25 +24,30 @@ thread_local! {
 
 struct AuditedSystem;
 
+impl AuditedSystem {
+    fn record(&self, layout: Layout) {
+        if MEASURED.load(Ordering::SeqCst) && !INSIDE_ADAPTER.with(Cell::get) {
+            let previous = HARNESS_ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
+            if previous == 0 {
+                FIRST_OFFENDING_SIZE.store(layout.size() as u64, Ordering::SeqCst);
+            }
+        }
+    }
+}
+
 unsafe impl GlobalAlloc for AuditedSystem {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if MEASURED.load(Ordering::SeqCst) && !INSIDE_ADAPTER.with(Cell::get) {
-            HARNESS_ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
-        }
+        self.record(layout);
         unsafe { System.alloc(layout) }
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        if MEASURED.load(Ordering::SeqCst) && !INSIDE_ADAPTER.with(Cell::get) {
-            HARNESS_ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
-        }
+        self.record(layout);
         unsafe { System.alloc_zeroed(layout) }
     }
 
     unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
-        if MEASURED.load(Ordering::SeqCst) && !INSIDE_ADAPTER.with(Cell::get) {
-            HARNESS_ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
-        }
+        self.record(layout);
         unsafe { System.realloc(pointer, layout, size) }
     }
 
@@ -143,13 +142,13 @@ impl AllocatorAdapter for InstrumentedAdapter {
     }
 }
 
-#[test]
-#[cfg_attr(
-    target_os = "macos",
-    ignore = "macOS realloc may route through the global allocator"
-)]
 fn ordinary_measured_region_performs_zero_harness_allocations() {
-    let _test_guard = TEST_GATE.lock().unwrap_or_else(PoisonError::into_inner);
+    if cfg!(target_os = "macos") {
+        println!(
+            "test ordinary_measured_region_performs_zero_harness_allocations ... skipped (macOS realloc may route through the global allocator)"
+        );
+        return;
+    }
     let adapter = InstrumentedAdapter {
         layouts: Mutex::new(HashMap::new()),
     };
@@ -184,10 +183,12 @@ fn ordinary_measured_region_performs_zero_harness_allocations() {
         1,
         "native thread creation is the sole explicit timed-allocation exemption"
     );
+    println!("test ordinary_measured_region_performs_zero_harness_allocations ... ok");
 }
 
 fn audit_cell(adapter: &InstrumentedAdapter, cell: &ScenarioCell) {
     HARNESS_ALLOCATIONS.store(0, Ordering::SeqCst);
+    FIRST_OFFENDING_SIZE.store(u64::MAX, Ordering::SeqCst);
     set_measured_region_hook(Some(timing_hook));
     let result = execute_cell(adapter, cell);
     set_measured_region_hook(None);
@@ -195,18 +196,19 @@ fn audit_cell(adapter: &InstrumentedAdapter, cell: &ScenarioCell) {
     assert_eq!(
         HARNESS_ALLOCATIONS.load(Ordering::SeqCst),
         0,
-        "Rust control-plane allocation entered the measured interval for {:?}",
-        cell.card
+        "Rust control-plane allocation entered the measured interval for {:?} (first offending allocation size = {} bytes)",
+        cell.card,
+        FIRST_OFFENDING_SIZE.load(Ordering::SeqCst)
     );
 }
 
-#[test]
-#[cfg_attr(
-    target_os = "macos",
-    ignore = "macOS realloc may route through the global allocator"
-)]
 fn latency_sampling_buffers_do_not_allocate_after_warmup() {
-    let _test_guard = TEST_GATE.lock().unwrap_or_else(PoisonError::into_inner);
+    if cfg!(target_os = "macos") {
+        println!(
+            "test latency_sampling_buffers_do_not_allocate_after_warmup ... skipped (macOS realloc may route through the global allocator)"
+        );
+        return;
+    }
     let adapter = InstrumentedAdapter {
         layouts: Mutex::new(HashMap::new()),
     };
@@ -235,6 +237,7 @@ fn latency_sampling_buffers_do_not_allocate_after_warmup() {
         let cell = ScenarioCell::new(card, point, topology, 8, 0x5eed).unwrap();
         for control in [false, true] {
             HARNESS_ALLOCATIONS.store(0, Ordering::SeqCst);
+            FIRST_OFFENDING_SIZE.store(u64::MAX, Ordering::SeqCst);
             set_measured_region_hook(Some(timing_hook));
             let result = execute_latency_cell(&adapter, &cell, 2, control);
             set_measured_region_hook(None);
@@ -242,8 +245,27 @@ fn latency_sampling_buffers_do_not_allocate_after_warmup() {
             assert_eq!(
                 HARNESS_ALLOCATIONS.load(Ordering::SeqCst),
                 0,
-                "latency sampling allocated in the measured region for {card:?}, control={control}"
+                "latency sampling allocated in the measured region for {card:?}, control={control} (first offending allocation size = {} bytes)",
+                FIRST_OFFENDING_SIZE.load(Ordering::SeqCst)
             );
         }
     }
+    println!("test latency_sampling_buffers_do_not_allocate_after_warmup ... ok");
+}
+
+fn main() {
+    // No libtest harness: both audits run sequentially, on this thread only.
+    // libtest's default harness spawns each `#[test]` fn on its own OS thread
+    // and initializes per-thread output capture the moment that thread
+    // starts -- an allocation with no ordering relative to `MEASURED`. That
+    // stray allocation from the *sibling* test's thread could land inside
+    // this test's measured interval and be misattributed to the code under
+    // audit (reproduced locally: ~10% failure rate under `--test-threads=4`
+    // with two logical CPUs pinned via `taskset`, 0/60 with
+    // `--test-threads=1`). Running everything on one thread with no sibling
+    // test threads in the process removes the interference at the source.
+    // See #236 / #206.
+    println!("running 2 tests");
+    ordinary_measured_region_performs_zero_harness_allocations();
+    latency_sampling_buffers_do_not_allocate_after_warmup();
 }


### PR DESCRIPTION
## Summary

`rust/benchmark-suite/tests/timed_allocation_audit.rs` runs two `#[test]` fns that
share process-global state (`MEASURED`, `HARNESS_ALLOCATIONS`, the measured-region
hook) and assert that zero non-adapter allocations happen inside a measured
interval. Under libtest's default harness, `#[test]` fns run concurrently, each on
its own OS thread, and libtest initializes per-thread output capture the instant
that thread starts -- an allocation with no ordering relative to this file's
`MEASURED` gate. That stray allocation from the *sibling* test's thread could land
inside the other test's measured interval and get misattributed to the code under
audit, producing:

```
assertion `left == right` failed: Rust control-plane allocation entered the
measured interval for TinyFixed16
```

**Evidence**: reproduced locally on Linux under CPU-pinned contention
(`taskset -c 0,1`, `--test-threads=4`): ~10% failure rate (3/30), with the exact
panic message and line (`timed_allocation_audit.rs:195`) seen in CI (#236, #206,
duplicate #280). `--test-threads=1` under the same contention: 0/60. `TEST_GATE`
only serializes the two tests' own work against each other -- it does nothing
about libtest's per-thread setup on the sibling test's thread, which is why the
mutex didn't help.

## Fix

- `rust/benchmark-suite/Cargo.toml`: declare the test with `harness = false`.
- `rust/benchmark-suite/tests/timed_allocation_audit.rs`: replace the two
  `#[test]` fns with plain functions called sequentially from a hand-written
  `fn main()`. With no libtest harness, there is no sibling test thread in the
  process during either measured interval, so the interference is removed at the
  source rather than retried, tolerated, or allowlisted. `TEST_GATE` and its
  poison-recovery handling are removed as no longer needed (nothing left to
  serialize against).
- The audit hook now also records the size of the first offending allocation (no
  thread id or backtrace capture -- that would itself allocate inside the hook)
  so a future regression names something about the culprit instead of a bare
  `left == 0 / right == 1`.

## Test plan

- [x] `cargo test -p benchmark-suite --test timed_allocation_audit` x50 (via
      `cargo test`, checking exit code): 0 failures
- [x] Direct binary run under the exact `taskset -c 0,1` contention scenario that
      previously reproduced the flake x60: 0 failures
- [x] `cargo test -p benchmark-suite` (full crate): all tests pass
- [x] `rustfmt --check` on the changed file: clean
- [x] `cargo clippy` on the changed test target: no new warnings (pre-existing
      warnings in unrelated `src/` files are untouched by this change)
- [ ] CI: `rust-native` green on ubuntu/windows-latest/win-gnu

Closes #236
Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S