### PR TITLE
ci: build windows-msvc test bundles on Linux via soldr clang-cl, run them on the single Windows runner (#277 phase D)

### DIFF
--- a/.github/workflows/benchmark-sentinel.yml
+++ b/.github/workflows/benchmark-sentinel.yml
@@ -27,6 +27,14 @@ jobs:
     name: benchmark-sentinel (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    # TODO(#277 phase D, added 2026-09-02): DELETE the windows-latest row after ten pushes
+    # have compared it against the `PR benchmark sentinel` step in windows-bundles.yml's
+    # `run-windows`, which runs a Linux-cross-built `dashboard.exe` on the shared Windows
+    # VM. Informational until then. The numbers were already labelled informational (#171,
+    # #170: hosted runners are not a stable reference host) and no gate reads them, which
+    # is what makes it acceptable for the replacement to measure on a VM that has just run
+    # four ctest suites. The ubuntu-latest row is NOT affected.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -18,6 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # THE RETAINED NATIVE MSVC GATE (#277 phase D). Every other windows-latest row in this
+  # repository is now informational, replaced by Linux-cross-built bundles that
+  # windows-bundles.yml's `run-windows` executes on one shared VM. This one is not, and
+  # must not become so without the owner amending CLAUDE.md rule 3 ("MSVC and win-gnu are
+  # priority platforms -- both, always"): the bundles are built by clang-cl, and a
+  # clang-cl binary is not a `cl` binary. clang-cl accepts `__attribute__`s that cl
+  # rejects, and cl's codegen, TLS lowering and DLL runtime are its own. This job is the
+  # only thing in CI that compiles this tree with Microsoft's compiler and runs the
+  # result. Do NOT add continue-on-error here.
   ctest:
     strategy:
       fail-fast: false
@@ -113,6 +122,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # TODO(#277 phase D, added 2026-09-02): DELETE the windows-latest row after ten pushes
+    # have compared it against `run-windows` in windows-bundles.yml, which runs the same
+    # test set from a Linux-built bundle on the shared Windows VM. Informational until
+    # then -- it is the control arm for a deliberate toolchain change (native `cl` /MDd
+    # vs cross clang-cl /MD), so do not delete it before that comparison has actually
+    # happened. A permanently-yellow job is worse than an absent one. The ubuntu-latest
+    # row of this matrix is NOT affected and stays a hard gate.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v4
       - run: cmake -B build -DMI_PPROF=ON -DMI_DEBUG_FULL=ON && cmake --build build --config Debug && ctest --test-dir build -C Debug --output-on-failure
@@ -229,6 +246,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # TODO(#277 phase D, added 2026-09-02): DELETE the windows-latest row after ten pushes
+    # have compared it against `run-windows` in windows-bundles.yml, which runs the same
+    # test set from a Linux-built bundle on the shared Windows VM. Informational until
+    # then -- it is the control arm for a deliberate toolchain change (native `cl` /MDd
+    # vs cross clang-cl /MD), so do not delete it before that comparison has actually
+    # happened. A permanently-yellow job is worse than an absent one. The ubuntu-latest
+    # row of this matrix is NOT affected and stays a hard gate.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v4
       - run: cmake -B build -DMI_PPROF=ON -DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF -DMI_BUILD_OBJECT=OFF
@@ -271,6 +296,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # TODO(#277 phase D, added 2026-09-02): DELETE the windows-latest row after ten pushes
+    # have compared it against `run-windows` in windows-bundles.yml, which runs the same
+    # test set from a Linux-built bundle on the shared Windows VM. Informational until
+    # then -- it is the control arm for a deliberate toolchain change (native `cl` /MDd
+    # vs cross clang-cl /MD), so do not delete it before that comparison has actually
+    # happened. A permanently-yellow job is worse than an absent one. The ubuntu-latest
+    # row of this matrix is NOT affected and stays a hard gate.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v4
       - run: cmake -B build -DMI_PPROF=ON

--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -175,7 +175,7 @@ jobs:
   ctest-debug-full-win-gnu:
     runs-on: windows-latest
     # TODO(#277 phase C, added 2026-09-02): DELETE this job after ten pushes have compared
-    # it against `run-windows-gnu` in windows-bundles.yml, which runs the same test set
+    # it against `run-windows` in windows-bundles.yml, which runs the same test set
     # from a Linux-built bundle on a shared Windows VM. Informational until then -- it is
     # the control arm for a deliberate CRT change (MSYS2 MINGW64 is msvcrt, soldr's
     # mingw-w64 is UCRT), so do not delete it before that comparison has actually
@@ -263,7 +263,7 @@ jobs:
   ctest-shared-win-gnu:
     runs-on: windows-latest
     # TODO(#277 phase C, added 2026-09-02): DELETE this job after ten pushes have compared
-    # it against `run-windows-gnu` in windows-bundles.yml, which runs the same test set
+    # it against `run-windows` in windows-bundles.yml, which runs the same test set
     # from a Linux-built bundle on a shared Windows VM. Informational until then -- it is
     # the control arm for a deliberate CRT change (MSYS2 MINGW64 is msvcrt, soldr's
     # mingw-w64 is UCRT), so do not delete it before that comparison has actually
@@ -370,7 +370,7 @@ jobs:
   ctest-win-gnu:
     runs-on: windows-latest
     # TODO(#277 phase C, added 2026-09-02): DELETE this job after ten pushes have compared
-    # it against `run-windows-gnu` in windows-bundles.yml, which runs the same test set
+    # it against `run-windows` in windows-bundles.yml, which runs the same test set
     # from a Linux-built bundle on a shared Windows VM. Informational until then -- it is
     # the control arm for a deliberate CRT change (MSYS2 MINGW64 is msvcrt, soldr's
     # mingw-w64 is UCRT), so do not delete it before that comparison has actually

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -293,10 +293,18 @@ jobs:
     #
     # TODO(#277 phase C, added 2026-09-02): DELETE the x86_64-pc-windows-gnu row -- and
     # `build-win-gnu` above -- after ten pushes have compared them against
-    # windows-bundles.yml's `build-rust (x86_64-pc-windows-gnu)` + `run-windows-gnu`,
-    # which build the same binaries on ubuntu-latest through soldr's Linux-hosted
-    # mingw-w64 and run them on the shared Windows VM. Informational until then.
-    continue-on-error: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
+    # windows-bundles.yml's `build-rust (x86_64-pc-windows-gnu)` + `run-windows`, which
+    # build the same binaries on ubuntu-latest through soldr's Linux-hosted mingw-w64 and
+    # run them on the shared Windows VM. Informational until then.
+    #
+    # TODO(#277 phase D, added 2026-09-02): DELETE the x86_64-pc-windows-msvc row on the
+    # same terms, against windows-bundles.yml's `build-rust (x86_64-pc-windows-msvc)` +
+    # `run-windows`. That job builds the WHOLE workspace (not just `-p mimalloc-pprof`),
+    # because it also stands in for rust-native.yml's `test (windows-latest)`. NOTE:
+    # `build-cross`'s x86_64-pc-windows-msvc row above must go with it, but
+    # aarch64-pc-windows-msvc must NOT -- that one is build-only and has no runner.
+    # A permanently-yellow job is worse than an absent one.
+    continue-on-error: ${{ matrix.target == 'x86_64-pc-windows-gnu' || matrix.target == 'x86_64-pc-windows-msvc' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -240,7 +240,7 @@ jobs:
     # TODO(#277 phase C, added 2026-09-02): DELETE this job -- and the
     # x86_64-pc-windows-gnu row of test-binaries below -- after ten pushes have compared
     # them against windows-bundles.yml's `build-rust (x86_64-pc-windows-gnu)` +
-    # `run-windows-gnu`, which build the same test binaries on ubuntu-latest through
+    # `run-windows`, which build the same test binaries on ubuntu-latest through
     # soldr's Linux-hosted mingw-w64 and run them on the shared Windows VM. Informational
     # until then. A permanently-yellow job is worse than an absent one.
     continue-on-error: true

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -60,7 +60,7 @@ jobs:
   test-win-gnu:
     runs-on: windows-latest
     # TODO(#277 phase C, added 2026-09-02): DELETE this job after ten pushes have compared
-    # it against `run-windows-gnu` in windows-bundles.yml, which runs the same Rust test
+    # it against `run-windows` in windows-bundles.yml, which runs the same Rust test
     # binaries, cross-built on Linux, on a shared Windows VM. Informational until then -- it is
     # the control arm for a deliberate CRT change (MSYS2 MINGW64 is msvcrt, soldr's
     # mingw-w64 is UCRT), so do not delete it before that comparison has actually

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -21,6 +21,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # TODO(#277 phase D, added 2026-09-02): DELETE the windows-latest row after ten pushes
+    # have compared it against `run-windows` in windows-bundles.yml, which runs the whole
+    # workspace's test binaries -- cross-built on Linux for x86_64-pc-windows-msvc -- on
+    # the shared Windows VM. Informational until then. A permanently-yellow job is worse
+    # than an absent one. The ubuntu-latest row is NOT affected and stays a hard gate.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     defaults:
       run:
         working-directory: rust
@@ -32,12 +38,22 @@ jobs:
           lockfile: rust/Cargo.lock
           target-dir: rust/target
           build-cache-mode: full
+      # `xtask check`, `cargo publish --dry-run` and the package check are
+      # platform-INDEPENDENT: they compare the vendored C amalgamation against src/ and
+      # inspect a .crate archive. Running them on a second OS proves nothing, and #277's
+      # review addendum (item 5) asked for them to be dropped from the non-Linux runners
+      # rather than carried into a test bundle. `cargo test` is the only row-specific
+      # step, and windows-bundles.yml's `run-windows` now runs the same tests from
+      # Linux-cross-built binaries.
       - name: xtask check (vendored C amalgamation must match src/include/)
+        if: runner.os != 'Windows'
         run: soldr cargo run -p xtask -- check
       - run: soldr cargo test --locked
       - name: cargo publish --dry-run (mimalloc-pprof)
+        if: runner.os != 'Windows'
         run: soldr cargo publish --dry-run -p mimalloc-pprof --locked
       - name: Verify publish archive contains feature gate and DHAT
+        if: runner.os != 'Windows'
         shell: bash
         run: python ../ci/check_crate_package.py target/package
 

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -1,27 +1,41 @@
 name: windows-bundles
 
-# Issue #277 phase C: build the windows-gnu (MinGW-w64) test binaries on Linux, execute
-# them on ONE Windows runner.
+# Issue #277 phases C and D: build the Windows test binaries on Linux, execute them on
+# ONE Windows runner.
 #
-# Five jobs per push go away: c-unit.yml's `ctest-win-gnu`, `ctest-debug-full-win-gnu` and
-# `ctest-shared-win-gnu` (each an `msys2/setup-msys2` install of gcc+cmake+ninja on its own
-# VM before it compiles anything), rust-native.yml's `test-win-gnu`, and cross.yml's
-# `build-win-gnu` + `test (x86_64-pc-windows-gnu)`. They are replaced by four Linux build
-# jobs, one Linux Rust build job, and one `windows-latest` job that runs everything
-# serially.
+# TWELVE jobs per push go away, six per phase.
 #
-# The Linux side needs no MSYS2 and no Windows: `soldr prepare --target
-# x86_64-pc-windows-gnu` provisions mingw-w64-gcc 15.3.0, and
-# cmake/toolchains/soldr-x86_64-pc-windows-gnu.cmake feeds CMake nothing but what soldr
-# exported. `ci/bundle_tests.py` turns the build tree into a directory that runs with no
+#   phase C  c-unit.yml        ctest-win-gnu, ctest-debug-full-win-gnu, ctest-shared-win-gnu
+#            rust-native.yml   test-win-gnu
+#            cross.yml         build-win-gnu, test (x86_64-pc-windows-gnu)
+#   phase D  c-unit.yml        ctest-debug-full, ctest-shared, memory-gate  (windows rows)
+#            rust-native.yml   test (windows-latest)
+#            cross.yml         test (x86_64-pc-windows-msvc)
+#            benchmark-sentinel.yml  benchmark-sentinel (windows-latest)
+#
+# Each of the phase-C ones was an `msys2/setup-msys2` install of gcc+cmake+ninja on its own
+# VM before it compiled anything. They are all replaced by eight Linux build jobs and one
+# `windows-latest` job that runs everything serially.
+#
+# ONE native Windows job survives on purpose: c-unit.yml's `ctest (windows-latest)`,
+# Release, built by Microsoft's `cl`. CLAUDE.md rule 3 makes MSVC a priority platform, and
+# a clang-cl binary is not a `cl` binary -- clang-cl accepts `__attribute__`s cl rejects,
+# and its codegen, TLS lowering and DLL runtime are its own. That job stays a hard gate
+# and is NOT informational. Windows runner jobs per push: 13 -> 2.
+#
+# The Linux side needs no MSYS2, no Visual Studio and no Windows. `soldr prepare --target
+# x86_64-pc-windows-gnu` provisions mingw-w64-gcc 15.3.0; `--target x86_64-pc-windows-msvc`
+# provisions clang-cl + lld-link + llvm-lib against an xwin-materialised MS CRT and Windows
+# SDK. The two toolchain files under cmake/toolchains/ feed CMake nothing but what soldr
+# exported. `ci/bundle_tests.py` turns each build tree into a directory that runs with no
 # CMake and no checkout (see docs/ci-gates.md, "Test bundles").
 #
-# THE CRT CHANGES. MSYS2's MINGW64 environment, which the three native jobs use, is
-# msvcrt. soldr's mingw-w64 is UCRT (`libmsvcrt.a` is an archive of `lib64_libucrt_*.o`,
-# `_mingw.h` defines `_UCRT`, and a hello-world imports `api-ms-win-crt-*` rather than
-# `msvcrt.dll`). That is a deliberate coverage change and it has two consequences this
-# workflow has to handle explicitly, because `MI_MINGW_UCRT64` keys on `$ENV{MSYSTEM}`
-# upstream and cannot fire in a cross build:
+# THE CRT CHANGES ON THE GNU LANE. MSYS2's MINGW64 environment, which the three native
+# jobs use, is msvcrt. soldr's mingw-w64 is UCRT (`libmsvcrt.a` is an archive of
+# `lib64_libucrt_*.o`, `_mingw.h` defines `_UCRT`, and a hello-world imports
+# `api-ms-win-crt-*` rather than `msvcrt.dll`). That is a deliberate coverage change and it
+# has two consequences this workflow handles explicitly, because `MI_MINGW_UCRT64` keys on
+# `$ENV{MSYSTEM}` upstream and cannot fire in a cross build:
 #   * the toolchain file sets `MI_MINGW_UCRT64` ON, which turns on the `.CRT$XLB` TLS
 #     callback path in src/prim/windows/prim.c, and
 #   * mingw put the wrong thing first in TWO import tables -- `mimalloc.dll` last in
@@ -29,11 +43,18 @@ name: windows-bundles
 #     api-sets in `mimalloc.dll` itself -- so the redirection module was initialised after
 #     the runtime it patches and refused to do anything. Both are a path-spelling property
 #     of the link line, not a CRT property; see CMakeLists.txt (MI_MINGW_REDIRECT_FIRST).
-# `run-windows-gnu` asserts the import order on the BUNDLE'S OWN binaries
-# (`ci/pe_imports.py`) as a hard failure, and gates the override itself on a BEHAVIOURAL
-# probe (`mimalloc-test-redirect-probe`: a CRT `malloc` pointer must land in a mimalloc
-# region) across all three bundles. Both halves of #277 -- the import order and the
-# emulated-TLS recursion it exposed -- are fixed; the bundle redirects.
+#
+# THE CRT IS PINNED ON THE MSVC LANE. soldr's splat carries `msvcrt.lib`/`libcmt.lib` and
+# no `msvcrtd.lib`, so `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL` is pinned in the
+# toolchain file and this lane cannot reproduce the native debug-full job's `/MDd` compile
+# -- only its resolved DEFINES, which is what MI_DEBUG_FULL is actually for. Recorded in
+# docs/ci-gates.md and in the build matrix below.
+#
+# `run-windows` asserts the import order on the BUNDLES' OWN binaries (`ci/pe_imports.py`)
+# as a hard failure, and gates the override itself on a BEHAVIOURAL probe
+# (`mimalloc-test-redirect-probe`: a CRT `malloc` pointer must land in a mimalloc region)
+# across every shared-library bundle in both lanes. It also builds both native toolchains'
+# Release trees so the two arms' import tables and probes are printed side by side.
 # The msvcrt row MSYS2 builds is printed but is NOT a control: see the step that says so.
 #
 # While this is being compared against the jobs it replaces, those jobs are
@@ -314,13 +335,361 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  run-windows-gnu:
-    # The point of the whole workflow: one Windows VM, one queue slot, everything serial.
-    needs: [build-windows-gnu, build-rust-windows-gnu]
+  build-windows-msvc:
+    name: build-windows-msvc (${{ matrix.bundle }})
+    # Issue #277 phase D. soldr's `blessed-msvc` lane is clang-cl + lld-link + llvm-lib
+    # against an xwin-materialised MS CRT and Windows SDK, all Linux-hosted. See
+    # cmake/toolchains/soldr-x86_64-pc-windows-msvc.cmake for what it consumes and why
+    # `/MD` is pinned there.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Today's MSVC C coverage, config for config, with ONE deliberate difference
+          # (the debug-full row) forced by soldr's CRT splat. Each row names the c-unit.yml
+          # job it stands in for.
+          - bundle: windows-msvc-x64-release
+            # `ctest (windows-latest)`: `cmake -B build -DMI_PPROF=ON` then
+            # `--config Release`. That job uses the Visual Studio generator (no -G), where
+            # CMAKE_BUILD_TYPE is empty at configure time and CMakeLists.txt (~142-150)
+            # defaults it from the binary directory's name -- `build` -> Release. Spelled
+            # out here because Ninja is single-config.
+            #
+            # This is the one native MSVC job that is NOT being replaced: it stays a hard
+            # gate (CLAUDE.md rule 3). This bundle is the cross-built comparison arm.
+            cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON
+          - bundle: windows-msvc-x64-debug-full
+            # `ctest-debug-full (windows-latest)`: `-DMI_PPROF=ON -DMI_DEBUG_FULL=ON` then
+            # `--config Debug`.
+            #
+            # NOT `-DCMAKE_BUILD_TYPE=Debug`. Two reasons, and they point the same way:
+            #
+            #  1. soldr's CRT splat has `msvcrt.lib`/`libcmt.lib` and NO `msvcrtd.lib`, so
+            #     CMake's Debug default of MultiThreadedDebugDLL cannot link. Measured:
+            #     with the toolchain's /MD pin removed, configure dies with
+            #     `lld-link: error: could not open 'msvcrtd.lib'`.
+            #  2. Even if it could, `Debug` is not what the native job configures WITH.
+            #     The VS generator takes the build type from `--build --config`, leaving
+            #     CMAKE_BUILD_TYPE at its `build`-directory default of Release -- so the
+            #     native job's RESOLVED defines are MI_DEBUG=3 + MI_GUARDED=1 +
+            #     MI_FREE_IS_CHECKED=1 + MI_BUILD_RELEASE, and its library is `mimalloc`,
+            #     not `mimalloc-debug`. Passing Release here reproduces all of that
+            #     exactly; passing Debug would NOT (it renames the library and drops
+            #     MI_BUILD_RELEASE).
+            #
+            # What is genuinely lost is the compile flavour: native compiles /MDd /Od
+            # /RTC1, this compiles /MD /O2. The assertions and invariant checks -- which
+            # is what MI_DEBUG_FULL is for -- are identical. docs/ci-gates.md records it.
+            # (Phase C correction 4 said phase B's "debug-full is really Release" finding
+            # was macOS-only. It is not: it applies to windows-MSVC too, for the different
+            # reason above. windows-GNU remains the odd one out.)
+            cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_DEBUG_FULL=ON
+          - bundle: windows-msvc-x64-shared
+            # `ctest-shared (windows-latest)`.
+            cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF -DMI_BUILD_OBJECT=OFF
+          - bundle: windows-msvc-x64-leak
+            # The memory gate's positive control, replacing the second half of
+            # `memory-gate (windows-latest)`. A separate BUILD (MI_BENCH_INJECT_LEAK), so
+            # it cannot be an entry in another bundle's manifest.
+            cmake: -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BENCH_INJECT_LEAK=200000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - uses: zackees/setup-soldr@v0
+        with:
+          # This job drives CMake directly; there is no `soldr cargo` for zccache to wrap.
+          cache: false
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+      - name: Cache the prepared MSVC toolchain
+        uses: actions/cache@v4
+        with:
+          # The xwin CRT/SDK splat is the expensive part of this lane: `soldr prepare`
+          # downloads and materialises it from Microsoft on a cold runner.
+          path: ~/soldr-x86_64-pc-windows-msvc.tar.zst
+          key: soldr-prepare-x86_64-pc-windows-msvc-${{ hashFiles('rust/rust-toolchain.toml') }}
+      - name: Prepare the soldr MSVC toolchain
+        # `soldr prepare` resolves rustc from a rust-toolchain.toml at or above the working
+        # directory, which is why this runs in rust/ like cross.yml does.
+        working-directory: rust
+        run: |
+          set -euo pipefail
+          archive="$HOME/soldr-x86_64-pc-windows-msvc.tar.zst"
+          args=(--target x86_64-pc-windows-msvc --github-env "$GITHUB_ENV" --save "$archive")
+          # --restore on a nonexistent archive is not a documented no-op, so only pass it
+          # on a cache hit.
+          if [ -f "$archive" ]; then
+            args=(--restore "$archive" "${args[@]}")
+          fi
+          soldr prepare "${args[@]}"
+      - name: Configure for x86_64-pc-windows-msvc
+        run: |
+          set -euo pipefail
+          cmake -S . -B build -G Ninja ${{ matrix.cmake }} \
+            --toolchain cmake/toolchains/soldr-x86_64-pc-windows-msvc.cmake \
+            --log-level=VERBOSE 2>&1 | tee configure.log
+          # Assert on the RESOLVED list, not on the option that was passed in -- the
+          # MI_GUARDED lesson from docs/ci-gates.md.
+          if ! grep -qE '^-- Link libraries *: *psapi;shell32;user32;advapi32;bcrypt$' configure.log; then
+            echo "::error::the MSVC link resolved unexpected libraries"
+            grep -E 'Link libraries' configure.log || true
+            exit 1
+          fi
+          # CMakeLists.txt (~205-212) recognises clang-cl by CMAKE_C_COMPILER_ID=Clang +
+          # FRONTEND_VARIANT=MSVC and turns MI_USE_CXX on itself, exactly as it does for
+          # `cl`. The toolchain file deliberately does NOT pass it, so this is the check
+          # that the detection still fires -- if it stopped, the whole library would
+          # quietly switch from C++ atomics to C11 ones with no other symptom.
+          if ! grep -qE '^-- Compiler flags .*(/|-)Zc:__cplusplus' configure.log; then
+            echo "::error::clang-cl was not detected as MSVC-like (MI_USE_CXX/Zc:__cplusplus missing)"
+            grep -E 'Compiler flags|Use the C\+\+' configure.log || true
+            exit 1
+          fi
+      - run: cmake --build build --parallel
+      - name: Prove the output is x86-64 PE, /MD, with the profiler's Windows sections
+        run: |
+          set -euo pipefail
+          lib=$(ls build/mimalloc*.dll | grep -v 'redirect' | head -1)
+          echo "## ${{ matrix.bundle }}" >> "$GITHUB_STEP_SUMMARY"
+          # soldr's own LLVM, so this does not depend on what the runner image ships.
+          llvm-objdump -f "$lib" | tee headers.txt
+          grep -q 'file format coff-x86-64' headers.txt
+          # THE /MD PIN, checked on the artifact rather than on the cache variable. The
+          # object's .drectve section carries the /DEFAULTLIB the compiler chose: it must
+          # name the release import library, because the debug one does not exist in
+          # soldr's splat and the link would fail later with a much worse message.
+          obj=$(find build -name 'prim.c.obj' | head -1)
+          test -n "$obj"
+          llvm-readobj --coff-directives "$obj" > directives.txt
+          if ! grep -qi 'msvcrt\.lib' directives.txt; then
+            echo "::error::$obj does not request msvcrt.lib -- the /MD pin did not reach the compiler"
+            grep -oiE '[a-z0-9_]+\.lib' directives.txt | sort -u
+            exit 1
+          fi
+          if grep -qiE 'msvcrtd\.lib|libcmtd\.lib|ucrtd\.lib' directives.txt; then
+            echo "::error::$obj requests a DEBUG CRT, which soldr's splat does not contain"
+            exit 1
+          fi
+          # MI_MINGW_UCRT64 is a MinGW concern, but the .CRT$XL* initialiser tables are
+          # how src/prim/windows/prim.c registers process/thread init on MSVC too. If a
+          # cross build silently dropped them, mimalloc would load on the runner and never
+          # initialise -- which no test failure would obviously explain.
+          llvm-objdump -h "$obj" > prim-sections.txt
+          for section in '.CRT$XLB' '.CRT$XLY' '.CRT$XIB'; do
+            if ! grep -qF "$section" prim-sections.txt; then
+              echo "::error::$section is missing from $obj"
+              cat prim-sections.txt
+              exit 1
+            fi
+          done
+          # ... and the linked image must actually carry a TLS directory, which is what
+          # makes the .CRT$XLB callback fire.
+          llvm-objdump --private-headers "$lib" > private.txt
+          if ! grep -qE '^Entry 9 +0*[1-9a-f][0-9a-f]* +0*[1-9a-f]' private.txt; then
+            echo "::error::$lib has no Thread Storage Directory; the .CRT\$XLB callback cannot fire"
+            grep -E '^Entry 9' private.txt || true
+            exit 1
+          fi
+          # NO EMULATED TLS. This is what killed the windows-gnu lane (#277 phase C): GCC
+          # has no native Windows TLS, so `__thread` became `__emutls_get_address`, which
+          # allocates with malloc, which is mi_malloc once the override is live. clang-cl
+          # emits real `__declspec(thread)` and must never need the emulation -- asserted,
+          # not assumed, because the failure mode is a stack overflow before `main` with
+          # no diagnostic at all.
+          if grep -q '__emutls' private.txt; then
+            echo "::error::$lib references emulated TLS; a thread-local on the allocation path will recurse through the redirected malloc (#277)"
+            grep -n '__emutls' private.txt
+            exit 1
+          fi
+      - name: The redirection module must be initialised before the CRT
+        # The half of the Windows override that decides whether it engages at all.
+        # `mimalloc-redirect.dll` reads `ucrtbase.dll`'s LDR_DATA_TABLE_ENTRY.Flags and
+        # refuses to patch a runtime whose DllMain has already run (LDRP_PROCESS_ATTACH_
+        # CALLED, 0x00080000); the loader initialises a module's dependencies in THAT
+        # module's import-descriptor order. So the requirement is a strict ordering inside
+        # `mimalloc.dll`: the redirect module before every CRT module.
+        #
+        # NOT "import #0", which is what #277 phase D asked for. Measured on this lane:
+        #
+        #   ADVAPI32.dll  mimalloc-redirect.dll  KERNEL32.dll  MSVCP140.dll
+        #   VCRUNTIME140.dll  api-ms-win-crt-*
+        #
+        # lld-link emits the descriptors in link order, and `${mi_libraries}` (which is
+        # where advapi32 comes from) is attached to the target before the redirect import
+        # library is. ADVAPI32 is a KnownDLL whose own subtree uses legacy `msvcrt.dll`,
+        # not `ucrtbase`, so it does not trip the check the module makes. Asserting index
+        # 0 would therefore fail on a layout that works. `run-windows` proves the
+        # behaviour on the real loader, and compares this ordering against the one native
+        # `cl` produces on the same commit.
+        run: |
+          set -euo pipefail
+          lib=$(ls build/mimalloc*.dll | grep -v 'redirect' | head -1)
+          uv run ci/pe_imports.py "$lib" > imports-dll.txt
+          cat imports-dll.txt
+          if ! grep -qix 'mimalloc-redirect.dll' imports-dll.txt; then
+            echo "::error::$lib does not import mimalloc-redirect.dll; it overrides nothing"
+            exit 1
+          fi
+          redirect_at=$(grep -nix 'mimalloc-redirect.dll' imports-dll.txt | cut -d: -f1)
+          # Every module that is, or forwards to, the C runtime this module must patch.
+          crt_at=$(grep -niE '^(api-ms-win-crt-|ucrtbase|msvcp140|vcruntime140)' imports-dll.txt \
+                   | head -1 | cut -d: -f1)
+          if [ -n "$crt_at" ] && [ "$redirect_at" -gt "$crt_at" ]; then
+            echo "::error::mimalloc-redirect.dll is import #$redirect_at, behind the CRT at #$crt_at -- it will refuse to patch an already-initialised ucrtbase (#277)"
+            exit 1
+          fi
+          {
+            echo '```'
+            echo "mimalloc.dll imports (redirect at #$redirect_at, first CRT at #${crt_at:-none}):"
+            cat imports-dll.txt
+            echo "mimalloc-test-stress-dynamic.exe imports:"
+            uv run ci/pe_imports.py build/mimalloc-test-stress-dynamic.exe
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Bundle the tests
+        # No --dll-search-dir: unlike the mingw lane there is no toolchain DLL to ship
+        # (soldr's xwin splat is import libraries only, and clang-cl links against the
+        # system UCRT through the api-sets). --check-dll-closure runs the same import scan
+        # anyway, so a bundle that cannot load is still caught here rather than as a
+        # dialog-free 0xC0000135 on the runner.
+        #
+        # --allow-msvc-runtime is the one assumption this lane makes: `mimalloc.dll`
+        # imports VCRUNTIME140.dll and MSVCP140.dll (the latter because MI_USE_CXX is on
+        # for every MSVC-ABI build of this tree). Those are the Visual C++
+        # redistributable, NOT part of Windows -- `windows-latest` has them because Visual
+        # Studio is installed. `run-windows` asserts they are really present before it
+        # runs anything, so the assumption is checked rather than hoped for.
+        run: |
+          set -euo pipefail
+          uv run ci/bundle_tests.py build bundle \
+            --objdump llvm-objdump --check-dll-closure --allow-msvc-runtime
+      - name: The manifest must carry no absolute path
+        # bundle_tests.py already refuses one; this is the independent check, because the
+        # whole portability claim rests on it.
+        run: |
+          set -euo pipefail
+          if grep -nE '"(/|[A-Za-z]:[\\/])' bundle/tests.json; then
+            echo "::error::the bundle manifest contains an absolute path"
+            exit 1
+          fi
+          uv run python -c "import json; d=json.load(open('bundle/tests.json')); print(len(d['tests']), 'tests')"
+          ls bundle | grep -q '^mimalloc-redirect\.dll$'
+      - name: Pack the bundle
+        # tar, not a plain artifact upload: upload-artifact@v4 drops the executable bit.
+        run: tar -C bundle -czf "${{ matrix.bundle }}.tar.gz" .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bundle-${{ matrix.bundle }}
+          path: ${{ matrix.bundle }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  build-rust-windows-msvc:
+    name: build-rust (x86_64-pc-windows-msvc)
+    # Duplicated from cross.yml's `build-cross` rather than reused: artifacts do not cross
+    # workflows without run-id plumbing (#277 phase B correction 1). That row stays where
+    # it is, feeding its now-informational `test (x86_64-pc-windows-msvc)`, until the
+    # comparison window closes.
+    #
+    # `--workspace`, not `-p mimalloc-pprof`. This job replaces TWO native jobs with
+    # different scopes: cross.yml's row runs the 19 `mimalloc-pprof` test binaries, and
+    # rust-native.yml's `test (windows-latest)` runs `cargo test` across the whole
+    # workspace (110 further tests in bench-harness, benchmark-suite, dashboard and
+    # stress-harness). Building only the narrow set would have cut Windows Rust coverage
+    # by more than half while the coverage table claimed parity.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: false
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+      - name: Prepare blessed cross toolchain
+        run: soldr prepare --target x86_64-pc-windows-msvc --github-env "$GITHUB_ENV"
+      - name: Build test binaries through Soldr
+        run: |
+          # pipefail is NOT on by default in GitHub's `bash -e` shell, so without it this
+          # pipeline reports jq's exit status and a FAILED cargo build looks green. And
+          # the raw JSON is kept because piping cargo straight into jq discards every
+          # `compiler-message`, which is where the error text lives.
+          set -euo pipefail
+          rc=0
+          # Plain `cargo`, NOT `soldr cargo` -- see the long note in cross.yml's
+          # build-cross: the wrapper drops mi_prof_* symbols at link time. No
+          # frame-pointer flags either: the profiler does not walk frame pointers on
+          # Windows (it uses RtlCaptureStackBackTrace), which is why cross.yml's
+          # frame-pointer steps are gated on `apple-darwin`.
+          cargo test --workspace --no-run --target x86_64-pc-windows-msvc --release \
+            --message-format=json > cargo.json || rc=$?
+          jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' cargo.json > bins.txt
+          if [ "$rc" -ne 0 ]; then
+            jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' cargo.json >&2
+            exit "$rc"
+          fi
+          test -s bins.txt
+          mkdir -p dist/x86_64-pc-windows-msvc
+          xargs -r -a bins.txt -I{} cp {} dist/x86_64-pc-windows-msvc/
+          # cross.yml's `test (x86_64-pc-windows-msvc)` has `pprof: true`, so run-windows
+          # needs these two specifically. Assert it here, next to the compiler output,
+          # instead of letting the consumer fail without saying why.
+          for required in t3_stats t12_proto; do
+            if ! ls "dist/x86_64-pc-windows-msvc/$required"-* >/dev/null 2>&1; then
+              echo "::error::$required was not built. Staged binaries:"
+              ls -1 dist/x86_64-pc-windows-msvc || echo "  (none)"
+              exit 1
+            fi
+          done
+          echo "staged $(wc -l < bins.txt) test binaries"
+      - name: Build the PR benchmark sentinel
+        # benchmark-sentinel.yml's `benchmark-sentinel (windows-latest)` row runs
+        # `soldr cargo run -p dashboard --release`, which is a self-contained binary: it
+        # re-execs itself as its own stress child and writes benchmark-report.html into
+        # the working directory. Nothing about it needs a Windows builder, so it is
+        # cross-built here and executed in run-windows, which is what removes the last
+        # Windows VM from the per-push count.
+        #
+        # Staged in its OWN directory, not next to the test binaries: run-windows runs
+        # every executable in that directory with `--test-threads`, and the sentinel is
+        # not a test binary -- it would run a five-card benchmark suite under a libtest
+        # argument it does not understand.
+        run: |
+          set -euo pipefail
+          cargo build -p dashboard --release --target x86_64-pc-windows-msvc
+          mkdir -p dist/sentinel-x86_64-pc-windows-msvc
+          cp target/x86_64-pc-windows-msvc/release/dashboard.exe dist/sentinel-x86_64-pc-windows-msvc/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rust-test-bins-x86_64-pc-windows-msvc
+          path: rust/dist/x86_64-pc-windows-msvc
+          if-no-files-found: error
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rust-sentinel-x86_64-pc-windows-msvc
+          path: rust/dist/sentinel-x86_64-pc-windows-msvc
+          if-no-files-found: error
+          retention-days: 7
+
+  run-windows:
+    # The point of the whole workflow: ONE Windows VM, one queue slot, everything serial.
+    # Phase C put the three win-gnu bundles here; phase D adds the four MSVC ones, both
+    # Rust test-binary sets, both memory gates and the PR benchmark sentinel. The only
+    # other Windows job left per push is c-unit.yml's `ctest (windows-latest)`, kept
+    # native and kept a hard gate because clang-cl is not `cl` (CLAUDE.md rule 3).
+    needs: [build-windows-gnu, build-rust-windows-gnu, build-windows-msvc, build-rust-windows-msvc]
     runs-on: windows-latest
     # Everything here is serial, so a hung test would otherwise hold the slot for the
-    # workflow's whole timeout.
-    timeout-minutes: 45
+    # workflow's whole timeout. Raised from 45 with phase D's work added.
+    timeout-minutes: 75
     defaults:
       run:
         shell: bash
@@ -331,12 +700,20 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - uses: actions/download-artifact@v4
         with:
-          pattern: bundle-windows-gnu-*
+          pattern: bundle-windows-*
           path: artifacts
       - uses: actions/download-artifact@v4
         with:
           name: rust-test-bins-x86_64-pc-windows-gnu
           path: rust-bins
+      - uses: actions/download-artifact@v4
+        with:
+          name: rust-test-bins-x86_64-pc-windows-msvc
+          path: rust-bins-msvc
+      - uses: actions/download-artifact@v4
+        with:
+          name: rust-sentinel-x86_64-pc-windows-msvc
+          path: rust-sentinel-msvc
       - name: Unpack the bundles
         run: |
           set -euo pipefail
@@ -349,6 +726,20 @@ jobs:
           # risks, so say what these files are before running anything.
           uv --version
           ls -l bundle/windows-gnu-x64-release | head -40
+          ls -l bundle/windows-msvc-x64-release | head -40
+          # Seven bundles are expected: three win-gnu + a leak control, three MSVC + a
+          # leak control. A download that silently produced fewer would otherwise show up
+          # as a confusing `No such file` in the middle of a gate.
+          for expected in windows-gnu-x64-release windows-gnu-x64-debug-full \
+                          windows-gnu-x64-shared windows-gnu-x64-leak \
+                          windows-msvc-x64-release windows-msvc-x64-debug-full \
+                          windows-msvc-x64-shared windows-msvc-x64-leak; do
+            if [ ! -d "bundle/$expected" ]; then
+              echo "::error::bundle/$expected was not downloaded"
+              ls bundle
+              exit 1
+            fi
+          done
 
       - name: The bundle's own binaries must import mimalloc.dll first
         # The measurable half of the override. `ld`'s PE script emits import descriptors
@@ -586,6 +977,269 @@ jobs:
             leak-*.json
           if-no-files-found: error
 
+      # ================================================================================
+      # windows-msvc (#277 phase D). Same shape as the win-gnu half above: prove the
+      # bundle can load, prove the override engages BEHAVIOURALLY, then run everything.
+      # ================================================================================
+
+      - name: The Visual C++ redistributable must be present
+        # The one assumption the MSVC bundles make. soldr's xwin splat has import
+        # libraries only -- no redistributable DLLs -- so `mimalloc.dll`'s
+        # VCRUNTIME140.dll / MSVCP140.dll imports (the latter because MI_USE_CXX is on for
+        # every MSVC-ABI build of this tree) cannot be carried in the bundle. They are on
+        # `windows-latest` because Visual Studio is installed, which is a property of the
+        # runner image and not of Windows. `bundle_tests.py --allow-msvc-runtime` is where
+        # the assumption is declared; this is where it is checked, before anything runs
+        # and while a failure can still say what happened -- a missing DLL is otherwise a
+        # dialog-free 0xC0000135 exit, not a test failure.
+        run: |
+          set -euo pipefail
+          missing=0
+          for dll in VCRUNTIME140.dll MSVCP140.dll; do
+            if where "$dll" > /dev/null 2>&1; then
+              echo "  $dll: $(where "$dll" | head -1 | tr -d '\r')"
+            else
+              echo "::error::$dll is not on this runner; the MSVC bundles cannot load"
+              missing=1
+            fi
+          done
+          exit $missing
+
+      - name: The MSVC bundle's binaries must import mimalloc.dll, and the redirect before the CRT
+        # Recorded on the artifact, exactly as for win-gnu, so a bundle can be diagnosed
+        # from its own files. The strict requirement -- the redirection module ahead of
+        # every CRT module inside `mimalloc.dll` -- is gated in the Linux build job; here
+        # it is printed next to what native `cl` produces further down, which is the
+        # comparison that shows the layout is MSVC's and not this lane's invention.
+        run: |
+          set -euo pipefail
+          for bundle in bundle/windows-msvc-x64-release bundle/windows-msvc-x64-debug-full bundle/windows-msvc-x64-shared; do
+            exe="$bundle/mimalloc-test-stress-dynamic.exe"
+            dll=$(basename "$(ls "$bundle"/mimalloc*.dll | grep -v 'redirect' | head -1)")
+            echo "::group::$bundle"
+            uv run ci/pe_imports.py "$exe" | tee "$bundle/imports.txt"
+            first=$(head -1 "$bundle/imports.txt")
+            if [ "$first" != "$dll" ]; then
+              echo "::error::$exe imports '$first' first, expected '$dll'"
+              exit 1
+            fi
+            uv run ci/pe_imports.py "$bundle/$dll" | tee "$bundle/imports-dll.txt"
+            echo "::endgroup::"
+          done
+
+      - name: Windows override gate (MSVC) -- the bundle's own malloc must reach mimalloc
+        # BEHAVIOURAL and a HARD failure, for the reason #277 phase C established:
+        # `mi_is_redirected()` reports only what the redirection module believed it did,
+        # and that flag has been observed true on a binary whose own allocations were
+        # never touched. `mimalloc-test-redirect-probe` takes a pointer from the CRT's
+        # `malloc` and asks `mi_is_in_heap_region`.
+        #
+        # This is the owner requirement for phase D: a cross-compiled artifact must behave
+        # like a natively-built one, and on Windows that means the override works. The
+        # native `cl` row further down runs the same probe on the same commit, so the two
+        # numbers are directly comparable.
+        run: |
+          set -uo pipefail
+          failed=0
+          gate() {
+            local label="$1" bundle="$2" rc=0
+            local probe="$bundle/mimalloc-test-redirect-probe.exe"
+            if [ ! -f "$probe" ]; then
+              echo "::error::$probe is missing from the bundle"
+              failed=1; return
+            fi
+            PATH="$PWD/$bundle:$PATH" "$probe" > "$bundle/redirect-probe.txt" 2>&1 || rc=$?
+            echo "$label:"
+            sed 's/^/  /' "$bundle/redirect-probe.txt"
+            if [ "$rc" -ne 0 ] || ! grep -q '^REDIRECT_BEHAVIOURAL=1$' "$bundle/redirect-probe.txt"; then
+              echo "::error::$probe did not prove the override (rc=$rc)"
+              # The redirection module imports no output API at all: its only diagnostic
+              # channel is the `const char**` mi_allocator_init returns, which src/init.c
+              # prints AFTER the option dump. So print all of it, options filtered out.
+              MIMALLOC_VERBOSE=1 PATH="$PWD/$bundle:$PATH" \
+                "$bundle/mimalloc-test-stress-dynamic.exe" 4 10 1 2>&1 | grep -v "^option '" || true
+              failed=1
+            fi
+          }
+          gate "MSVC release bundle   " bundle/windows-msvc-x64-release
+          gate "MSVC shared bundle    " bundle/windows-msvc-x64-shared
+          gate "MSVC debug-full bundle" bundle/windows-msvc-x64-debug-full
+          exit $failed
+
+      - name: ctest (windows-latest) equivalent -- windows-msvc-x64-release
+        # The one native MSVC job that is NOT replaced still runs this same set in
+        # c-unit.yml (CLAUDE.md rule 3). Both arms run on every push; the coverage step
+        # below requires their name sets to be identical.
+        run: |
+          uv run ci/run_test_bundle.py bundle/windows-msvc-x64-release \
+            --junit "$GITHUB_WORKSPACE/bundle-msvc-release.xml"
+      - name: ctest-debug-full (windows-latest) equivalent -- windows-msvc-x64-debug-full
+        # Carries the run-negative.cmake controls. /MD + MI_DEBUG=3, not /MDd -- see the
+        # build job's matrix comment and docs/ci-gates.md.
+        run: |
+          uv run ci/run_test_bundle.py bundle/windows-msvc-x64-debug-full \
+            --junit "$GITHUB_WORKSPACE/bundle-msvc-debug-full.xml"
+      - name: ctest-shared (windows-latest) equivalent -- windows-msvc-x64-shared
+        run: |
+          uv run ci/run_test_bundle.py bundle/windows-msvc-x64-shared \
+            --junit "$GITHUB_WORKSPACE/bundle-msvc-shared.xml"
+
+      - name: Run the cross-built MSVC Rust test binaries
+        # Replaces cross.yml's `test (x86_64-pc-windows-msvc)` AND the `cargo test` half of
+        # rust-native.yml's `test (windows-latest)`, which is why the build job builds the
+        # whole workspace rather than just `-p mimalloc-pprof`. These binaries link
+        # MI_STATIC_LIB, so no DLL and no redirection module is involved.
+        run: |
+          set -euo pipefail
+          count=0
+          for test_binary in rust-bins-msvc/*.exe; do
+            echo "::group::$(basename "$test_binary")"
+            "$test_binary" --test-threads=4
+            echo "::endgroup::"
+            count=$((count + 1))
+          done
+          echo "ran $count MSVC test binaries"
+          # A silently-empty artifact would make this step pass having run nothing.
+          if [ "$count" -eq 0 ]; then
+            echo "::error::no MSVC Rust test binaries were staged"
+            exit 1
+          fi
+      - name: Prove pprof parses a native dump (MSVC)
+        # cross.yml's msvc row has `pprof: true`; these two steps are that row's dump
+        # checks, unchanged in substance. `$PPROF` was resolved by the win-gnu half above.
+        run: |
+          set -euo pipefail
+          generator=$(ls rust-bins-msvc/t3_stats-*.exe | head -1)
+          MIMALLOC_PPROF_CI_DUMP="$GITHUB_WORKSPACE/heap-msvc.prof" "$generator"
+          "$PPROF" -raw "$GITHUB_WORKSPACE/heap-msvc.prof" > raw-msvc.txt
+          grep -Eq 'PeriodType: space|heap_v2|inuse_space' raw-msvc.txt
+      - name: Prove pprof parses a proto dump (MSVC)
+        run: |
+          set -euo pipefail
+          generator=$(ls rust-bins-msvc/t12_proto-*.exe | head -1)
+          MIMALLOC_PROF_PROTO_PATH="$GITHUB_WORKSPACE/heap-msvc.pb" "$generator"
+          "$PPROF" -raw "$GITHUB_WORKSPACE/heap-msvc.pb" > raw-msvc-pb.txt
+          grep -Eq 'inuse_space|alloc_space' raw-msvc-pb.txt
+
+      - name: Memory gate (MSVC) -- 8 runs from the release bundle
+        # Replaces `memory-gate (windows-latest)`. The committed
+        # ci/memory-baselines/windows-pprof1.json was recorded by `cl`, so this lane must
+        # NOT borrow it: --arch/--compiler give the clang-cl lane its own file, exactly as
+        # phase C did for mingw. Until that file is committed this takes the yellow
+        # bootstrap path -- and, as phase B correction 8 and phase C correction 7 both
+        # record, its positive control does not run at all until then.
+        run: |
+          set -euo pipefail
+          exe="bundle/windows-msvc-x64-release/mimalloc-test-memory-gate.exe"
+          for i in 1 2 3 4 5 6 7 8; do
+            MI_BENCH_JSON="msvc-result-$i.json" "$exe" > /dev/null
+          done
+          # A gate binary that crashed writes no JSON, the glob stays unexpanded, and
+          # every downstream error would be indistinguishable from "no baseline yet" --
+          # i.e. a green step. Count first, with a glob rather than `ls | wc -l` (which
+          # fails under pipefail when it finds nothing).
+          count=0
+          for produced in msvc-result-*.json; do
+            if [ -e "$produced" ]; then count=$((count + 1)); fi
+          done
+          if [ "$count" -ne 8 ]; then
+            echo "::error::only $count of 8 MSVC memory-gate runs produced JSON"
+            exit 1
+          fi
+          cat msvc-result-1.json
+          # "Is this lane new?" is decided by `where`, which answers 3 for "no baseline"
+          # and 2 for "cannot read this run". `check` collapses both into 2, so gating the
+          # yellow bootstrap path on check's own status would report an unreadable result
+          # as a bootstrap and exit green.
+          rc=0
+          uv run ci/memory_gate.py where --arch x64 --compiler soldr-clang-cl-21 msvc-result-1.json || rc=$?
+          case "$rc" in
+            0)
+              uv run ci/memory_gate.py check --arch x64 --compiler soldr-clang-cl-21 msvc-result-*.json
+              ;;
+            3)
+              echo "::warning::No committed baseline for the soldr MSVC lane yet -- bootstrap it from this run's memory-gate artifact."
+              # `check` exits 2 here by construction: the probe just proved the baseline is
+              # absent, so its status carries no information -- but its report does.
+              uv run ci/memory_gate.py check --arch x64 --compiler soldr-clang-cl-21 msvc-result-*.json || true
+              ;;
+            *)
+              echo "::error::memory_gate could not read this run's JSON (rc=$rc)"
+              exit 1
+              ;;
+          esac
+      - name: Positive control (MSVC) -- the gate must catch an injected leak
+        run: |
+          set -euo pipefail
+          exe="bundle/windows-msvc-x64-leak/mimalloc-test-memory-gate.exe"
+          for i in 1 2 3 4 5 6 7 8; do
+            MI_BENCH_JSON="msvc-leak-$i.json" "$exe" > /dev/null || true
+          done
+          # The leak build is EXPECTED to exit non-zero (hence `|| true`), which makes the
+          # file count the only evidence that it ran at all.
+          count=0
+          for produced in msvc-leak-*.json; do
+            if [ -e "$produced" ]; then count=$((count + 1)); fi
+          done
+          if [ "$count" -ne 8 ]; then
+            echo "::error::only $count of 8 MSVC leak-control runs produced JSON"
+            exit 1
+          fi
+          # `control` requires `check` to FAIL. A missing baseline is not a failure, it is
+          # a bootstrap, so before this lane's baseline is committed the control would go
+          # red for the wrong reason.
+          rc=0
+          uv run ci/memory_gate.py where --arch x64 --compiler soldr-clang-cl-21 msvc-leak-1.json || rc=$?
+          case "$rc" in
+            0)
+              uv run ci/memory_gate.py control --arch x64 --compiler soldr-clang-cl-21 msvc-leak-*.json
+              ;;
+            3)
+              echo "::warning::the soldr MSVC lane has no committed baseline yet, so its positive control cannot run. Commit the baseline, then this becomes a hard gate."
+              ;;
+            *)
+              echo "::error::memory_gate could not read the MSVC leak control's JSON (rc=$rc)"
+              exit 1
+              ;;
+          esac
+      - if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: memory-gate-windows-msvc-x64-soldr
+          # The leak runs too: they are what a reader needs to see why the control did or
+          # did not fire, and the gate runs are what the baseline is bootstrapped from.
+          path: |
+            msvc-result-*.json
+            msvc-leak-*.json
+          if-no-files-found: error
+
+      - name: PR benchmark sentinel (MSVC, cross-built)
+        # Replaces benchmark-sentinel.yml's `benchmark-sentinel (windows-latest)` row.
+        # Guarded on the event so the fold does not turn a pull_request-only benchmark
+        # into a per-push one -- windows-bundles.yml runs on push as well.
+        #
+        # #171 already labels hosted-runner numbers informational and no gate reads them,
+        # which is what makes it acceptable to take them on a VM that has just run four
+        # ctest suites and a memory gate. `continue-on-error` for the same reason: a
+        # benchmark that fails to produce a report must not fail the correctness runner.
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p sentinel
+          cd sentinel
+          "$GITHUB_WORKSPACE/rust-sentinel-msvc/dashboard.exe"
+          ls -l benchmark-report.html
+      - if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-report-windows-msvc-soldr
+          path: |
+            sentinel/benchmark-report.html
+            sentinel/*.json
+          if-no-files-found: warn
+
       - uses: msys2/setup-msys2@v2
         if: ${{ !cancelled() }}
         with:
@@ -650,6 +1304,66 @@ jobs:
           # `msvcrt.dll`, which the redirection module cannot patch.
           ./native-release/mimalloc-test-redirect-probe.exe > msvcrt-probe.txt 2>&1 || true
           sed 's/^/  /' msvcrt-probe.txt
+      - name: Native compile-compat check and native ctest enumeration (MSVC cl)
+        # `clang-cl` is not `cl`. It accepts `__attribute__`s cl rejects, and its codegen,
+        # TLS lowering and DLL runtime are its own -- which is exactly why CLAUDE.md rule
+        # 3 keeps ONE native `cl` job (c-unit.yml's `ctest (windows-latest)`, still a hard
+        # gate, still running the full Release suite). This step is the other half: it
+        # configures all three MSVC configs with `cl` so the coverage comparison below has
+        # a real native name set to compare against, and it builds Release so the two
+        # arms' `mimalloc.dll` import tables and redirect probes can be put side by side.
+        #
+        # Same discipline as the MSYS2 step above: each configure must stay in step with
+        # the c-unit.yml job it mirrors, or the coverage table silently stops describing
+        # the job being replaced.
+        #
+        # No -G: that is what the native jobs do, and it selects the Visual Studio
+        # generator, which is the multi-config behaviour the debug-full row depends on.
+        if: ${{ !cancelled() }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # `ctest (windows-latest)` -- the retained gate
+          cmake -B native-msvc-release -DMI_PPROF=ON
+          if ($LASTEXITCODE -ne 0) { throw 'native MSVC Release configure failed' }
+          cmake --build native-msvc-release --config Release
+          if ($LASTEXITCODE -ne 0) { throw 'native MSVC Release build failed' }
+          # `ctest-debug-full (windows-latest)`
+          cmake -B native-msvc-debug-full -DMI_PPROF=ON -DMI_DEBUG_FULL=ON
+          if ($LASTEXITCODE -ne 0) { throw 'native MSVC debug-full configure failed' }
+          # `ctest-shared (windows-latest)`
+          cmake -B native-msvc-shared -DMI_PPROF=ON -DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF -DMI_BUILD_OBJECT=OFF
+          if ($LASTEXITCODE -ne 0) { throw 'native MSVC shared configure failed' }
+          ctest --test-dir native-msvc-release -C Release --show-only=json-v1 > native-msvc-release.json
+          ctest --test-dir native-msvc-debug-full -C Debug --show-only=json-v1 > native-msvc-debug-full.json
+          ctest --test-dir native-msvc-shared -C Release --show-only=json-v1 > native-msvc-shared.json
+      - name: Native cl vs cross clang-cl -- import order and the override, side by side
+        # The comparison that makes the import-order claim measured rather than argued.
+        # #277 phase D asked for `mimalloc-redirect.dll` at import #0 of `mimalloc.dll`.
+        # It is not, on either arm: `ADVAPI32.dll` is #0 and the redirect module is #1,
+        # ahead of every CRT module -- which is all the loader check requires (the module
+        # bails only when `ucrtbase`'s LDRP_PROCESS_ATTACH_CALLED is already set, and
+        # ADVAPI32's subtree uses legacy `msvcrt.dll`). If native `cl` and cross clang-cl
+        # ever stop agreeing here, that is the interesting event; a fixed index is not.
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          native_dll=$(find native-msvc-release -name 'mimalloc.dll' | head -1)
+          test -n "$native_dll"
+          uv run ci/pe_imports.py "$native_dll" > native-msvc-imports-dll.txt
+          echo "::group::native cl: mimalloc.dll import order"
+          cat native-msvc-imports-dll.txt
+          echo "::endgroup::"
+          native_probe=$(find native-msvc-release -name 'mimalloc-test-redirect-probe.exe' | head -1)
+          if [ -n "$native_probe" ]; then
+            probe_dir=$(dirname "$native_probe")
+            PATH="$PWD/$probe_dir:$PATH" "$native_probe" > native-msvc-probe.txt 2>&1 || true
+            echo "native cl redirect probe:"
+            sed 's/^/  /' native-msvc-probe.txt
+          else
+            echo "REDIRECT_BEHAVIOURAL=?" > native-msvc-probe.txt
+            echo "::warning::the native cl tree built no redirect probe"
+          fi
       - name: Coverage -- the bundles must run every test the native runner would
         if: ${{ !cancelled() }}
         run: |
@@ -657,6 +1371,9 @@ jobs:
             --compare "ctest-win-gnu" native-release.json bundle/windows-gnu-x64-release/tests.json \
             --compare "ctest-debug-full-win-gnu" native-debug-full.json bundle/windows-gnu-x64-debug-full/tests.json \
             --compare "ctest-shared-win-gnu" native-shared.json bundle/windows-gnu-x64-shared/tests.json \
+            --compare "ctest (windows-latest)" native-msvc-release.json bundle/windows-msvc-x64-release/tests.json \
+            --compare "ctest-debug-full (windows-latest)" native-msvc-debug-full.json bundle/windows-msvc-x64-debug-full/tests.json \
+            --compare "ctest-shared (windows-latest)" native-msvc-shared.json bundle/windows-msvc-x64-shared/tests.json \
             --summary "$GITHUB_STEP_SUMMARY"
       - name: Summary -- the flag, the behaviour, and why they differ
         # `ctest-win-gnu` (what this lane replaces) only ever looked at
@@ -687,14 +1404,36 @@ jobs:
               echo "| soldr mingw-w64 (**UCRT**) $b bundle | $(behavioural "$f") | $(flag "$f") |"
             done
             echo "| MSYS2 MINGW64 (**msvcrt**), built by this job | $(behavioural msvcrt-probe.txt) | $(flag msvcrt-probe.txt) |"
+            for b in release shared debug-full; do
+              f="bundle/windows-msvc-x64-$b/redirect-probe.txt"
+              echo "| soldr clang-cl (**MSVC ABI, /MD**) $b bundle | $(behavioural "$f") | $(flag "$f") |"
+            done
+            echo "| native \`cl\` Release, built by this job | $(behavioural native-msvc-probe.txt) | $(flag native-msvc-probe.txt) |"
             echo
             echo "First import of each \`test-stress-dynamic\`:"
             echo
             echo '```'
-            echo "bundle (cross): $(head -1 bundle/windows-gnu-x64-release/imports.txt)"
-            echo "native (MSYS2): $(head -1 native-imports.txt)"
+            echo "gnu bundle (cross): $(head -1 bundle/windows-gnu-x64-release/imports.txt)"
+            echo "gnu native (MSYS2): $(head -1 native-imports.txt)"
+            echo "msvc bundle (cross): $(head -1 bundle/windows-msvc-x64-release/imports.txt)"
+            echo '```'
+            echo
+            echo "\`mimalloc.dll\` import order -- the redirection module must precede every CRT module."
+            echo "#277 phase D expected it at index 0; both arms put \`ADVAPI32.dll\` there instead,"
+            echo "which is harmless (its subtree uses legacy \`msvcrt.dll\`, not \`ucrtbase\`)."
+            echo
+            echo '```'
+            echo "cross clang-cl: $(tr '\n' ' ' < bundle/windows-msvc-x64-release/imports-dll.txt)"
+            echo "native cl     : $(tr '\n' ' ' < native-msvc-imports-dll.txt)"
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
+          # The MSVC arms must agree with each other on the property that matters. The
+          # cross bundle's probe is already a hard gate above; this catches the case where
+          # BOTH arms lose the override -- a real regression that comparing them to each
+          # other would otherwise call a match.
+          if ! grep -q '^REDIRECT_BEHAVIOURAL=1$' native-msvc-probe.txt; then
+            echo "::warning::the native cl build does not prove the override either; this is a mimalloc regression, not a cross-compilation one"
+          fi
           # Native row, flag only: while this MSYS2 build exists, losing even the flag
           # there is a regression worth knowing about.
           if [ "$msvcrt" != "REDIRECTED" ]; then
@@ -705,14 +1444,31 @@ jobs:
       - if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: windows-gnu-bundle-results
+          name: windows-bundle-results
           path: |
             bundle-release.xml
             bundle-debug-full.xml
             bundle-shared.xml
+            bundle-msvc-release.xml
+            bundle-msvc-debug-full.xml
+            bundle-msvc-shared.xml
             native-release.json
             native-debug-full.json
             native-shared.json
+            native-msvc-release.json
+            native-msvc-debug-full.json
+            native-msvc-shared.json
+            native-msvc-imports-dll.txt
+            native-msvc-probe.txt
+            bundle/windows-msvc-x64-release/redirect-probe.txt
+            bundle/windows-msvc-x64-shared/redirect-probe.txt
+            bundle/windows-msvc-x64-debug-full/redirect-probe.txt
+            bundle/windows-msvc-x64-release/imports.txt
+            bundle/windows-msvc-x64-release/imports-dll.txt
+            bundle/windows-msvc-x64-debug-full/imports.txt
+            bundle/windows-msvc-x64-debug-full/imports-dll.txt
+            bundle/windows-msvc-x64-shared/imports.txt
+            bundle/windows-msvc-x64-shared/imports-dll.txt
             bundle/windows-gnu-x64-release/redirect-probe.txt
             bundle/windows-gnu-x64-shared/redirect-probe.txt
             bundle/windows-gnu-x64-debug-full/redirect-probe.txt

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -637,7 +637,64 @@ jobs:
           fi
           test -s bins.txt
           mkdir -p dist/x86_64-pc-windows-msvc
-          xargs -r -a bins.txt -I{} cp {} dist/x86_64-pc-windows-msvc/
+          # NOT every workspace test binary can be moved to another machine, and the ones
+          # that cannot say so in their own bytes.
+          #
+          # `env!("CARGO_BIN_EXE_<name>")` is expanded by cargo AT COMPILE TIME into the
+          # absolute path of the companion binary in the builder's target directory. Four
+          # tests here spawn `stress-child` that way (bench-harness's planted_control,
+          # rejections and throughput; dashboard's stress_child), so their binaries carry
+          # a literal `/home/runner/work/.../target/.../release/stress-child.exe`. There
+          # is no env override -- the string is frozen into the image -- and a Linux path
+          # cannot be reconstructed on a Windows runner, so shipping `stress-child.exe`
+          # alongside them would not help either. Cross-built, they can only run on the
+          # machine that built them.
+          #
+          # So detect them by the thing that makes them unrelocatable -- the builder's own
+          # target path appearing inside the executable -- rather than by a hardcoded list
+          # of names that would rot the moment a test is added or renamed. This is the
+          # same "a portable artifact contains no build-tree absolute path" rule
+          # ci/bundle_tests.py enforces on the C bundles.
+          target_root="$PWD/target/x86_64-pc-windows-msvc/release"
+          # SELF-TEST FIRST. `grep -F` without `-a` treats these images as binary and can
+          # report no match for a string that is demonstrably present -- which would make
+          # this scan silently stage an unrelocatable binary and fail much later on the
+          # runner, with a panic that says nothing about paths. Prove the matcher works on
+          # a known-positive before trusting its negatives.
+          # The control must contain a NUL, or it is not binary and `grep -F` would match
+          # it even WITHOUT `-a` -- a self-test that cannot fail is decoration.
+          printf 'prefix%s/stress-child.exe\000\001tail' "$target_root" > scanner-control.bin
+          if ! grep -aqF "$target_root/" scanner-control.bin; then
+            echo "::error::the unrelocatable-binary scanner cannot match a path it was just handed; its negatives are worthless"
+            exit 1
+          fi
+          rm -f scanner-control.bin
+          excluded=""
+          while read -r bin; do
+            if grep -aqF "$target_root/" "$bin" 2>/dev/null; then
+              excluded="$excluded $(basename "$bin")"
+            else
+              cp "$bin" dist/x86_64-pc-windows-msvc/
+            fi
+          done < bins.txt
+          if [ -n "$excluded" ]; then
+            echo "::warning::not staged (they embed the builder's absolute path via CARGO_BIN_EXE_*, so they cannot run on another machine):$excluded"
+            {
+              echo "### Rust test binaries that cannot be relocated"
+              echo
+              echo "\`env!(\"CARGO_BIN_EXE_*\")\` freezes the builder's absolute path into the image."
+              echo
+              echo '```'
+              for name in $excluded; do echo "$name"; done
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          # The profiler's own crate must NEVER land in that set -- it is the reason this
+          # lane exists, and losing it silently is exactly the failure this whole phase is
+          # supposed to make impossible.
+          case "$excluded" in *mimalloc_pprof*)
+            echo "::error::a mimalloc-pprof test binary embeds the builder's absolute path; the MSVC lane would silently stop testing the profiler"
+            exit 1;; esac
           # cross.yml's `test (x86_64-pc-windows-msvc)` has `pprof: true`, so run-windows
           # needs these two specifically. Assert it here, next to the compiler output,
           # instead of letting the consumer fail without saying why.
@@ -648,7 +705,7 @@ jobs:
               exit 1
             fi
           done
-          echo "staged $(wc -l < bins.txt) test binaries"
+          echo "staged $(ls -1 dist/x86_64-pc-windows-msvc | wc -l) of $(wc -l < bins.txt) test binaries"
       - name: Build the PR benchmark sentinel
         # benchmark-sentinel.yml's `benchmark-sentinel (windows-latest)` row runs
         # `soldr cargo run -p dashboard --release`, which is a self-contained binary: it

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -993,11 +993,19 @@ jobs:
         # and while a failure can still say what happened -- a missing DLL is otherwise a
         # dialog-free 0xC0000135 exit, not a test failure.
         run: |
-          set -euo pipefail
+          set -uo pipefail
           missing=0
           for dll in VCRUNTIME140.dll MSVCP140.dll; do
-            if where "$dll" > /dev/null 2>&1; then
-              echo "  $dll: $(where "$dll" | head -1 | tr -d '\r')"
+            # `where` is the native lookup and searches the real PATH the loader will use.
+            # The System32 fallback is not redundant: this step runs in Git Bash, and if
+            # `where.exe` itself were unavailable the loop would otherwise report every
+            # DLL missing and fail the job for the wrong reason.
+            found=$(where "$dll" 2>/dev/null | head -1 | tr -d '\r')
+            if [ -z "$found" ] && [ -f "/c/Windows/System32/$dll" ]; then
+              found="C:\\Windows\\System32\\$dll"
+            fi
+            if [ -n "$found" ]; then
+              echo "  $dll: $found"
             else
               echo "::error::$dll is not on this runner; the MSVC bundles cannot load"
               missing=1
@@ -1224,12 +1232,18 @@ jobs:
         # benchmark that fails to produce a report must not fail the correctness runner.
         if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         continue-on-error: true
+        #
+        # `dashboard` writes benchmark-report.html into the CURRENT directory and prints
+        # its JSON to STDOUT -- it writes no .json file at all, which is why
+        # benchmark-sentinel.yml's `rust/target/release/*.json` upload has always been an
+        # empty `if-no-files-found: warn`. Redirect it so the artifact actually carries
+        # the numbers.
         run: |
           set -euo pipefail
           mkdir -p sentinel
           cd sentinel
-          "$GITHUB_WORKSPACE/rust-sentinel-msvc/dashboard.exe"
-          ls -l benchmark-report.html
+          "$GITHUB_WORKSPACE/rust-sentinel-msvc/dashboard.exe" > benchmark-report.json
+          ls -l benchmark-report.html benchmark-report.json
       - if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         continue-on-error: true
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -1117,6 +1117,13 @@ jobs:
         # checks, unchanged in substance. `$PPROF` was resolved by the win-gnu half above.
         run: |
           set -euo pipefail
+          # $PPROF is exported by the win-gnu half's `Install pprof` step. Say so out loud:
+          # when the win-gnu rows are eventually deleted, that step goes with them and this
+          # would otherwise fail as an unset-variable error nowhere near the cause.
+          test -n "${PPROF:-}" || {
+            echo "::error::PPROF is unset -- the 'Install pprof' step (win-gnu half) must run before this one"
+            exit 1
+          }
           generator=$(ls rust-bins-msvc/t3_stats-*.exe | head -1)
           MIMALLOC_PPROF_CI_DUMP="$GITHUB_WORKSPACE/heap-msvc.prof" "$generator"
           "$PPROF" -raw "$GITHUB_WORKSPACE/heap-msvc.prof" > raw-msvc.txt
@@ -1362,13 +1369,20 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
-          native_dll=$(find native-msvc-release -name 'mimalloc.dll' | head -1)
-          test -n "$native_dll"
+          # The Visual Studio generator puts per-config output in <build>/<Config>/. Look
+          # there specifically rather than anywhere under the tree: an unqualified find
+          # could pick up an intermediate copy under CMakeFiles/ and compare the wrong PE.
+          native_dll=$(find native-msvc-release/Release -maxdepth 1 -name 'mimalloc.dll' 2>/dev/null | head -1 || true)
+          if [ -z "$native_dll" ]; then
+            echo "::error::the native cl Release tree produced no mimalloc.dll"
+            ls -R native-msvc-release 2>/dev/null | head -40 || true
+            exit 1
+          fi
           uv run ci/pe_imports.py "$native_dll" > native-msvc-imports-dll.txt
           echo "::group::native cl: mimalloc.dll import order"
           cat native-msvc-imports-dll.txt
           echo "::endgroup::"
-          native_probe=$(find native-msvc-release -name 'mimalloc-test-redirect-probe.exe' | head -1)
+          native_probe=$(find native-msvc-release/Release -maxdepth 1 -name 'mimalloc-test-redirect-probe.exe' 2>/dev/null | head -1 || true)
           if [ -n "$native_probe" ]; then
             probe_dir=$(dirname "$native_probe")
             PATH="$PWD/$probe_dir:$PATH" "$native_probe" > native-msvc-probe.txt 2>&1 || true

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -594,12 +594,30 @@ jobs:
     # it is, feeding its now-informational `test (x86_64-pc-windows-msvc)`, until the
     # comparison window closes.
     #
-    # `--workspace`, not `-p mimalloc-pprof`. This job replaces TWO native jobs with
-    # different scopes: cross.yml's row runs the 19 `mimalloc-pprof` test binaries, and
-    # rust-native.yml's `test (windows-latest)` runs `cargo test` across the whole
-    # workspace (110 further tests in bench-harness, benchmark-suite, dashboard and
-    # stress-harness). Building only the narrow set would have cut Windows Rust coverage
-    # by more than half while the coverage table claimed parity.
+    # TWO builds, because this job replaces TWO native jobs with different scopes AND
+    # different profiles, and collapsing them would silently change what is tested:
+    #
+    #   cross.yml `test (x86_64-pc-windows-msvc)`  ->  `-p mimalloc-pprof`, RELEASE
+    #   rust-native.yml `test (windows-latest)`    ->  `--workspace`, DEBUG
+    #
+    # They stage into `dist/msvc-tests/{debug,release}/` rather than one flat directory,
+    # because `t3_stats` and `t12_proto` exist in both and the pprof dump checks stand in
+    # for a release row.
+    #
+    # Building only the narrow set would have cut Windows Rust coverage by more than half
+    # (110 of the workspace's tests live in bench-harness, benchmark-suite, dashboard and
+    # stress-harness) while the coverage table claimed parity.
+    #
+    # Building the workspace in RELEASE instead -- which this job did first -- is not a
+    # free "stricter" choice either. `stress-harness`'s `timing_contract` tests assert
+    # `outer_started.elapsed().as_millis() >= 100` around a 100 ms test-hook sleep; with
+    # the surrounding work optimised away that lands on 99 and the assertion fails. It is
+    # a pre-existing, profile-dependent bug and NOT a Windows or clang-cl one: the same
+    # test binary, built natively for Linux, fails 3/3 in release at --test-threads=1 and
+    # passes 3/3 in debug. `cargo test` is a debug build, which is why no native job has
+    # ever run it. Reported on #277 rather than fixed here -- "changing what any test
+    # asserts" is out of scope for this issue (rule 7), and a test fix is a rust/ commit
+    # (rule 2).
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -628,15 +646,31 @@ jobs:
           # frame-pointer flags either: the profiler does not walk frame pointers on
           # Windows (it uses RtlCaptureStackBackTrace), which is why cross.yml's
           # frame-pointer steps are gated on `apple-darwin`.
-          cargo test --workspace --no-run --target x86_64-pc-windows-msvc --release \
-            --message-format=json > cargo.json || rc=$?
-          jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' cargo.json > bins.txt
-          if [ "$rc" -ne 0 ]; then
-            jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' cargo.json >&2
-            exit "$rc"
-          fi
-          test -s bins.txt
-          mkdir -p dist/x86_64-pc-windows-msvc
+          build() {
+            local label="$1"; shift
+            rc=0
+            cargo test --no-run --target x86_64-pc-windows-msvc "$@" \
+              --message-format=json > "cargo-$label.json" || rc=$?
+            jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' \
+              "cargo-$label.json" > "bins-$label.txt"
+            if [ "$rc" -ne 0 ]; then
+              jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' "cargo-$label.json" >&2
+              exit "$rc"
+            fi
+            test -s "bins-$label.txt"
+          }
+          # rust-native.yml's `test (windows-latest)`: the whole workspace, DEBUG.
+          build workspace-debug --workspace
+          # cross.yml's `test (x86_64-pc-windows-msvc)`: the profiler crate, RELEASE.
+          build pprof-release -p mimalloc-pprof --release
+          # Staged into separate directories, not one flat one. `t3_stats` and `t12_proto`
+          # exist in BOTH sets, and the pprof dump checks stand in for cross.yml's row,
+          # which is a RELEASE row -- a flat directory would leave `ls … | head -1`
+          # picking a profile by hash ordering.
+          mkdir -p dist/msvc-tests/debug dist/msvc-tests/release
+          excluded=""
+          stage() {
+          local label="$1" profile="$2"
           # NOT every workspace test binary can be moved to another machine, and the ones
           # that cannot say so in their own bytes.
           #
@@ -644,7 +678,7 @@ jobs:
           # absolute path of the companion binary in the builder's target directory. Four
           # tests here spawn `stress-child` that way (bench-harness's planted_control,
           # rejections and throughput; dashboard's stress_child), so their binaries carry
-          # a literal `/home/runner/work/.../target/.../release/stress-child.exe`. There
+          # a literal `/home/runner/work/.../target/.../<profile>/stress-child.exe`. There
           # is no env override -- the string is frozen into the image -- and a Linux path
           # cannot be reconstructed on a Windows runner, so shipping `stress-child.exe`
           # alongside them would not help either. Cross-built, they can only run on the
@@ -655,7 +689,9 @@ jobs:
           # of names that would rot the moment a test is added or renamed. This is the
           # same "a portable artifact contains no build-tree absolute path" rule
           # ci/bundle_tests.py enforces on the C bundles.
-          target_root="$PWD/target/x86_64-pc-windows-msvc/release"
+          # Both profiles' output directories: a binary is unrelocatable if it names
+          # either, and the workspace set is built under debug/.
+          target_root="$PWD/target/x86_64-pc-windows-msvc"
           # SELF-TEST FIRST. `grep -F` without `-a` treats these images as binary and can
           # report no match for a string that is demonstrably present -- which would make
           # this scan silently stage an unrelocatable binary and fail much later on the
@@ -663,20 +699,22 @@ jobs:
           # a known-positive before trusting its negatives.
           # The control must contain a NUL, or it is not binary and `grep -F` would match
           # it even WITHOUT `-a` -- a self-test that cannot fail is decoration.
-          printf 'prefix%s/stress-child.exe\000\001tail' "$target_root" > scanner-control.bin
+          printf 'prefix%s/debug/stress-child.exe\000\001tail' "$target_root" > scanner-control.bin
           if ! grep -aqF "$target_root/" scanner-control.bin; then
             echo "::error::the unrelocatable-binary scanner cannot match a path it was just handed; its negatives are worthless"
             exit 1
           fi
           rm -f scanner-control.bin
-          excluded=""
           while read -r bin; do
             if grep -aqF "$target_root/" "$bin" 2>/dev/null; then
               excluded="$excluded $(basename "$bin")"
             else
-              cp "$bin" dist/x86_64-pc-windows-msvc/
+              cp "$bin" "dist/msvc-tests/$profile/"
             fi
-          done < bins.txt
+          done < "bins-$label.txt"
+          }
+          stage workspace-debug debug
+          stage pprof-release release
           if [ -n "$excluded" ]; then
             echo "::warning::not staged (they embed the builder's absolute path via CARGO_BIN_EXE_*, so they cannot run on another machine):$excluded"
             {
@@ -698,14 +736,20 @@ jobs:
           # cross.yml's `test (x86_64-pc-windows-msvc)` has `pprof: true`, so run-windows
           # needs these two specifically. Assert it here, next to the compiler output,
           # instead of letting the consumer fail without saying why.
+          # cross.yml's `test (x86_64-pc-windows-msvc)` has `pprof: true`, and it is a
+          # RELEASE row, so the dump checks must find these in the release set. Assert it
+          # here, next to the compiler output, instead of letting the consumer fail
+          # without saying why.
           for required in t3_stats t12_proto; do
-            if ! ls "dist/x86_64-pc-windows-msvc/$required"-* >/dev/null 2>&1; then
-              echo "::error::$required was not built. Staged binaries:"
-              ls -1 dist/x86_64-pc-windows-msvc || echo "  (none)"
+            if ! ls "dist/msvc-tests/release/$required"-* >/dev/null 2>&1; then
+              echo "::error::$required was not built into the release set. Staged:"
+              ls -1 dist/msvc-tests/release || echo "  (none)"
               exit 1
             fi
           done
-          echo "staged $(ls -1 dist/x86_64-pc-windows-msvc | wc -l) of $(wc -l < bins.txt) test binaries"
+          built=$(cat bins-workspace-debug.txt bins-pprof-release.txt | wc -l)
+          staged=$(( $(ls -1 dist/msvc-tests/debug | wc -l) + $(ls -1 dist/msvc-tests/release | wc -l) ))
+          echo "staged $staged of $built test binaries ($(ls -1 dist/msvc-tests/debug | wc -l) debug + $(ls -1 dist/msvc-tests/release | wc -l) release)"
       - name: Build the PR benchmark sentinel
         # benchmark-sentinel.yml's `benchmark-sentinel (windows-latest)` row runs
         # `soldr cargo run -p dashboard --release`, which is a self-contained binary: it
@@ -726,7 +770,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: rust-test-bins-x86_64-pc-windows-msvc
-          path: rust/dist/x86_64-pc-windows-msvc
+          path: rust/dist/msvc-tests
           if-no-files-found: error
           retention-days: 7
       - uses: actions/upload-artifact@v4
@@ -1157,11 +1201,15 @@ jobs:
         run: |
           set -euo pipefail
           count=0
-          for test_binary in rust-bins-msvc/*.exe; do
-            echo "::group::$(basename "$test_binary")"
-            "$test_binary" --test-threads=4
-            echo "::endgroup::"
-            count=$((count + 1))
+          for profile in debug release; do
+            echo "== $profile =="
+            for test_binary in "rust-bins-msvc/$profile"/*.exe; do
+              [ -e "$test_binary" ] || continue
+              echo "::group::$profile/$(basename "$test_binary")"
+              "$test_binary" --test-threads=4
+              echo "::endgroup::"
+              count=$((count + 1))
+            done
           done
           echo "ran $count MSVC test binaries"
           # A silently-empty artifact would make this step pass having run nothing.
@@ -1181,14 +1229,14 @@ jobs:
             echo "::error::PPROF is unset -- the 'Install pprof' step (win-gnu half) must run before this one"
             exit 1
           }
-          generator=$(ls rust-bins-msvc/t3_stats-*.exe | head -1)
+          generator=$(ls rust-bins-msvc/release/t3_stats-*.exe | head -1)
           MIMALLOC_PPROF_CI_DUMP="$GITHUB_WORKSPACE/heap-msvc.prof" "$generator"
           "$PPROF" -raw "$GITHUB_WORKSPACE/heap-msvc.prof" > raw-msvc.txt
           grep -Eq 'PeriodType: space|heap_v2|inuse_space' raw-msvc.txt
       - name: Prove pprof parses a proto dump (MSVC)
         run: |
           set -euo pipefail
-          generator=$(ls rust-bins-msvc/t12_proto-*.exe | head -1)
+          generator=$(ls rust-bins-msvc/release/t12_proto-*.exe | head -1)
           MIMALLOC_PROF_PROTO_PATH="$GITHUB_WORKSPACE/heap-msvc.pb" "$generator"
           "$PPROF" -raw "$GITHUB_WORKSPACE/heap-msvc.pb" > raw-msvc-pb.txt
           grep -Eq 'inuse_space|alloc_space' raw-msvc-pb.txt

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -318,7 +318,7 @@ jobs:
           test -s bins.txt
           mkdir -p dist/x86_64-pc-windows-gnu
           xargs -r -a bins.txt -I{} cp {} dist/x86_64-pc-windows-gnu/
-          # `test (x86_64-pc-windows-gnu)` has `pprof: true`, so run-windows-gnu needs
+          # `test (x86_64-pc-windows-gnu)` has `pprof: true`, so run-windows needs
           # these two specifically. Assert it here, next to the compiler output, instead
           # of letting the consumer fail without saying why.
           for required in t3_stats t12_proto; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,18 @@ if the sub-issue conflicts with older prose in #2, the sub-issue + #2's Decision
    win-gnu is built, not whether it is tested — soldr's mingw-w64 is **UCRT**, while the
    native MSYS2 MINGW64 jobs it replaces were msvcrt, so those stay informational for a
    ≥10-push window. Keep win-gnu gated; do not drop it to "MSVC covers Windows".
+   The **MSVC** gate is split in two (#277 phase D), and the split is the rule, not an
+   implementation detail. `windows-bundles.yml` cross-builds the MSVC-ABI bundles on Linux
+   with soldr's **clang-cl** and runs them on the same single Windows runner as win-gnu —
+   but **`c-unit.yml`'s `ctest (windows-latest)` (Release) stays native, stays built by
+   Microsoft's `cl`, and stays a hard gate.** A clang-cl binary is not a `cl` binary:
+   clang-cl accepts `__attribute__`s cl rejects, and cl's codegen, TLS lowering and DLL
+   runtime are its own. Do NOT make that job `continue-on-error` and do not delete it
+   without amending this rule explicitly. Every *other* `windows-latest` row is
+   informational for a ≥10-push window and carries a dated TODO. One further consequence:
+   soldr's CRT splat has no `msvcrtd.lib`, so the cross lane is `/MD` only and cannot
+   reproduce the native debug-full job's `/MDd` compile — it reproduces its defines
+   (`MI_DEBUG=3`), which is what `MI_DEBUG_FULL` is for. See docs/ci-gates.md.
 4. **Profiler memory-safety invariant:** profiler-internal memory (sample records, intern table,
    dump buffers) comes ONLY from the raw-OS-layer arena (`_mi_os_alloc`), never from hooked
    allocation paths (`mi_malloc`/`operator new`/`GlobalAlloc`). Debug builds assert this.

--- a/ci/bundle_tests.py
+++ b/ci/bundle_tests.py
@@ -33,11 +33,22 @@ tree does not contain: soldr's mingw-w64 links `mimalloc.dll` against `libgcc_s_
 which does not exist on a plain `windows-latest` runner. `--dll-search-dir` turns on an
 import scan (`--objdump`, transitive) that copies exactly those and refuses to write a
 bundle whose executables import something neither carried nor supplied by Windows itself.
+`--check-dll-closure` runs that same scan with nothing to copy from, which is what the
+clang-cl lane wants: it has no toolchain DLL to ship, but it still must not produce a
+bundle that cannot load.
+
+`--allow-msvc-runtime` additionally accepts the Visual C++ redistributable DLLs
+(`VCRUNTIME140.dll`, `MSVCP140.dll`, ...) as present. They are NOT part of Windows -- they
+come with Visual Studio, which the `windows-latest` image has and a bare Windows install
+does not -- so this is an explicit, per-lane assumption rather than a default, and the job
+that consumes such a bundle is expected to assert they are really there (`where
+VCRUNTIME140.dll`).
 
 Usage:
 
     uv run ci/bundle_tests.py <build-dir> <out-dir> [--config Debug]
                               [--objdump PROG] [--dll-search-dir DIR ...]
+                              [--check-dll-closure] [--allow-msvc-runtime]
 """
 
 from __future__ import annotations
@@ -628,13 +639,42 @@ SYSTEM_DLLS = frozenset(
     )
 )
 
+#: The Visual C++ redistributable. NOT part of Windows -- these ship with Visual Studio,
+#: and a bare Windows install does not have them -- which is why they are a separate set
+#: behind `--allow-msvc-runtime` rather than entries in SYSTEM_DLLS. Every MSVC-ABI build
+#: of this tree imports `VCRUNTIME140.dll`, and `MSVCP140.dll` too once MI_USE_CXX is on
+#: (CMakeLists.txt turns that on by itself for `cl` and clang-cl alike). soldr's xwin splat
+#: carries import libraries only and no redistributable DLLs, so a cross build could not
+#: ship them even if it wanted to; the `windows-latest` image has them in System32.
+MSVC_RUNTIME_DLLS = frozenset(
+    name.lower()
+    for name in (
+        "concrt140.dll",
+        "msvcp140.dll",
+        "msvcp140_1.dll",
+        "msvcp140_2.dll",
+        "msvcp140_atomic_wait.dll",
+        "msvcp140_codecvt_ids.dll",
+        "vcruntime140.dll",
+        "vcruntime140_1.dll",
+    )
+)
+
 #: Files whose imports are worth reading. `.a`/`.lib` import libraries are not loaded at
 #: run time, so they are not scanned even when they sit in the bundle.
 PE_SUFFIXES = (".exe", ".dll")
 
 
-def is_system_dll(name: str) -> bool:
+def is_system_dll(name: str, allow_msvc_runtime: bool = False) -> bool:
+    """True for a DLL the target machine supplies, so the bundle need not carry it.
+
+    `allow_msvc_runtime` widens "the target machine" from "any Windows" to "a machine with
+    the Visual C++ redistributable installed" -- true of `windows-latest`, and an explicit
+    per-lane choice rather than a default.
+    """
     lowered = name.lower()
+    if allow_msvc_runtime and lowered in MSVC_RUNTIME_DLLS:
+        return True
     return lowered in SYSTEM_DLLS or lowered.startswith(SYSTEM_DLL_PREFIXES)
 
 
@@ -656,7 +696,10 @@ def read_pe_imports(path: Path, objdump: str) -> list[str]:
 
 
 def resolve_runtime_dlls(
-    staged: Sequence[Path], search_dirs: Sequence[Path], objdump: str
+    staged: Sequence[Path],
+    search_dirs: Sequence[Path],
+    objdump: str,
+    allow_msvc_runtime: bool = False,
 ) -> list[Path]:
     """Every non-system DLL the staged files import, transitively, found in `search_dirs`.
 
@@ -667,6 +710,10 @@ def resolve_runtime_dlls(
     An import that is neither a system DLL nor findable is a hard error naming both the
     importer and the directories that were searched -- shipping the bundle anyway would
     trade a legible failure here for an unexplained exit code on the Windows runner.
+
+    `search_dirs` may be empty: the scan then copies nothing and is purely the "this bundle
+    can load" assertion, which is what the clang-cl lane needs (it imports no toolchain DLL
+    at all, so there is no directory to point at, but the assertion is still worth making).
     """
     # Case-insensitive, because PE import names are (`KERNEL32.dll` vs `kernel32.dll`) and
     # the search directories live on a case-sensitive filesystem during a cross build.
@@ -685,7 +732,7 @@ def resolve_runtime_dlls(
         current = pending.pop(0)
         for imported in read_pe_imports(current, objdump):
             key = imported.lower()
-            if key in carried or is_system_dll(imported):
+            if key in carried or is_system_dll(imported, allow_msvc_runtime):
                 continue
             resolved = available.get(key)
             if resolved is None:
@@ -794,10 +841,28 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--check-dll-closure",
+        action="store_true",
+        help=(
+            "run the PE import scan even with no --dll-search-dir. Nothing is copied; the "
+            "bundle is only checked for an import it neither carries nor can expect to "
+            "find. Implied by --dll-search-dir."
+        ),
+    )
+    parser.add_argument(
+        "--allow-msvc-runtime",
+        action="store_true",
+        help=(
+            "treat the Visual C++ redistributable DLLs (VCRUNTIME140.dll, MSVCP140.dll, "
+            "...) as supplied by the machine that will run the bundle. They are not part "
+            "of Windows; the consuming job should assert they are present."
+        ),
+    )
+    parser.add_argument(
         "--objdump",
         default="llvm-objdump",
         metavar="PROG",
-        help="objdump used by --dll-search-dir (llvm-objdump or x86_64-w64-mingw32-objdump)",
+        help="objdump used by the PE import scan (llvm-objdump or x86_64-w64-mingw32-objdump)",
     )
     args = parser.parse_args(argv)
 
@@ -818,8 +883,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 seen[source.name] = source
                 unique.append(source)
         runtime_dlls: list[Path] = []
-        if search_dirs:
-            runtime_dlls = resolve_runtime_dlls(unique, search_dirs, objdump)
+        if search_dirs or bool(args.check_dll_closure):
+            runtime_dlls = resolve_runtime_dlls(
+                unique, search_dirs, objdump, bool(args.allow_msvc_runtime)
+            )
             for dll in runtime_dlls:
                 if dll.name not in seen:
                     seen[dll.name] = dll

--- a/ci/tests/test_test_bundles.py
+++ b/ci/tests/test_test_bundles.py
@@ -855,3 +855,52 @@ class RuntimeDllScanTest(unittest.TestCase):
     def test_import_libraries_are_not_scanned(self) -> None:
         found = self._run({"libmimalloc.dll.a": ["nope.dll"]}, ["libmimalloc.dll.a"], [])
         self.assertEqual(found, [])
+
+    # -- the clang-cl lane (#277 phase D) ------------------------------------------------
+
+    def test_the_scan_runs_with_no_search_dir_and_still_rejects(self) -> None:
+        # The MSVC bundles have no toolchain DLL to ship, so there is no directory to
+        # point at -- but "this bundle can load" is still worth asserting, which is what
+        # --check-dll-closure buys. An empty search list must not turn the scan into a
+        # no-op that reports success on a bundle that cannot start.
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            self._run_no_dirs({"t.exe": ["something-else.dll"]}, ["t.exe"])
+        self.assertIn("t.exe imports something-else.dll", str(caught.exception))
+
+    def test_msvc_runtime_dlls_are_rejected_by_default(self) -> None:
+        # VCRUNTIME140.dll is not part of Windows. Defaulting to "assume it is there"
+        # would let the win-gnu lane silently acquire a dependency it cannot satisfy.
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            self._run_no_dirs({"t.exe": ["VCRUNTIME140.dll"]}, ["t.exe"])
+        self.assertIn("t.exe imports VCRUNTIME140.dll", str(caught.exception))
+
+    def test_msvc_runtime_dlls_are_accepted_when_the_lane_says_so(self) -> None:
+        found = self._run_no_dirs(
+            {"t.exe": ["VCRUNTIME140.dll", "MSVCP140.dll", "KERNEL32.dll"]},
+            ["t.exe"],
+            allow_msvc_runtime=True,
+        )
+        # Accepted means "not carried", not "copied in": there is nothing to copy.
+        self.assertEqual(found, [])
+
+    def test_allowing_the_msvc_runtime_does_not_widen_anything_else(self) -> None:
+        with self.assertRaises(bundle_tests.BundleError) as caught:
+            self._run_no_dirs({"t.exe": ["libgcc_s_seh-1.dll"]}, ["t.exe"], allow_msvc_runtime=True)
+        self.assertIn("t.exe imports libgcc_s_seh-1.dll", str(caught.exception))
+
+    def _run_no_dirs(
+        self,
+        imports: dict[str, list[str]],
+        staged: list[str],
+        allow_msvc_runtime: bool = False,
+    ) -> list[Path]:
+        build = self.root / "build"
+        build.mkdir(exist_ok=True)
+        for name in staged:
+            (build / name).write_bytes(b"MZ")
+        return bundle_tests.resolve_runtime_dlls(
+            [build / name for name in staged],
+            [],
+            self._launcher(imports),
+            allow_msvc_runtime,
+        )

--- a/cmake/toolchains/soldr-x86_64-pc-windows-msvc.cmake
+++ b/cmake/toolchains/soldr-x86_64-pc-windows-msvc.cmake
@@ -1,0 +1,133 @@
+# CMake toolchain: build this repository for x86_64 Windows (MSVC ABI), on Linux, through
+# soldr's clang-cl lane.
+#
+# Issue #277 phase D. The MSVC gates are cross-compiled on a Linux runner into portable
+# test bundles (ci/bundle_tests.py) and executed on ONE Windows runner, alongside the
+# windows-gnu bundles phase C already put there.
+#
+# This file consumes ONLY the environment `soldr prepare --target x86_64-pc-windows-msvc`
+# exports; it hardcodes no path and no compiler version.
+#
+#   soldr prepare --target x86_64-pc-windows-msvc --github-env "$GITHUB_ENV"
+#   cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON \
+#         --toolchain cmake/toolchains/soldr-x86_64-pc-windows-msvc.cmake
+#
+# soldr exports (verified with soldr 0.9.11, LLVM 21.1.5, xwin splat 2026-06-22):
+#   CC_x86_64_pc_windows_msvc      `clang-cl`   -- a BARE NAME, resolved from the PATH
+#   CXX_x86_64_pc_windows_msvc     `clang-cl`      soldr prepends, unlike the win-gnu lane
+#   AR_x86_64_pc_windows_msvc      `llvm-lib`      whose CC_ is an absolute program path
+#   CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER   `lld-link`
+#   CFLAGS_x86_64_pc_windows_msvc  the six `/imsvc<dir>` header search paths
+#   CXXFLAGS_x86_64_pc_windows_msvc  the same six
+#   XWIN_CACHE_DIR                 the unpacked CRT + Windows SDK splat
+#
+# soldr exports NO linker search paths for CMake: the three `/LIBPATH:` arguments live
+# only inside CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS, which is a rustc command
+# line. They are derived from XWIN_CACHE_DIR below, in the same layout `soldr prepare`
+# prints -- crt/lib/<arch>, sdk/lib/um/<arch>, sdk/lib/ucrt/<arch>.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR AMD64)
+
+set(_soldr_triple "x86_64_pc_windows_msvc")
+set(_soldr_arch "x86_64")
+
+# Refuse to guess. Without `soldr prepare` in the same shell, CC_<triple> is unset,
+# CMAKE_C_COMPILER would be empty and CMake would fall back to the host `cc` -- producing
+# ELF objects that only fail much later, with an error about the wrong thing.
+foreach(_required CC_${_soldr_triple} CXX_${_soldr_triple} XWIN_CACHE_DIR)
+  if(NOT DEFINED ENV{${_required}})
+    message(FATAL_ERROR
+      "${_required} is not set: run `soldr prepare --target x86_64-pc-windows-msvc` "
+      "(with --github-env \"$GITHUB_ENV\" on CI) before configuring with this toolchain.")
+  endif()
+endforeach()
+
+set(CMAKE_C_COMPILER "$ENV{CC_${_soldr_triple}}")
+set(CMAKE_CXX_COMPILER "$ENV{CXX_${_soldr_triple}}")
+
+# clang-cl accepts `--target=` but CMake drives the MSVC-like driver, which takes `-m64`
+# from the platform module; naming the target triple explicitly keeps a host-native
+# clang-cl (if one is ever ahead of soldr's on PATH) from emitting host code.
+set(CMAKE_C_COMPILER_TARGET "x86_64-pc-windows-msvc")
+set(CMAKE_CXX_COMPILER_TARGET "x86_64-pc-windows-msvc")
+
+if(DEFINED ENV{AR_${_soldr_triple}})
+  set(CMAKE_AR "$ENV{AR_${_soldr_triple}}")
+endif()
+# CMake's Windows-MSVC platform module defaults CMAKE_LINKER to `link`, which on a Linux
+# host is either absent or (worse) GNU coreutils' `link`. soldr names the linker only in
+# its cargo-shaped variable; that is still soldr's own export, so consume it rather than
+# hardcoding a second copy of the string.
+if(DEFINED ENV{CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER})
+  set(CMAKE_LINKER "$ENV{CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER}")
+else()
+  set(CMAKE_LINKER "lld-link")
+endif()
+
+# THE /MD PIN. soldr's CRT splat carries the release import libraries ONLY --
+# `msvcrt.lib` and `libcmt.lib`, with no `msvcrtd.lib`/`libcmtd.lib`, and the SDK side has
+# `ucrt.lib`/`libucrt.lib` with no `ucrtd.lib`. CMake's default for a Debug configuration
+# is MultiThreadedDebugDLL (`/MDd` -> `msvcrtd.lib`), which cannot link here. Pinning the
+# release DLL runtime for every configuration is what makes a Debug-flavoured build
+# possible at all on this lane; it is also the only runtime the `mimalloc-redirect`
+# override can work against, since a statically-linked CRT has no `ucrtbase.dll` to patch.
+# Consequence, recorded in docs/ci-gates.md: this lane cannot reproduce the native
+# `ctest-debug-full (windows-latest)` job's `/MDd` compile, only its DEFINES (see the
+# windows-msvc section there).
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+
+# Headers. Passed as flags rather than CMAKE_C_STANDARD_INCLUDE_DIRECTORIES because
+# `/imsvc` marks them as system headers, which is what suppresses the SDK's own warnings
+# under this tree's `-W`.
+set(CMAKE_C_FLAGS_INIT "$ENV{CFLAGS_${_soldr_triple}}")
+set(CMAKE_CXX_FLAGS_INIT "$ENV{CXXFLAGS_${_soldr_triple}}")
+
+# Libraries, plus the manifest opt-out.
+#
+# `/MANIFEST:NO` is load-bearing and is NOT a cosmetic choice. CMake's Windows-MSVC module
+# wraps every exe/dll link in `cmake -E vs_link_exe --rc=<CMAKE_RC_COMPILER>
+# --mt=<CMAKE_MT> --manifests`, which compiles and embeds a default side-by-side manifest.
+# That needs a resource compiler and an `mt`, and soldr's LLVM ships NEITHER (`llvm-rc`
+# and `llvm-mt` are absent from the bin directory it puts on PATH). Without this flag the
+# lane's outcome depends on whether the host happens to have some other `llvm-rc` ahead on
+# PATH: with one, CMake silently bakes that absolute host path into the cache; without
+# one, `CMAKE_RC_COMPILER` falls back to `rc`, and configure dies inside
+# CMakeTestCCompiler with `RC Pass 1: command "rc /fo .../manifest.rc" failed`. `cmVSLink`
+# parses the link line for `/MANIFEST:NO` and skips the rc/mt pass entirely, so this
+# removes the dependency instead of papering over it. The tree registers no `.rc` source
+# and none of its test executables needs a manifest.
+set(_soldr_msvc_link
+  "/MANIFEST:NO \
+/LIBPATH:$ENV{XWIN_CACHE_DIR}/crt/lib/${_soldr_arch} \
+/LIBPATH:$ENV{XWIN_CACHE_DIR}/sdk/lib/um/${_soldr_arch} \
+/LIBPATH:$ENV{XWIN_CACHE_DIR}/sdk/lib/ucrt/${_soldr_arch}")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "${_soldr_msvc_link}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "${_soldr_msvc_link}")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "${_soldr_msvc_link}")
+
+# The same confinement the other two soldr toolchains carry. CMakeLists.txt's
+# find_link_library() (~648-660) falls back to find_library() when check_linker_flag()
+# rejects a name, and an unconfined search on a Linux host can then hand
+# /usr/lib/x86_64-linux-gnu/librt.so to a PE link. As on windows-gnu this is
+# belt-and-braces rather than load-bearing -- CMake's Windows-MSVC
+# CMAKE_FIND_LIBRARY_SUFFIXES is `.lib;.a`, so a host `.so` is not a candidate -- and the
+# build job asserts on the RESOLVED link library list, which is what would notice if that
+# ever changed.
+set(CMAKE_FIND_ROOT_PATH "$ENV{XWIN_CACHE_DIR}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# NOT set here, on purpose:
+#   MI_USE_CXX -- CMakeLists.txt (~205-212) detects clang-cl by
+#     CMAKE_C_COMPILER_ID=Clang + CMAKE_C_COMPILER_FRONTEND_VARIANT=MSVC and turns it ON
+#     itself, exactly as it does for `cl`. Passing it would be a second source of truth
+#     for something the native jobs already get for free, and `/Zc:__cplusplus` comes
+#     with it.
+#   CMAKE_RC_COMPILER -- see the /MANIFEST:NO note above; nothing compiles a resource.
+
+unset(_soldr_triple)
+unset(_soldr_arch)
+unset(_soldr_msvc_link)

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -702,10 +702,31 @@ The Rust side is where the accounting needed care. `cross.yml`'s
 `test (x86_64-pc-windows-msvc)` runs the 19 `mimalloc-pprof` test binaries;
 `rust-native.yml`'s `test (windows-latest)` runs `cargo test` across the **whole
 workspace**, which is 110 further tests in `bench-harness`, `benchmark-suite`, `dashboard`
-and `stress-harness`. `build-rust (x86_64-pc-windows-msvc)` therefore builds
-`--workspace`, not `-p mimalloc-pprof`: 53 test binaries are built and **49 are executed**
-on the runner. Building only the narrow set would have cut Windows Rust coverage by more
-than half while the table claimed parity.
+and `stress-harness`. They also differ in **profile**, and collapsing that would quietly change what is tested.
+So `build-rust (x86_64-pc-windows-msvc)` runs cargo **twice**, staging into
+`dist/msvc-tests/{debug,release}/`:
+
+| build | stands in for | staged / built |
+|---|---|---:|
+| `cargo test --workspace --no-run` (**debug**) | `rust-native.yml` `test (windows-latest)` | 49 / 53 |
+| `cargo test -p mimalloc-pprof --no-run --release` | `cross.yml` `test (x86_64-pc-windows-msvc)` | 19 / 19 |
+
+**68 test binaries execute on the runner.** Building only the narrow set would have cut
+Windows Rust coverage by more than half while the table claimed parity; building the
+*workspace* in release instead — which this job did first — is not a free "stricter" choice
+either. `stress-harness`'s `timing_contract` tests assert
+`outer_started.elapsed().as_millis() >= 100` around a 100 ms test-hook sleep, and with the
+surrounding work optimised away that lands on 99. Measured, and **not** a Windows or
+clang-cl property: the same test binary built natively for **Linux** fails 3/3 in release
+at `--test-threads=1` and passes 3/3 in debug, on unmodified `main`. `cargo test` is a
+debug build, which is why no native job has ever run it. Reported on #277 rather than
+fixed here — "changing what any test asserts" is out of scope for that issue, and a test
+fix is a `rust/` commit (rule 2).
+
+The two profiles stage into separate directories rather than one flat one because
+`t3_stats` and `t12_proto` exist in both, and the pprof dump checks stand in for a
+*release* row — a flat directory would leave `ls … | head -1` picking a profile by hash
+ordering.
 
 **Four cannot be executed anywhere but the machine that built them, and this is
 structural.** `env!("CARGO_BIN_EXE_<name>")` is expanded by cargo *at compile time* into
@@ -740,9 +761,6 @@ change and out of scope for a CI phase (rule 2, rule 7).
 
 Stated rather than gated:
 
-- **Profile.** The cross-built Rust binaries are `--release` (matching `cross.yml`);
-  `rust-native.yml` ran the workspace in **debug**, so `debug_assertions` is no longer
-  exercised on Windows. It still is on `ubuntu-latest`, which keeps the debug row.
 - **Doctests.** `cargo test` includes the 8 doctests in `rust/mimalloc-pprof/src/lib.rs`;
   cross-built `--tests` binaries cannot. Linux-only since phase B, and now on Windows too.
 - **`xtask check` / `cargo publish --dry-run` / `check_crate_package.py`** are platform-

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -402,7 +402,7 @@ the outcome. See below.
 
 ### The override is gated on the bundle's own binaries
 
-`run-windows-gnu` asserts all of this, as hard failures, on the artifacts it ships:
+`run-windows` (`run-windows-gnu` before phase D) asserts all of this, as hard failures, on the artifacts it ships:
 
 - **the exe's table:** `mimalloc*.dll` is import #0 of `mimalloc-test-stress-dynamic.exe`
   in the release, debug-full and shared bundles. Read with `ci/pe_imports.py`, a PE
@@ -496,7 +496,8 @@ candidate for `find_link_library()` even with the search unconfined (verified bo
 
 ### Coverage accounting
 
-`ci/bundle_coverage.py` runs on every `run-windows-gnu`. The runner installs MSYS2
+`ci/bundle_coverage.py` runs on every `run-windows` (called `run-windows-gnu` before
+phase D). The runner installs MSYS2
 MINGW64, configures the same three CMake trees with **msvcrt gcc**, and the script fails if
 any test name the native `ctest` would run is absent from the bundles. That same MSYS2 step
 is the native compile-compat check: it *builds* the Release tree (no tests — the bundles do
@@ -529,6 +530,225 @@ The native jobs stay as a control arm, `continue-on-error: true`, for at least t
 `test (x86_64-pc-windows-gnu)`. Each carries a dated TODO naming what deletes it. Because
 this phase changes the CRT, that window is the only place the two runtimes are exercised
 side by side — do not delete the msvcrt arm before the comparison has actually happened.
+
+## windows-msvc via cross-built bundles, and the one native `cl` gate that stays
+
+Issue #277 phase D. The same `windows-bundles.yml` that carries the MinGW lane now also
+builds the **MSVC-ABI** test binaries on **ubuntu-latest**, through soldr's `blessed-msvc`
+toolchain — clang-cl + lld-link + llvm-lib against an xwin-materialised Microsoft CRT and
+Windows SDK — and the single `windows-latest` job (`run-windows-gnu` is now
+**`run-windows`**) runs them alongside the win-gnu ones.
+
+| Linux job | produces | replaces |
+|---|---|---|
+| `build-windows-msvc (windows-msvc-x64-release)` | `bundle-windows-msvc-x64-release` | *(comparison arm for the retained native `ctest`)* |
+| `build-windows-msvc (windows-msvc-x64-debug-full)` | `bundle-windows-msvc-x64-debug-full` | `ctest-debug-full (windows-latest)` |
+| `build-windows-msvc (windows-msvc-x64-shared)` | `bundle-windows-msvc-x64-shared` | `ctest-shared (windows-latest)` |
+| `build-windows-msvc (windows-msvc-x64-leak)` | `bundle-windows-msvc-x64-leak` | the positive control half of `memory-gate (windows-latest)` |
+| `build-rust (x86_64-pc-windows-msvc)` | `rust-test-bins-…`, `rust-sentinel-…` | `cross.yml` `test (x86_64-pc-windows-msvc)`, `rust-native.yml` `test (windows-latest)`, `benchmark-sentinel.yml` `benchmark-sentinel (windows-latest)` |
+
+### One native `cl` job is retained, deliberately
+
+CLAUDE.md rule 3 makes MSVC a priority platform. **A clang-cl binary is not a `cl`
+binary**: clang-cl accepts `__attribute__`s that `cl` rejects, and `cl`'s codegen, TLS
+lowering and DLL runtime are its own. So `c-unit.yml`'s **`ctest (windows-latest)`
+(Release) stays native and stays a hard gate** — it is not `continue-on-error`, and it is
+not scheduled for deletion. Every *other* `windows-latest` row in the repository is now
+informational with a dated TODO. Windows runner jobs per push: **13 → 2**.
+
+`run-windows` additionally configures all three MSVC configs with `cl` and builds the
+Release tree. That is not a duplicate gate; it is what gives the coverage comparison a real
+native `ctest` name set, and what lets the job print the native and cross `mimalloc.dll`
+import tables and redirect probes side by side.
+
+### `/MD` only: today's `/MDd` debug-full config cannot be reproduced
+
+soldr's CRT splat carries the **release** import libraries only — `msvcrt.lib`,
+`libcmt.lib`, `ucrt.lib`, `libucrt.lib` — and no `msvcrtd.lib`, `libcmtd.lib` or
+`ucrtd.lib`. `cmake/toolchains/soldr-x86_64-pc-windows-msvc.cmake` therefore pins
+`CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL`. Measured, with that one line removed:
+
+```
+lld-link: error: could not open 'msvcrtd.lib': No such file or directory
+```
+
+`/MD` is also the only runtime the `mimalloc-redirect` override can work against at all: a
+statically-linked CRT has no `ucrtbase.dll` for the module to patch.
+
+**What that costs, precisely.** The `windows-msvc-x64-debug-full` bundle is configured
+`-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_DEBUG_FULL=ON`, *not* `Debug`. That is not
+only the CRT constraint — it is also what reproduces the native job. `ctest-debug-full
+(windows-latest)` runs `cmake -B build -DMI_PPROF=ON -DMI_DEBUG_FULL=ON` with **no `-G`**,
+which selects the Visual Studio generator; `CMAKE_BUILD_TYPE` is empty at configure time,
+so `CMakeLists.txt` (~142-150) defaults it from the binary directory's name — `build` →
+Release. The native job's *resolved* configuration is therefore:
+
+```
+MI_DEBUG=3  MI_GUARDED=1  MI_FREE_IS_CHECKED=1  MI_BUILD_RELEASE   library: mimalloc
+```
+
+which is byte-for-byte what this bundle configures. Passing `-DCMAKE_BUILD_TYPE=Debug`
+would have been *less* faithful: it drops `MI_BUILD_RELEASE` and renames the library
+`mimalloc-debug`. The genuine loss is the **compile flavour** that `--config Debug` selects
+on the multi-config generator: native compiles `/MDd /Od /RTC1`, the bundle `/MD /O2`. The
+assertions and expensive invariant checks — what `MI_DEBUG_FULL` exists for — are
+identical, and the test-name sets are compared on every run.
+
+(#277 phase C correction 4 said phase B's "debug-full is really Release + `MI_DEBUG=3`"
+finding was macOS-only. It is not: it holds for windows-MSVC too, for the different reason
+above. windows-GNU remains the one lane that really does configure `Debug`.)
+
+### Import order: the redirect module must precede the CRT, not be index 0
+
+`mimalloc-redirect.dll` reads `ucrtbase.dll`'s `LDR_DATA_TABLE_ENTRY.Flags` and refuses to
+patch a runtime whose `DllMain` has already run (`LDRP_PROCESS_ATTACH_CALLED`, `0x00080000`
+— disassembled at `0x180003720` in v1.3.3). The loader initialises a module's dependencies
+in *that module's* import-descriptor order, so the requirement is an ordering **inside
+`mimalloc.dll`**.
+
+#277 phase D asked for the redirect module at **import #0**. It is not, on either arm.
+Measured, identically for cross clang-cl and native `cl`:
+
+```
+ADVAPI32.dll  mimalloc-redirect.dll  KERNEL32.dll  MSVCP140.dll  VCRUNTIME140.dll
+api-ms-win-crt-stdio-…  api-ms-win-crt-runtime-…  …
+```
+
+`ADVAPI32.dll` is #0 because `${mi_libraries}` is attached to the target before the
+redirect import library is, and lld-link emits descriptors in link order. It is harmless:
+ADVAPI32 is a KnownDLL whose own subtree uses legacy `msvcrt.dll`, not `ucrtbase`, so
+initialising it first does not set the flag the module checks. **The gate is therefore
+"redirect before every CRT module", not a fixed index** — asserting index 0 would fail a
+layout that works. MinGW needed the `MI_MINGW_REDIRECT_FIRST` trick because `ld` sorted the
+redirect module *behind* `api-ms-win-crt-*`; lld-link needs no equivalent.
+
+### No emulated TLS, asserted
+
+The windows-gnu lane's second bug was GCC emulated TLS: `__thread` became
+`__emutls_get_address`, which allocates with `malloc`, which is `mi_malloc` once the
+override is live — unbounded recursion, dead before `main`, with no diagnostic. clang-cl
+emits real `__declspec(thread)`, so this cannot happen; the build job **asserts** it
+(`__emutls` must not appear in the linked DLL) rather than assuming it, because the failure
+mode is silent.
+
+### The override is gated behaviourally, on the cross-built binary
+
+Same standard as phase C, and the same reason: `mi_is_redirected()` reports only what the
+redirection module *believed* it did, and that flag has been observed true on a binary
+whose own allocations were never touched. `mimalloc-test-redirect-probe` takes a pointer
+from the CRT's own `malloc` and asks `mi_is_in_heap_region`. All three shared-library MSVC
+bundles must print `REDIRECT_BEHAVIOURAL=1`; it is a **hard failure**. The native `cl`
+Release build runs the same probe on the same commit and the two are printed together.
+
+### The runtime DLLs are the runner's, and that is checked
+
+Unlike the mingw lane there is nothing to ship: soldr's xwin splat is import libraries
+only. But `mimalloc.dll` imports **`VCRUNTIME140.dll` and `MSVCP140.dll`** — the latter
+because `CMakeLists.txt` (~205-212) detects clang-cl as MSVC-like and turns `MI_USE_CXX` on
+by itself, exactly as it does for `cl`. Those are the **Visual C++ redistributable, not
+part of Windows**; `windows-latest` has them because Visual Studio is installed.
+
+So the assumption is declared and then checked, in two places:
+
+- `bundle_tests.py --check-dll-closure --allow-msvc-runtime` runs the transitive PE import
+  scan with nothing to copy from, so a bundle that imports anything *else* unresolvable is
+  still refused at build time. `--allow-msvc-runtime` is opt-in and lane-scoped: the
+  win-gnu lane cannot silently acquire a VC++ dependency it could not satisfy.
+- `run-windows` runs `where VCRUNTIME140.dll` / `where MSVCP140.dll` before anything else,
+  so a runner image that dropped them fails with a sentence instead of a dialog-free
+  `0xC0000135`.
+
+### `llvm-rc` is absent, so manifests are off
+
+CMake's Windows-MSVC module wraps every link in `cmake -E vs_link_exe --rc=… --mt=…
+--manifests`, which compiles and embeds a default side-by-side manifest. soldr's LLVM ships
+**neither `llvm-rc` nor `llvm-mt`**. Without an opt-out the lane's outcome depends on
+whether the *host* happens to have some other `llvm-rc` ahead on `PATH`: with one, CMake
+bakes that absolute host path into the cache; without one, `CMAKE_RC_COMPILER` falls back to
+`rc` and configure dies inside `CMakeTestCCompiler` with `RC Pass 1: command "rc /fo
+…/manifest.rc" failed`. The toolchain file passes `/MANIFEST:NO`, which `cmVSLink` parses
+and which skips the rc/mt pass entirely. The tree registers no `.rc` source and none of its
+test executables needs a manifest; hardcoding the `llvm-rc` that lives outside soldr's
+exported `PATH` would have broken the "consume only soldr's env" rule.
+
+### What the build job proves before shipping a bundle
+
+- `file format coff-x86-64`
+- the `/MD` pin **on the artifact**: `prim.c.obj`'s `.drectve` requests `msvcrt.lib` and no
+  `*d.lib` — a flag that never reaches the compiler is this repository's most-repeated CI
+  bug
+- clang-cl was detected as MSVC-like, via `/Zc:__cplusplus` in the resolved compiler flags
+  (the toolchain deliberately does not pass `MI_USE_CXX`; if the detection stopped firing
+  the library would quietly switch from C++ atomics to C11 ones with no other symptom)
+- `.CRT$XLB`, `.CRT$XLY`, `.CRT$XIB` in `prim.c.obj`, **and** a non-empty Thread Storage
+  Directory in the linked DLL
+- no `__emutls` reference anywhere in the DLL
+- `mimalloc-redirect.dll` imported, and ahead of every `api-ms-win-crt-*` / `ucrtbase` /
+  `MSVCP140` / `VCRUNTIME140` descriptor
+- resolved `Link libraries : psapi;shell32;user32;advapi32;bcrypt`, exactly
+- `tests.json` contains no absolute path
+
+`CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY` is set here as well, and as on windows-gnu it is
+belt-and-braces rather than load-bearing: CMake's Windows-MSVC
+`CMAKE_FIND_LIBRARY_SUFFIXES` is `.lib;.a`, so a host `librt.so` is not a candidate.
+
+### Coverage accounting
+
+`ci/bundle_coverage.py` compares all six bundles against native `ctest --show-only`
+enumerations produced on the runner — three from MSYS2 gcc, three from `cl` — and fails if
+a name the native job would run is missing.
+
+The Rust side is where the accounting needed care. `cross.yml`'s
+`test (x86_64-pc-windows-msvc)` runs the 19 `mimalloc-pprof` test binaries;
+`rust-native.yml`'s `test (windows-latest)` runs `cargo test` across the **whole
+workspace**, which is 110 further tests in `bench-harness`, `benchmark-suite`, `dashboard`
+and `stress-harness`. `build-rust (x86_64-pc-windows-msvc)` therefore builds
+`--workspace`, not `-p mimalloc-pprof`: **53 test binaries**, all executed on the runner.
+Building only the narrow set would have cut Windows Rust coverage by more than half while
+the table claimed parity.
+
+Stated rather than gated:
+
+- **Profile.** The cross-built Rust binaries are `--release` (matching `cross.yml`);
+  `rust-native.yml` ran the workspace in **debug**, so `debug_assertions` is no longer
+  exercised on Windows. It still is on `ubuntu-latest`, which keeps the debug row.
+- **Doctests.** `cargo test` includes the 8 doctests in `rust/mimalloc-pprof/src/lib.rs`;
+  cross-built `--tests` binaries cannot. Linux-only since phase B, and now on Windows too.
+- **`xtask check` / `cargo publish --dry-run` / `check_crate_package.py`** are platform-
+  independent (they compare the vendored amalgamation against `src/` and inspect a
+  `.crate` archive). Per #277's review addendum item 5 they are now skipped on the Windows
+  row rather than carried into a bundle; the ubuntu row still runs them.
+- **The PR benchmark sentinel** moves into `run-windows` as a cross-built `dashboard.exe`,
+  guarded on `github.event_name == 'pull_request'` so folding it into a push-triggered
+  workflow does not turn a PR-only benchmark into a per-push one. It is
+  `continue-on-error`: #171/#170 already label hosted-runner numbers informational and no
+  gate reads them, which is also what makes it acceptable to measure on a VM that has just
+  run four ctest suites.
+
+### Memory-gate baseline
+
+The MSVC bundle lane asks for
+`ci/memory-baselines/windows-x64-soldr-clang-cl-21-pprof1.json` via
+`--arch x64 --compiler soldr-clang-cl-21`. It must **not** borrow `windows-pprof1.json`,
+which native `cl` recorded on the same runner — that would be a cross-toolchain comparison
+dressed as a regression check. That file does not exist yet, so the first runs take the
+"no baseline → bootstrap it" path (`memory_gate.py where` exits 3) and upload their JSON;
+the positive control is skipped with a warning until the baseline is committed, because
+`control` requires `check` to *fail* and a missing baseline is not a failure. Same
+follow-up as phase B's correction 8 and phase C's correction 7.
+
+### Rollout
+
+Informational (`continue-on-error`) for at least ten pushes, each with a dated TODO naming
+what deletes it: `c-unit.yml`'s `ctest-debug-full`, `ctest-shared` and `memory-gate`
+**windows rows only**, `rust-native.yml`'s `test (windows-latest)`, `cross.yml`'s
+`test (x86_64-pc-windows-msvc)`, and `benchmark-sentinel.yml`'s
+`benchmark-sentinel (windows-latest)`. When `cross.yml`'s msvc row goes, `build-cross`'s
+`x86_64-pc-windows-msvc` row goes with it — but **not** `aarch64-pc-windows-msvc`, which is
+build-only and has no runner.
+
+`c-unit.yml`'s `ctest (windows-latest)` is **not** on that list and must not be added to it
+without the owner amending CLAUDE.md rule 3.
 
 ## Concurrency: superseded runs are cancelled
 

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -703,9 +703,40 @@ The Rust side is where the accounting needed care. `cross.yml`'s
 `rust-native.yml`'s `test (windows-latest)` runs `cargo test` across the **whole
 workspace**, which is 110 further tests in `bench-harness`, `benchmark-suite`, `dashboard`
 and `stress-harness`. `build-rust (x86_64-pc-windows-msvc)` therefore builds
-`--workspace`, not `-p mimalloc-pprof`: **53 test binaries**, all executed on the runner.
-Building only the narrow set would have cut Windows Rust coverage by more than half while
-the table claimed parity.
+`--workspace`, not `-p mimalloc-pprof`: 53 test binaries are built and **49 are executed**
+on the runner. Building only the narrow set would have cut Windows Rust coverage by more
+than half while the table claimed parity.
+
+**Four cannot be executed anywhere but the machine that built them, and this is
+structural.** `env!("CARGO_BIN_EXE_<name>")` is expanded by cargo *at compile time* into
+the absolute path of a companion binary in the builder's target directory. Four tests spawn
+`stress-child` that way — `bench-harness`'s `planted_control`, `rejections` and
+`throughput`, and `dashboard`'s `stress_child` — so their images carry a literal
+`/home/runner/work/…/target/x86_64-pc-windows-msvc/release/stress-child.exe`. There is no
+environment override (the string is frozen into the binary), and a Linux path cannot be
+reconstructed on a Windows runner, so shipping `stress-child.exe` beside them would not
+help either. They fail with `expect("valid normal benchmark")` — measured, on the first
+green-everywhere-else run of this lane.
+
+They are excluded by **detecting the property**, not by a hardcoded list of names that
+would rot the moment a test is added or renamed: the build job greps each staged image for
+the builder's own target path, which is the same "a portable artifact contains no
+build-tree absolute path" rule `ci/bundle_tests.py` enforces on the C bundles. Two guards
+around it:
+
+- the scanner **self-tests on a known-positive first** (a control file containing that path
+  *and a NUL byte*, so it is genuinely binary). `grep -F` without `-a` reports no match on
+  binary input, which would silently stage an unrelocatable binary and surface much later
+  as a panic that says nothing about paths — the scan's negatives are only worth having if
+  its positives are proven;
+- a `mimalloc-pprof` test binary landing in the excluded set is a **hard error**. That
+  crate is the reason the lane exists, and losing it silently is exactly the failure this
+  phase is meant to make impossible.
+
+Those four tests still run on `ubuntu-latest`, where builder and runner are the same
+machine. Restoring them on Windows needs an upstream change to the tests (resolve
+`stress-child` relative to `current_exe()` instead of `CARGO_BIN_EXE_*`), which is a Rust
+change and out of scope for a CI phase (rule 2, rule 7).
 
 Stated rather than gated:
 


### PR DESCRIPTION
Closes the Windows half of #277: the MSVC-ABI test binaries are now cross-built on
`ubuntu-latest` through soldr's `blessed-msvc` lane (clang-cl 21.1.5 + lld-link + llvm-lib
against an xwin-materialised MS CRT and Windows SDK) and executed on the **same single
Windows runner** phase C created. `run-windows-gnu` is renamed **`run-windows`** and now
carries both lanes.

**Windows runner jobs per push: 13 → 2.**

## Rule 3: one native `cl` job is retained, and that is now written down

CLAUDE.md rule 3 makes MSVC a priority platform. **A clang-cl binary is not a `cl`
binary** — clang-cl accepts `__attribute__`s cl rejects, and cl's codegen, TLS lowering and
DLL runtime are its own. So `c-unit.yml`'s **`ctest (windows-latest)` (Release) stays
native and stays a hard gate**: not `continue-on-error`, not scheduled for deletion, with a
comment on the job saying it must not become either without the owner amending rule 3.
Rule 3 and `docs/ci-gates.md` both say so now.

Every *other* `windows-latest` row is informational for the ≥10-push window, each with a
dated TODO: `c-unit.yml`'s `ctest-debug-full` / `ctest-shared` / `memory-gate` (windows
rows only — the ubuntu rows stay hard gates), `rust-native.yml`'s `test (windows-latest)`,
`cross.yml`'s `test (x86_64-pc-windows-msvc)`, and `benchmark-sentinel.yml`'s
`benchmark-sentinel (windows-latest)`.

## The override works in the cross-built artifact, and it is gated behaviourally

The owner requirement — a cross-compiled artifact must behave like a native one — is gated
the way phase C gated it. All three shared-library MSVC bundles must print
`REDIRECT_BEHAVIOURAL=1` from `mimalloc-test-redirect-probe` (a pointer from the CRT's own
`malloc` landing in a mimalloc region), a **hard failure**. `mi_is_redirected()` is not the
gate: phase C established that it reports true on binaries whose allocations were never
touched. `run-windows` also builds the native `cl` Release tree on the same commit, so the
two arms' import tables and probes are printed side by side.

## Three corrections to #277's phase D row, all measured

**1. `mimalloc-redirect.dll` is not import #0, and does not need to be.** Both arms produce:

```
ADVAPI32.dll  mimalloc-redirect.dll  KERNEL32.dll  MSVCP140.dll  VCRUNTIME140.dll
api-ms-win-crt-stdio-…  api-ms-win-crt-runtime-…  …
```

`ADVAPI32.dll` is #0 because `${mi_libraries}` is attached to the target before the
redirect import library is. It is harmless: the module bails only when `ucrtbase`'s
`LDRP_PROCESS_ATTACH_CALLED` is already set, and ADVAPI32 is a KnownDLL whose subtree uses
legacy `msvcrt.dll`. The gate is therefore **"redirect before every CRT module"**, not a
fixed index — asserting #0 would fail a layout that works. lld-link needs no
`MI_MINGW_REDIRECT_FIRST` equivalent.

**2. "clang-cl links against the system UCRT — no extra runtime DLLs expected" is wrong.**
`mimalloc.dll` imports `VCRUNTIME140.dll` **and** `MSVCP140.dll` (the latter because
`CMakeLists.txt` ~205-212 detects clang-cl as MSVC-like and turns `MI_USE_CXX` on itself,
exactly as for `cl` — so the workflow does *not* pass it, it asserts the detection still
fires via `/Zc:__cplusplus`). Those are the Visual C++ redistributable, **not part of
Windows**, and soldr's splat has import libraries only so they cannot be shipped. Declared
via a new `bundle_tests.py --allow-msvc-runtime` (opt-in and lane-scoped, so the win-gnu
lane cannot silently acquire a VC++ dependency) and **checked** with `where` on the runner
before anything runs.

**3. `llvm-rc` is not in soldr's exported toolchain, and CMake's MSVC link rule needs one.**
`cmake -E vs_link_exe --rc=… --mt=… --manifests` embeds a default manifest on every link.
soldr's LLVM ships neither `llvm-rc` nor `llvm-mt`. Without an opt-out the lane's outcome
depends on the host: with a stray `llvm-rc` on `PATH`, CMake bakes an absolute host path
into the cache; without one, configure dies inside `CMakeTestCCompiler` with
`RC Pass 1: command "rc /fo …/manifest.rc" failed`. The toolchain passes `/MANIFEST:NO`,
which `cmVSLink` parses and which skips the rc/mt pass entirely. Verified by configuring
with every `llvm-rc` removed from `PATH`.

## The `/MD` pin, and what debug-full really is

The pin is load-bearing and verified — with that one line removed:

```
lld-link: error: could not open 'msvcrtd.lib': No such file or directory
```

The `windows-msvc-x64-debug-full` bundle is configured **`Release` + `MI_DEBUG_FULL`**, not
`Debug` — and that is not only the CRT constraint, it is what reproduces the native job.
`ctest-debug-full (windows-latest)` passes no `-G`, so the Visual Studio generator takes
the build type from `--config` and leaves `CMAKE_BUILD_TYPE` at its `build`-directory
default of Release. The native job's *resolved* configuration is
`MI_DEBUG=3 MI_GUARDED=1 MI_FREE_IS_CHECKED=1 MI_BUILD_RELEASE`, library `mimalloc` — which
this bundle reproduces exactly. Passing `Debug` would be *less* faithful (it drops
`MI_BUILD_RELEASE` and renames the library). The genuine loss is the compile flavour:
`/MD /O2` vs `/MDd /Od /RTC1`. The assertions and expensive invariant checks — what
`MI_DEBUG_FULL` is for — are identical.

*(This also corrects phase C's correction 4: phase B's "debug-full is really Release +
`MI_DEBUG=3`" finding is not macOS-only, it holds for windows-MSVC too, for the different
reason above. windows-GNU remains the one lane that really configures `Debug`.)*

## Coverage

`build-rust (x86_64-pc-windows-msvc)` runs cargo **twice**, because it replaces two native
jobs that differ in scope *and* in profile — collapsing them would quietly change what is
tested:

| build | stands in for | staged / built |
|---|---|---:|
| `cargo test --workspace --no-run` (**debug**) | `rust-native.yml` `test (windows-latest)` | 49 / 53 |
| `cargo test -p mimalloc-pprof --no-run --release` | `cross.yml` `test (x86_64-pc-windows-msvc)` | 19 / 19 |

**68 test binaries execute on the runner** (`ran 68 MSVC test binaries`). Building only the
narrow set would have cut Windows Rust coverage by more than half while the table claimed
parity.

Two pre-existing Rust-side defects surfaced along the way. Neither is a clang-cl, MSVC or
cross-compilation property — **both reproduce natively** — so both are reported on #277
rather than fixed here (rule 7; "changing what any test asserts" is out of scope for that
issue, and a test fix is a `rust/` commit under rule 2). Full write-up:
https://github.com/zackees/mimalloc-pprof/issues/277#issuecomment-5511396609

1. **Four test binaries cannot leave the machine that built them.**
   `env!("CARGO_BIN_EXE_<name>")` is expanded at *compile time* into the builder's absolute
   path, so `bench-harness`'s `planted_control`/`rejections`/`throughput` and `dashboard`'s
   `stress_child` carry a literal `/home/runner/.../stress-child.exe`. Excluded by
   **detecting the property** (grep each image for the builder's target path) rather than a
   name list that would rot; the scanner self-tests on a NUL-containing control first,
   because `grep -F` without `-a` silently matches nothing on binaries — which is exactly
   how the first cut of this scan was a false green. A `mimalloc-pprof` binary landing in
   that set is a hard error.
2. **`stress-harness`'s `timing_contract` tests only pass in a debug build.** They assert
   `outer_started.elapsed().as_millis() >= 100` around a 100 ms sleep; optimised, that
   lands on 99. The same binary built natively for **Linux** fails 3/3 in release at
   `--test-threads=1` and passes 3/3 in debug, on unmodified `main`. `cargo test` is a
   debug build, which is why no native job has ever run it.

Stated rather than gated, in `docs/ci-gates.md`:

- doctests cannot run from `--tests` binaries (Linux-only since phase B, now on Windows too);
- `xtask check` / `cargo publish --dry-run` / `check_crate_package.py` are platform-
  independent and are now skipped on the Windows row per #277's addendum item 5, rather
  than carried into a bundle;
- the PR sentinel moves into `run-windows` as a cross-built `dashboard.exe`, guarded on
  `github.event_name == 'pull_request'` so folding it into a push-triggered workflow does
  not turn a PR-only benchmark into a per-push one, and `continue-on-error` because #171 /
  #170 already label hosted-runner numbers informational. (Incidentally: `dashboard` prints
  its JSON to stdout and writes no `.json` file, which is why `benchmark-sentinel.yml`'s
  `rust/target/release/*.json` upload has always been empty. The new step redirects it.)

## Memory gate

`--arch x64 --compiler soldr-clang-cl-21`, so it cannot borrow `windows-pprof1.json` which
native `cl` recorded on the same runner. That baseline does not exist yet, so the lane
bootstraps yellow (`where` rc 3) and its positive control is skipped with a warning until
`ci/memory-baselines/windows-x64-soldr-clang-cl-21-pprof1.json` is committed from the
artifact — same follow-up as phase B's correction 8 and phase C's correction 7.

## Verification

`run-windows` is **green in 11m34s** on one `windows-latest` VM: 29/29 + 36/36 + 27/27
win-gnu and 28/28 + 35/35 + 26/26 MSVC against `cl`-configured trees ("Every test in the
native side is present in the bundle side"), `REDIRECT_BEHAVIOURAL=1` on all three MSVC
bundles *and* on the native `cl` build, 68 Rust test binaries, both pprof dump checks, both
memory gates and the sentinel.

Spiked locally on Linux before any YAML was written: all four configs configure and build,
`/MD` confirmed on the artifact (`prim.c.obj` `.drectve` requests `msvcrt.lib`, no `*d.lib`),
`file format coff-x86-64`, `.CRT$XLB`/`$XLY`/`$XIB` present, non-empty Thread Storage
Directory, **no `__emutls` anywhere**, and four bundles with zero absolute paths. `ruff`,
`pyright` (0 errors), `pytest ci/tests` (215 passed, 4 new) and
`uv run ci/verify_local.py --keep-going` all green.

Refs #277. Do not merge before CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
