### PR TITLE
ci: gate the macOS bundle lanes behind MACOS_LANE_ENABLED (off for now)

### DIFF
--- a/.github/workflows/macos-bundles.yml
+++ b/.github/workflows/macos-bundles.yml
@@ -54,6 +54,10 @@ concurrency:
 
 jobs:
   build-macos:
+    # Disabled 2026-09-02 at the owner's request until the x64 golden image / unattended
+    # install question (#277, #283) is settled: set repo variable MACOS_LANE_ENABLED=true
+    # to re-enable. The no-native-macOS lint (ci/lint_no_macos_runners.py) stays active.
+    if: ${{ vars.MACOS_LANE_ENABLED == 'true' }}
     name: build-macos (${{ matrix.bundle }})
     runs-on: ubuntu-latest
     strategy:
@@ -273,6 +277,10 @@ jobs:
           retention-days: 7
 
   build-rust-apple:
+    # Disabled 2026-09-02 at the owner's request until the x64 golden image / unattended
+    # install question (#277, #283) is settled: set repo variable MACOS_LANE_ENABLED=true
+    # to re-enable. The no-native-macOS lint (ci/lint_no_macos_runners.py) stays active.
+    if: ${{ vars.MACOS_LANE_ENABLED == 'true' }}
     name: build-rust (${{ matrix.target }})
     runs-on: ubuntu-latest
     strategy:
@@ -408,6 +416,10 @@ jobs:
   # two minutes and costs one Linux runner.
   # ---------------------------------------------------------------------------------
   run-macos-x64-dockur:
+    # Disabled 2026-09-02 at the owner's request until the x64 golden image / unattended
+    # install question (#277, #283) is settled: set repo variable MACOS_LANE_ENABLED=true
+    # to re-enable. The no-native-macOS lint (ci/lint_no_macos_runners.py) stays active.
+    if: ${{ vars.MACOS_LANE_ENABLED == 'true' }}
     name: run-macos-x64 (dockurr/macos on Linux)
     needs: [build-macos, build-rust-apple]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Owner request: disable macOS x64 and arm64 from the testing regime for now so PRs are not red on the designed `run-macos-x64-dockur` failure (no golden image yet; unattended-install investigation in progress, #277/#283).

- `build-macos`, `build-rust-apple`, `run-macos-x64-dockur` run only when repo variable `MACOS_LANE_ENABLED == 'true'` (unset now → skipped). Re-enable = set the variable; no PR needed.
- Unchanged: the no-native-macOS lint, the Windows lanes, `cross.yml`'s Apple Rust *compile* rows (Linux-hosted), and the cross-built release lanes in `auto-release.yml`.
- Side effect while off: P8's Apple TSD-slot header guard and the arm64 `MI_TLS_MODEL_FIXED` compile lane (both live in `build-macos`) are also skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S