### PR TITLE
ci: zero-tracking and release assets from cross-built bundles; verify_local --bundle (#277 phases E+F)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,6 +1,47 @@
 name: auto-release
 
-# Cuts a release of the mimalloc-pprof C amalgamation + crates.io publish.
+# Cuts a release of the mimalloc-pprof C amalgamation + crates.io publish, plus the
+# cross-built binary assets (#277 phase E).
+#
+# WHO BUILDS THE SHIPPED BINARIES -- the decision, and why it is not the one #277's
+# phase table first wrote down:
+#
+#   Every binary release asset is CROSS-BUILT ON LINUX through soldr. Not one of them is
+#   produced by the platform's own toolchain on that platform's own runner.
+#
+# #277 row E originally said "shipped release assets stay built by the platform's own
+# toolchain". Two owner decisions since then overrode it:
+#
+#   1. No macOS build or test may run on a native Mac runner anywhere in this repository
+#      (enforced by ci/lint_no_macos_runners.py, which this workflow is checked by). There
+#      is therefore no Apple toolchain available to build an Apple asset with.
+#   2. Cross-compilation is a PRODUCT requirement, not a CI cost measure: mimalloc-pprof
+#      ships inside cross-compiled code, so the Linux-cross-built artifact IS the product.
+#      Shipping a natively-built binary while testing a cross-built one would mean the
+#      thing under test and the thing shipped are different binaries.
+#
+# So: the same `soldr prepare` toolchains, the same `cmake/toolchains/soldr-<triple>.cmake`
+# toolchain files and the same commit that produce the test bundles executed by
+# `macos-bundles.yml` and `windows-bundles.yml` also produce these assets. The bundles are
+# the evidence for the assets.
+#
+# What that costs, stated rather than hidden:
+#   - macOS assets are built by soldr's clang 21 against soldr's Apple SDK, NOT by Xcode's
+#     clang against Xcode's SDK. Nothing in this repository compiles with Apple's toolchain
+#     any more (docs/ci-gates.md, "macOS").
+#   - The `windows-x64-msvc` asset is MSVC-ABI, but built by clang-cl + lld-link with the
+#     CRT pinned to /MD -- it is not a `cl` binary. c-unit.yml keeps one native `cl`
+#     Release ctest job as the correctness gate for `cl` (CLAUDE.md rule 3); that job ships
+#     nothing, and never did. There has never been a natively-built release asset here to
+#     "retain".
+#   - The `windows-x64-gnu` asset is mingw-w64 gcc 15 UCRT. `mimalloc.dll` imports
+#     `libgcc_s_seh-1.dll` (for `__popcountdi2`), which a plain Windows machine does not
+#     have, so the archive SHIPS that DLL beside it and the job asserts the whole import
+#     closure resolves. Shipping it (rather than relinking `-static-libgcc`) keeps the
+#     shipped binary byte-identical to the one `windows-bundles.yml` tests.
+#   - The `windows-x64-msvc` asset imports VCRUNTIME140.dll/MSVCP140.dll: the Visual C++
+#     redistributable, which is not part of Windows. Recorded in the archive's
+#     PROVENANCE.txt rather than silently assumed.
 #
 # Trigger design (see rust/mimalloc-pprof/vendor/README.md for what gets shipped):
 #   - workflow_dispatch: manual, explicit human/agent decision. Default `dry_run: true`
@@ -41,12 +82,14 @@ env:
 
 jobs:
   build-and-package:
-    name: Build, validate, package (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    name: Build, validate, package (ubuntu-latest)
+    # One row, not a matrix. #277's review addendum, item 5: everything this job does --
+    # `xtask check`, `cargo test`, `cargo publish --dry-run`, and packaging a vendored C
+    # amalgamation that is architecture-independent -- is platform-independent, so the
+    # `windows-latest` row it used to carry was a second Windows queue slot per release
+    # that verified nothing the ubuntu row does not. The binaries are built by
+    # `build-binaries` below, on Linux, for every shipped platform.
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rust
@@ -83,10 +126,7 @@ jobs:
       - name: cargo publish --dry-run (mimalloc-pprof)
         run: soldr cargo publish --dry-run -p mimalloc-pprof --locked
 
-      # The vendor/ contents are identical across the matrix (xtask check above just
-      # proved that); only one OS needs to actually produce the release ZIP.
       - name: Package release ZIP (vendor/ files only)
-        if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           set -euo pipefail
@@ -102,16 +142,252 @@ jobs:
           cp "$RUNNER_TEMP/mimalloc-pprof-c.zip" dist/
 
       - name: Upload release ZIP artifact
-        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: mimalloc-pprof-c-zip
           path: rust/dist/mimalloc-pprof-c.zip
           if-no-files-found: error
 
+  # ---------------------------------------------------------------------------------
+  # The shipped binaries. Four lanes, all on Linux, all through soldr -- see this file's
+  # header for why none of them runs on the platform it targets, and docs/ci-gates.md
+  # ("Release assets are cross-built") for the same decision written out at length.
+  #
+  # These use the SAME toolchain files and the SAME `soldr prepare` targets as
+  # macos-bundles.yml and windows-bundles.yml, so the binary a release ships is produced
+  # by the toolchain whose output those workflows actually execute. Locally reproducible
+  # with `uv run ci/verify_local.py --bundle <lane>-release` (#277 phase F), which builds
+  # the test bundle from the same configure line plus MI_BUILD_TESTS.
+  build-binaries:
+    name: Cross-build release binaries (${{ matrix.asset }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - asset: macos-arm64
+            triple: aarch64-apple-darwin
+            archive: tar.gz
+          - asset: macos-x86_64
+            triple: x86_64-apple-darwin
+            archive: tar.gz
+          - asset: windows-x64-gnu
+            triple: x86_64-pc-windows-gnu
+            archive: zip
+          - asset: windows-x64-msvc
+            triple: x86_64-pc-windows-msvc
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - uses: zackees/setup-soldr@v0
+        with:
+          # This job drives CMake directly; there is no `soldr cargo` for zccache to wrap.
+          cache: false
+          toolchain-file: rust/rust-toolchain.toml
+          lockfile: rust/Cargo.lock
+          target-dir: rust/target
+      - name: Cache the prepared ${{ matrix.triple }} toolchain
+        uses: actions/cache@v4
+        with:
+          # Deliberately the same path and key macos-bundles.yml / windows-bundles.yml use,
+          # so a release run hits the cache those workflows already warmed on this commit.
+          path: ~/soldr-${{ matrix.triple }}.tar.zst
+          key: soldr-prepare-${{ matrix.triple }}-${{ hashFiles('rust/rust-toolchain.toml') }}
+      - name: Prepare the soldr ${{ matrix.triple }} toolchain
+        # `soldr prepare` resolves rustc from a rust-toolchain.toml at or above the working
+        # directory, which is why this runs in rust/.
+        working-directory: rust
+        env:
+          TRIPLE: ${{ matrix.triple }}
+        run: |
+          set -euo pipefail
+          archive="$HOME/soldr-$TRIPLE.tar.zst"
+          args=(--target "$TRIPLE" --github-env "$GITHUB_ENV" --save "$archive")
+          if [ -f "$archive" ]; then
+            args=(--restore "$archive" "${args[@]}")
+          fi
+          soldr prepare "${args[@]}"
+      - name: Configure, build and install
+        # MI_BUILD_TESTS=OFF is the only difference from the bundle lanes' Release
+        # configure line: a release asset ships the library, not 35 test executables.
+        # The install rules carry this fork's own headers (include/mimalloc/profile.h and
+        # memory-events.h) as well as upstream's, plus the pkg-config and CMake package
+        # files and, on Windows, mimalloc-redirect.dll -- verified on all four lanes.
+        run: |
+          set -euo pipefail
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BUILD_TESTS=OFF \
+            --toolchain cmake/toolchains/soldr-${{ matrix.triple }}.cmake \
+            --log-level=VERBOSE 2>&1 | tee configure.log
+          # Assert on the RESOLVED library list, not on the option that was passed in --
+          # the MI_GUARDED lesson from docs/ci-gates.md. On Darwin this is load-bearing:
+          # without the toolchain file's find-root confinement, CMakeLists.txt's
+          # find_link_library() hands the host's ELF librt.so to a Mach-O link.
+          case "${{ matrix.triple }}" in
+            *-apple-darwin) want='pthread' ;;
+            *)              want='psapi;shell32;user32;advapi32;bcrypt' ;;
+          esac
+          if ! grep -qE "^-- Link libraries *: *${want}\$" configure.log; then
+            echo "::error::the ${{ matrix.triple }} link resolved unexpected libraries; expected exactly '${want}'"
+            grep -E 'Link libraries' configure.log || true
+            exit 1
+          fi
+          cmake --build build --parallel
+          cmake --install build --prefix "$PWD/stage"
+      - name: Ship the toolchain runtime DLLs, and prove the import closure resolves
+        # windows-gnu only in effect: soldr's mingw-w64 links mimalloc.dll against
+        # libgcc_s_seh-1.dll (for __popcountdi2), which a plain Windows machine does not
+        # have -- and a missing DLL is a dialog-free 0xC0000135, not a legible error. The
+        # scan is the same one ci/bundle_tests.py runs for the test bundles, called
+        # directly so the asset and the tested bundle make the same guarantee.
+        #
+        # --allow-msvc-runtime for the MSVC-ABI lane: VCRUNTIME140.dll/MSVCP140.dll are the
+        # Visual C++ redistributable, not part of Windows. That is a real requirement on
+        # the consumer, so it is recorded in PROVENANCE.txt below rather than papered over.
+        if: startsWith(matrix.triple, 'x86_64-pc-windows')
+        env:
+          TRIPLE: ${{ matrix.triple }}
+        run: |
+          set -euo pipefail
+          if [ "$TRIPLE" = "x86_64-pc-windows-gnu" ]; then
+            objdump="$MINGW_W64_CROSS_BIN/x86_64-w64-mingw32-objdump"
+            search="$MINGW_W64_CROSS_ROOT/x86_64-w64-mingw32/lib"
+            allow_msvc=0
+          else
+            objdump=llvm-objdump
+            search=""
+            allow_msvc=1
+          fi
+          OBJDUMP="$objdump" SEARCH="$search" ALLOW_MSVC="$allow_msvc" uv run python - <<'PY'
+          import os, shutil, sys
+          from pathlib import Path
+          sys.path.insert(0, "ci")
+          from bundle_tests import resolve_runtime_dlls
+          stage = Path("stage")
+          staged = [p for p in stage.rglob("*") if p.suffix.lower() in (".dll", ".exe")]
+          if not staged:
+              sys.exit("no PE files were installed into stage/ -- nothing to ship")
+          dirs = [Path(os.environ["SEARCH"])] if os.environ["SEARCH"] else []
+          extra = resolve_runtime_dlls(
+              staged, dirs, os.environ["OBJDUMP"], os.environ["ALLOW_MSVC"] == "1"
+          )
+          for src in extra:
+              shutil.copy2(src, stage / "bin" / src.name)
+              print(f"shipping toolchain runtime: {src}")
+          print(f"import closure resolves for {len(staged)} PE file(s)")
+          PY
+      - name: Prove the asset is really for ${{ matrix.asset }}
+        # A release that silently shipped host ELF objects under a macOS name is the
+        # failure this whole cross-built design risks. Assert on the artifact.
+        env:
+          TRIPLE: ${{ matrix.triple }}
+        run: |
+          set -euo pipefail
+          echo "## ${{ matrix.asset }}" >> "$GITHUB_STEP_SUMMARY"
+          case "$TRIPLE" in
+            aarch64-apple-darwin)
+              llvm-objdump --macho --private-headers stage/lib/libmimalloc.3*.dylib | tee hdr.txt
+              grep -E 'MH_MAGIC_64 +ARM64' hdr.txt
+              ;;
+            x86_64-apple-darwin)
+              llvm-objdump --macho --private-headers stage/lib/libmimalloc.3*.dylib | tee hdr.txt
+              grep -E 'MH_MAGIC_64 +X86_64' hdr.txt
+              ;;
+            x86_64-pc-windows-gnu)
+              "$MINGW_W64_CROSS_BIN/x86_64-w64-mingw32-objdump" -f stage/bin/mimalloc.dll | tee hdr.txt
+              grep -q 'file format pei-x86-64' hdr.txt
+              test -f stage/bin/mimalloc-redirect.dll
+              test -f stage/bin/libgcc_s_seh-1.dll
+              ;;
+            x86_64-pc-windows-msvc)
+              llvm-objdump -f stage/bin/mimalloc.dll | tee hdr.txt
+              grep -q 'file format coff-x86-64' hdr.txt
+              test -f stage/bin/mimalloc-redirect.dll
+              ;;
+          esac
+          {
+            echo '```'
+            find stage -type f -o -type l | sort
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Write PROVENANCE.txt
+        # The archive has to say what built it and what the consumer still needs. A user
+        # who downloads `windows-x64-msvc` and finds it needs the VC++ redistributable
+        # should learn that from the archive, not from a linker error.
+        env:
+          TRIPLE: ${{ matrix.triple }}
+        run: |
+          set -euo pipefail
+          {
+            echo "mimalloc-pprof ${GITHUB_REF_NAME} -- ${{ matrix.asset }}"
+            echo
+            echo "commit:   ${GITHUB_SHA}"
+            echo "target:   ${TRIPLE}"
+            echo "built on: ubuntu-latest (Linux), cross-compiled through soldr $(soldr --version 2>/dev/null || echo '?')"
+            echo "config:   -DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BUILD_TESTS=OFF"
+            echo
+            echo "This binary was NOT built on the platform it targets. Every mimalloc-pprof"
+            echo "release asset is cross-compiled on Linux, deliberately: mimalloc-pprof ships"
+            echo "inside cross-compiled code, so the cross-built artifact is the product, and"
+            echo "it is the artifact this project's CI actually executes its test suite from"
+            echo "(.github/workflows/macos-bundles.yml, windows-bundles.yml)."
+            echo
+            case "${TRIPLE}" in
+              *-apple-darwin)
+                echo "compiler: soldr's clang (LLVM 21) + ld64.lld, against soldr's Apple SDK."
+                echo "          Not Xcode's clang and not Xcode's SDK."
+                echo "requires: nothing beyond the deployment target recorded in the Mach-O"
+                echo "          load commands."
+                ;;
+              x86_64-pc-windows-gnu)
+                echo "compiler: soldr's mingw-w64 gcc 15 (UCRT), not MSYS2's msvcrt lane."
+                echo "requires: libgcc_s_seh-1.dll, SHIPPED in bin/ beside mimalloc.dll."
+                echo "          mimalloc.dll imports it for __popcountdi2; keep them together."
+                ;;
+              x86_64-pc-windows-msvc)
+                echo "compiler: clang-cl + lld-link (LLVM 21), MSVC ABI, CRT pinned to /MD."
+                echo "          This is NOT a \`cl\` binary. A native \`cl\` Release ctest job"
+                echo "          remains a hard CI gate for cl compatibility (CLAUDE.md rule 3),"
+                echo "          but it ships nothing."
+                echo "requires: the Visual C++ redistributable (VCRUNTIME140.dll, MSVCP140.dll)."
+                echo "          These are not part of Windows."
+                ;;
+            esac
+            echo
+            echo "layout:   bin/ runtime DLLs (Windows), lib/ import+static libraries and the"
+            echo "          CMake package + pkg-config files, include/ headers (this fork's"
+            echo "          mimalloc/profile.h and mimalloc/memory-events.h included)."
+          } > stage/PROVENANCE.txt
+          cat stage/PROVENANCE.txt
+      - name: Archive
+        # tar.gz for macOS: the libmimalloc.dylib -> libmimalloc.3.dylib SONAME chain is
+        # symlinks, which zip does not preserve. zip for Windows, where nothing is a
+        # symlink and a .zip is what a Windows consumer can open with no extra tool.
+        env:
+          ASSET: ${{ matrix.asset }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          name="mimalloc-pprof-${ASSET}"
+          if [ "${{ matrix.archive }}" = "tar.gz" ]; then
+            tar -C stage -czf "dist/${name}.tar.gz" .
+          else
+            (cd stage && zip -r "$GITHUB_WORKSPACE/dist/${name}.zip" .)
+          fi
+          ls -l dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries-${{ matrix.asset }}
+          path: dist/*
+          if-no-files-found: error
+
   release:
     name: Create GitHub Release + publish to crates.io
-    needs: build-and-package
+    # build-binaries is a hard dependency, not a best-effort extra: a release that
+    # published to crates.io and then shipped three of its four platform archives would be
+    # a release nobody can tell is incomplete. `release-outcome` says so out loud too.
+    needs: [build-and-package, build-binaries]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -144,6 +420,15 @@ jobs:
           name: mimalloc-pprof-c-zip
           path: dist
 
+      - name: Download the cross-built binary assets
+        uses: actions/download-artifact@v4
+        with:
+          # merge-multiple so all four land directly in dist/ rather than in one
+          # subdirectory each -- the rename step and `files:` below both glob dist/.
+          pattern: release-binaries-*
+          merge-multiple: true
+          path: dist
+
       - name: Determine release tag
         id: tag
         shell: bash
@@ -167,11 +452,33 @@ jobs:
           fi
           echo "tag version $tag_version matches Cargo.toml version $cargo_version"
 
-      - name: Rename ZIP to versioned artifact name
+      - name: Rename assets to versioned artifact names, and require all five
+        # Five, counted: the architecture-independent C amalgamation ZIP plus one archive
+        # per cross lane. `needs:` already makes a failed lane fail this job, but an
+        # artifact that uploaded *nothing* under a green step would otherwise reach
+        # softprops/action-gh-release as a silently shorter `files:` list.
         shell: bash
         run: |
           set -euo pipefail
-          mv dist/mimalloc-pprof-c.zip "dist/mimalloc-pprof-c-${{ steps.tag.outputs.tag }}.zip"
+          tag='${{ steps.tag.outputs.tag }}'
+          mv dist/mimalloc-pprof-c.zip "dist/mimalloc-pprof-c-${tag}.zip"
+          for asset in macos-arm64 macos-x86_64 windows-x64-gnu windows-x64-msvc; do
+            case "$asset" in macos-*) ext=tar.gz ;; *) ext=zip ;; esac
+            src="dist/mimalloc-pprof-${asset}.${ext}"
+            if [ ! -f "$src" ]; then
+              echo "::error::${src} was not produced by build-binaries; refusing to cut a release missing the ${asset} asset"
+              ls -l dist
+              exit 1
+            fi
+            mv "$src" "dist/mimalloc-pprof-${asset}-${tag}.${ext}"
+          done
+          count=$(ls dist | wc -l)
+          if [ "$count" -ne 5 ]; then
+            echo "::error::expected exactly 5 release assets, found ${count}"
+            ls -l dist
+            exit 1
+          fi
+          ls -l dist
 
       - name: cargo publish (mimalloc-pprof)
         if: env.IS_DRY_RUN != 'true'
@@ -219,14 +526,21 @@ jobs:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: mimalloc-pprof ${{ steps.tag.outputs.tag }}
           draft: ${{ env.IS_DRY_RUN == 'true' }}
-          files: dist/mimalloc-pprof-c-${{ steps.tag.outputs.tag }}.zip
+          files: |
+            dist/mimalloc-pprof-c-${{ steps.tag.outputs.tag }}.zip
+            dist/mimalloc-pprof-macos-arm64-${{ steps.tag.outputs.tag }}.tar.gz
+            dist/mimalloc-pprof-macos-x86_64-${{ steps.tag.outputs.tag }}.tar.gz
+            dist/mimalloc-pprof-windows-x64-gnu-${{ steps.tag.outputs.tag }}.zip
+            dist/mimalloc-pprof-windows-x64-msvc-${{ steps.tag.outputs.tag }}.zip
 
-  # Issue #55: the publish job is gated on all three OS builds, so a single transient
-  # runner failure silently turns a tagged release into a no-op. This job makes that
-  # outcome impossible to miss and says exactly how to recover.
+  # Issue #55: the publish job is gated on every build job, so a single transient runner
+  # failure silently turns a tagged release into a no-op. This job makes that outcome
+  # impossible to miss and says exactly how to recover. (The "three OS builds" this comment
+  # used to name are gone: #277 phase E made `build-and-package` one ubuntu row and moved
+  # the platform binaries into `build-binaries`, four Linux cross lanes.)
   release-outcome:
     name: Release outcome check
-    needs: [build-and-package, release]
+    needs: [build-and-package, build-binaries, release]
     if: always() && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -234,12 +548,14 @@ jobs:
         shell: bash
         run: |
           build='${{ needs.build-and-package.result }}'
+          binaries='${{ needs.build-binaries.result }}'
           release='${{ needs.release.result }}'
           echo "build-and-package: ${build}"
+          echo "build-binaries: ${binaries}"
           echo "release: ${release}"
           if [ "$release" = "success" ]; then
             echo "tag ${GITHUB_REF_NAME} released successfully"
             exit 0
           fi
-          echo "::error::Tag ${GITHUB_REF_NAME} was pushed but NOT released (build=${build}, release=${release}). Nothing was published to crates.io. If this was a transient runner failure, recover with: gh run rerun ${GITHUB_RUN_ID} --failed"
+          echo "::error::Tag ${GITHUB_REF_NAME} was pushed but NOT released (build=${build}, binaries=${binaries}, release=${release}). Nothing was published to crates.io. If this was a transient runner failure, recover with: gh run rerun ${GITHUB_RUN_ID} --failed"
           exit 1

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -1366,6 +1366,73 @@ jobs:
             sentinel/*.json
           if-no-files-found: warn
 
+      # ---------------------------------------------------------------------------------
+      # zero-tracking (#67), moved here by #277 phase E. See zero-tracking.yml's header for
+      # the full reasoning; the short version is that its `windows-latest` row built the
+      # tree natively and then ran an A/B on it, costing a whole extra Windows VM per
+      # matching PR, and both halves fit here for free:
+      #
+      #   * correctness is ALREADY covered, unconditionally: `test-zero-tracking` and
+      #     `test-zero-tracking-enabled` are registered ctest tests, so they are in every
+      #     bundle manifest and the `ctest (windows-latest) equivalent` step above ran both.
+      #   * only the interleaved A/B timing loop is new, and it is gated to the same paths
+      #     zero-tracking.yml triggers on so an unrelated PR does not pay for it.
+      #
+      # Runs on the MSVC release bundle -- the closest thing to the `windows-latest` row it
+      # replaces, with the honest caveat that soldr's clang-cl is not `cl`. The A/B's own
+      # design (interleaved, paired, single binary, raw numbers rather than a verdict)
+      # already exists to survive a noisy machine, and this job is entirely serial, so
+      # nothing else is running on the VM while it does.
+      - name: Does this PR touch the zero-tracking paths?
+        id: zt_scope
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "event is ${{ github.event_name }}; zero-tracking.yml only ever ran on pull_request"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Fail OPEN: if the API call breaks, run the A/B rather than silently skipping a
+          # gate. It costs ~1 minute on a job that is already several.
+          if ! files=$(gh api --paginate \
+                "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files" \
+                --jq '.[].filename'); then
+            echo "::warning::could not list this PR's changed files; running the A/B anyway"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "$files"
+          # zero-tracking.yml's own `paths:` list, minus zero-tracking.yml itself (which
+          # does not trigger THIS workflow, so keying on it would promise a run that the
+          # trigger cannot deliver -- see that file's header).
+          if echo "$files" | grep -qxE 'src/arena\.c|test/bench-zero-tracking\.c|\.github/workflows/windows-bundles\.yml'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no zero-tracking path touched; skipping the A/B"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: zero-tracking interleaved A/B (MSVC release bundle)
+        if: ${{ !cancelled() && steps.zt_scope.outputs.run == 'true' }}
+        run: |
+          set -euo pipefail
+          exe="bundle/windows-msvc-x64-release/mimalloc-test-zero-tracking.exe"
+          test -f "$exe"
+          echo "benchmark binary: $exe"
+          export MIMALLOC_PURGE_DELAY=0
+          for i in 1 2 3 4 5 6 7 8; do
+            MIMALLOC_PURGE_ZEROES=0 "$exe"
+            MIMALLOC_PURGE_ZEROES=1 "$exe"
+          done | tee ab.jsonl
+          uv run ci/zero_tracking_report.py ab.jsonl | tee -a "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && steps.zt_scope.outputs.run == 'true' }}
+        with:
+          name: zero-tracking-windows-msvc-x64
+          path: ab.jsonl
+
       - uses: msys2/setup-msys2@v2
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/zero-tracking.yml
+++ b/.github/workflows/zero-tracking.yml
@@ -8,6 +8,25 @@ name: zero-tracking
 # measurement order on a loaded machine -- the interleaved rerun reversed the sign. So
 # the arms here are interleaved and paired, from a single binary, and the raw numbers
 # are printed rather than a verdict.
+#
+# LINUX ONLY, since #277 phase E. The `windows-latest` row this workflow used to carry
+# built the tree natively with MSVC and then ran the A/B on it; that was one more Windows
+# VM per matching PR, which is exactly what #277 exists to stop. Both of its halves moved
+# into `windows-bundles.yml`'s single `run-windows` job:
+#
+#   * correctness (`ctest -R zero-tracking`) was ALREADY there and is not conditional:
+#     `test-zero-tracking` and `test-zero-tracking-enabled` are ordinary registered ctest
+#     tests, so ci/bundle_tests.py puts them in every bundle manifest and run-windows's
+#     full replay of `windows-{gnu,msvc}-x64-release` runs both on every push. That is
+#     strictly MORE coverage than this workflow's path-filtered trigger gave.
+#   * the interleaved A/B became a gated step on the same `run-windows` job, keyed to the
+#     same paths as this workflow's trigger, so it costs zero extra Windows queue slots.
+#
+# The quiet-runner property survives the move: run-windows is entirely serial, so nothing
+# else is executing on that VM while the A/B runs, and the arms are still interleaved and
+# paired from a single binary. What does NOT survive: the Windows arm is now built by
+# soldr's clang-cl rather than by `cl`, and a PR that touches only THIS file exercises the
+# Linux arm alone (windows-bundles.yml is not triggered by it). See docs/ci-gates.md.
 
 on:
   workflow_dispatch:
@@ -24,11 +43,7 @@ concurrency:
 
 jobs:
   ab:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: cmake -B build -DMI_PPROF=ON -DCMAKE_BUILD_TYPE=Release
@@ -54,5 +69,5 @@ jobs:
           python3 ci/zero_tracking_report.py ab.jsonl
       - uses: actions/upload-artifact@v4
         with:
-          name: zero-tracking-${{ matrix.os }}
+          name: zero-tracking-ubuntu-latest
           path: ab.jsonl

--- a/ci/tests/test_auto_release_workflow.py
+++ b/ci/tests/test_auto_release_workflow.py
@@ -1,0 +1,173 @@
+"""Structural gate for `.github/workflows/auto-release.yml` (#277 phase E).
+
+`auto-release.yml` does not run on pull requests -- it runs on `workflow_dispatch` and on
+a `v*` tag push -- so a wiring mistake in it is invisible until someone cuts a release and
+discovers the assets are missing or the publish job never ran. Issue #55 is exactly that
+failure once already. These tests are the substitute for a CI run: they assert the shape
+the workflow has to have, from the YAML itself.
+
+What they check:
+  * no non-Linux runner anywhere (the owner requirement that macOS never runs natively is
+    enforced repository-wide by ci/lint_no_macos_runners.py; this adds "and nothing here
+    runs on Windows either, because every shipped binary is cross-built");
+  * `release` waits for every job that produces one of its assets;
+  * every artifact a build job uploads is actually downloaded by `release`;
+  * the release's `files:` list, the rename step and the build matrix all name the same
+    set of assets -- three places that have to agree and no compiler to check them;
+  * every cross lane names a toolchain file that exists.
+"""
+
+from __future__ import annotations
+
+# pyright: reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false
+import unittest
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "auto-release.yml"
+
+# The four cross lanes, and the archive extension each one ships. Spelled out here rather
+# than read from the matrix so that a lane silently disappearing from the matrix fails.
+EXPECTED_LANES: dict[str, tuple[str, str]] = {
+    "macos-arm64": ("aarch64-apple-darwin", "tar.gz"),
+    "macos-x86_64": ("x86_64-apple-darwin", "tar.gz"),
+    "windows-x64-gnu": ("x86_64-pc-windows-gnu", "zip"),
+    "windows-x64-msvc": ("x86_64-pc-windows-msvc", "zip"),
+}
+
+
+def load() -> dict[str, Any]:
+    with WORKFLOW.open(encoding="utf-8") as handle:
+        return cast(dict[str, Any], yaml.safe_load(handle))
+
+
+def job_run_text(job: dict[str, Any]) -> str:
+    return "\n".join(
+        step["run"] for step in job.get("steps", []) if isinstance(step.get("run"), str)
+    )
+
+
+class AutoReleaseStructureTests(unittest.TestCase):
+    doc: dict[str, Any]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.doc = load()
+
+    def jobs(self) -> dict[str, Any]:
+        return cast(dict[str, Any], self.doc["jobs"])
+
+    def test_every_job_runs_on_linux(self) -> None:
+        for name, job in self.jobs().items():
+            runs_on = job.get("runs-on")
+            self.assertEqual(
+                runs_on,
+                "ubuntu-latest",
+                f"auto-release job {name!r} runs on {runs_on!r}; every release asset is "
+                "cross-built on Linux (#277 phase E)",
+            )
+            matrix = cast(dict[str, Any], job.get("strategy", {})).get("matrix", {})
+            keys = set(matrix) | {k for row in matrix.get("include", []) for k in row}
+            self.assertNotIn(
+                "os",
+                keys,
+                f"auto-release job {name!r} still has an `os` matrix dimension; the "
+                "platform is chosen by the cross toolchain now, not by the runner",
+            )
+
+    def test_release_waits_for_every_build_job(self) -> None:
+        release = self.jobs()["release"]
+        needs = release["needs"]
+        self.assertIsInstance(needs, list)
+        self.assertIn("build-and-package", needs)
+        self.assertIn("build-binaries", needs)
+
+    def test_release_outcome_reports_every_build_job(self) -> None:
+        outcome = self.jobs()["release-outcome"]
+        self.assertEqual(
+            sorted(outcome["needs"]), ["build-and-package", "build-binaries", "release"]
+        )
+        text = job_run_text(outcome)
+        for job in ("build-and-package", "build-binaries", "release"):
+            self.assertIn(f"needs.{job}.result", text)
+
+    def test_build_binaries_matrix_is_the_four_cross_lanes(self) -> None:
+        rows = self.jobs()["build-binaries"]["strategy"]["matrix"]["include"]
+        seen = {row["asset"]: (row["triple"], row["archive"]) for row in rows}
+        self.assertEqual(seen, EXPECTED_LANES)
+
+    def test_every_lane_names_an_existing_toolchain_file(self) -> None:
+        for triple, _ in EXPECTED_LANES.values():
+            toolchain = ROOT / "cmake" / "toolchains" / f"soldr-{triple}.cmake"
+            self.assertTrue(toolchain.is_file(), f"missing {toolchain}")
+
+    def test_every_uploaded_artifact_is_downloaded_by_release(self) -> None:
+        uploaded: set[str] = set()
+        for name, job in self.jobs().items():
+            if name == "release":
+                continue
+            for step in job.get("steps", []):
+                if str(step.get("uses", "")).startswith("actions/upload-artifact"):
+                    uploaded.add(str(step["with"]["name"]))
+        downloaded: set[str] = set()
+        patterns: list[str] = []
+        for step in self.jobs()["release"]["steps"]:
+            if str(step.get("uses", "")).startswith("actions/download-artifact"):
+                with_ = cast(dict[str, Any], step["with"])
+                if "name" in with_:
+                    downloaded.add(str(with_["name"]))
+                if "pattern" in with_:
+                    patterns.append(str(with_["pattern"]))
+        for artifact in uploaded:
+            covered = artifact in downloaded or any(
+                artifact.startswith(pattern.rstrip("*")) for pattern in patterns
+            )
+            self.assertTrue(
+                covered,
+                f"artifact {artifact!r} is uploaded but never downloaded by `release`; it "
+                "would not reach the GitHub Release",
+            )
+
+    def test_release_files_rename_and_matrix_agree(self) -> None:
+        release = self.jobs()["release"]
+        gh_release = next(
+            step
+            for step in release["steps"]
+            if str(step.get("uses", "")).startswith("softprops/action-gh-release")
+        )
+        files = [line.strip() for line in str(gh_release["with"]["files"]).splitlines()]
+        files = [line for line in files if line]
+        # The architecture-independent amalgamation ZIP plus one archive per cross lane.
+        self.assertEqual(len(files), 1 + len(EXPECTED_LANES), files)
+        rename_text = job_run_text(release)
+        for asset, (_, ext) in EXPECTED_LANES.items():
+            attached = [f for f in files if f"mimalloc-pprof-{asset}-" in f]
+            self.assertEqual(
+                len(attached), 1, f"{asset} is attached {len(attached)} times: {files}"
+            )
+            self.assertTrue(
+                attached[0].endswith(f".{ext}"),
+                f"{asset} is attached as {attached[0]}, expected a .{ext}",
+            )
+            self.assertIn(
+                asset,
+                rename_text,
+                f"the rename/verify step does not mention {asset}; a missing lane would "
+                "reach action-gh-release as a shorter file list",
+            )
+        self.assertTrue(any("mimalloc-pprof-c-" in f for f in files))
+
+    def test_the_cross_build_decision_is_documented_in_the_header(self) -> None:
+        # #277 row E as first written said release assets "stay built by the platform's own
+        # toolchain". Two owner decisions overrode that. The reversal has to be legible in
+        # the file that implements it, not only in the issue thread.
+        header = WORKFLOW.read_text(encoding="utf-8").split("on:", 1)[0]
+        for phrase in ("CROSS-BUILT ON LINUX", "soldr", "native Mac"):
+            self.assertIn(phrase, header)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_verify_local.py
+++ b/ci/tests/test_verify_local.py
@@ -205,5 +205,135 @@ class SelftestTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
 
 
+# --------------------------------------------------------------------------------------
+# #277 phase F: the --bundle name table vs. the bundle workflows' build matrices.
+# --------------------------------------------------------------------------------------
+
+BUNDLE_WORKFLOW_JOBS: list[tuple[str, str]] = [
+    ("macos-bundles.yml", "build-macos"),
+    ("windows-bundles.yml", "build-windows-gnu"),
+    ("windows-bundles.yml", "build-windows-msvc"),
+]
+
+TOOLCHAIN_RE = re.compile(r"cmake/toolchains/soldr-([A-Za-z0-9_.-]+)\.cmake")
+
+
+def matrix_bundles(workflow_name: str, job_name: str) -> list[dict[str, Any]]:
+    """The `include:` rows of one bundle-building job's matrix, plus the triple.
+
+    The macOS matrix carries `triple:` per row; the two Windows jobs do not (they are
+    single-target jobs, so the triple is spelled once, in the toolchain path their steps
+    pass to cmake). Reading it out of the run text rather than hardcoding it here means a
+    job that is repointed at a different toolchain fails this test.
+    """
+    doc = load_workflow(workflow_name)
+    job = cast(dict[str, Any], doc["jobs"][job_name])
+    rows = cast(list[dict[str, Any]], job["strategy"]["matrix"]["include"])
+    text = job_run_text(job)
+    job_triples = {t for t in TOOLCHAIN_RE.findall(text) if "${{" not in t}
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        triple = row.get("triple")
+        if triple is None:
+            assert len(job_triples) == 1, (
+                f"{workflow_name}:{job_name} has no matrix `triple:` and its steps name "
+                f"{sorted(job_triples)} toolchains -- cannot infer one target"
+            )
+            triple = next(iter(job_triples))
+        out.append(
+            {
+                "bundle": row["bundle"],
+                "triple": triple,
+                "cmake": row["cmake"],
+                "workflow": workflow_name,
+                "job": job_name,
+                "run_text": text,
+            }
+        )
+    return out
+
+
+def all_matrix_bundles() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for workflow_name, job_name in BUNDLE_WORKFLOW_JOBS:
+        rows.extend(matrix_bundles(workflow_name, job_name))
+    return rows
+
+
+class BundleTableDriftTests(unittest.TestCase):
+    """`verify_local.py --bundle NAME` must offer exactly the CI matrices' bundles.
+
+    Same contract as the config table above and for the same reason: the flags are copied
+    by hand so that a workflow edit fails loudly here instead of silently changing what
+    `--bundle` builds. A name that exists in CI but not here is a lane a developer cannot
+    reproduce locally; a name that exists here but not in CI builds something CI does not.
+    """
+
+    def test_names_match_the_workflow_matrices_exactly(self) -> None:
+        expected = [row["bundle"] for row in all_matrix_bundles()]
+        self.assertEqual(sorted(verify_local.BUNDLE_NAMES), sorted(expected))
+        self.assertEqual(len(expected), len(set(expected)))
+
+    def test_triple_and_cmake_flags_match_verbatim(self) -> None:
+        by_name = {b.name: b for b in verify_local.BUNDLES}
+        for row in all_matrix_bundles():
+            spec = by_name[row["bundle"]]
+            self.assertEqual(
+                spec.triple,
+                row["triple"],
+                f"{row['workflow']}:{row['job']} builds {row['bundle']} for "
+                f"{row['triple']}, verify_local.py says {spec.triple}",
+            )
+            self.assertEqual(
+                spec.cmake,
+                row["cmake"],
+                f"{row['workflow']}:{row['job']}'s {row['bundle']} cmake flags drifted "
+                "from ci/verify_local.py",
+            )
+            self.assertEqual(spec.workflow, row["workflow"])
+            self.assertEqual(spec.job, row["job"])
+
+    def test_bundle_tests_arguments_match_the_workflow_step(self) -> None:
+        # The lane-specific ci/bundle_tests.py flags matter as much as the cmake ones:
+        # without --dll-search-dir the win-gnu bundle silently omits libgcc_s_seh-1.dll.
+        for row in all_matrix_bundles():
+            spec = next(b for b in verify_local.BUNDLES if b.name == row["bundle"])
+            for arg in spec.bundle_args:
+                self.assertIn(
+                    arg,
+                    row["run_text"],
+                    f"ci/verify_local.py passes {arg!r} to bundle_tests.py for "
+                    f"{row['bundle']}, but {row['workflow']}:{row['job']} does not",
+                )
+
+    def test_every_bundle_names_a_toolchain_file_that_exists(self) -> None:
+        for spec in verify_local.BUNDLES:
+            toolchain = ROOT / "cmake" / "toolchains" / f"soldr-{spec.triple}.cmake"
+            self.assertTrue(toolchain.is_file(), f"{spec.name} names a missing {toolchain}")
+
+    def test_list_prints_the_bundle_table(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "ci" / "verify_local.py"), "--list"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        for name in verify_local.BUNDLE_NAMES:
+            self.assertIn(name, result.stdout)
+
+    def test_unknown_bundle_is_rejected(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "ci" / "verify_local.py"), "--bundle", "not-a-bundle"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unknown bundle", result.stdout + result.stderr)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ci/verify_local.py
+++ b/ci/verify_local.py
@@ -13,11 +13,18 @@ of each matrixed job is covered (no Windows/macOS/MSYS2), and every job's exact 
 flags/env are copied from the workflow files rather than re-derived, so drift is
 caught by `ci/tests/test_verify_local.py` rather than trusted to stay in sync by hand.
 
+`--bundle <name>` is the one thing here that is not about Linux: it reproduces a
+macOS/Windows lane of `macos-bundles.yml`/`windows-bundles.yml` on this box, through
+the same `soldr prepare`, the same `cmake/toolchains/soldr-<triple>.cmake` and the same
+`ci/bundle_tests.py` CI uses -- everything up to the execution step, which needs the
+target OS (#277 phase F).
+
 Usage:
     uv run ci/verify_local.py                        # everything fast (slow tests excluded)
     uv run ci/verify_local.py --only release,lint     # just these configs
     uv run ci/verify_local.py --slow                  # also run the long-tail ctest suite
-    uv run ci/verify_local.py --list                  # print the config table and exit
+    uv run ci/verify_local.py --list                  # print the config + bundle tables
+    uv run ci/verify_local.py --bundle macos-arm64-release   # cross-build one CI bundle
     uv run ci/verify_local.py --jobs 8                # override the worker/build budget
     uv run ci/verify_local.py --keep-going             # don't skip queued configs on a failure
     uv run ci/verify_local.py --selftest               # trivially fast dry-run, no real builds
@@ -32,6 +39,7 @@ import argparse
 import contextlib
 import dataclasses
 import io
+import json
 import os
 import re
 import shlex
@@ -43,6 +51,7 @@ import time
 from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from string import Template
 
 ROOT = Path(__file__).resolve().parents[1]
 OUT_ROOT = ROOT / "out" / "verify"
@@ -801,6 +810,379 @@ CONFIGS: list[ConfigSpec] = [
 CONFIG_NAMES = [c.name for c in CONFIGS]
 
 
+# ---------------------------------------------------------------------------------
+# Cross bundles (#277 phase F)
+#
+# macOS and Windows are not executed here -- there is no Mac and no Windows on this box,
+# and by owner requirement there is no native Mac anywhere in this repository's CI either
+# (ci/lint_no_macos_runners.py). What IS reproducible locally is everything up to the
+# execution step: `soldr prepare` provisions the same cross toolchain the runner uses,
+# cmake/toolchains/soldr-<triple>.cmake feeds CMake nothing but what soldr exported, and
+# ci/bundle_tests.py turns the build tree into the same portable bundle the workflow
+# uploads. So a red `run-macos-x64-dockur` or `run-windows` that is really a *build* or
+# *bundling* failure can be reproduced in one command instead of a push-and-wait cycle.
+#
+# The flags below are copied verbatim out of macos-bundles.yml's and windows-bundles.yml's
+# matrices, exactly like the CONFIGS table above copies c-unit.yml's, and
+# ci/tests/test_verify_local.py parses those matrices and fails if the two drift.
+
+BUNDLE_OUT_ROOT = OUT_ROOT / "bundles"
+
+# The `-- Link libraries   : ...` line each lane's configure must resolve to. This is the
+# assertion the build jobs make, and on Darwin it is load-bearing rather than cosmetic:
+# without the toolchain file's CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY, CMakeLists.txt's
+# find_link_library() falls back to find_library() and hands the host's ELF librt.so to a
+# Mach-O link.
+DARWIN_LINK_LIBRARIES = "pthread"
+WINDOWS_LINK_LIBRARIES = "psapi;shell32;user32;advapi32;bcrypt"
+
+
+@dataclasses.dataclass(frozen=True)
+class BundleSpec:
+    """One row of a bundle workflow's build matrix, reproduced locally."""
+
+    name: str  # the matrix's `bundle:` value, and the artifact name CI uploads
+    workflow: str
+    job: str
+    triple: str
+    cmake: str  # the matrix's `cmake:` value, verbatim
+    link_libraries: str
+    # ci/bundle_tests.py arguments, verbatim from the workflow's "Bundle the tests" step.
+    # $VARS are expanded from the environment `soldr prepare` exported, not from this
+    # shell's -- MINGW_W64_CROSS_BIN only exists after a prepare.
+    bundle_args: tuple[str, ...] = ()
+
+
+BUNDLES: list[BundleSpec] = [
+    # --- macos-bundles.yml: build-macos -------------------------------------------
+    BundleSpec(
+        "macos-arm64-release",
+        "macos-bundles.yml",
+        "build-macos",
+        "aarch64-apple-darwin",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON",
+        DARWIN_LINK_LIBRARIES,
+    ),
+    BundleSpec(
+        "macos-arm64-debug-full",
+        "macos-bundles.yml",
+        "build-macos",
+        "aarch64-apple-darwin",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_DEBUG_FULL=ON -DMI_TLS_MODEL_FIXED=ON",
+        DARWIN_LINK_LIBRARIES,
+    ),
+    BundleSpec(
+        "macos-arm64-leak",
+        "macos-bundles.yml",
+        "build-macos",
+        "aarch64-apple-darwin",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BENCH_INJECT_LEAK=200000",
+        DARWIN_LINK_LIBRARIES,
+    ),
+    BundleSpec(
+        "macos-x64-release",
+        "macos-bundles.yml",
+        "build-macos",
+        "x86_64-apple-darwin",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON",
+        DARWIN_LINK_LIBRARIES,
+    ),
+    BundleSpec(
+        "macos-x64-debug-full",
+        "macos-bundles.yml",
+        "build-macos",
+        "x86_64-apple-darwin",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_DEBUG_FULL=ON",
+        DARWIN_LINK_LIBRARIES,
+    ),
+    BundleSpec(
+        "macos-x64-leak",
+        "macos-bundles.yml",
+        "build-macos",
+        "x86_64-apple-darwin",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BENCH_INJECT_LEAK=200000",
+        DARWIN_LINK_LIBRARIES,
+    ),
+    # --- windows-bundles.yml: build-windows-gnu -----------------------------------
+    # --dll-search-dir turns on bundle_tests.py's transitive PE import scan: soldr's
+    # mingw-w64 links mimalloc.dll against libgcc_s_seh-1.dll, which no windows-latest
+    # runner has, and a missing DLL is a dialog-free 0xC0000135 rather than a test failure.
+    BundleSpec(
+        "windows-gnu-x64-release",
+        "windows-bundles.yml",
+        "build-windows-gnu",
+        "x86_64-pc-windows-gnu",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON",
+        WINDOWS_LINK_LIBRARIES,
+        (
+            "--objdump",
+            "$MINGW_W64_CROSS_BIN/x86_64-w64-mingw32-objdump",
+            "--dll-search-dir",
+            "$MINGW_W64_CROSS_ROOT/x86_64-w64-mingw32/lib",
+        ),
+    ),
+    BundleSpec(
+        "windows-gnu-x64-debug-full",
+        "windows-bundles.yml",
+        "build-windows-gnu",
+        "x86_64-pc-windows-gnu",
+        "-DCMAKE_BUILD_TYPE=Debug -DMI_PPROF=ON -DMI_DEBUG_FULL=ON",
+        WINDOWS_LINK_LIBRARIES,
+        (
+            "--objdump",
+            "$MINGW_W64_CROSS_BIN/x86_64-w64-mingw32-objdump",
+            "--dll-search-dir",
+            "$MINGW_W64_CROSS_ROOT/x86_64-w64-mingw32/lib",
+        ),
+    ),
+    BundleSpec(
+        "windows-gnu-x64-shared",
+        "windows-bundles.yml",
+        "build-windows-gnu",
+        "x86_64-pc-windows-gnu",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF -DMI_BUILD_OBJECT=OFF",
+        WINDOWS_LINK_LIBRARIES,
+        (
+            "--objdump",
+            "$MINGW_W64_CROSS_BIN/x86_64-w64-mingw32-objdump",
+            "--dll-search-dir",
+            "$MINGW_W64_CROSS_ROOT/x86_64-w64-mingw32/lib",
+        ),
+    ),
+    BundleSpec(
+        "windows-gnu-x64-leak",
+        "windows-bundles.yml",
+        "build-windows-gnu",
+        "x86_64-pc-windows-gnu",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BENCH_INJECT_LEAK=200000",
+        WINDOWS_LINK_LIBRARIES,
+        (
+            "--objdump",
+            "$MINGW_W64_CROSS_BIN/x86_64-w64-mingw32-objdump",
+            "--dll-search-dir",
+            "$MINGW_W64_CROSS_ROOT/x86_64-w64-mingw32/lib",
+        ),
+    ),
+    # --- windows-bundles.yml: build-windows-msvc ----------------------------------
+    # No --dll-search-dir: soldr's xwin splat is import libraries only. --check-dll-closure
+    # runs the same scan anyway, and --allow-msvc-runtime is the one assumption this lane
+    # makes (VCRUNTIME140/MSVCP140 come from the Visual C++ redistributable on the runner).
+    BundleSpec(
+        "windows-msvc-x64-release",
+        "windows-bundles.yml",
+        "build-windows-msvc",
+        "x86_64-pc-windows-msvc",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON",
+        WINDOWS_LINK_LIBRARIES,
+        ("--objdump", "llvm-objdump", "--check-dll-closure", "--allow-msvc-runtime"),
+    ),
+    BundleSpec(
+        "windows-msvc-x64-debug-full",
+        "windows-bundles.yml",
+        "build-windows-msvc",
+        "x86_64-pc-windows-msvc",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_DEBUG_FULL=ON",
+        WINDOWS_LINK_LIBRARIES,
+        ("--objdump", "llvm-objdump", "--check-dll-closure", "--allow-msvc-runtime"),
+    ),
+    BundleSpec(
+        "windows-msvc-x64-shared",
+        "windows-bundles.yml",
+        "build-windows-msvc",
+        "x86_64-pc-windows-msvc",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BUILD_SHARED=ON -DMI_BUILD_STATIC=OFF -DMI_BUILD_OBJECT=OFF",
+        WINDOWS_LINK_LIBRARIES,
+        ("--objdump", "llvm-objdump", "--check-dll-closure", "--allow-msvc-runtime"),
+    ),
+    BundleSpec(
+        "windows-msvc-x64-leak",
+        "windows-bundles.yml",
+        "build-windows-msvc",
+        "x86_64-pc-windows-msvc",
+        "-DCMAKE_BUILD_TYPE=Release -DMI_PPROF=ON -DMI_BENCH_INJECT_LEAK=200000",
+        WINDOWS_LINK_LIBRARIES,
+        ("--objdump", "llvm-objdump", "--check-dll-closure", "--allow-msvc-runtime"),
+    ),
+]
+
+BUNDLE_NAMES = [b.name for b in BUNDLES]
+
+
+def soldr_prepare(triple: str, log: Path) -> dict[str, str] | None:
+    """Run `soldr prepare --target <triple>` and return the environment it exported.
+
+    Mirrors the workflows' "Prepare the soldr <X> toolchain" step, including its working
+    directory: `soldr prepare` resolves rustc from a rust-toolchain.toml at or above the
+    cwd, and this repository's lives in rust/.
+
+    Returns None (after logging) if soldr is missing or the prepare failed. The exported
+    environment is returned rather than applied to os.environ so a caller can hand it to
+    exactly the subprocesses that should see it.
+    """
+    if shutil.which("soldr") is None:
+        log_write(log, "\n[verify_local] soldr not found on PATH\n")
+        return None
+    env_file = BUNDLE_OUT_ROOT / f"soldr-{triple}.env"
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text("", encoding="utf-8")  # --github-env appends; start clean
+    rc, _ = run_logged(
+        ["soldr", "prepare", "--target", triple, "--github-env", str(env_file)],
+        cwd=ROOT / "rust",
+        log=log,
+    )
+    if rc:
+        return None
+    exported: dict[str, str] = {}
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        key, sep, value = line.partition("=")
+        # GitHub's env-file format also has a `KEY<<DELIM` heredoc shape. soldr does not
+        # emit it today; parse it wrong silently and the toolchain file would fail with a
+        # confusing "CC_<triple> is not set" much later, so refuse instead.
+        if not sep or "<<" in key:
+            log_write(log, f"\n[verify_local] unparseable soldr env line: {line!r}\n")
+            return None
+        exported[key] = value
+    return exported
+
+
+def build_one_bundle(spec: BundleSpec, jobs: int, log: Path) -> tuple[bool, Path | None]:
+    """Configure, build and bundle one cross lane. Returns (ok, bundle dir)."""
+    out = BUNDLE_OUT_ROOT / spec.name
+    build = out / "build"
+    bundle = out / "bundle"
+    out.mkdir(parents=True, exist_ok=True)
+
+    exported = soldr_prepare(spec.triple, log)
+    if exported is None:
+        return False, None
+    # soldr prepends its own LLVM/ninja/cmake bin directories to PATH; llvm-objdump on the
+    # MSVC lane comes from there, not from this host.
+    env = dict(exported)
+
+    ctx = RunCtx(name=spec.name, dir=out, log=log, jobs=jobs, slow=False)
+    rc, configure_out = run_logged(
+        [
+            cmake_bin(),
+            "-S",
+            str(ROOT),
+            "-B",
+            str(build),
+            "-G",
+            "Ninja",
+            *shlex.split(spec.cmake),
+            "--toolchain",
+            str(ROOT / "cmake" / "toolchains" / f"soldr-{spec.triple}.cmake"),
+            "--log-level=VERBOSE",
+        ],
+        cwd=ROOT,
+        log=log,
+        env=env,
+    )
+    if rc:
+        return False, None
+    # The same assertion the build job makes, on the RESOLVED list rather than on the
+    # option that was passed in.
+    if not re.search(
+        rf"^-- Link libraries *: *{re.escape(spec.link_libraries)}$", configure_out, re.MULTILINE
+    ):
+        log_write(
+            log,
+            f"\n[verify_local] the {spec.triple} link resolved unexpected libraries; "
+            f"expected exactly '{spec.link_libraries}'\n",
+        )
+        for line in configure_out.splitlines():
+            if "Link libraries" in line:
+                log_write(log, f"  {line}\n")
+        return False, None
+
+    if cmake_build(ctx, build, env=env):
+        return False, None
+
+    if bundle.exists():
+        shutil.rmtree(bundle)
+    expanded: list[str] = []
+    for arg in spec.bundle_args:
+        try:
+            expanded.append(Template(arg).substitute(env))
+        except KeyError as exc:
+            log_write(
+                log,
+                f"\n[verify_local] {arg!r} needs {exc} which `soldr prepare --target "
+                f"{spec.triple}` did not export\n",
+            )
+            return False, None
+    rc, _ = run_logged(
+        [
+            sys.executable,
+            str(ROOT / "ci" / "bundle_tests.py"),
+            str(build),
+            str(bundle),
+            *expanded,
+        ],
+        cwd=ROOT,
+        log=log,
+        env=env,
+    )
+    if rc:
+        return False, None
+    return True, bundle
+
+
+def summarize_bundle(spec: BundleSpec, bundle: Path) -> None:
+    """Print the bundle path and a manifest summary -- what CI would have uploaded."""
+    manifest = json.loads((bundle / "tests.json").read_text(encoding="utf-8"))
+    tests = manifest.get("tests", [])
+    files = sorted(p.name for p in bundle.iterdir() if p.name != "tests.json")
+    libs = [f for f in files if f.endswith((".dylib", ".dll", ".so"))]
+    print()
+    print(f"bundle    : {bundle}")
+    print(f"lane      : {spec.workflow} :: {spec.job} ({spec.triple})")
+    print(f"cmake     : {spec.cmake}")
+    print(f"tests     : {len(tests)}")
+    print(f"files     : {len(files)} ({len(libs)} shared libraries)")
+    for lib in libs:
+        print(f"    lib   : {lib}")
+    for test in tests:
+        argv = test.get("argv", [])
+        extra: list[str] = []
+        if test.get("expect_nonzero"):
+            extra.append("expect-nonzero")
+        if test.get("env"):
+            extra.append(f"env[{len(test['env'])}]")
+        suffix = f"  [{', '.join(extra)}]" if extra else ""
+        print(f"    test  : {test.get('name')}  <- {' '.join(argv)}{suffix}")
+    print()
+    print("This host cannot execute it -- that is the one step this tool cannot")
+    print("reproduce. Copy the directory to the target OS and replay it there with:")
+    print(f"    uv run ci/run_test_bundle.py {bundle}")
+    print("(CI does the same, from the artifact `bundle-" + spec.name + "`.)")
+
+
+def run_bundle_build(name: str, jobs: int) -> int:
+    """`--bundle <name>`: reproduce one cross lane's build+bundle stage locally."""
+    spec = next((b for b in BUNDLES if b.name == name), None)
+    if spec is None:
+        print(f"error: unknown bundle {name!r}; choose from {BUNDLE_NAMES}", file=sys.stderr)
+        return 2
+    out = BUNDLE_OUT_ROOT / spec.name
+    log = out / "verify.log"
+    out.mkdir(parents=True, exist_ok=True)
+    log_start(log, f"=== bundle {spec.name} starting {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n")
+    print(f"verify_local: building bundle {spec.name} for {spec.triple} (log: {log})")
+    start = time.monotonic()
+    ok, bundle = build_one_bundle(spec, jobs, log)
+    elapsed = time.monotonic() - start
+    if not ok or bundle is None:
+        print(f"[{elapsed:7.1f}s] {spec.name:<28} FAIL")
+        print_tail(log)
+        return 1
+    print(f"[{elapsed:7.1f}s] {spec.name:<28} PASS")
+    summarize_bundle(spec, bundle)
+    return 0
+
+
 def format_table(rows: Iterable[Outcome]) -> str:
     rows = list(rows)
     headers = ["config", "result", "seconds", "build dir", "log"]
@@ -881,7 +1263,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--only", help=f"comma-separated subset of: {','.join(CONFIG_NAMES)}")
     parser.add_argument("--slow", action="store_true", help="also run the long-tail ctest tier")
-    parser.add_argument("--list", action="store_true", help="print the config table and exit")
+    parser.add_argument(
+        "--list", action="store_true", help="print the config and bundle tables and exit"
+    )
+    parser.add_argument(
+        "--bundle",
+        metavar="NAME",
+        help=(
+            "cross-build one CI test bundle locally and stop before the execution step "
+            f"(#277 phase F); one of: {','.join(BUNDLE_NAMES)}"
+        ),
+    )
     parser.add_argument(
         "--jobs",
         type=int,
@@ -902,10 +1294,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"{'config':<12} {'mirrors':<45} description")
         for c in CONFIGS:
             print(f"{c.name:<12} {c.job:<45} {c.description}")
+        print()
+        print("cross bundles (--bundle NAME): built here, executed on the target OS")
+        print(f"{'bundle':<28} {'triple':<24} {'workflow':<21} cmake")
+        for b in BUNDLES:
+            print(f"{b.name:<28} {b.triple:<24} {b.workflow:<21} {b.cmake}")
         return 0
 
     if args.selftest:
         return do_selftest()
+
+    if args.bundle:
+        return run_bundle_build(args.bundle, args.jobs or os.cpu_count() or 4)
 
     if args.only:
         requested = [x.strip() for x in args.only.split(",") if x.strip()]
@@ -987,7 +1387,17 @@ def do_selftest() -> int:
     if rc != 0:
         print("FAIL: cmake not runnable")
         ok = False
+    if len(BUNDLE_NAMES) != len(set(BUNDLE_NAMES)):
+        print("FAIL: duplicate bundle names")
+        ok = False
+    for bundle in BUNDLES:
+        toolchain = ROOT / "cmake" / "toolchains" / f"soldr-{bundle.triple}.cmake"
+        if not toolchain.is_file():
+            print(f"FAIL: bundle {bundle.name!r} names a missing toolchain file {toolchain}")
+            ok = False
     print(f"selftest: {len(CONFIGS)} configs registered: {', '.join(CONFIG_NAMES)}")
+    print(f"selftest: {len(BUNDLES)} cross bundles registered: {', '.join(BUNDLE_NAMES)}")
+    print(f"selftest: soldr={'yes' if shutil.which('soldr') else 'no'}")
     print(
         f"selftest: ninja={'yes' if have_ninja() else 'no'} ccache={'yes' if have_ccache() else 'no'} clang={'yes' if _need_clang() is None else 'no'}"
     )

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -31,7 +31,7 @@ verifying nothing**, each discovered by asking "has this ever actually failed?":
 | **amalgamation-drift** | a C change that never reached the vendored copy the Rust crate compiles — which broke `main` twice before this gate existed | — |
 | **doc-snippets** (`ci/check_doc_snippets.py`) | fenced ```c examples in `README.md`/`docs/*.md` that don't compile against the real headers — caught one in PR #259 (a snippet using `mi_prof_config_t_decl`/`mi_prof_start_ex` with no `#include` at all) | `--self-test` plants a snippet calling an undeclared mimalloc function; the checker must reject it, on both gcc and clang |
 | **python-lint** | the gate scripts themselves — `ruff` + `pyright --strict` | — |
-| **zero-tracking** | correctness and footprint of `mi_option_purge_zeroes`, reported as paired interleaved A/B medians with the within-arm spread alongside | — |
+| **zero-tracking** | correctness and footprint of `mi_option_purge_zeroes`, reported as paired interleaved A/B medians with the within-arm spread alongside. Linux runs it in its own path-filtered workflow; Windows runs it as a gated step inside `run-windows` (#277 phase E), and the *correctness* half is unconditional there because `test-zero-tracking*` are ordinary ctest tests carried in every bundle | — |
 
 ## Test bundles
 
@@ -856,3 +856,140 @@ Three details worth stating, because each was an assumption that measurement ove
   was satisfied by libFuzzer's advice *to use* AddressSanitizer. Assertions about tool
   output should anchor on that tool's actual report format (`^(==[0-9]+==)?(ERROR|SUMMARY):`),
   never on a keyword that can appear in an explanatory sentence.
+
+## zero-tracking on Windows: a gated step, not a VM (#277 phase E)
+
+`zero-tracking.yml` used to be a two-row matrix, `ubuntu-latest` and `windows-latest`. The
+Windows row checked out, configured and built the tree with MSVC, ran
+`ctest -R zero-tracking`, then ran the interleaved A/B — a whole extra Windows VM per PR
+that touched `src/arena.c` or `test/bench-zero-tracking.c`. That is precisely the cost
+#277 exists to remove, so both halves moved into `windows-bundles.yml`'s single
+`run-windows` job and the matrix row is gone.
+
+The two halves did not move the same way, and the difference matters:
+
+| half | before | after |
+|---|---|---|
+| correctness (`ctest -R zero-tracking`) | Windows row, only on a matching PR | **unconditional, every push** — `test-zero-tracking` and `test-zero-tracking-enabled` are registered ctest tests, so `ci/bundle_tests.py` puts them in every bundle manifest and `run-windows` replays the whole manifest for `windows-gnu-x64-release` **and** `windows-msvc-x64-release` |
+| interleaved A/B timing | Windows row, only on a matching PR | a gated step on `run-windows`, keyed to the same paths |
+
+So the correctness gate got *stronger* (two lanes, every push, instead of one lane on a
+path-filtered PR) while the Windows job count went **down by one**.
+
+**The quiet-runner property survives.** `zero-tracking.yml`'s header explains why the A/B
+is its own workflow: a first local attempt measured a 13% regression that was really
+measurement order on a loaded machine. `run-windows` is entirely serial, so nothing else
+executes on that VM while the A/B runs, and the mitigation that actually did the work —
+interleaved, paired arms from a single binary, raw numbers rather than a verdict — is
+unchanged.
+
+**Two costs, stated:**
+
+- The Windows arm is now built by soldr's **clang-cl**, not by `cl`. It is the
+  `windows-msvc-x64-release` bundle's `mimalloc-test-zero-tracking.exe`.
+- The gate step asks the API for the PR's changed files rather than using a workflow
+  `paths:` filter (a step cannot have one). It keys on `src/arena.c`,
+  `test/bench-zero-tracking.c` and `.github/workflows/windows-bundles.yml` — deliberately
+  **not** on `zero-tracking.yml`, because editing that file does not trigger
+  `windows-bundles.yml` at all, so keying on it would promise a run the trigger cannot
+  deliver. A PR touching only `zero-tracking.yml` therefore exercises the Linux arm alone.
+  The API call **fails open**: if it errors, the A/B runs.
+
+## Release assets are cross-built, all of them (#277 phase E)
+
+`auto-release.yml` ships the shared library, the static library, the object file, the
+CMake package and pkg-config files, and the headers — including this fork's own
+`mimalloc/profile.h` and `mimalloc/memory-events.h` — for four targets, plus the
+architecture-independent vendored C amalgamation ZIP it always shipped:
+
+| asset | target | built by | consumer still needs |
+|---|---|---|---|
+| `mimalloc-pprof-macos-arm64-<tag>.tar.gz` | `aarch64-apple-darwin` | soldr clang 21 + ld64.lld, soldr's Apple SDK, on `ubuntu-latest` | — |
+| `mimalloc-pprof-macos-x86_64-<tag>.tar.gz` | `x86_64-apple-darwin` | same | — |
+| `mimalloc-pprof-windows-x64-gnu-<tag>.zip` | `x86_64-pc-windows-gnu` | soldr mingw-w64 gcc 15 (UCRT), on `ubuntu-latest` | nothing — `libgcc_s_seh-1.dll` is **shipped in the archive** |
+| `mimalloc-pprof-windows-x64-msvc-<tag>.zip` | `x86_64-pc-windows-msvc` | soldr clang-cl + lld-link, `/MD` pinned, on `ubuntu-latest` | the Visual C++ redistributable (`VCRUNTIME140.dll`, `MSVCP140.dll`) |
+| `mimalloc-pprof-c-<tag>.zip` | any | `ubuntu-latest` (source, not binaries) | a C compiler |
+
+### The decision, and the row it overrides
+
+#277's phase table said "shipped release assets stay built by the platform's own
+toolchain (state the decision)". **They are not.** Every binary asset is cross-built on
+Linux. Two owner decisions taken after that row was written force it:
+
+1. **No macOS build or test may run on a native Mac runner**, anywhere in this repository
+   (`ci/lint_no_macos_runners.py` fails the `python-lint` gate if a macOS label reappears).
+   There is no Apple toolchain available to build an Apple asset with.
+2. **Cross-compilation is a product requirement**, not a CI cost measure: mimalloc-pprof
+   ships inside cross-compiled code, so the Linux-cross-built artifact *is* the product.
+
+The second is the one that settles Windows, where a native runner does still exist.
+Building the shipped MSVC-ABI binary with `cl` on `windows-latest` while
+`windows-bundles.yml` executes the test suite from a clang-cl bundle would mean the thing
+tested and the thing shipped are different binaries. So the assets come off the same
+toolchains, the same `cmake/toolchains/soldr-<triple>.cmake` files and the same commit as
+the bundles that are actually executed — the bundles are the evidence for the assets.
+
+`c-unit.yml` keeps one native `cl` Release `ctest` job as the correctness gate for `cl`
+(CLAUDE.md rule 3). **That job ships nothing, and never did**: before this phase
+`auto-release.yml` had no binary assets at all, only the amalgamation ZIP, so there is no
+natively-built asset here to "retain".
+
+### What the release job proves before attaching anything
+
+Each lane, on the artifact rather than on the flags that produced it:
+
+- the resolved `-- Link libraries` list is exactly `pthread` (Darwin) or
+  `psapi;shell32;user32;advapi32;bcrypt` (Windows) — on Darwin this is load-bearing, since
+  without the toolchain file's find-root confinement `find_link_library()` hands the host's
+  ELF `librt.so` to a Mach-O link;
+- the Mach-O header says `ARM64` / `X86_64`, or the PE header says `pei-x86-64` /
+  `coff-x86-64`;
+- `mimalloc-redirect.dll` is installed on both Windows lanes;
+- the **whole PE import closure resolves**, via the same `ci/bundle_tests.py`
+  `resolve_runtime_dlls()` the test bundles use. This is what puts `libgcc_s_seh-1.dll` in
+  the win-gnu archive: `mimalloc.dll` imports it for `__popcountdi2`, and a missing DLL on
+  the consumer's machine is a dialog-free `0xC0000135`, not a legible error. Shipping it
+  rather than relinking `-static-libgcc` keeps the shipped binary byte-identical to the one
+  `windows-bundles.yml` tests.
+
+Every archive carries a `PROVENANCE.txt` naming the commit, the target, the compiler and
+the runtime the consumer still needs, because a user who downloads `windows-x64-msvc`
+should learn about the VC++ redistributable from the archive rather than from a loader
+error.
+
+`release` `needs:` both build jobs, `release-outcome` reports both, and the rename step
+hard-fails if fewer than five assets are present — a release that published to crates.io
+and then shipped three of its four platform archives would be a release nobody can tell is
+incomplete (issue #55 is that failure once already). `auto-release.yml` never runs on a
+pull request, so none of this wiring is exercised by CI before a tag:
+`ci/tests/test_auto_release_workflow.py` is the substitute, asserting the shape from the
+YAML itself.
+
+## Reproducing a macOS or Windows bundle from Linux (#277 phase F)
+
+```bash
+uv run ci/verify_local.py --list                            # config table + bundle table
+uv run ci/verify_local.py --bundle macos-arm64-release      # build one lane locally
+```
+
+`--bundle <name>` runs the same `soldr prepare --target <triple>` (from `rust/`, where the
+`rust-toolchain.toml` pin lives), the same `cmake/toolchains/soldr-<triple>.cmake`, the same
+matrix `cmake` flags, and the same `ci/bundle_tests.py` invocation — including the
+lane-specific `--objdump` / `--dll-search-dir` / `--check-dll-closure` /
+`--allow-msvc-runtime` arguments — that `macos-bundles.yml` and `windows-bundles.yml` use.
+It asserts the resolved `-- Link libraries` line the build jobs assert, prints the bundle
+path, the manifest's test count and every test's lowered argv, and ends with the exact
+`ci/run_test_bundle.py` command to replay it on the target OS.
+
+It stops **before** execution, which is the one step a Linux box cannot do. That is still
+most of the failure surface: a configure that picked up a host library, a link that lost
+`__interpose` or a TLS directory, an emulated-TLS import, a bundle missing a runtime DLL,
+a manifest with a leaked absolute path — all of those are build-side and all of them
+reproduce here in about a minute, instead of a push-and-wait cycle against a runner.
+
+The fourteen names are exactly the two workflows' matrices
+(`macos-{arm64,x64}-{release,debug-full,leak}`,
+`windows-{gnu,msvc}-x64-{release,debug-full,shared,leak}`), and
+`ci/tests/test_verify_local.py` parses those matrices and fails if a name, triple, cmake
+flag or `bundle_tests.py` argument drifts out of sync — the same contract the
+`--only` config table has had since phase A.

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -14,14 +14,14 @@ and fails if a job's flags drift out of sync with the script.
 uv run ci/verify_local.py                     # everything fast (slow ctest tier excluded)
 uv run ci/verify_local.py --only release,lint  # just these configs
 uv run ci/verify_local.py --slow               # also run the long-tail ctest tier
-uv run ci/verify_local.py --list                # print the config table and exit
+uv run ci/verify_local.py --list                # print the config + bundle tables
 uv run ci/verify_local.py --jobs 8              # override the total build/ctest job budget
 uv run ci/verify_local.py --keep-going          # run every config even after one fails
 uv run ci/verify_local.py --selftest            # trivially fast dry-run, no real builds
 ```
 
-Ten configs run concurrently (`release`, `off`, `debug-full`, `guarded`, `shared`,
-`memory-gate`, `diag`, `rust`, `lint`, `asan`), each building into its own directory
+Eleven configs run concurrently (`release`, `off`, `debug-full`, `guarded`, `shared`,
+`bundle`, `memory-gate`, `diag`, `rust`, `lint`, `asan`), each building into its own directory
 under `out/verify/<config>/` (gitignored, incremental across invocations) with Ninja
 and ccache when available. `asan` needs `clang`/`clang++` on `PATH` and reports
 SKIPPED with a reason otherwise. The long tests (`test-profile-race`,
@@ -31,6 +31,34 @@ expect on the order of a few minutes wall-clock for the fast tier -- well under 
 sum of the per-config times, which the final table reports alongside the wall clock so
 the parallel speedup is visible. A failed config prints the last ~40 lines of its full
 log (`out/verify/<config>/verify.log`) inline.
+
+## Reproducing a macOS or Windows CI bundle here
+
+The macOS and Windows gates do not build on the platform they target: `macos-bundles.yml`
+and `windows-bundles.yml` cross-compile the test binaries on Linux through soldr and ship
+them to one runner per OS as a portable *test bundle* (#277). That means everything up to
+the execution step is reproducible on this box, and `--bundle` does it:
+
+```bash
+uv run ci/verify_local.py --list                          # names, triples, cmake flags
+uv run ci/verify_local.py --bundle macos-arm64-release
+uv run ci/verify_local.py --bundle windows-gnu-x64-debug-full
+```
+
+Fourteen names, exactly the two workflows' build matrices:
+`macos-{arm64,x64}-{release,debug-full,leak}` and
+`windows-{gnu,msvc}-x64-{release,debug-full,shared,leak}`. Each one runs the same
+`soldr prepare --target <triple>`, the same `cmake/toolchains/soldr-<triple>.cmake`, the
+same matrix flags and the same `ci/bundle_tests.py` arguments CI uses, asserts the resolved
+`-- Link libraries` line the build job asserts, and prints the bundle path, its manifest
+summary and the `ci/run_test_bundle.py` command to replay it on the target OS. Output goes
+to `out/verify/bundles/<name>/` (gitignored, incremental).
+
+It cannot *run* the bundle -- that needs the target OS. Everything else fails here first:
+a configure that picked up a host library, a link that lost `__interpose` or its TLS
+directory, a bundle missing a toolchain runtime DLL, a manifest carrying an absolute path.
+`ci/tests/test_verify_local.py` parses both workflow matrices and fails if a name, triple,
+cmake flag or `bundle_tests.py` argument drifts.
 
 # Fast local Linux build loop
 


### PR DESCRIPTION
Implements **#277 phases E and F**. `ci/`, `.github/` and docs only — no C-core or `rust/` paths (CLAUDE.md rule 2).

## Phase E1 — `zero-tracking.yml` loses its `windows-latest` row

That row checked out, built the tree natively with MSVC and *then* ran the A/B: one whole extra Windows VM per matching PR, which is exactly the cost #277 exists to remove. Both halves move into `windows-bundles.yml`'s single `run-windows` job, and they move differently:

| half | before | after |
|---|---|---|
| correctness (`ctest -R zero-tracking`) | Windows row, only on a matching PR | **unconditional, every push, two lanes** — `test-zero-tracking` and `test-zero-tracking-enabled` are registered ctest tests, so `bundle_tests.py` already puts them in every bundle manifest and `run-windows` already replays the whole manifest for `windows-gnu-x64-release` *and* `windows-msvc-x64-release` |
| interleaved A/B timing | Windows row, only on a matching PR | a gated step on `run-windows`, keyed to the same paths |

So the correctness gate got *stronger* while the Windows job count went **down by one**.

A step cannot carry a `paths:` filter, so the gate asks the PR-files API and **fails open** on an API error. It keys on `src/arena.c`, `test/bench-zero-tracking.c` and `.github/workflows/windows-bundles.yml` — deliberately **not** `zero-tracking.yml`, which does not trigger this workflow at all, so keying on it would promise a run the trigger cannot deliver.

Costs stated in `docs/ci-gates.md`: the Windows arm is **clang-cl**, not `cl`; a PR touching only `zero-tracking.yml` exercises the Linux arm alone; and because the gate keys on `windows-bundles.yml`, future CI-only PRs to that file pay ~1 min for the A/B — that is the price of the trigger being provable, and it can be narrowed later.

## Phase E2 — every release binary is cross-built, and `auto-release.yml` says so

**This reverses #277 row E's wording** ("shipped release assets stay built by the platform's own toolchain"). Two owner decisions taken after that row was written force it:

1. **No macOS build or test may run on a native Mac runner** anywhere in this repository (`ci/lint_no_macos_runners.py` enforces it). There is no Apple toolchain available to build an Apple asset with.
2. **Cross-compilation is a product requirement**, not a CI cost measure: mimalloc-pprof ships inside cross-compiled code, so the Linux-cross-built artifact *is* the product.

The second settles Windows, where a native runner does still exist: building the shipped MSVC-ABI binary with `cl` while `windows-bundles.yml` executes a clang-cl bundle would mean **the tested binary and the shipped binary are different binaries**. So the assets come off the same soldr toolchains, the same `cmake/toolchains/soldr-<triple>.cmake` files and the same commit as the executed bundles — the bundles are the evidence for the assets.

`c-unit.yml`'s native `cl` Release `ctest` stays a hard gate (rule 3) and **ships nothing** — there was never a natively-built release asset here to "retain": before this PR `auto-release.yml` shipped only the architecture-independent amalgamation ZIP.

| asset | target | built by | consumer still needs |
|---|---|---|---|
| `mimalloc-pprof-macos-arm64-<tag>.tar.gz` | `aarch64-apple-darwin` | soldr clang 21 + ld64.lld + Apple SDK, on `ubuntu-latest` | — |
| `mimalloc-pprof-macos-x86_64-<tag>.tar.gz` | `x86_64-apple-darwin` | same | — |
| `mimalloc-pprof-windows-x64-gnu-<tag>.zip` | `x86_64-pc-windows-gnu` | soldr mingw-w64 gcc 15 (UCRT) | nothing — `libgcc_s_seh-1.dll` is **shipped in the archive** |
| `mimalloc-pprof-windows-x64-msvc-<tag>.zip` | `x86_64-pc-windows-msvc` | soldr clang-cl + lld-link, `/MD` pinned | the Visual C++ redistributable (`VCRUNTIME140.dll`, `MSVCP140.dll`) |
| `mimalloc-pprof-c-<tag>.zip` | any | source, unchanged | a C compiler |

`cmake --install` (not a hand-picked `cp` list) carries this fork's own `mimalloc/profile.h` and `mimalloc/memory-events.h`, the CMake package, pkg-config, and `mimalloc-redirect.dll` on both Windows lanes — verified on all four lanes, so **no CMakeLists change was needed** (rule 7 escalation not required). The win-gnu archive also ships `libgcc_s_seh-1.dll`, found by `bundle_tests.py`'s own `resolve_runtime_dlls()` import closure: `mimalloc.dll` imports it for `__popcountdi2` and a plain Windows box does not have it, and a missing DLL is a dialog-free `0xC0000135`, not a legible error. Shipping it rather than relinking `-static-libgcc` keeps the shipped binary byte-identical to the one `windows-bundles.yml` tests. Every archive carries a `PROVENANCE.txt` naming commit, target, compiler and the runtime still required.

`build-and-package` drops its `windows-latest` row (review addendum item 5: `xtask check`, `cargo test` and `publish --dry-run` are all platform-independent). `release` `needs:` both build jobs, `release-outcome` reports both, and the rename step hard-fails on fewer than five assets — issue #55 is the "green pipeline published nothing" failure once already.

### How E2 was verified without tagging a release

`auto-release.yml` runs on `workflow_dispatch` and `v*` tag pushes only, so **CI on this PR will not exercise it**. Two substitutes:

- **All four `build-binaries` lanes' `run:` blocks were executed locally on Linux** against real soldr toolchains (`aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-pc-windows-gnu`, `x86_64-pc-windows-msvc`): configure + link-libraries assertion + build + install + DLL closure + arch evidence + `PROVENANCE.txt` + archive. The only step that could not run is the final `zip` on the two Windows lanes — `zip` is absent on this box and present on `ubuntu-latest` (the pre-existing package step already uses it). The gnu lane printed `shipping toolchain runtime: …/libgcc_s_seh-1.dll` and `import closure resolves for 2 PE file(s)`. **No release was tagged and no workflow was dispatched.**
- `ci/tests/test_auto_release_workflow.py` (8 tests): no non-Linux `runs-on`, no `os` matrix dimension, `release` waits for every build job, every uploaded artifact is downloaded, and the build matrix / rename step / `action-gh-release` `files:` list all name the same five assets.

## Phase F — `uv run ci/verify_local.py --bundle <name>`

Fourteen names, exactly the two bundle workflows' build matrices (`macos-{arm64,x64}-{release,debug-full,leak}`, `windows-{gnu,msvc}-x64-{release,debug-full,shared,leak}`). Each runs the same `soldr prepare --target <triple>` (from `rust/`, where the toolchain pin lives), the same toolchain file, the same matrix `cmake` flags and the same `bundle_tests.py` arguments — including `--objdump` / `--dll-search-dir` / `--check-dll-closure` / `--allow-msvc-runtime` — then asserts the resolved `-- Link libraries` line the build job asserts and prints the bundle path, manifest summary and the `run_test_bundle.py` command for the target OS. `--list` prints the table.

It stops **before** execution, the one step Linux cannot do. Everything build-side reproduces in about a minute instead of a push-and-wait cycle: a configure that picked up a host library, a link that lost `__interpose` or its TLS directory, a bundle missing a runtime DLL, a manifest with a leaked absolute path.

The prepared environment is parsed out of `--github-env` and handed to the subprocesses rather than applied to `os.environ`, and a GitHub heredoc-form line is refused rather than mis-parsed.

Verified locally, for real:

```
macos-arm64-release      PASS   38 tests, arm64 Mach-O, Link libraries = pthread
windows-gnu-x64-release  PASS   33 tests, libgcc_s_seh-1.dll shipped
windows-msvc-x64-shared  PASS   30 tests
```

`ci/tests/test_verify_local.py` gains a `BundleTableDriftTests` class that parses both matrices and fails if a bundle name, triple, cmake flag or `bundle_tests.py` argument drifts — the same contract the `--only` config table has had since phase A. The Windows jobs carry no matrix `triple:`, so the test reads it out of the toolchain path their steps pass to cmake rather than hardcoding it.

## Gates

```
pytest ci/tests            229 passed
ruff check / format        clean
pyright 1.1.411 (strict)   0 errors, 0 warnings
lint_no_macos_runners      24 files, no macOS runner labels
```

## Expected red

`macos-bundles.yml`'s `run-macos-x64 (dockurr/macos on Linux)` is **red on `main` too** and unrelated to this PR — the one-time human macOS golden-disk install (`ci/macos_golden_local.sh` → `macos-golden-upload.yml`) is still owed by the owner, and the job deliberately hard-fails on the cache miss rather than skipping itself green. Evidence: run 33654891521 on `main`, same single failing job.

Refs #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
