### PR TITLE
ci: make the memory gate measure the allocator, not the runner (#298)

### DIFF
--- a/ci/memory-baselines/linux-pprof1.json
+++ b/ci/memory-baselines/linux-pprof1.json
@@ -1,23 +1,23 @@
 {
-  "baseline_runs": 4,
-  "baseline_spread_pct": 5.8,
+  "baseline_runs": 16,
+  "baseline_spread_pct": 0.9,
   "counters": {
-    "pages_end": 1,
-    "pages_start": 1,
+    "pages_end": 2,
+    "pages_start": 2,
     "theaps_end": 1,
-    "theaps_start": 0,
+    "theaps_start": 1,
     "threads_end": 1,
     "threads_start": 1
   },
   "gated_metric": "peak_rss",
   "inject_leak": 0,
   "mi_pprof": 1,
-  "peak_commit_mb": 49.7,
-  "peak_mb": 22.3,
-  "peak_minus_profiler_mb": 22.3,
-  "peak_rss_mb": 22.3,
+  "peak_commit_mb": 61.4,
+  "peak_mb": 58.0,
+  "peak_minus_profiler_mb": 58.0,
+  "peak_rss_mb": 58.0,
   "platform": "linux",
   "profiler_arena_mb": 0.0,
-  "purged_gb": 0.06,
+  "purged_gb": 0.1,
   "schema": 1
 }

--- a/ci/memory-baselines/windows-pprof1.json
+++ b/ci/memory-baselines/windows-pprof1.json
@@ -1,23 +1,23 @@
 {
-  "baseline_runs": 4,
-  "baseline_spread_pct": 9.9,
+  "baseline_runs": 8,
+  "baseline_spread_pct": 0.1,
   "counters": {
-    "pages_end": 1,
+    "pages_end": 0,
     "pages_start": 0,
     "theaps_end": 1,
-    "theaps_start": 0,
+    "theaps_start": 1,
     "threads_end": 1,
     "threads_start": 1
   },
   "gated_metric": "peak_commit",
   "inject_leak": 0,
   "mi_pprof": 1,
-  "peak_commit_mb": 52.5,
-  "peak_mb": 52.5,
-  "peak_minus_profiler_mb": 52.5,
-  "peak_rss_mb": 16.2,
+  "peak_commit_mb": 74.4,
+  "peak_mb": 74.4,
+  "peak_minus_profiler_mb": 74.4,
+  "peak_rss_mb": 22.6,
   "platform": "windows",
   "profiler_arena_mb": 0.0,
-  "purged_gb": 0.06,
+  "purged_gb": 0.1,
   "schema": 1
 }

--- a/ci/memory_gate.py
+++ b/ci/memory_gate.py
@@ -10,12 +10,19 @@ Windows commit report different numbers for identical allocator behavior, and ma
 compresses memory so its resident figure falls under pressure while a leak grows. Only
 same-OS deltas are meaningful.
 
-Peak memory is *not* a low-variance signal, so both commands take several runs of the
-same binary and use the **minimum** observed peak. Noise on a shared CI runner only ever
-adds memory (another tenant's page cache, a straggler thread still winding down), so the
-minimum is the estimator closest to the allocator's true high-water mark, and it is far
-more stable than any single run. The spread across runs is printed every time -- if it
+Both commands take several runs of the same binary and use the **minimum** observed peak.
+Noise on a shared CI runner only ever adds memory (another tenant's page cache, a
+straggler thread still winding down), so the minimum is the estimator closest to the
+allocator's true high-water mark. The spread across runs is printed every time -- if it
 ever approaches the tolerance, the tolerance is wrong and the printout says so.
+
+The minimum is not what makes this gate stable, though; #298 established that no
+statistic could rescue the old workload (min-of-8 across twelve consecutive `main` runs
+spanned 22.3-28.0 MB, the median 25.6-31.2 MB), because the peak was set by how many of
+test-memory-gate's churn workers the runner's scheduler happened to overlap. The fix was
+in the workload, not here: test/test-memory-gate.c now rendezvouses those workers, so the
+peak is the structural cost of N live sets rather than a scheduler coin flip. The minimum
+stays because one-sided noise makes it the right estimator, not because it is load-bearing.
 
 Usage:
     memory_gate.py check   [<result.json> ...]   # no paths: build/run the binary itself
@@ -95,42 +102,66 @@ class Result(TypedDict):
 
 # Peak memory tolerance, applied to the minimum of RUNS_EXPECTED runs.
 #
-# An earlier version of this file asserted that memory was "the low-variance signal here
-# (the gated numbers are kernel high-water marks, not sampled)" and set this to 0.10.
-# That was an assumption, and measuring disproved it: repeated runs of the same binary
-# span roughly 20% peak-to-peak. Taking the minimum of several runs cuts that to a few
-# percent, which is what makes a tight threshold defensible rather than flaky.
+# 2026-09-03 (#298). This number is derived from measurement, not chosen. History first,
+# because it is what the derivation has to beat:
 #
-# This number is set from the observed spread reported by the runs below, not guessed.
-# Raise it only with the measurement that justifies it; a gate that flakes gets ignored,
-# and an ignored gate is worse than none.
+#   The tolerance was 0.15 and the ubuntu gate still flipped red on commits that changed
+#   no allocator code at all (docs-only #275, ci-only #278/#297). The `memory-gate-
+#   ubuntu-latest` artifacts of the last twelve `main` runs of c-unit.yml say why --
+#   min-of-8 / median / within-run spread, against a 22.3 MB baseline and a 25.6 MB
+#   allowed:
+#     33618717188  26.7 / 29.6 / 32.6%      33647332787  24.5 / 26.5 / 17.6%
+#     33629562858  24.7 / 27.4 / 19.0%      33654892179  27.9 / 31.2 / 24.4%
+#     33631613324  28.0 / 29.2 / 15.7%      33660325957  26.5 / 27.6 / 18.5%
+#     33635722154  26.0 / 28.0 / 19.6%      33689409217  22.7 / 25.6 / 25.6%
+#     33636560081  22.3 / 26.9 / 30.0%      33692432919  25.5 / 27.9 / 28.2%
+#     33646494496  24.3 / 28.2 / 44.4%      33699070304  27.8 / 30.2 / 19.8%
+#   Every within-run spread exceeds the tolerance it was compared under, min-of-8 across
+#   runs spans 25.6% and the median 21.9%. No tolerance and no statistic can separate a
+#   regression from that; a per-scenario decomposition (idle host, `taskset -c 0-3`)
+#   found scenario 1 -- the 8-thread churn -- alone ranging 14.1 -> 24.6 MB run to run,
+#   with every later scenario adding <= 2 MB on top. The gate was measuring the runner.
 #
-# 2026-09-02 (#266): min-of-4 on ubuntu-latest was flaky enough to flip PASS/FAIL between
-# consecutive pushes of the *same* Release object code (diagnostic.c-only commits do not
-# touch the Release build). Five consecutive PR #276 / main measurements, all min-of-4,
-# baseline 22.3 MB, allowed 25.6 MB:
-#   238218d5 -> 24.7 MB PASS (spread 17.8%)
-#   5d1d6ae3 -> 26.5 MB FAIL (spread  9.1%)
-#   32e08564 -> 25.4 MB PASS (spread 23.2%)
-#   0e23010b -> 29.2 MB FAIL (spread 14.7%)   <- identical Release code to 32e08564
-#   main #275 (docs-only, no allocator-path changes at all) -> 25.8 MB FAIL (+15.7%)
-# Four of five spreads are at or above PEAK_TOLERANCE itself -- the threshold this
-# comment used to warn "cannot distinguish a regression from noise" was already
-# happening in practice, not just hypothetically. Per that same comment's own rule
-# ("raise RUNS_EXPECTED or the tolerance, with this measurement as the justification"),
-# these five measurements are that justification for min-of-8: RUNS_EXPECTED below moves
-# from 4 to 8. PEAK_TOLERANCE stays 0.15 and ci/memory-baselines/*.json is deliberately
-# NOT touched -- the baseline was recorded as a min-of-4 (22.3 MB, 5.8% spread, #70), and
-# a min-of-8 of the same underlying peak-RSS distribution can only be <= a min-of-4 of
-# that distribution, never higher, so doubling the run count here is strictly
-# conservative with respect to that baseline: it cannot manufacture a new pass, only
-# remove noise-driven false failures.
-PEAK_TOLERANCE = 0.15
+#   So the workload was fixed instead (test/test-memory-gate.c: the churn workers
+#   rendezvous, and the cross-thread handoff no longer busy-spins). Three independent
+#   ubuntu-latest runner VMs (nproc=4, THP=always), 16 runs each, the same object code:
+#     33700518749  min 58.0  med 58.3  max 58.5  spread 0.9%
+#     33700575788  min 58.0  med 58.5  max 58.5  spread 0.9%
+#     33700583919  min 58.0  med 58.3  max 58.6  spread 1.0%
+#   min-of-16 is 58.0 MB on all three -- 0.0% across-run variation of the estimator, and
+#   1.0% across all 48 samples. Pinning changes nothing any more (`taskset -c 0-1` 0.5%,
+#   `-c 0` 0.7%), `MIMALLOC_SCAVENGER=0 MIMALLOC_PURGE_HOLES=0` changes nothing (1.2%),
+#   and an unpinned 16-core workstation reads 58.2-58.3 -- the same number as the 4-vCPU
+#   runner, where the old workload read 58 MB unpinned vs 23 MB pinned. The old workload
+#   re-measured on those same three VMs for comparison: 26.4 / 27.4 / 25.5 min-of-16,
+#   spreads 26.1% / 24.5% / 23.1%.
+#
+# 0.05 is therefore 5x the largest observed spread (1.0%) and infinitely more than the
+# observed across-run variation of the estimator itself (0.0%), leaving 2.9 MB of
+# absolute headroom on a 58 MB baseline. The measurement would support 0.03; the
+# difference is reserved for runner-image drift, which three runs on one image cannot
+# bound. Tighten it once ten `main` runs on a new image have been observed, with those
+# numbers written here.
+#
+# The positive control's margin, which is the other half of a defensible threshold: the
+# MI_BENCH_INJECT_LEAK=200000 build read min-of-8 82.6 / 82.4 / 82.5 MB on the same three
+# VMs -- +42.1% over the baseline, or 8.4x this tolerance. The rule is that the control
+# must fail by at least 2x the tolerance, so a leak this size is caught with a factor of
+# four to spare, and the smallest regression the gate can now see is 2.9 MB (5% of a
+# 58 MB structural peak) instead of "nothing at all under 25% of noise".
+PEAK_TOLERANCE = 0.05
 
 # Number of runs the CI job is expected to supply. Fewer is allowed (with a warning) so
-# the script stays usable locally, but the committed baselines are min-of-N (N=4 for the
-# existing ci/memory-baselines/*.json; see the RUNS_EXPECTED comment above for why a
-# larger N here is still a valid, strictly-conservative comparison against those files).
+# the script stays usable locally.
+#
+# Left at 8 by #298 rather than raised or lowered, and that is a measured decision both
+# ways. Raising it buys nothing: min-of-16 and min-of-8 of the post-#298 distribution are
+# the same 58.0 MB on all three runner VMs measured above, because the distribution is
+# 0.6 MB wide. Lowering it to 4 would also be defensible on those numbers and would need a
+# matching edit to the `for i in 1 2 3 4 5 6 7 8` loops in c-unit.yml -- not worth the
+# churn for a binary that now completes in ~0.1 s (the busy-spin removal in scenario 3
+# made it faster, not slower). Eight runs also keep the printed spread informative enough
+# to notice an image change before it becomes a red gate.
 RUNS_EXPECTED = 8
 
 # Counters are exact, not statistical. A thread that was created and joined must not
@@ -139,17 +170,17 @@ RUNS_EXPECTED = 8
 MAX_LIVE_THREADS = 32
 
 
-# CI's runners are 4-core (ubuntu-latest/windows-latest/macos-latest as of the baselines
-# this gate compares against). A wider local box measurably inflates the peak this test
-# exercises: it drives MI_BENCH_THREADS()-many concurrently-running threads doing an
-# allocation churn, and peak RSS/commit scales with how many of those threads the OS
-# actually schedules onto distinct CPUs at once, not just with the allocator's true
-# high-water mark. Observed on this repo: 58 MB on an unrestricted 16-core host vs ~23 MB
-# under `taskset -c 0-3` on the same host, for the identical binary and commit -- an
-# apples-to-oranges comparison against the 4-core baselines that nothing about the JSON
-# schema flags as such. Pinning the child to <= 4 CPUs here is what makes a local
-# `python ci/memory_gate.py check` (no path arguments) comparable to the CI numbers
-# instead of just plausible-looking.
+# CI's runners are 4-core. This pinning was load-bearing before #298: the old workload's
+# peak scaled with how many of its churn threads the OS put on distinct CPUs at once, so
+# an unrestricted 16-core host read 58 MB against a 4-core baseline of ~23 MB for the
+# identical binary and commit -- an apples-to-oranges comparison nothing in the JSON
+# flagged as such.
+#
+# It is no longer load-bearing, and the measurement that says so is in PEAK_TOLERANCE
+# above: with the rendezvoused workload the same 16-core host reads 58.2-58.3 MB unpinned
+# and the 4-vCPU runner reads 58.0-58.6 MB. It is kept as a cheap guard -- a future
+# scenario that reintroduces CPU-count sensitivity would otherwise make local numbers
+# quietly incomparable to CI's again, which is exactly how #298 stayed hidden for so long.
 MAX_GATE_CPUS = 4
 
 
@@ -292,7 +323,16 @@ def load_runs(
     return best, peaks, spread
 
 
-def report_runs(peaks: list[float], spread: float) -> None:
+def report_runs(peaks: list[float], spread: float, *, gated: bool = True) -> None:
+    """Print the run distribution; `gated=False` for a run nothing is thresholded against.
+
+    The spread warning below is advice about *this gate's* threshold, so it must not fire
+    on the positive control. A leak build's runs legitimately span tens of percent (the
+    injected blocks land in already-resident arena memory or not, depending on purge
+    timing: 82.6-129.8 MB across one measured control run), and telling a reader to raise
+    RUNS_EXPECTED or the tolerance on the strength of that would be advice to loosen a
+    real gate because a deliberately broken build was noisy.
+    """
     print("  {:<22} {}".format("runs (MB)", "  ".join(f"{p:.1f}" for p in peaks)))
     print(
         "  {:<22} {:.1f}%  (min is used; noise on a shared runner only adds memory)".format(
@@ -304,10 +344,11 @@ def report_runs(peaks: list[float], spread: float) -> None:
             f"  WARNING: only {len(peaks)} run(s); the committed baselines are min-of-{RUNS_EXPECTED}. "
             "A single run is not comparable."
         )
-    if spread >= 100.0 * PEAK_TOLERANCE:
+    if gated and spread >= 100.0 * PEAK_TOLERANCE:
         print(
             f"  WARNING: observed spread ({spread:.1f}%) is at or above the tolerance "
             f"({100.0 * PEAK_TOLERANCE:.0f}%). The threshold cannot distinguish a regression from noise -- "
+            "fix the workload's determinism first (that is what #298 did), and only then "
             "raise RUNS_EXPECTED or the tolerance, with this measurement as the "
             "justification."
         )
@@ -404,7 +445,7 @@ def check(
             "profiler arena", result.get("profiler_arena_mb", 0.0)
         )
     )
-    report_runs(peaks, spread)
+    report_runs(peaks, spread, gated=not _control)
 
     if peak > allowed:
         failures.append(

--- a/ci/tests/test_memory_gate.py
+++ b/ci/tests/test_memory_gate.py
@@ -13,6 +13,8 @@ its own file instead of silently borrowing another's.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import tempfile
 import unittest
@@ -162,6 +164,73 @@ class OptionParsingTest(unittest.TestCase):
     def test_a_dangling_option_is_an_error(self) -> None:
         with self.assertRaises(ValueError):
             memory_gate.take_option(["check", "--arch"], "arch")
+
+
+class ToleranceTest(unittest.TestCase):
+    """#298: the threshold, and the two invariants that keep it from being a guess.
+
+    The gate spent months red on commits that changed no allocator code because the
+    tolerance (0.15) was smaller than the workload's own run-to-run spread (16-44%). The
+    fix was to make the workload deterministic, and these tests pin the two properties
+    that make the resulting number defensible rather than merely smaller.
+    """
+
+    def _check(self, peaks: list[float], **overrides: object) -> tuple[int, str]:
+        base = json.loads((BASELINES / "linux-pprof1.json").read_text(encoding="utf-8"))["peak_mb"]
+        with tempfile.TemporaryDirectory() as tmp:
+            paths: list[str] = []
+            for i, factor in enumerate(peaks):
+                path = Path(tmp) / f"r{i}.json"
+                result = _result(platform="linux", peak_mb=base * factor, **overrides)
+                path.write_text(json.dumps(result), encoding="utf-8")
+                paths.append(str(path))
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = memory_gate.check(paths, _control=bool(overrides.get("inject_leak")))
+        return rc, out.getvalue()
+
+    def test_a_run_inside_the_tolerance_passes(self) -> None:
+        rc, _ = self._check([1.0 + memory_gate.PEAK_TOLERANCE * 0.9] * 8)
+        self.assertEqual(rc, 0)
+
+    def test_a_run_past_the_tolerance_fails(self) -> None:
+        rc, out = self._check([1.0 + memory_gate.PEAK_TOLERANCE * 1.1] * 8)
+        self.assertEqual(rc, 1)
+        self.assertIn("regressed", out)
+
+    def test_the_measured_control_margin_is_at_least_twice_the_tolerance(self) -> None:
+        # Measured on three ubuntu-latest runner VMs (#298): the
+        # MI_BENCH_INJECT_LEAK=200000 build reads min-of-8 82.4 MB against a 58.0 MB
+        # baseline, i.e. +42.1%. A gate whose control only just fires is a gate one
+        # runner-image change away from proving nothing, so the rule is 2x -- and this
+        # test turns "the tolerance may not be raised past that" into a failing test
+        # rather than a sentence in a comment.
+        measured_control_margin = (82.4 - 58.0) / 58.0
+        self.assertGreaterEqual(measured_control_margin, 2.0 * memory_gate.PEAK_TOLERANCE)
+
+    def test_every_committed_baseline_is_quieter_than_the_tolerance(self) -> None:
+        # A baseline recorded from a measurement noisier than the threshold it will be
+        # compared under is the #298 failure mode in miniature: the number is then a
+        # sample of the noise, not the allocator. `update` records the spread it saw, so
+        # this is checkable rather than a matter of trust.
+        for path in sorted(BASELINES.glob("*.json")):
+            record = json.loads(path.read_text(encoding="utf-8"))
+            spread = record.get("baseline_spread_pct")
+            if spread is None:
+                continue  # recorded before `update` started stamping it
+            with self.subTest(baseline=path.name):
+                self.assertLess(spread, 100.0 * memory_gate.PEAK_TOLERANCE, path.name)
+
+    def test_a_control_run_is_not_told_to_raise_the_tolerance(self) -> None:
+        # A leak build's spread is meaningless as advice about the real threshold.
+        rc, out = self._check([1.4, 1.8, 2.4], inject_leak=200000)
+        self.assertEqual(rc, 1)
+        self.assertNotIn("raise RUNS_EXPECTED", out)
+
+    def test_a_real_run_still_is(self) -> None:
+        rc, out = self._check([1.0, 1.0 + 2 * memory_gate.PEAK_TOLERANCE])
+        self.assertEqual(rc, 0)  # min is inside the tolerance ...
+        self.assertIn("raise RUNS_EXPECTED", out)  # ... but the spread is not credible
 
 
 if __name__ == "__main__":

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -916,7 +916,9 @@ workers on a portable condition-variable barrier: every worker in a round alloca
 live set, waits for all of them, then churns and waits again before freeing. "All N live
 at once" becomes the only reachable state, so the peak is the structural cost of N live
 sets. Scenario 3's `while (ready == 0) {}` handoff became the same barrier, so six
-consumers no longer burn the vCPUs the producers need. The binary got *faster* (~0.1 s).
+consumers no longer burn the vCPUs the producers need. Wall time roughly halved and
+stopped scattering: 0.26 / 0.47 / 0.52 s before, 0.27 / 0.18 / 0.18 s after (same
+library, three runs each, `taskset -c 0-3` on an otherwise idle host).
 
 **The numbers.** Three independent `ubuntu-latest` runner VMs (`nproc=4`,
 THP=`always`), 16 runs each, identical object code:

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -948,7 +948,14 @@ would need a matching edit to `c-unit.yml`'s run loops.
 
 **Control margin.** The `MI_BENCH_INJECT_LEAK=200000` build reads min-of-8 82.6 / 82.4 /
 82.5 MB on those same three VMs — **+42.1%**, or 8.4× the tolerance, against a rule that
-the control must fire by at least 2×. `ci/tests/test_memory_gate.py` asserts that ratio,
+the control must fire by at least 2×. CI confirms it on both gated metrics: run
+33701827771's controls report `peak_rss regressed: 82.5 MB vs baseline 58.0 MB (+42.2%)`
+and `peak_commit regressed: 113.7 MB vs baseline 74.4 MB (+52.8%)`. Note that the control
+no longer fires at ~3× the baseline as it did before this change — the injected leak is
+still the same ~32 MB, but the structural peak it has to clear went from ~22 MB to 58 MB.
+The rule that matters (≥2× the tolerance) is met with a factor of four to spare; if a
+larger absolute ratio is wanted, `MI_BENCH_INJECT_LEAK` is set in the workflow, so raising
+it belongs with #307's `c-unit.yml` rewrite rather than here. `ci/tests/test_memory_gate.py` asserts that ratio,
 so raising the tolerance past half the measured control margin is a failing test rather
 than a judgement call. Leak injection now `memset`s the whole block: RSS counts *resident*
 pages, and a leak whose pages were committed-but-untouched moved the peak by an amount
@@ -956,11 +963,13 @@ that depended on purge timing — one measured batch had a control run land with
 the clean baseline, i.e. the control came within one sample of silently not firing.
 
 **Baselines.** `linux-pprof1.json` re-recorded at 58.0 MB (min-of-16, 0.9% spread) from
-run 33700518749; independently confirmed on a fourth runner VM by run 33701098707, which
-read min-of-8 58.2 MB at 0.7% spread against it.
+run 33700518749; independently confirmed on two further runner VMs by runs 33701098707
+(min-of-8 58.2 MB, 0.7% spread) and 33701827771 (58.1 MB, 0.7%), for five independent
+`ubuntu-latest` VMs in total, all reading 58.0-58.2 MB.
 
 `windows-pprof1.json` re-recorded at **74.4 MB (min-of-8, 0.1% spread)** from run
-33701098707, because a workload change invalidates every baseline, not just the flaky one.
+33701098707, and reproduced exactly by run 33701827771 (min-of-8 74.4 MB, 0.1% spread) on
+a second Windows runner — two runs, not one. Re-recorded because a workload change invalidates every baseline, not just the flaky one.
 Windows was never the *failing* lane but it was the noisy one: across the same twelve
 `main` runs it read min-of-8 51.2–57.0 MB (11.3% across runs) with within-run spreads of
 3.9–17.5%, and its committed baseline had itself been recorded at 9.9% spread. The

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -954,11 +954,20 @@ that depended on purge timing — one measured batch had a control run land with
 the clean baseline, i.e. the control came within one sample of silently not firing.
 
 **Baselines.** `linux-pprof1.json` re-recorded at 58.0 MB (min-of-16, 0.9% spread) from
-run 33700518749. `windows-pprof1.json` re-recorded from this PR's own
-`memory-gate-windows-latest` artifact, because a workload change invalidates every
-baseline, not just the flaky one — the historical Windows lane was itself noisier than the
-new tolerance (min-of-8 51.2–57.0 MB across the same twelve `main` runs, within-run
-spreads 3.9–17.5%, baseline recorded at 9.9% spread). `macos-pprof1.json` is **left
+run 33700518749; independently confirmed on a fourth runner VM by run 33701098707, which
+read min-of-8 58.2 MB at 0.7% spread against it.
+
+`windows-pprof1.json` re-recorded at **74.4 MB (min-of-8, 0.1% spread)** from run
+33701098707, because a workload change invalidates every baseline, not just the flaky one.
+Windows was never the *failing* lane but it was the noisy one: across the same twelve
+`main` runs it read min-of-8 51.2–57.0 MB (11.3% across runs) with within-run spreads of
+3.9–17.5%, and its committed baseline had itself been recorded at 9.9% spread. The
+rendezvous fixed it too, and by more than it fixed ubuntu — 17.5% → 0.1%, which is the
+clearest evidence available that the scheduler-overlap diagnosis was the right one: the
+same source code change collapses the spread on two unrelated kernels and two different
+gated metrics (peak RSS and peak commit).
+
+`macos-pprof1.json` is **left
 untouched and is stale**: it records a native-Xcode arm64 lane that #277 phase B2 deleted,
 and no lane compares against it any more (the dockur x86_64 lane keys on
 `macos-x86_64-soldr-clang-21-pprof1.json` and bootstraps its own). Delete or regenerate it

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -856,10 +856,11 @@ without touching the network.
 
 Three details worth stating, because each was an assumption that measurement overturned:
 
-- **Peak memory is not a low-variance signal.** Repeated runs of the same unchanged
-  binary span 6–12% on CI runners. The memory gate therefore compares the **minimum of
-  four runs** and prints the observed spread every time, warning if it ever approaches
-  the tolerance. A gate that flakes gets ignored, and an ignored gate is worse than none.
+- **Peak memory is not a low-variance signal — but a workload can be made one.** See
+  [the memory gate](#the-memory-gate-what-it-measures-298) below: the first version of
+  this bullet said the spread was 6–12% and that a minimum-of-N would absorb it. Measured
+  over twelve `main` runs it was 16–44%, no statistic absorbed it, and the fix had to be
+  in the workload rather than in the threshold.
 - **The gate scripts are gating code.** Several of the silent failures above were Python
   or YAML bugs rather than C bugs — the arm64 instruction scanner matched nothing at all
   and reported "clean". Hence `pyright --strict` over `ci/`, with the result schema
@@ -868,6 +869,106 @@ Three details worth stating, because each was an assumption that measurement ove
   was satisfied by libFuzzer's advice *to use* AddressSanitizer. Assertions about tool
   output should anchor on that tool's actual report format (`^(==[0-9]+==)?(ERROR|SUMMARY):`),
   never on a keyword that can appear in an explanatory sentence.
+
+## The memory gate: what it measures (#298)
+
+`memory-gate` builds `test/test-memory-gate.c` with `MI_PPROF=ON` in Release, runs it
+eight times, and compares the **minimum** peak of those runs against a committed
+per-platform/arch/compiler baseline in `ci/memory-baselines/`. On Windows the gated
+number is peak *commit* (the working set is trimmed under pressure and would hide
+committed-but-untouched growth); everywhere else it is peak RSS, from `ru_maxrss` via
+`mi_process_info`. A second build with `-DMI_BENCH_INJECT_LEAK=200000` runs the identical
+comparison through `memory_gate.py control`, which passes only if the gate *fails*.
+
+**What went wrong.** The gate was red on `main` for commits that changed no allocator
+code (docs-only #275, ci-only #278/#297), and its own output warned that the observed
+spread exceeded the tolerance it was being compared under. The `memory-gate-ubuntu-latest`
+artifacts of the last twelve `main` runs of `c-unit.yml`, against a 22.3 MB baseline with
+25.6 MB allowed:
+
+| run | min-of-8 | median | within-run spread |
+|---|---|---|---|
+| 33618717188 | 26.7 | 29.6 | 32.6% |
+| 33629562858 | 24.7 | 27.4 | 19.0% |
+| 33631613324 | 28.0 | 29.2 | 15.7% |
+| 33635722154 | 26.0 | 28.0 | 19.6% |
+| 33636560081 | 22.3 | 26.9 | 30.0% |
+| 33646494496 | 24.3 | 28.2 | 44.4% |
+| 33647332787 | 24.5 | 26.5 | 17.6% |
+| 33654892179 | 27.9 | 31.2 | 24.4% |
+| 33660325957 | 26.5 | 27.6 | 18.5% |
+| 33689409217 | 22.7 | 25.6 | 25.6% |
+| 33692432919 | 25.5 | 27.9 | 28.2% |
+| 33699070304 | 27.8 | 30.2 | 19.8% |
+
+min-of-8 spans 25.6% across runs and the median 21.9%, so **no statistic was going to
+rescue this** — the signal was not there to extract. The `profiler_arena_mb`,
+`purged_gb` and liveness counters in those same artifacts are constant across every run,
+which rules out the profiler's arena and the P7a/P7b purge machinery: the variance is
+entirely in peak RSS. A per-scenario decomposition (idle host, `taskset -c 0-3`) located
+it: scenario 1, the 8-thread churn, alone ranged 14.1 → 24.6 MB run to run, and every
+later scenario added ≤ 2 MB on top of it. Peak RSS is a high-water mark, so what the gate
+was actually measuring was **how many of the churn workers the runner's scheduler
+happened to overlap** — a property of the runner, not of the allocator.
+
+**The fix is in the workload.** `test/test-memory-gate.c` now rendezvouses the churn
+workers on a portable condition-variable barrier: every worker in a round allocates its
+live set, waits for all of them, then churns and waits again before freeing. "All N live
+at once" becomes the only reachable state, so the peak is the structural cost of N live
+sets. Scenario 3's `while (ready == 0) {}` handoff became the same barrier, so six
+consumers no longer burn the vCPUs the producers need. The binary got *faster* (~0.1 s).
+
+**The numbers.** Three independent `ubuntu-latest` runner VMs (`nproc=4`,
+THP=`always`), 16 runs each, identical object code:
+
+| lane | min | median | max | spread |
+|---|---|---|---|---|
+| new workload, run A | 58.0 | 58.3 | 58.5 | **0.9%** |
+| new workload, run B | 58.0 | 58.5 | 58.5 | **0.9%** |
+| new workload, run C | 58.0 | 58.3 | 58.6 | **1.0%** |
+| old workload, same three VMs | 26.4 / 27.4 / 25.5 | — | — | 26.1% / 24.5% / 23.1% |
+
+min-of-16 is 58.0 MB on all three VMs — 0.0% across-run variation of the estimator.
+Variants that changed nothing: `taskset -c 0-1` (0.5%), `taskset -c 0` (0.7%),
+`MIMALLOC_SCAVENGER=0 MIMALLOC_PURGE_HOLES=0` (1.2%). An unpinned 16-core workstation
+reads 58.2–58.3 MB — the same number as the 4-vCPU runner, where the *old* workload read
+58 MB unpinned against 23 MB pinned. The gate is now host-independent, which is why
+`memory_gate.py`'s local CPU pinning is no longer load-bearing (it is kept as a guard
+against a future scenario reintroducing the sensitivity).
+
+**Tolerance.** `PEAK_TOLERANCE = 0.05`, down from 0.15. That is 5× the largest observed
+spread and 2.9 MB of absolute headroom on the 58.0 MB baseline. The measurement would
+support 0.03; the difference is reserved for runner-image drift, which three runs on one
+image cannot bound — tighten it once ten `main` runs on a new image have been observed,
+with those numbers written into `ci/memory_gate.py`. `RUNS_EXPECTED` stays 8: min-of-8 and
+min-of-16 of this distribution are the same number, so more runs buy nothing and fewer
+would need a matching edit to `c-unit.yml`'s run loops.
+
+**Control margin.** The `MI_BENCH_INJECT_LEAK=200000` build reads min-of-8 82.6 / 82.4 /
+82.5 MB on those same three VMs — **+42.1%**, or 8.4× the tolerance, against a rule that
+the control must fire by at least 2×. `ci/tests/test_memory_gate.py` asserts that ratio,
+so raising the tolerance past half the measured control margin is a failing test rather
+than a judgement call. Leak injection now `memset`s the whole block: RSS counts *resident*
+pages, and a leak whose pages were committed-but-untouched moved the peak by an amount
+that depended on purge timing — one measured batch had a control run land within 1% of
+the clean baseline, i.e. the control came within one sample of silently not firing.
+
+**Baselines.** `linux-pprof1.json` re-recorded at 58.0 MB (min-of-16, 0.9% spread) from
+run 33700518749. `windows-pprof1.json` re-recorded from this PR's own
+`memory-gate-windows-latest` artifact, because a workload change invalidates every
+baseline, not just the flaky one — the historical Windows lane was itself noisier than the
+new tolerance (min-of-8 51.2–57.0 MB across the same twelve `main` runs, within-run
+spreads 3.9–17.5%, baseline recorded at 9.9% spread). `macos-pprof1.json` is **left
+untouched and is stale**: it records a native-Xcode arm64 lane that #277 phase B2 deleted,
+and no lane compares against it any more (the dockur x86_64 lane keys on
+`macos-x86_64-soldr-clang-21-pprof1.json` and bootstraps its own). Delete or regenerate it
+if a macOS lane ever compares against `macos-pprof1.json` again.
+
+`ci/tests/test_memory_gate.py` additionally asserts that **every** committed baseline's
+own recorded `baseline_spread_pct` is below the tolerance it will be compared under —
+baselining from a measurement noisier than the threshold is the #298 failure mode in
+miniature.
+
 
 ## zero-tracking on Windows: a gated step, not a VM (#277 phase E)
 

--- a/test/test-memory-gate.c
+++ b/test/test-memory-gate.c
@@ -75,6 +75,75 @@ static void thread_start(thread_t* t, thread_fun_t fn, void* arg) {
 static void thread_join(thread_t t) { assert(pthread_join(t, NULL) == 0); }
 #endif
 
+/* ---- portable rendezvous barrier -------------------------------------- */
+/* Why this exists at all: the gated number is peak RSS, a high-water mark, and before
+   this barrier the high-water mark was set by *how many* of the CHURN_THREADS workers
+   happened to be holding their live set at the same instant. On a 4-vCPU shared runner
+   that is a scheduler coin flip, and it was the single largest term in the measurement:
+   a per-scenario decomposition on an idle 4-CPU-pinned host showed scenario 1 alone
+   ranging 14.1 -> 24.6 MB across four consecutive runs of the identical binary, with
+   every later scenario adding <= 2 MB on top. Rendezvousing the workers makes "all of
+   them live at once" the *only* reachable state, so the peak becomes a property of the
+   allocator (how much memory N threads' live sets actually cost) instead of a property
+   of the runner's scheduler.
+
+   Condition variables rather than a spin flag or C11 atomics: a spin flag burns a vCPU
+   that a 4-vCPU runner needs for the threads we are actually measuring (that is a second
+   noise source -- see scenario 3), and MSVC's <stdatomic.h> is gated behind
+   /experimental:c11atomics, which this test cannot require. Both primitives below ship
+   in every toolchain the gate builds on. */
+#ifdef _WIN32
+typedef struct barrier_s {
+  CRITICAL_SECTION    lock;
+  CONDITION_VARIABLE  cond;
+  int n, waiting, generation;
+} barrier_t;
+static void barrier_init(barrier_t* b, int n) {
+  InitializeCriticalSection(&b->lock);
+  InitializeConditionVariable(&b->cond);
+  b->n = n; b->waiting = 0; b->generation = 0;
+}
+static void barrier_destroy(barrier_t* b) { DeleteCriticalSection(&b->lock); }
+static void barrier_wait(barrier_t* b) {
+  EnterCriticalSection(&b->lock);
+  const int gen = b->generation;
+  if (++b->waiting == b->n) {
+    b->waiting = 0; b->generation++;
+    WakeAllConditionVariable(&b->cond);
+  }
+  else {
+    while (b->generation == gen) { SleepConditionVariableCS(&b->cond, &b->lock, INFINITE); }
+  }
+  LeaveCriticalSection(&b->lock);
+}
+#else
+typedef struct barrier_s {
+  pthread_mutex_t lock;
+  pthread_cond_t  cond;
+  int n, waiting, generation;
+} barrier_t;
+static void barrier_init(barrier_t* b, int n) {
+  assert(pthread_mutex_init(&b->lock, NULL) == 0);
+  assert(pthread_cond_init(&b->cond, NULL) == 0);
+  b->n = n; b->waiting = 0; b->generation = 0;
+}
+static void barrier_destroy(barrier_t* b) {
+  pthread_mutex_destroy(&b->lock); pthread_cond_destroy(&b->cond);
+}
+static void barrier_wait(barrier_t* b) {
+  pthread_mutex_lock(&b->lock);
+  const int gen = b->generation;
+  if (++b->waiting == b->n) {
+    b->waiting = 0; b->generation++;
+    pthread_cond_broadcast(&b->cond);
+  }
+  else {
+    while (b->generation == gen) { pthread_cond_wait(&b->cond, &b->lock); }
+  }
+  pthread_mutex_unlock(&b->lock);
+}
+#endif
+
 /* ---- measurement ------------------------------------------------------- */
 
 typedef struct sample_s {
@@ -166,7 +235,15 @@ static void inject_leak(void) {
   if (n == 0 || inject_armed == 0) return;
   void* p = mi_malloc(n);
   if (p != NULL) {
-    memset(p, 0x5A, n < 4096 ? n : 4096);
+    /* Touch the WHOLE block, not the first page. RSS counts resident pages, so a leak
+       whose pages are committed-but-untouched moves peak RSS by an amount that depends
+       on when the allocator happened to zero or reuse them: measured across 24 runs of
+       the control, that made the control's own peak span 78-105 MB, and one run in an
+       earlier batch read within 1% of the clean baseline -- i.e. the control came within
+       one sample of silently not firing. Faulting every page makes the injected leak
+       worth a deterministic n bytes of RSS. This code exists only in a build compiled
+       with MI_BENCH_INJECT_LEAK, so it cannot affect a real measurement. */
+    memset(p, 0x5A, n);
     size_t i = inject_idx++;
     if (i < 4096) { inject_sink[i] = p; } else { /* keep leaking, drop the handle */ }
   }
@@ -184,18 +261,23 @@ static void arm_injection(void) {
 /* Scenario 1: thread churn. The shape of both shipped leaks -- threads that own real
    pages and then exit. If thread-exit cleanup regresses, this is what catches it. */
 static THREAD_RET churn_worker(void* arg) {
-  (void)arg;
+  barrier_t* rendezvous = (barrier_t*)arg;
   void* keep[48];
   for (size_t i = 0; i < 48; i++) {
     keep[i] = mi_malloc(64*1024);
     assert(keep[i] != NULL);
     memset(keep[i], 0x5A, 4096);
   }
+  /* Every worker in the round now holds its live set. Nobody frees until everybody has
+     allocated, so the round's contribution to peak RSS is CHURN_THREADS live sets --
+     always, not "as many as the scheduler happened to overlap". */
+  barrier_wait(rendezvous);
   for (size_t i = 0; i < 1500; i++) {
     void* p = mi_malloc(64 + (i % 900));
     assert(p != NULL);
     mi_free(p);
   }
+  barrier_wait(rendezvous);   /* ... and the churn free lists are all live at once too. */
   for (size_t i = 0; i < 48; i++) { mi_free(keep[i]); }
   inject_leak();
   return THREAD_OK;
@@ -203,9 +285,12 @@ static THREAD_RET churn_worker(void* arg) {
 
 static void scenario_thread_churn(void) {
   for (int r = 0; r < CHURN_ROUNDS; r++) {
+    barrier_t rendezvous;
+    barrier_init(&rendezvous, CHURN_THREADS);
     thread_t th[CHURN_THREADS];
-    for (int i = 0; i < CHURN_THREADS; i++) thread_start(&th[i], (thread_fun_t)churn_worker, NULL);
+    for (int i = 0; i < CHURN_THREADS; i++) thread_start(&th[i], (thread_fun_t)churn_worker, &rendezvous);
     for (int i = 0; i < CHURN_THREADS; i++) thread_join(th[i]);
+    barrier_destroy(&rendezvous);
   }
 }
 
@@ -224,16 +309,21 @@ static void scenario_sawtooth(void) {
 
 /* Scenario 3: cross-thread free. Allocate on one thread, free on another -- the path
    that defers work and therefore the one most able to hide retention. */
-typedef struct xchan_s { void* blocks[3000]; volatile int ready; } xchan_t;
+/* The handoff is a two-party barrier rather than the `while (ready==0) {}` spin this
+   used to be: six spinning consumers on a 4-vCPU runner preempt the producers they are
+   waiting on, which both slows the scenario and randomizes how much of the 6 x 3000
+   block set is resident at once. Blocking on a condition variable leaves the vCPUs to
+   the threads doing the allocating. */
+typedef struct xchan_s { void* blocks[3000]; barrier_t handoff; } xchan_t;
 static THREAD_RET x_producer(void* arg) {
   xchan_t* c = (xchan_t*)arg;
   for (size_t i = 0; i < 3000; i++) { c->blocks[i] = mi_malloc(((i%6)+1)*128); assert(c->blocks[i]!=NULL); }
-  c->ready = 1;
+  barrier_wait(&c->handoff);
   return THREAD_OK;
 }
 static THREAD_RET x_consumer(void* arg) {
   xchan_t* c = (xchan_t*)arg;
-  while (c->ready == 0) { /* spin */ }
+  barrier_wait(&c->handoff);
   for (size_t i = 0; i < 3000; i++) { mi_free(c->blocks[i]); }
   return THREAD_OK;
 }
@@ -242,10 +332,14 @@ static void scenario_cross_thread_free(void) {
   for (int r = 0; r < 6; r++) {
     static xchan_t ch[pairs];
     thread_t p[pairs], c[pairs];
-    memset(ch, 0, sizeof(ch));
+    for (int i = 0; i < pairs; i++) {
+      memset(ch[i].blocks, 0, sizeof(ch[i].blocks));
+      barrier_init(&ch[i].handoff, 2);
+    }
     for (int i = 0; i < pairs; i++) { thread_start(&p[i], (thread_fun_t)x_producer, &ch[i]);
                                      thread_start(&c[i], (thread_fun_t)x_consumer, &ch[i]); }
     for (int i = 0; i < pairs; i++) { thread_join(p[i]); thread_join(c[i]); }
+    for (int i = 0; i < pairs; i++) { barrier_destroy(&ch[i].handoff); }
   }
 }
 


### PR DESCRIPTION
Closes #298.

The ubuntu `memory-gate` job flipped red on commits that changed no allocator code, and
its own printout warned that the observed spread exceeded the tolerance it was compared
under. This makes the measurement deterministic, then sets the tolerance from what was
measured.

### What the artifacts said

`memory-gate-ubuntu-latest` for the last twelve `main` runs of `c-unit.yml`, against a
22.3 MB baseline with 25.6 MB allowed:

| run | min-of-8 | median | within-run spread |
|---|---|---|---|
| 33618717188 | 26.7 | 29.6 | 32.6% |
| 33629562858 | 24.7 | 27.4 | 19.0% |
| 33631613324 | 28.0 | 29.2 | 15.7% |
| 33635722154 | 26.0 | 28.0 | 19.6% |
| 33636560081 | 22.3 | 26.9 | 30.0% |
| 33646494496 | 24.3 | 28.2 | 44.4% |
| 33647332787 | 24.5 | 26.5 | 17.6% |
| 33654892179 | 27.9 | 31.2 | 24.4% |
| 33660325957 | 26.5 | 27.6 | 18.5% |
| 33689409217 | 22.7 | 25.6 | 25.6% |
| 33692432919 | 25.5 | 27.9 | 28.2% |
| 33699070304 | 27.8 | 30.2 | 19.8% |

min-of-8 spans 25.6% across runs and the median 21.9%. **No statistic was going to rescue
this** — the answer to "are the tolerances wrong?" is that the tolerance was not the
problem. `profiler_arena_mb`, `purged_gb` and the liveness counters are constant in every
one of those 96 records, so the profiler arena and the P7a/P7b purge machinery are ruled
out; the variance is entirely in peak RSS.

The same twelve runs' `memory-gate-windows-latest` artifacts: min-of-8 51.2–57.0 MB
(11.3% across runs), within-run spreads 3.9–17.5%. Noisy, but it passed — confirming that
only ubuntu was actually flaky, and that the Windows baseline had itself been recorded
from a measurement noisier than any tolerance worth having (9.9%).

### Where the noise was

Per-scenario decomposition on an idle host pinned to 4 CPUs: **scenario 1's 8-thread churn
alone ranged 14.1 → 24.6 MB run to run**, and every later scenario added ≤ 2 MB on top.
Peak RSS is a high-water mark, so the gated number was *how many churn workers the
scheduler happened to overlap*.

### The fix is in the workload, not the threshold

`test/test-memory-gate.c`: the churn workers rendezvous on a portable condition-variable
barrier (allocate → all wait → churn → all wait → free), so "all N live at once" is the
only reachable state and the peak is the structural cost of N live sets. Scenario 3's
`while (ready == 0) {}` handoff becomes the same barrier — six spinning consumers on a
4-vCPU runner preempt the producers they wait on. Wall time roughly halved (0.26 / 0.47 /
0.52 s → 0.27 / 0.18 / 0.18 s, three runs each, `taskset -c 0-3`).

Three independent `ubuntu-latest` runner VMs (`nproc=4`, THP=`always`), 16 runs each,
identical object code:

| lane | min | median | max | spread |
|---|---|---|---|---|
| new workload, VM A | 58.0 | 58.3 | 58.5 | **0.9%** |
| new workload, VM B | 58.0 | 58.5 | 58.5 | **0.9%** |
| new workload, VM C | 58.0 | 58.3 | 58.6 | **1.0%** |
| old workload, same three VMs | 26.4 / 27.4 / 25.5 | | | 26.1% / 24.5% / 23.1% |

min-of-16 is 58.0 MB on all three. `taskset -c 0-1` (0.5%), `taskset -c 0` (0.7%) and
`MIMALLOC_SCAVENGER=0 MIMALLOC_PURGE_HOLES=0` (1.2%) change nothing — **the spread
collapsed because of the barrier, not because of any knob.** An unpinned 16-core
workstation reads 58.2–58.3 MB, the same number as the 4-vCPU runner, where the old
workload read 58 MB unpinned vs 23 MB pinned.

### Statistic, tolerance, baselines

- **Statistic: still min-of-8.** One-sided noise makes the minimum right, but it is no
  longer load-bearing — min-of-8 and min-of-16 of this distribution are the same number.
  `RUNS_EXPECTED` stays 8 for that reason (measured, not assumed).
- **`PEAK_TOLERANCE` 0.15 → 0.05.** 5× the largest observed spread, 2.9 MB of headroom on
  58.0 MB. The measurement supports 0.03; the rest is reserved for runner-image drift,
  which three runs on one image cannot bound. The comment says what to measure before
  tightening.
- **Control margin: +42.1%, 8.4× the tolerance.** CI confirms it on both gated metrics:
  run 33701827771 reports `peak_rss regressed: 82.5 MB vs baseline 58.0 MB (+42.2%)` and
  `peak_commit regressed: 113.7 MB vs baseline 74.4 MB (+52.8%)`. The rule is that the
  control must fire by ≥2× the tolerance, and a test asserts that ratio, so raising the
  tolerance past half the measured control margin is a failing test rather than a
  judgement call. Note the control no longer fires at ~3× the *baseline* as it used to:
  the injected leak is the same ~32 MB, but the structural peak it must clear went from
  ~22 MB to 58 MB. `MI_BENCH_INJECT_LEAK` is set in the workflow, so raising it belongs
  with #307's `c-unit.yml` rewrite rather than here.
  Leak injection now `memset`s the whole block: one measured batch had a control run land
  within 1% of the clean baseline, i.e. the control came within one sample of silently not
  firing.
- **`linux-pprof1.json` → 58.0 MB** (min-of-16, 0.9% spread) from run 33700518749.
- **`windows-pprof1.json` → 74.4 MB** (min-of-8, **0.1% spread**, from 17.5%) from run
  33701098707, reproduced exactly by run 33701827771 on a second Windows runner. That one
  source change collapses the spread on two unrelated kernels and two different gated
  metrics is the strongest evidence the diagnosis was right.
- **`macos-pprof1.json` deliberately untouched and now stale**: it records the native
  Xcode arm64 lane #277 phase B2 deleted, and nothing compares against it (the dockur
  x86_64 lane keys on `macos-x86_64-soldr-clang-21-pprof1.json` and bootstraps its own).
  Documented as such in `docs/ci-gates.md`.
- A new test asserts **every** committed baseline's own recorded `baseline_spread_pct` is
  below the tolerance it will be compared under. It is what caught the stale Windows one.

### Verification

`memory-gate (ubuntu-latest)` and `memory-gate (windows-latest)` both **pass**, positive
controls included, on runs 33701098707 and 33701827771. Five independent `ubuntu-latest`
VMs read 58.0–58.2 MB (0.7–1.0% spread); two Windows runners read 74.4 MB (0.1%).
`run-macos-x64 (dockurr/macos on Linux)` is red for the pre-existing reason documented in
`docs/ci-gates.md` (no golden disk yet), unrelated to this change.

Follow-up, not done here: `gh run rerun` on a `main` run only re-runs main's workload
against main's baseline, so it proves nothing pre-merge — worth doing once this lands.

### Coordination

**No workflow file is touched.** Everything is in `test/test-memory-gate.c`,
`ci/memory_gate.py`, `ci/memory-baselines/`, `ci/tests/` and `docs/ci-gates.md`, so #307's
rewrite of `c-unit.yml` carries this without a conflict. The C-core workload change is its
own commit (rule 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
