### PR TITLE
ci: run the PR benchmarks on demand or daily, never on a docs edit

### DIFF
--- a/.github/workflows/benchmark-sentinel.yml
+++ b/.github/workflows/benchmark-sentinel.yml
@@ -4,14 +4,38 @@ name: benchmark-sentinel
 # Produces JSON + HTML report uploaded as a CI artifact.
 # Hosted-runner results are labelled informational — not accepted for
 # small-timing claims (requires stable reference host per #170).
+#
+# ON DEMAND, OR ONCE A DAY -- NOT ON EVERY PUSH. This used to run two 10-minute
+# jobs on every pull_request push that touched rust/, src/ or include/. Nobody
+# reads the result of most of those: the numbers are informational by
+# construction (#170/#171 -- a hosted runner is not a stable reference host) and
+# no gate consumes them, so a per-push cadence bought a trend nobody plots at the
+# price of ~20 runner-minutes per push, on the same hosted pool the correctness
+# lanes queue for. It now runs when someone actually wants a number --
+# `workflow_dispatch`, or a `benchmark` label on the PR (add the label and the
+# `labeled` event below starts it, no push needed) -- and once a day on schedule
+# so the trend line still gets a daily point.
 
 on:
   pull_request:
+    # `labeled` is what makes the escape hatch work without a dummy commit.
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - rust/**
       - src/**
       - include/**
       - .github/workflows/benchmark-sentinel.yml
+      # Documentation is not a benchmark input. These `!` patterns subtract from the
+      # includes above (path filters are evaluated in order), so a markdown-only edit
+      # inside rust/ -- a README, a design note -- no longer even queues the gate job.
+      - '!**/*.md'
+      - '!**/*.txt'
+      - '!docs/**'
+  schedule:
+    # Daily, off the hour to dodge scheduler congestion. This is the "or one day has
+    # passed" half of the policy above; the benchmark-* publication workflows keep
+    # their own (weekly/daily) crons and are untouched.
+    - cron: "43 6 * * *"
   workflow_dispatch:
 
 env:
@@ -25,6 +49,11 @@ concurrency:
 jobs:
   sentinel:
     name: benchmark-sentinel (${{ matrix.os }})
+    # The on-demand half of the policy in the header: a pull_request event only
+    # measures when the PR carries the `benchmark` label. Schedule and manual
+    # dispatch always measure. A skipped job still reports on the PR, so the check
+    # stays visible (and re-runnable by labelling) instead of silently vanishing.
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'benchmark') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     # TODO(#277 phase D, added 2026-09-02): DELETE the windows-latest row after ten pushes

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -751,6 +751,12 @@ jobs:
           staged=$(( $(ls -1 dist/msvc-tests/debug | wc -l) + $(ls -1 dist/msvc-tests/release | wc -l) ))
           echo "staged $staged of $built test binaries ($(ls -1 dist/msvc-tests/debug | wc -l) debug + $(ls -1 dist/msvc-tests/release | wc -l) release)"
       - name: Build the PR benchmark sentinel
+        # NOT gated on the `benchmark` label even though running it is (see run-windows):
+        # this is a cross-build on the Linux builder that already builds the whole Rust
+        # workspace, and its artifact is an unconditional `download-artifact` input over
+        # there. Gating the build would fail the download; gating the RUN is what saves the
+        # scarce thing, which is time on the single shared Windows VM.
+        #
         # benchmark-sentinel.yml's `benchmark-sentinel (windows-latest)` row runs
         # `soldr cargo run -p dashboard --release`, which is a self-contained binary: it
         # re-execs itself as its own stress child and writes benchmark-report.html into
@@ -1338,11 +1344,18 @@ jobs:
         # Guarded on the event so the fold does not turn a pull_request-only benchmark
         # into a per-push one -- windows-bundles.yml runs on push as well.
         #
+        # ... and guarded on the `benchmark` label for the same reason benchmark-sentinel.yml
+        # now is (see its header): these numbers are informational, no gate reads them, and
+        # measuring on every push spends minutes on a trend nobody plots. Label the PR
+        # `benchmark` to get them. Unlike that workflow this one cannot offer a daily
+        # schedule -- windows-bundles.yml exists to run correctness bundles per push -- so
+        # the daily point comes from benchmark-sentinel.yml's cron instead.
+        #
         # #171 already labels hosted-runner numbers informational and no gate reads them,
         # which is what makes it acceptable to take them on a VM that has just run four
         # ctest suites and a memory gate. `continue-on-error` for the same reason: a
         # benchmark that fails to produce a report must not fail the correctness runner.
-        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmark') && !cancelled() }}
         continue-on-error: true
         #
         # `dashboard` writes benchmark-report.html into the CURRENT directory and prints
@@ -1356,7 +1369,7 @@ jobs:
           cd sentinel
           "$GITHUB_WORKSPACE/rust-sentinel-msvc/dashboard.exe" > benchmark-report.json
           ls -l benchmark-report.html benchmark-report.json
-      - if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+      - if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'benchmark') && !cancelled() }}
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
`benchmark-sentinel` ran two 10-minute jobs (ubuntu + windows) on every `pull_request` push touching `rust/`, `src/` or `include/`, and `windows-bundles` ran a third sentinel on the single shared Windows VM on the same event. Nothing consumes those numbers — they are informational by construction (#170/#171: a hosted runner is not a stable reference host) and no gate reads them — so the per-push cadence spent ~20 runner-minutes per push, in the same hosted pool the correctness lanes queue for. A markdown-only edit under `rust/` paid it too.

## After

| when | measures? |
|---|---|
| docs-only PR (`**/*.md`, `**/*.txt`, `docs/**`) | not even queued |
| ordinary PR push | no — job reports `skipped` |
| PR labelled `benchmark` | yes (the `labeled` event starts it, no dummy commit) |
| `workflow_dispatch` | yes |
| daily cron (`43 6 * * *`) | yes — keeps the trend line |

`windows-bundles`' `PR benchmark sentinel (MSVC, cross-built)` step and its artifact upload take the same label condition. Its Linux-side cross-build stays unconditional: it feeds an unconditional `download-artifact`, and time on the shared Windows VM — not a cargo build on the Linux builder — is the scarce thing.

The publication workflows (`benchmark-stats` daily; `benchmark-memory`, `benchmark-latency`, `benchmark-scaling` weekly) are untouched: they are already dispatch-plus-cron only and never ran on a pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S