### PR TITLE
fix: gcc-ASan test-api crash (#301) and toolchain-agnostic local asan config

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -25,11 +25,36 @@ concurrency:
 
 jobs:
   asan:
-    name: address sanitizer
+    # Issue #301. One row is not enough. `MI_TRACK_ASAN` implies `MI_PADDING`, and
+    # CMakeLists auto-enables `MI_OPT_FREE_SMALL` (hence `MI_PAGE_META_ALIGNED_FREE_SMALL`)
+    # only when `MI_DEBUG` is off -- so a Debug-only ASan lane can never reach the
+    # `mi_free_small` fast path at all, and sat green through a NULL-deref SEGV in
+    # `mi_arenas_page_free_ex` that any release-type padding build hits in `test-api`'s
+    # `free_small1`. The RelWithDebInfo rows are that missing coverage. gcc is in the matrix
+    # because gcc is what the bug was reported against, and clang stays because the bug is
+    # compiler-independent -- if a row ever goes red on one compiler only, that asymmetry is
+    # itself the finding.
+    name: address sanitizer (${{ matrix.cc }}, ${{ matrix.build_type }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cc: clang
+            cxx: clang++
+            build_type: Debug
+            extra: -DMI_DEBUG_FULL=ON
+          - cc: gcc
+            cxx: g++
+            build_type: RelWithDebInfo
+            extra: ''
+          - cc: clang
+            cxx: clang++
+            build_type: RelWithDebInfo
+            extra: ''
     env:
-      CC: clang
-      CXX: clang++
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
     steps:
       - uses: actions/checkout@v4
 
@@ -39,8 +64,8 @@ jobs:
       - name: Configure (and prove ASan actually enabled)
         run: |
           set -euo pipefail
-          cmake -B build-asan -DCMAKE_BUILD_TYPE=Debug \
-                -DMI_PPROF=ON -DMI_DEBUG_FULL=ON -DMI_TRACK_ASAN=ON 2>&1 | tee configure.log
+          cmake -B build-asan -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+                -DMI_PPROF=ON ${{ matrix.extra }} -DMI_TRACK_ASAN=ON 2>&1 | tee configure.log
           if ! grep -q "Compile with address sanitizer support (MI_TRACK_ASAN=ON)" configure.log; then
             echo "::error::MI_TRACK_ASAN did not survive configure -- the sanitizer is NOT enabled."
             grep -i "sanitizer" configure.log || true

--- a/ci/tests/test_verify_local.py
+++ b/ci/tests/test_verify_local.py
@@ -30,6 +30,7 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 
 DFLAG_RE = re.compile(r'-D([A-Z_][A-Z0-9_]*)=("\$pprof"|\$pprof|[^\s"\'\)]+)')
 SCRIPT_RE = re.compile(r"ci/[A-Za-z0-9_./-]+\.py")
+MATRIX_REF_RE = re.compile(r"\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}")
 
 
 def load_workflow(name: str) -> dict[str, Any]:
@@ -61,6 +62,48 @@ def job_run_text(job: dict[str, Any]) -> str:
         if isinstance(run, str):
             chunks.append(run)
     return "\n".join(chunks)
+
+
+def matrix_rows(job: dict[str, Any]) -> list[dict[str, Any]]:
+    """The concrete matrix rows of `job` -- `include:` entries, else the cartesian product
+    of the plain axes. Empty when the job has no matrix.
+
+    Needed because a matrixed job may template its cmake flags (asan.yml does:
+    `-DCMAKE_BUILD_TYPE=${{ matrix.build_type }}`). Without expansion the drift guard would
+    demand the literal token `-DCMAKE_BUILD_TYPE=${{` appear in verify_local.py, i.e. it
+    would either fail on a correct mirror or, if silenced, stop checking that job's flags at
+    all -- the exact blind spot issue #301 was hiding in.
+    """
+    strategy = job.get("strategy")
+    matrix = strategy.get("matrix") if isinstance(strategy, dict) else None
+    if not isinstance(matrix, dict):
+        return []
+    include = matrix.get("include")
+    if isinstance(include, list):
+        return [row for row in include if isinstance(row, dict)]
+    axes = {k: v for k, v in matrix.items() if k != "exclude" and isinstance(v, list)}
+    if not axes:
+        return []
+    rows: list[dict[str, Any]] = [{}]
+    for key, values in axes.items():
+        rows = [{**row, key: value} for row in rows for value in values]
+    return rows
+
+
+def expand_matrix(text: str, rows: list[dict[str, Any]]) -> list[str]:
+    """`text` once per matrix row, with `${{ matrix.<key> }}` substituted. A reference the
+    row does not define is left alone, so it surfaces as an obviously-wrong token rather
+    than being silently dropped."""
+    if not rows:
+        return [text]
+
+    def substitute(row: dict[str, Any]) -> str:
+        def one(m: re.Match[str]) -> str:
+            return str(row[m.group(1)]) if m.group(1) in row else m.group(0)
+
+        return MATRIX_REF_RE.sub(one, text)
+
+    return [substitute(row) for row in rows]
 
 
 def expected_tokens(text: str) -> set[str]:
@@ -106,7 +149,10 @@ def linux_job_tokens(workflow_name: str) -> dict[str, set[str]]:
     for job_name, job in jobs.items():
         if not is_linux_job(job):
             continue
-        out[job_name] = expected_tokens(job_run_text(job))
+        tokens: set[str] = set()
+        for text in expand_matrix(job_run_text(job), matrix_rows(job)):
+            tokens |= expected_tokens(text)
+        out[job_name] = tokens
     return out
 
 
@@ -143,6 +189,17 @@ class VerifyLocalDriftTests(unittest.TestCase):
 
     def test_asan_yml(self) -> None:
         self.assert_all_present("asan.yml")
+
+    def test_asan_yml_matrix_expands_to_both_build_types(self) -> None:
+        """#301: the release-type ASan row is the one that can reach `mi_free_small`'s
+        page-from-alignment fast path (CMakeLists only auto-enables MI_OPT_FREE_SMALL when
+        MI_DEBUG is off), so losing it would silently un-cover the bug. Assert it is both in
+        the workflow and mirrored locally, not just that the matrix parses."""
+        tokens = linux_job_tokens("asan.yml")["asan"]
+        self.assertIn("-DCMAKE_BUILD_TYPE=Debug", tokens)
+        self.assertIn("-DCMAKE_BUILD_TYPE=RelWithDebInfo", tokens)
+        self.assertIn("-DMI_TRACK_ASAN=ON", tokens)
+        self.assertNotIn("-DCMAKE_BUILD_TYPE=${{", tokens)
 
     def test_config_table_names_are_unique(self) -> None:
         names = verify_local.CONFIG_NAMES

--- a/ci/verify_local.py
+++ b/ci/verify_local.py
@@ -46,6 +46,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from collections.abc import Callable, Iterable
@@ -679,17 +680,64 @@ def run_lint(ctx: RunCtx) -> bool:
     return ok and rc == 0
 
 
-def run_asan(ctx: RunCtx) -> bool:
-    """asan.yml job `asan` (already ubuntu-latest only): CC=clang CXX=clang++,
-    -DMI_TRACK_ASAN=ON, plus its two positive/negative controls."""
-    build = ctx.dir / "build-asan"
-    env = {"CC": "clang", "CXX": "clang++"}
-    rc, configure_out = cmake_configure(
-        ctx,
-        build,
-        ["-DCMAKE_BUILD_TYPE=Debug", "-DMI_PPROF=ON", "-DMI_DEBUG_FULL=ON", "-DMI_TRACK_ASAN=ON"],
-        env=env,
-    )
+# Issue #301. `MI_TRACK_ASAN` is not a compiler flag we control -- CMakeLists probes for
+# `sanitizer/asan_interface.h` and silently resolves the option to OFF when it is missing.
+# On a distribution whose clang ships without compiler-rt's headers (Nix, some minimal
+# containers) the previous clang-only config could not configure at all, and every agent
+# hand-rolled a gcc ASan build instead -- which is how #301 sat unreproduced in CI. So
+# probe instead of assuming: prefer clang (what asan.yml's Debug row uses), fall back to
+# gcc, and SKIP with the reason when neither compiler can see the header.
+ASAN_PROBE_SOURCE = "#include <sanitizer/asan_interface.h>\nint main(void){return 0;}\n"
+
+
+_ASAN_TOOLCHAIN_CACHE: dict[str, tuple[str, str] | None] = {}
+
+
+def _asan_toolchain() -> tuple[str, str] | None:
+    """(cc, cxx) for the first compiler on PATH whose <sanitizer/asan_interface.h> resolves,
+    or None. Cached, since both `needs()` and the runner ask."""
+    if "value" in _ASAN_TOOLCHAIN_CACHE:
+        return _ASAN_TOOLCHAIN_CACHE["value"]
+    found: tuple[str, str] | None = None
+    for cc, cxx in (("clang", "clang++"), ("gcc", "g++")):
+        if shutil.which(cc) is None or shutil.which(cxx) is None:
+            continue
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "probe.c"
+            src.write_text(ASAN_PROBE_SOURCE, encoding="utf-8")
+            try:
+                rc = subprocess.run(
+                    [cc, "-fsyntax-only", str(src)],
+                    cwd=td,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=120,
+                ).returncode
+            except (OSError, subprocess.SubprocessError):
+                continue
+        if rc == 0:
+            found = (cc, cxx)
+            break
+    _ASAN_TOOLCHAIN_CACHE["value"] = found
+    return found
+
+
+def _need_asan_toolchain() -> str | None:
+    if _asan_toolchain() is None:
+        return (
+            "no compiler on PATH resolves <sanitizer/asan_interface.h> "
+            "(tried clang then gcc); CMake would silently set MI_TRACK_ASAN=OFF"
+        )
+    return None
+
+
+def _run_asan_one(ctx: RunCtx, cc: str, cxx: str, label: str, cmake_args: list[str]) -> bool:
+    """One asan.yml matrix row: configure, prove ASan survived, build, ctest, UAF control.
+    `cmake_args` is copied verbatim from the workflow (ci/tests/test_verify_local.py expands
+    the matrix and checks it), so build it at the call site rather than from `label`."""
+    build = ctx.dir / f"build-asan-{label}"
+    env = {"CC": cc, "CXX": cxx}
+    rc, configure_out = cmake_configure(ctx, build, cmake_args, env=env)
     if rc:
         return False
     if "Compile with address sanitizer support (MI_TRACK_ASAN=ON)" not in configure_out:
@@ -736,6 +784,39 @@ def run_asan(ctx: RunCtx) -> bool:
         )
         return False
     return True
+
+
+def run_asan(ctx: RunCtx) -> bool:
+    """asan.yml job `asan` (already ubuntu-latest only), both build types.
+
+    The RelWithDebInfo row is not a duplicate of the Debug one: `MI_TRACK_ASAN` implies
+    `MI_PADDING`, and CMakeLists auto-enables `MI_OPT_FREE_SMALL` (hence
+    `MI_PAGE_META_ALIGNED_FREE_SMALL`) only when `MI_DEBUG` is off, so the Debug lane never
+    executes `mi_free_small`'s page-from-alignment fast path -- the one #301's SEGV lived on.
+    """
+    toolchain = _asan_toolchain()
+    if toolchain is None:  # pragma: no cover -- guarded by _need_asan_toolchain
+        log_write(ctx.log, "\n[verify_local] FAIL: no ASan-capable compiler\n")
+        return False
+    cc, cxx = toolchain
+    log_write(ctx.log, f"\n[verify_local] asan toolchain: CC={cc} CXX={cxx}\n")
+    debug_ok = _run_asan_one(
+        ctx,
+        cc,
+        cxx,
+        "debug",
+        ["-DCMAKE_BUILD_TYPE=Debug", "-DMI_PPROF=ON", "-DMI_DEBUG_FULL=ON", "-DMI_TRACK_ASAN=ON"],
+    )
+    # `and` in this order, not short-circuited away by `debug_ok and ...`: --keep-going is
+    # about seeing every failure in one run, and the release row is the interesting one here.
+    release_ok = _run_asan_one(
+        ctx,
+        cc,
+        cxx,
+        "relwithdebinfo",
+        ["-DCMAKE_BUILD_TYPE=RelWithDebInfo", "-DMI_PPROF=ON", "-DMI_TRACK_ASAN=ON"],
+    )
+    return release_ok and debug_ok
 
 
 @dataclasses.dataclass(frozen=True)
@@ -801,9 +882,9 @@ CONFIGS: list[ConfigSpec] = [
     ConfigSpec(
         "asan",
         "asan.yml: asan",
-        "clang ASan build, ctest, UAF positive control",
+        "ASan Debug + RelWithDebInfo builds, ctest, UAF positive control",
         run_asan,
-        _need_clang,
+        _need_asan_toolchain,
     ),
 ]
 

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -26,7 +26,7 @@ verifying nothing**, each discovered by asking "has this ever actually failed?":
 | **isa-baseline** (`ci/check_isa_baseline.py`) | binaries containing instructions above the CPU baseline, which SIGILL on older hardware | builds with `MI_OPT_ARCH=ON`; the scanner must fire. The parser also self-tests against x86 and arm64 fixtures on every run |
 | **ctest matrix** | correctness on ubuntu / windows-MSVC / windows-MinGW / macos, `MI_PPROF` on and off, `MI_DEBUG_FULL`, and shared-library builds on all three of ubuntu, MSVC and MinGW. **macOS uses no Apple hardware** (#277 phase B2): both arches are cross-built on Linux, x86_64 is executed under `dockurr/macos` on a Linux runner, arm64 is compile-only. **windows-MinGW is gated from Linux-built bundles run on one Windows runner** (`windows-bundles.yml`, #277 phase C — which also moves that lane from msvcrt to UCRT); the native MSYS2 MinGW jobs are informational during the comparison window | `ci/bundle_coverage.py` fails if a test in the arm64 bundle is missing from the executed x86_64 one, or if any test the native MinGW `ctest` would run is missing from a bundle; `ci/lint_no_macos_runners.py` fails if any workflow names a macOS runner |
 | **ctest-guarded** | the `MI_GUARDED` guard-page path, run twice: at the default sample rate and again with `MIMALLOC_GUARDED_SAMPLE_RATE=1` so every eligible allocation is guarded | configure step greps the resolved compiler defines for `MI_GUARDED=1`, since the original bug was the flag never reaching the compiler |
-| **asan** | use-after-free, overflow and leaks under AddressSanitizer | — |
+| **asan** | use-after-free, overflow and leaks under AddressSanitizer, across **two build types** — see below | the `mimalloc-test-asan-control` binary reads freed memory through `mi_free` and must abort with an AddressSanitizer report; the configure step also greps its own output for `MI_TRACK_ASAN=ON`, since the option silently self-disables when its header is missing |
 | **fuzz** (`test/fuzz/`) | crashes from structured random allocator-API sequences, with ASan as the oracle | builds with a planted use-after-free and requires an anchored `(ERROR\|SUMMARY): AddressSanitizer:` report naming it |
 | **amalgamation-drift** | a C change that never reached the vendored copy the Rust crate compiles — which broke `main` twice before this gate existed | — |
 | **doc-snippets** (`ci/check_doc_snippets.py`) | fenced ```c examples in `README.md`/`docs/*.md` that don't compile against the real headers — caught one in PR #259 (a snippet using `mi_prof_config_t_decl`/`mi_prof_start_ex` with no `#include` at all) | `--self-test` plants a snippet calling an undeclared mimalloc function; the checker must reject it, on both gcc and clang |
@@ -44,6 +44,39 @@ so the job in `.github/workflows/c-unit.yml` runs with no `continue-on-error`: a
 regression here blocks merge, the same as every other row in the table above.
 `docs/bun-gap-analysis-2026-09-02.md` tracks the rest of what's still open (hole
 purging, #302) before the Bun issue itself (P9c) can be filed.
+
+### The ASan job runs Debug **and** RelWithDebInfo, and that is the rule
+
+Issue #301. A Debug-only ASan lane cannot see an entire class of bug, and sat green
+through a NULL-pointer SEGV that any release-type sanitizer build hits within seconds.
+
+The mechanism: `MI_TRACK_ASAN` implies `MI_PADDING` (`types.h`), and `CMakeLists.txt`
+auto-enables `MI_OPT_FREE_SMALL` — hence `MI_PAGE_META_ALIGNED_FREE_SMALL`, the
+`mi_free_small` fast path that finds a page by aligning the pointer down instead of
+consulting the page map — **only when `MI_DEBUG` is off**. So the two features that had
+to be combined to expose the bug are, by construction, mutually exclusive in a Debug
+build. `test-api`'s `free_small1` crashed in `mi_arenas_page_free_ex` on every
+`RelWithDebInfo -DMI_TRACK_ASAN=ON` build and on none of CI's.
+
+`asan.yml` is therefore a matrix, and all three rows are hard gates:
+
+| Row | Why |
+|---|---|
+| `clang, Debug` (+ `MI_DEBUG_FULL=ON`) | the original lane: every internal assertion armed |
+| `gcc, RelWithDebInfo` | the configuration #301 was reported against, and the one that reaches `mi_free_small` |
+| `clang, RelWithDebInfo` | the same coverage on the other compiler — #301 was *reported* as gcc-specific and is not, so an asymmetry between these two rows is itself a finding |
+
+`ci/verify_local.py`'s `asan` config mirrors both build types. It also **probes for a
+compiler that can actually see `sanitizer/asan_interface.h`** — clang first, then gcc,
+else SKIP with that reason — because on a distribution whose clang ships without
+compiler-rt's headers the config previously could not configure at all, every agent
+hand-rolled a gcc ASan build instead, and #301 stayed out of CI as a result.
+
+Because a matrixed job can template its cmake flags, `ci/tests/test_verify_local.py`
+expands `${{ matrix.* }}` before checking that every `-D` flag in a workflow still
+appears in `verify_local.py`. Without that, a templated flag would read as the literal
+token `-DCMAKE_BUILD_TYPE=${{` and the drift guard would have to be silenced — the same
+kind of blind spot as the seven dead gates listed at the top of this page.
 
 ## Test bundles
 

--- a/docs/upstream-bugs.md
+++ b/docs/upstream-bugs.md
@@ -3,8 +3,9 @@
 *Part of the [mimalloc-pprof](../README.md) documentation.*
 
 This page exists because the bugs below are **defects in upstream
-microsoft/mimalloc**, not in the profiler, and they affect anyone using mimalloc on
-Windows/MinGW whether or not they use this fork.
+microsoft/mimalloc**, not in the profiler, and they affect anyone using mimalloc
+whether or not they use this fork — bugs 1-3 on Windows/MinGW, bugs 4-5 on every
+platform.
 
 Every one was confirmed by building **stock upstream at the same commit with the
 same toolchain** and reproducing it there with zero fork changes. Where a fix is
@@ -75,10 +76,88 @@ check, so any allocation failure becomes an opaque segfault far from its cause.
 This is what made bug 1 present as a mysterious crash rather than an obvious
 out-of-memory.
 
+## Bug 4: `mi_free_small` reads the user's block as a page when `MI_PADDING` is on
+
+|  |  |
+|---|---|
+| **Affects** | upstream **v3** at `6def7be9` — the base this fork pins, which is also Bun's mimalloc merge-base. **Gone at `dev3` HEAD** (`34fbd7e7`), see *Upstream's own fix* below |
+| **Symptom** | NULL-pointer SEGV in `mi_arenas_page_free_ex` on `free()` of a 1009..1024 byte block |
+| **Status** | **fixed here** — one line in `src/arena.c` |
+
+Reported as [issue #301](https://github.com/zackees/mimalloc-pprof/issues/301): a gcc
+AddressSanitizer build of `test-api` crashed at `free_small1`. It is neither
+gcc-specific nor ASan-specific — `RelWithDebInfo -DMI_PADDING=1` crashes identically
+under gcc *and* clang, with no sanitizer involved.
+
+Confirmed on **stock upstream `6def7be9`, zero fork changes**: `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_FLAGS=-DMI_PADDING=1` then `mimalloc-test-api` segfaults at `free_small1`.
+
+**Root cause.** `MI_OPT_FREE_SMALL` makes `mi_free_small(p)` locate the page as
+`_mi_align_down_ptr(p, MI_SMALL_PAGE_SIZE)` instead of consulting the page map, which
+is only valid while the page metadata sits in front of the slice.
+`mi_arenas_page_alloc_fresh` decided that with the raw `MI_SMALL_SIZE_MAX`:
+
+<!-- doc-snippet: skip (source excerpt, not a program) -->
+```c
+if (block_size > MI_SMALL_SIZE_MAX) { /* meta goes in the separate pages_meta array */ }
+```
+
+But the *entry* condition for the small path is the **requested** size, not the block
+size, and `MI_PADDING` makes the two diverge: `mi_good_size(1024) == 1280`. So a
+1009..1024 byte request still took the small path, its page meta went to `pages_meta`,
+and `mi_free_small` then read the caller's own (zeroed) block as an `mi_page_t` —
+`mi_page_all_free()` on garbage, then a NULL `page->heap` dereference.
+
+The correct bound is the one `mi_free_small`'s own assertion already states,
+`mi_good_size(MI_SMALL_SIZE_MAX)`. Without padding that is exactly `MI_SMALL_SIZE_MAX`,
+so the fix is a no-op in ordinary release builds.
+
+**Why nobody hit it.** `MI_PADDING` is implied by `MI_TRACK_ASAN`, `MI_TRACK_VALGRIND`,
+`MI_TRACK_ETW` and `MI_SECURE>=3`, and CMake auto-enables `MI_OPT_FREE_SMALL` **only
+when `MI_DEBUG` is off**. The two therefore coexist only in a release-type sanitizer or
+secure build — and upstream's (and this fork's) ASan job built `Debug`.
+
+**Upstream's own fix.** At `dev3` HEAD (`34fbd7e7`) the option is relabelled
+*"Deprecated"*, the release auto-enable is gone, and the aligned-down lookup is validated
+against a new `page->self` pointer (`mi_ptr_page_is_valid_ex` in `free.c`). Stock
+`34fbd7e7` passes `test-api` 50/50 with `-DMI_OPT_FREE_SMALL=ON -DMI_PADDING=1`, so there
+is nothing to send upstream — but everything pinned at `6def7be9`, Bun included, still has
+this.
+
+## Bug 5: `mi_realloc` frees an interior pointer when the padding does not decode
+
+|  |  |
+|---|---|
+| **Affects** | upstream **v3** at `6def7be9`, any `MI_PADDING` non-debug build. **Gone at `dev3` HEAD** (`34fbd7e7`) |
+| **Symptom** | upstream's own `mi_urealloc_invalid` test fails; an interior pointer is pushed onto the page free list |
+| **Status** | **fixed here** — `src/alloc.c` |
+
+Found in the same configuration as bug 4, and independent of it. Confirmed on **stock
+upstream `6def7be9`, zero fork changes**: the same `RelWithDebInfo -DMI_PADDING=1` build
+reports `FAILED: mi_urealloc_invalid`. Stock `34fbd7e7` does not.
+
+With `MI_PADDING` on, `mi_page_usable_size_of` returns **0** when the padding canary
+does not decode — free.c says so itself: *"size can be zero if the padding is
+corrupted"*. That means `p` is not a block start, or the block was overrun.
+`mi_theap_realloc_zero_ex` took the 0 at face value, treated the block as zero bytes
+long, allocated a replacement, copied nothing into it, and **freed `p`** — an interior
+pointer onto the page's free list.
+
+The fix returns `NULL` without freeing `p`, which is both the contract stated at the top
+of that function (*"returning NULL always indicates an error, and `p` will not have been
+freed"*) and the answer a `MI_DEBUG` build already gives via `mi_validate_ptr_page`.
+No valid block ever reports usable size 0 — the padding path bumps a zero-byte request
+to `sizeof(void*)` — verified by exhaustively probing `mi_malloc`/`mi_zalloc`/
+`mi_calloc`/`mi_realloc` over 0..4096 bytes and `mi_*_aligned`/`mi_malloc_aligned_at`
+over 0..2048 bytes × alignments 1..8192, in padding and non-padding, debug and release
+builds: no allocation reports 0.
+
 ## What this means for you
 
 - **Using upstream mimalloc on Windows/MinGW?** Bug 1 applies to you and is worth
   carrying a patch for.
+- **Pinned to upstream v3 around `6def7be9`** (as Bun is) **and building with a
+  sanitizer, Valgrind, ETW tracking or `MI_SECURE>=3` in a release build?** Bugs 4 and 5
+  apply to you. Upstream `dev3` HEAD has moved past both.
 - **Using this fork?** All of the above are handled — v3 on `main`, and the v2 line
   carries its own variant of the bug 1 fix.
 

--- a/docs/upstream-bugs.md
+++ b/docs/upstream-bugs.md
@@ -80,7 +80,7 @@ out-of-memory.
 
 |  |  |
 |---|---|
-| **Affects** | upstream **v3** at `6def7be9` — the base this fork pins, which is also Bun's mimalloc merge-base. **Gone at `dev3` HEAD** (`34fbd7e7`), see *Upstream's own fix* below |
+| **Affects** | upstream **v3** at `6def7be9` — the base this fork pins, which is also Bun's mimalloc merge-base. **Not reproducible at `dev3` HEAD** (`34fbd7e7`), see *What changed at dev3 HEAD* below |
 | **Symptom** | NULL-pointer SEGV in `mi_arenas_page_free_ex` on `free()` of a 1009..1024 byte block |
 | **Status** | **fixed here** — one line in `src/arena.c` |
 
@@ -116,24 +116,53 @@ so the fix is a no-op in ordinary release builds.
 when `MI_DEBUG` is off**. The two therefore coexist only in a release-type sanitizer or
 secure build — and upstream's (and this fork's) ASan job built `Debug`.
 
-**Upstream's own fix.** At `dev3` HEAD (`34fbd7e7`) the option is relabelled
-*"Deprecated"*, the release auto-enable is gone, and the aligned-down lookup is validated
-against a new `page->self` pointer (`mi_ptr_page_is_valid_ex` in `free.c`). Stock
-`34fbd7e7` passes `test-api` 50/50 with `-DMI_OPT_FREE_SMALL=ON -DMI_PADDING=1`, so there
-is nothing to send upstream — but everything pinned at `6def7be9`, Bun included, still has
-this.
+**What changed at `dev3` HEAD — and a third upstream defect found on the way.** Do not
+conclude anything from a stock `34fbd7e7` run: **`MI_PADDING` cannot be enabled there at
+all.** `include/mimalloc/types.h:68` carries a bare, unconditional
+
+<!-- doc-snippet: skip (source excerpt, not a program) -->
+```c
+#define MI_PADDING 0
+```
+
+added by `cda82f99` *("check double free's even without padding", 2026-08-22)*, thirty
+lines *above* the `#if !defined(MI_PADDING) && (… MI_TRACK_ASAN …)` auto-enable it
+defeats. A `-DMI_PADDING=1` on the command line is clobbered by it with nothing but a
+`warning: 'MI_PADDING' redefined`, and `-DMI_TRACK_ASAN=ON` no longer turns padding on
+either. So `dev3` HEAD currently ships **no block padding in any configuration** — no
+byte-precise `mi_usable_size`, no heap-block-overflow detection on free. That is worth
+reporting upstream in its own right.
+
+Neutralize that one line so `MI_PADDING=1` actually takes effect (`MI_PADDING_SIZE == 8`,
+and `mi_good_size(1024) == 1280` — **the requested/block-size divergence is still there**,
+`arena.c:983` still uses the raw `MI_SMALL_SIZE_MAX`, `mi_free_small` still does the bare
+`_mi_align_down_ptr`, and its `page->self` checks are `mi_assert_internal`, compiled out in
+release), rebuild with `-DMI_OPT_FREE_SMALL=ON`, and `test-api` reports **49 ok / 1 failed**:
+
+- `free_small1` **passes** — bug 4 does not reproduce, even though a 1024-byte request
+  still comes back slice-aligned. The small-page free path was reworked in between
+  (`82fd55ff` "aligned page meta info for faster free", `fe5a54c4` / `eab1ebe6`
+  "faster/improve free_small", which introduce `MI_PAGE_META_IS_ALIGNED`,
+  `MI_PAGE_META_SMALL_IS_ALIGNED` and `page->self`). Which of those neutralizes it has not
+  been bisected — the claim here is the measurement, not a mechanism.
+- `mi_urealloc_invalid` **fails** — see bug 5, which *is* still live upstream.
+
+So bug 4 is a pinned-base defect: everything at or near `6def7be9`, Bun included, has it,
+and `dev3` HEAD does not.
 
 ## Bug 5: `mi_realloc` frees an interior pointer when the padding does not decode
 
 |  |  |
 |---|---|
-| **Affects** | upstream **v3** at `6def7be9`, any `MI_PADDING` non-debug build. **Gone at `dev3` HEAD** (`34fbd7e7`) |
+| **Affects** | upstream **v3** at `6def7be9` **and still at `dev3` HEAD** (`34fbd7e7`), any `MI_PADDING` non-debug build |
 | **Symptom** | upstream's own `mi_urealloc_invalid` test fails; an interior pointer is pushed onto the page free list |
 | **Status** | **fixed here** — `src/alloc.c` |
 
 Found in the same configuration as bug 4, and independent of it. Confirmed on **stock
 upstream `6def7be9`, zero fork changes**: the same `RelWithDebInfo -DMI_PADDING=1` build
-reports `FAILED: mi_urealloc_invalid`. Stock `34fbd7e7` does not.
+reports `FAILED: mi_urealloc_invalid`. **Still present at `dev3` HEAD** (`34fbd7e7`) once
+that tree's unconditional `#define MI_PADDING 0` (see bug 4) is neutralized so padding can
+actually be enabled — this one is genuinely upstreamable.
 
 With `MI_PADDING` on, `mi_page_usable_size_of` returns **0** when the padding canary
 does not decode — free.c says so itself: *"size can be zero if the padding is
@@ -157,7 +186,8 @@ builds: no allocation reports 0.
   carrying a patch for.
 - **Pinned to upstream v3 around `6def7be9`** (as Bun is) **and building with a
   sanitizer, Valgrind, ETW tracking or `MI_SECURE>=3` in a release build?** Bugs 4 and 5
-  apply to you. Upstream `dev3` HEAD has moved past both.
+  apply to you. `dev3` HEAD no longer reproduces bug 4; it still has bug 5, and it also
+  cannot enable `MI_PADDING` at all (see bug 4's *What changed* section).
 - **Using this fork?** All of the above are handled — v3 on `main`, and the v2 line
   carries its own variant of the bug 1 fix.
 

--- a/docs/upstreaming.md
+++ b/docs/upstreaming.md
@@ -363,6 +363,47 @@ stack-overflowed in the emulated-TLS recursion above, before `main`. Superseded 
 a cross build, where minject (a Windows PE utility) cannot run at all. Nothing to report
 upstream about minject.
 
+## Not upstreamable: two `MI_PADDING` release-build defects at the pinned base (#301)
+
+**Nothing to send upstream — recorded so the next person does not re-derive it.** Both
+defects reproduce on **stock upstream `6def7be9`** (the commit this fork's overlay pins,
+and Bun's mimalloc merge-base) with zero fork changes, and both are **already gone at
+`upstream/dev3` HEAD `34fbd7e7`**, which relabels `MI_OPT_FREE_SMALL` *"Deprecated"*,
+drops its release auto-enable, and validates the aligned-down page lookup against a new
+`page->self` pointer. Stock `34fbd7e7` passes `test-api` 50/50 with
+`-DMI_OPT_FREE_SMALL=ON -DMI_PADDING=1`.
+
+They still matter here, and to anyone else pinned near that base. Full analysis in
+[upstream-bugs.md](upstream-bugs.md) (bugs 4 and 5); the fixes are one hunk each in
+`src/arena.c` and `src/alloc.c`.
+
+1. **`mi_free_small` reads the caller's block as a page.** `mi_arenas_page_alloc_fresh`
+   keeps the page meta in front of the slice for `block_size <= MI_SMALL_SIZE_MAX`, but
+   the small *allocation* path is entered on the **requested** size. `MI_PADDING` makes
+   those diverge (`mi_good_size(1024) == 1280`), so a 1009..1024 byte request gets a page
+   whose meta is in `pages_meta` while `mi_free_small` looks for it at
+   `_mi_align_down_ptr(p, MI_SMALL_PAGE_SIZE)`. NULL `page->heap` dereference. The bound
+   should be `mi_good_size(MI_SMALL_SIZE_MAX)` — the invariant `mi_free_small`'s own
+   assertion states.
+2. **`mi_realloc` frees an interior pointer.** With `MI_PADDING`, a failed padding decode
+   makes `mi_page_usable_size_of` return 0; `mi_theap_realloc_zero_ex` then reallocates
+   and frees `p`, pushing an interior pointer onto the page free list. It should return
+   `NULL` without freeing, as its own header comment promises.
+
+Reproduce either on stock upstream `6def7be9`, with no sanitizer and either compiler
+(verified with gcc 15.2 and clang 21.1):
+
+```sh
+cmake -S . -B b -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_FLAGS=-DMI_PADDING=1
+cmake --build b && ./b/mimalloc-test-api
+```
+
+`free_small1` segfaults (defect 1); with that fixed, `mi_urealloc_invalid` fails
+(defect 2). Neither reproduces in a `Debug` build, because CMake auto-enables
+`MI_OPT_FREE_SMALL` only when `MI_DEBUG` is off — which is why upstream's ASan
+configuration never saw them either. Add `-DMI_OPT_FREE_SMALL=ON` when checking a tree
+whose CMake no longer auto-enables it.
+
 ## Local reproduction
 
 ```sh

--- a/docs/upstreaming.md
+++ b/docs/upstreaming.md
@@ -363,19 +363,33 @@ stack-overflowed in the emulated-TLS recursion above, before `main`. Superseded 
 a cross build, where minject (a Windows PE utility) cannot run at all. Nothing to report
 upstream about minject.
 
-## Not upstreamable: two `MI_PADDING` release-build defects at the pinned base (#301)
+## Candidate: `mi_realloc` frees an interior pointer under `MI_PADDING` (#301)
 
-**Nothing to send upstream — recorded so the next person does not re-derive it.** Both
-defects reproduce on **stock upstream `6def7be9`** (the commit this fork's overlay pins,
-and Bun's mimalloc merge-base) with zero fork changes, and both are **already gone at
-`upstream/dev3` HEAD `34fbd7e7`**, which relabels `MI_OPT_FREE_SMALL` *"Deprecated"*,
-drops its release auto-enable, and validates the aligned-down page lookup against a new
-`page->self` pointer. Stock `34fbd7e7` passes `test-api` 50/50 with
-`-DMI_OPT_FREE_SMALL=ON -DMI_PADDING=1`.
+Both defects #301 turned up reproduce on **stock upstream `6def7be9`** — the commit this
+fork's overlay pins, and Bun's mimalloc merge-base — with zero fork changes. Their status
+against `upstream/dev3` HEAD (`34fbd7e7`) differs, and the difference is easy to get wrong,
+so it is stated here as measured rather than inferred. Full analysis in
+[upstream-bugs.md](upstream-bugs.md) (bugs 4 and 5).
 
-They still matter here, and to anyone else pinned near that base. Full analysis in
-[upstream-bugs.md](upstream-bugs.md) (bugs 4 and 5); the fixes are one hunk each in
-`src/arena.c` and `src/alloc.c`.
+**First, the trap.** A stock `34fbd7e7` build tells you nothing about either defect,
+because `include/mimalloc/types.h:68` there carries an unconditional `#define MI_PADDING 0`
+(added by `cda82f99`) that sits *above* the `MI_TRACK_ASAN`/`MI_SECURE>=3` auto-enable and
+silently clobbers a command-line `-DMI_PADDING=1` with a redefinition warning. `dev3` HEAD
+ships no block padding in any configuration. **That is itself worth reporting upstream** —
+it removes byte-precise `mi_usable_size` and heap-block-overflow detection on free.
+
+With that one line neutralized so padding is genuinely on (`MI_PADDING_SIZE == 8`,
+`mi_good_size(1024) == 1280`, i.e. the requested/block-size divergence is unchanged) and
+`-DMI_OPT_FREE_SMALL=ON`, `dev3` HEAD's `test-api` reports 49 ok / 1 failed:
+
+| Defect | `6def7be9` (our pin) | `34fbd7e7` (dev3 HEAD) | Upstreamable? |
+|---|---|---|---|
+| **4** — `mi_free_small` reads the caller's block as a page (SEGV) | reproduces | does **not** reproduce; small-page free path reworked by `82fd55ff` / `fe5a54c4` / `eab1ebe6` (which of them neutralizes it is not bisected) | no — pinned-base only |
+| **5** — `mi_realloc` frees an interior pointer | reproduces | **still fails** `mi_urealloc_invalid` | **yes** |
+| `MI_PADDING` unreachable (`types.h:68`, `cda82f99`) | n/a | present | **yes** |
+
+The fixes here are one hunk each in `src/arena.c` and `src/alloc.c`; only the `alloc.c` one
+is a candidate for a `pr/*` branch cut from `dev3`.
 
 1. **`mi_free_small` reads the caller's block as a page.** `mi_arenas_page_alloc_fresh`
    keeps the page meta in front of the slice for `block_size <= MI_SMALL_SIZE_MAX`, but
@@ -401,8 +415,13 @@ cmake --build b && ./b/mimalloc-test-api
 `free_small1` segfaults (defect 1); with that fixed, `mi_urealloc_invalid` fails
 (defect 2). Neither reproduces in a `Debug` build, because CMake auto-enables
 `MI_OPT_FREE_SMALL` only when `MI_DEBUG` is off — which is why upstream's ASan
-configuration never saw them either. Add `-DMI_OPT_FREE_SMALL=ON` when checking a tree
-whose CMake no longer auto-enables it.
+configuration never saw them either.
+
+On a `dev3` tree at or after `cda82f99`, two extra steps are required or the run proves
+nothing: delete the unconditional `#define MI_PADDING 0` at `include/mimalloc/types.h:68`,
+and pass `-DMI_OPT_FREE_SMALL=ON` (its release auto-enable is gone there). Check the
+configure output for `MI_OPT_FREE_SMALL=1` and the compile log for the absence of a
+`'MI_PADDING' redefined` warning before believing a green result.
 
 ## Local reproduction
 

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit eaf92584 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 872c37d8 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -8423,23 +8423,23 @@ static mi_decl_forceinline void* mi_theap_realloc_zero_ex(mi_theap_t* theap, voi
       return NULL;
     } 
     size = _mi_page_usable_size(page,p);
+    #if (MI_PADDING || MI_GUARDED)
     // fork fix, issue #301: a usable size of 0 for a non-NULL `p` means the padding decode
-    // failed (`mi_page_usable_size_of` in free.c, and see the "size can be zero if the padding
-    // is corrupted" comment there) -- `p` is not a block start, or the block was overrun. Both
-    // are errors, and reallocating would free `p` (an interior pointer, corrupting the free
-    // list) after copying 0 bytes. Report it the way the contract above prescribes instead:
-    // NULL, with `p` not freed -- which is also what a MI_DEBUG build returns via
-    // `mi_validate_ptr_page`. Only reachable with MI_PADDING on (implied by
-    // MI_TRACK_ASAN/VALGRIND/ETW and MI_SECURE>=3): no valid block ever has usable size 0,
-    // since the padding path bumps a 0-byte request to `sizeof(void*)`. Reproduced by
-    // upstream's own `mi_urealloc_invalid` test in a non-debug MI_PADDING build, on STOCK
-    // upstream at our pinned base (6def7be9, zero fork changes); upstream's dev3 HEAD
-    // (34fbd7e7) no longer fails that test. See docs/upstream-bugs.md.
+    // failed (`mi_page_usable_size_of` in free.c: "size can be zero if the padding is
+    // corrupted") -- `p` is not a block start, or the block was overrun. Reallocating would
+    // free `p`, an interior pointer, corrupting the free list. Report it the way the contract
+    // above prescribes: NULL, with `p` not freed -- which is what a MI_DEBUG build already
+    // returns via `mi_validate_ptr_page`. Guarded like the zero-size bump in
+    // `mi_theap_malloc_small_zero_nonnull`, since only a padding build can reach it: no valid
+    // block has usable size 0 (the padding path bumps a 0-byte request to `sizeof(void*)`),
+    // and without padding `mi_page_usable_size_of` returns `mi_page_usable_block_size` > 0.
+    // Reproduced by upstream's own `mi_urealloc_invalid` test; see docs/upstream-bugs.md.
     if mi_unlikely(size == 0) {
       if (pblock_size_pre!=NULL) { *pblock_size_pre = 0; }
       if (pblock_size_post!=NULL) { *pblock_size_post = 0; }
       return NULL;
     }
+    #endif
     if (pblock_size_pre!=NULL) { *pblock_size_pre = mi_page_block_size(page); }
   }
   // check if we can reuse the existing block
@@ -11153,23 +11153,16 @@ static mi_page_t* mi_arenas_page_alloc_fresh(mi_theap_t* theap, size_t slice_cou
       mi_page_t* const page_meta = &arena->pages_meta[memid.mem.arena.slice_index];
       mi_assert_internal(page_meta->block_size == 0);
       #if MI_PAGE_META_ALIGNED_FREE_SMALL
-      // if the block size is one `mi_(heap_)malloc_small` can produce, we put the page info
-      // in front of the slice (note: it is important that `page_meta->block_size == 0` for
-      // `mi_arena_page_at_slice`).
-      //
-      // fork fix, issue #301: the bound must be `mi_good_size(MI_SMALL_SIZE_MAX)`, not the raw
-      // `MI_SMALL_SIZE_MAX` -- `mi_free_small` finds the page as `_mi_align_down_ptr(p,
-      // MI_SMALL_PAGE_SIZE)`, so the meta must be in front for every block `mi_malloc_small`
-      // can hand out (exactly the invariant free.c's own assert states). With MI_PADDING on
-      // (implied by MI_TRACK_ASAN/VALGRIND/ETW and MI_SECURE>=3) a 1009..1024 byte request
-      // still takes the small path but gets `mi_good_size(1024) == 1280` as its block size, so
-      // the meta went to `pages_meta` and `mi_free_small` read the user's own zeroed block as a
-      // `mi_page_t` (NULL `page->heap` deref here). Without padding this is a no-op, as
-      // `mi_good_size(MI_SMALL_SIZE_MAX) == MI_SMALL_SIZE_MAX`. Reproduced on STOCK upstream at
-      // our pinned base (6def7be9, arena.c:983, zero fork changes); upstream's dev3 HEAD
-      // (34fbd7e7) has since reworked the lookup and deprecated the option, so this is a
-      // pinned-base defect, not an upstreamable one. See docs/upstream-bugs.md.
+      // The meta stays in front of the slice for every block size `mi_(heap_)malloc_small` can
+      // produce, which is what `mi_free_small`'s align-down page lookup requires -- and with
+      // MI_PADDING on that is `mi_good_size(MI_SMALL_SIZE_MAX)`, not the raw constant (#301,
+      // docs/upstream-bugs.md bug 4). Split so non-padding codegen is bit-identical.
+      // (note: it is important that `page_meta->block_size == 0` for `mi_arena_page_at_slice`)
+      #if MI_PADDING
       if (block_size > mi_good_size(MI_SMALL_SIZE_MAX))
+      #else
+      if (block_size > MI_SMALL_SIZE_MAX)
+      #endif
       #endif
       {
         page = page_meta;

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 9f321fff of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit eaf92584 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -8423,6 +8423,23 @@ static mi_decl_forceinline void* mi_theap_realloc_zero_ex(mi_theap_t* theap, voi
       return NULL;
     } 
     size = _mi_page_usable_size(page,p);
+    // fork fix, issue #301: a usable size of 0 for a non-NULL `p` means the padding decode
+    // failed (`mi_page_usable_size_of` in free.c, and see the "size can be zero if the padding
+    // is corrupted" comment there) -- `p` is not a block start, or the block was overrun. Both
+    // are errors, and reallocating would free `p` (an interior pointer, corrupting the free
+    // list) after copying 0 bytes. Report it the way the contract above prescribes instead:
+    // NULL, with `p` not freed -- which is also what a MI_DEBUG build returns via
+    // `mi_validate_ptr_page`. Only reachable with MI_PADDING on (implied by
+    // MI_TRACK_ASAN/VALGRIND/ETW and MI_SECURE>=3): no valid block ever has usable size 0,
+    // since the padding path bumps a 0-byte request to `sizeof(void*)`. Reproduced by
+    // upstream's own `mi_urealloc_invalid` test in a non-debug MI_PADDING build, on STOCK
+    // upstream at our pinned base (6def7be9, zero fork changes); upstream's dev3 HEAD
+    // (34fbd7e7) no longer fails that test. See docs/upstream-bugs.md.
+    if mi_unlikely(size == 0) {
+      if (pblock_size_pre!=NULL) { *pblock_size_pre = 0; }
+      if (pblock_size_post!=NULL) { *pblock_size_post = 0; }
+      return NULL;
+    }
     if (pblock_size_pre!=NULL) { *pblock_size_pre = mi_page_block_size(page); }
   }
   // check if we can reuse the existing block
@@ -11136,9 +11153,23 @@ static mi_page_t* mi_arenas_page_alloc_fresh(mi_theap_t* theap, size_t slice_cou
       mi_page_t* const page_meta = &arena->pages_meta[memid.mem.arena.slice_index];
       mi_assert_internal(page_meta->block_size == 0);
       #if MI_PAGE_META_ALIGNED_FREE_SMALL
-      // if `block_size <= MI_SMALL_SIZE_MAX` we put the page info in front of the slice,
-      // (note: it is important that `page_meta->block_size == 0` for `mi_arena_page_at_slice`)
-      if (block_size > MI_SMALL_SIZE_MAX)
+      // if the block size is one `mi_(heap_)malloc_small` can produce, we put the page info
+      // in front of the slice (note: it is important that `page_meta->block_size == 0` for
+      // `mi_arena_page_at_slice`).
+      //
+      // fork fix, issue #301: the bound must be `mi_good_size(MI_SMALL_SIZE_MAX)`, not the raw
+      // `MI_SMALL_SIZE_MAX` -- `mi_free_small` finds the page as `_mi_align_down_ptr(p,
+      // MI_SMALL_PAGE_SIZE)`, so the meta must be in front for every block `mi_malloc_small`
+      // can hand out (exactly the invariant free.c's own assert states). With MI_PADDING on
+      // (implied by MI_TRACK_ASAN/VALGRIND/ETW and MI_SECURE>=3) a 1009..1024 byte request
+      // still takes the small path but gets `mi_good_size(1024) == 1280` as its block size, so
+      // the meta went to `pages_meta` and `mi_free_small` read the user's own zeroed block as a
+      // `mi_page_t` (NULL `page->heap` deref here). Without padding this is a no-op, as
+      // `mi_good_size(MI_SMALL_SIZE_MAX) == MI_SMALL_SIZE_MAX`. Reproduced on STOCK upstream at
+      // our pinned base (6def7be9, arena.c:983, zero fork changes); upstream's dev3 HEAD
+      // (34fbd7e7) has since reworked the lookup and deprecated the option, so this is a
+      // pinned-base defect, not an upstreamable one. See docs/upstream-bugs.md.
+      if (block_size > mi_good_size(MI_SMALL_SIZE_MAX))
       #endif
       {
         page = page_meta;

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 9f321fff of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit eaf92584 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit eaf92584 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 872c37d8 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -436,23 +436,23 @@ static mi_decl_forceinline void* mi_theap_realloc_zero_ex(mi_theap_t* theap, voi
       return NULL;
     } 
     size = _mi_page_usable_size(page,p);
+    #if (MI_PADDING || MI_GUARDED)
     // fork fix, issue #301: a usable size of 0 for a non-NULL `p` means the padding decode
-    // failed (`mi_page_usable_size_of` in free.c, and see the "size can be zero if the padding
-    // is corrupted" comment there) -- `p` is not a block start, or the block was overrun. Both
-    // are errors, and reallocating would free `p` (an interior pointer, corrupting the free
-    // list) after copying 0 bytes. Report it the way the contract above prescribes instead:
-    // NULL, with `p` not freed -- which is also what a MI_DEBUG build returns via
-    // `mi_validate_ptr_page`. Only reachable with MI_PADDING on (implied by
-    // MI_TRACK_ASAN/VALGRIND/ETW and MI_SECURE>=3): no valid block ever has usable size 0,
-    // since the padding path bumps a 0-byte request to `sizeof(void*)`. Reproduced by
-    // upstream's own `mi_urealloc_invalid` test in a non-debug MI_PADDING build, on STOCK
-    // upstream at our pinned base (6def7be9, zero fork changes); upstream's dev3 HEAD
-    // (34fbd7e7) no longer fails that test. See docs/upstream-bugs.md.
+    // failed (`mi_page_usable_size_of` in free.c: "size can be zero if the padding is
+    // corrupted") -- `p` is not a block start, or the block was overrun. Reallocating would
+    // free `p`, an interior pointer, corrupting the free list. Report it the way the contract
+    // above prescribes: NULL, with `p` not freed -- which is what a MI_DEBUG build already
+    // returns via `mi_validate_ptr_page`. Guarded like the zero-size bump in
+    // `mi_theap_malloc_small_zero_nonnull`, since only a padding build can reach it: no valid
+    // block has usable size 0 (the padding path bumps a 0-byte request to `sizeof(void*)`),
+    // and without padding `mi_page_usable_size_of` returns `mi_page_usable_block_size` > 0.
+    // Reproduced by upstream's own `mi_urealloc_invalid` test; see docs/upstream-bugs.md.
     if mi_unlikely(size == 0) {
       if (pblock_size_pre!=NULL) { *pblock_size_pre = 0; }
       if (pblock_size_post!=NULL) { *pblock_size_post = 0; }
       return NULL;
     }
+    #endif
     if (pblock_size_pre!=NULL) { *pblock_size_pre = mi_page_block_size(page); }
   }
   // check if we can reuse the existing block

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -436,6 +436,23 @@ static mi_decl_forceinline void* mi_theap_realloc_zero_ex(mi_theap_t* theap, voi
       return NULL;
     } 
     size = _mi_page_usable_size(page,p);
+    // fork fix, issue #301: a usable size of 0 for a non-NULL `p` means the padding decode
+    // failed (`mi_page_usable_size_of` in free.c, and see the "size can be zero if the padding
+    // is corrupted" comment there) -- `p` is not a block start, or the block was overrun. Both
+    // are errors, and reallocating would free `p` (an interior pointer, corrupting the free
+    // list) after copying 0 bytes. Report it the way the contract above prescribes instead:
+    // NULL, with `p` not freed -- which is also what a MI_DEBUG build returns via
+    // `mi_validate_ptr_page`. Only reachable with MI_PADDING on (implied by
+    // MI_TRACK_ASAN/VALGRIND/ETW and MI_SECURE>=3): no valid block ever has usable size 0,
+    // since the padding path bumps a 0-byte request to `sizeof(void*)`. Reproduced by
+    // upstream's own `mi_urealloc_invalid` test in a non-debug MI_PADDING build, on STOCK
+    // upstream at our pinned base (6def7be9, zero fork changes); upstream's dev3 HEAD
+    // (34fbd7e7) no longer fails that test. See docs/upstream-bugs.md.
+    if mi_unlikely(size == 0) {
+      if (pblock_size_pre!=NULL) { *pblock_size_pre = 0; }
+      if (pblock_size_post!=NULL) { *pblock_size_post = 0; }
+      return NULL;
+    }
     if (pblock_size_pre!=NULL) { *pblock_size_pre = mi_page_block_size(page); }
   }
   // check if we can reuse the existing block

--- a/src/arena.c
+++ b/src/arena.c
@@ -892,9 +892,23 @@ static mi_page_t* mi_arenas_page_alloc_fresh(mi_theap_t* theap, size_t slice_cou
       mi_page_t* const page_meta = &arena->pages_meta[memid.mem.arena.slice_index];
       mi_assert_internal(page_meta->block_size == 0);
       #if MI_PAGE_META_ALIGNED_FREE_SMALL
-      // if `block_size <= MI_SMALL_SIZE_MAX` we put the page info in front of the slice,
-      // (note: it is important that `page_meta->block_size == 0` for `mi_arena_page_at_slice`)
-      if (block_size > MI_SMALL_SIZE_MAX)
+      // if the block size is one `mi_(heap_)malloc_small` can produce, we put the page info
+      // in front of the slice (note: it is important that `page_meta->block_size == 0` for
+      // `mi_arena_page_at_slice`).
+      //
+      // fork fix, issue #301: the bound must be `mi_good_size(MI_SMALL_SIZE_MAX)`, not the raw
+      // `MI_SMALL_SIZE_MAX` -- `mi_free_small` finds the page as `_mi_align_down_ptr(p,
+      // MI_SMALL_PAGE_SIZE)`, so the meta must be in front for every block `mi_malloc_small`
+      // can hand out (exactly the invariant free.c's own assert states). With MI_PADDING on
+      // (implied by MI_TRACK_ASAN/VALGRIND/ETW and MI_SECURE>=3) a 1009..1024 byte request
+      // still takes the small path but gets `mi_good_size(1024) == 1280` as its block size, so
+      // the meta went to `pages_meta` and `mi_free_small` read the user's own zeroed block as a
+      // `mi_page_t` (NULL `page->heap` deref here). Without padding this is a no-op, as
+      // `mi_good_size(MI_SMALL_SIZE_MAX) == MI_SMALL_SIZE_MAX`. Reproduced on STOCK upstream at
+      // our pinned base (6def7be9, arena.c:983, zero fork changes); upstream's dev3 HEAD
+      // (34fbd7e7) has since reworked the lookup and deprecated the option, so this is a
+      // pinned-base defect, not an upstreamable one. See docs/upstream-bugs.md.
+      if (block_size > mi_good_size(MI_SMALL_SIZE_MAX))
       #endif
       {
         page = page_meta;

--- a/src/arena.c
+++ b/src/arena.c
@@ -892,23 +892,16 @@ static mi_page_t* mi_arenas_page_alloc_fresh(mi_theap_t* theap, size_t slice_cou
       mi_page_t* const page_meta = &arena->pages_meta[memid.mem.arena.slice_index];
       mi_assert_internal(page_meta->block_size == 0);
       #if MI_PAGE_META_ALIGNED_FREE_SMALL
-      // if the block size is one `mi_(heap_)malloc_small` can produce, we put the page info
-      // in front of the slice (note: it is important that `page_meta->block_size == 0` for
-      // `mi_arena_page_at_slice`).
-      //
-      // fork fix, issue #301: the bound must be `mi_good_size(MI_SMALL_SIZE_MAX)`, not the raw
-      // `MI_SMALL_SIZE_MAX` -- `mi_free_small` finds the page as `_mi_align_down_ptr(p,
-      // MI_SMALL_PAGE_SIZE)`, so the meta must be in front for every block `mi_malloc_small`
-      // can hand out (exactly the invariant free.c's own assert states). With MI_PADDING on
-      // (implied by MI_TRACK_ASAN/VALGRIND/ETW and MI_SECURE>=3) a 1009..1024 byte request
-      // still takes the small path but gets `mi_good_size(1024) == 1280` as its block size, so
-      // the meta went to `pages_meta` and `mi_free_small` read the user's own zeroed block as a
-      // `mi_page_t` (NULL `page->heap` deref here). Without padding this is a no-op, as
-      // `mi_good_size(MI_SMALL_SIZE_MAX) == MI_SMALL_SIZE_MAX`. Reproduced on STOCK upstream at
-      // our pinned base (6def7be9, arena.c:983, zero fork changes); upstream's dev3 HEAD
-      // (34fbd7e7) has since reworked the lookup and deprecated the option, so this is a
-      // pinned-base defect, not an upstreamable one. See docs/upstream-bugs.md.
+      // The meta stays in front of the slice for every block size `mi_(heap_)malloc_small` can
+      // produce, which is what `mi_free_small`'s align-down page lookup requires -- and with
+      // MI_PADDING on that is `mi_good_size(MI_SMALL_SIZE_MAX)`, not the raw constant (#301,
+      // docs/upstream-bugs.md bug 4). Split so non-padding codegen is bit-identical.
+      // (note: it is important that `page_meta->block_size == 0` for `mi_arena_page_at_slice`)
+      #if MI_PADDING
       if (block_size > mi_good_size(MI_SMALL_SIZE_MAX))
+      #else
+      if (block_size > MI_SMALL_SIZE_MAX)
+      #endif
       #endif
       {
         page = page_meta;


### PR DESCRIPTION
Closes #301.

## Root cause: not gcc, not ASan

`RelWithDebInfo -DMI_PADDING=1` — no sanitizer, **and it crashes identically under gcc and clang** — reproduces the SEGV. `MI_TRACK_ASAN` merely implies `MI_PADDING` (`types.h:105`).

ASan/gdb evidence: `mi_free_size(p, 1024)` → `mi_free_small(p)` → SEGV at `arena.c:1223`, `heap->subproc` with `heap == NULL`. `p == 0x7bffb3b60000` is itself 64 KiB-aligned, and the "page" the crash dereferences is the caller's own zeroed block:

```
$1 = {xthread_id = 0, free = 0x0, used = 0, ..., heap = 0x0, ...}   # p, not an mi_page_t
```

`MI_OPT_FREE_SMALL` makes `mi_free_small` find the page as `_mi_align_down_ptr(p, MI_SMALL_PAGE_SIZE)`, valid only while the page meta sits in front of the slice. `mi_arenas_page_alloc_fresh` decided that on `block_size > MI_SMALL_SIZE_MAX` — but the small path is *entered* on the **requested** size, and padding makes the two diverge: `mi_good_size(1024) == 1280`. A 1009..1024 byte request took the small path while its meta went to `pages_meta`. Fix: use the bound `mi_free_small`'s own assert states, `mi_good_size(MI_SMALL_SIZE_MAX)` — a literal no-op without padding.

**Why CI was green:** `asan.yml` built `Debug`, and CMakeLists auto-enables `MI_OPT_FREE_SMALL` **only when `MI_DEBUG` is off**. The two ingredients could never coexist in that lane.

## Second defect in the same configuration

With the SEGV fixed, upstream's own `mi_urealloc_invalid` fails in any non-debug `MI_PADDING` build. A failed padding decode makes `mi_page_usable_size_of` return 0 ("size can be zero if the padding is corrupted"); `mi_theap_realloc_zero_ex` then reallocated and **freed `p`** — an interior pointer onto the page free list. Now returns `NULL` without freeing, as its own header comment promises and as `MI_DEBUG` already does. No valid block reports usable size 0 — verified by exhaustively probing `mi_malloc`/`zalloc`/`calloc`/`realloc` 0..4096 and `mi_*_aligned`/`mi_malloc_aligned_at` 0..2048 × alignments 1..8192 across padding/non-padding, debug/release: zero hits.

## Provenance (measured against `dev3` HEAD, not inferred)

Both reproduce on **stock upstream `6def7be9`** — this fork's pin, and Bun's mimalloc merge-base — with zero fork changes.

A stock `34fbd7e7` run proves nothing about either: `include/mimalloc/types.h:68` there carries an unconditional `#define MI_PADDING 0` (added by `cda82f99`) *above* the `MI_TRACK_ASAN`/`MI_SECURE>=3` auto-enable, so `-DMI_PADDING=1` is clobbered with only a redefinition warning and **`dev3` HEAD ships no block padding in any configuration** — itself an upstream defect worth reporting.

Neutralize that line (padding then really engages: `MI_PADDING_SIZE == 8`, `mi_good_size(1024) == 1280` — the divergence is *unchanged* at dev3) and build with `-DMI_OPT_FREE_SMALL=ON`; `test-api` is 49 ok / 1 failed:

| Defect | `6def7be9` | `34fbd7e7` | Upstreamable |
|---|---|---|---|
| **4** `mi_free_small` reads the caller's block as a page | reproduces | does **not** reproduce (small-page free path reworked by `82fd55ff`/`fe5a54c4`/`eab1ebe6`; not bisected) | no |
| **5** `mi_realloc` frees an interior pointer | reproduces | **still fails** `mi_urealloc_invalid` | **yes** |
| `MI_PADDING` unreachable (`types.h:68`) | n/a | present | **yes** |

Recorded in `docs/upstream-bugs.md` (bugs 4–5) and `docs/upstreaming.md`.

## Cost in the default build: zero

The `arena.c` bound is `#if MI_PADDING`-selected and the `alloc.c` check is `#if (MI_PADDING || MI_GUARDED)`-guarded, so in a Release non-padding build **`arena.c.o` and `alloc.c.o` disassemble byte-identically to `main`**, `mi_urealloc` included (224 instruction lines, zero diff).

## Regression coverage

| Lane | Before | After |
|---|---|---|
| `asan.yml` `clang, Debug` (+`MI_DEBUG_FULL`) | hard gate | unchanged, hard gate |
| `asan.yml` `gcc, RelWithDebInfo` | — | **new**, hard gate — the reported config |
| `asan.yml` `clang, RelWithDebInfo` | — | **new**, hard gate — asymmetry would itself be a finding |
| `verify_local.py` `asan` | clang-only; could not configure where clang lacks `sanitizer/asan_interface.h` | probes clang → gcc → SKIP-with-reason; runs both build types |
| `ci/tests/test_verify_local.py` | a matrixed `-D` flag read as the literal token `-DCMAKE_BUILD_TYPE=${{` | expands `${{ matrix.* }}` first, so matrixed flags stay drift-checked |

## Verification (this workstation)

- `uv run ci/verify_local.py --keep-going` → **11/11 PASS** (the `asan` config picked gcc — clang here has no compiler-rt headers — and ran Debug + RelWithDebInfo).
- gcc ASan `RelWithDebInfo`: `test-api` 46 ok / 0 failed; full `ctest` **45/45**; UAF positive control still fires (`use-after-poison`).
- Same with `-DMI_DEBUG=2` so `mi_assert_internal` is armed on the widened meta-in-front set: **45/45**.
- Non-padding `RelWithDebInfo` unchanged: `test-api` 47 ok / 0 failed.
- Zero-usable-size probe extended through every page class (8K/64K/512K/1M/8M/64M ±1, aligned and `aligned_at`, plus realloc ping-pong across the small/large boundary): still no allocation reports 0.
- `ruff` + `pyright --strict` + `pytest ci/tests` (237 passed); `ci/check_doc_snippets.py` PASS; `xtask check` green after the amalgamation regen.

**Pre-existing red on `main` at the branch point (`af947dff`), not from this PR:** `memory-gate (ubuntu-latest)` (fails on main's own run 33699070304) and `run-macos-x64 (dockurr/macos on Linux)` (documented in `docs/ci-gates.md` — the golden disk does not exist yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
