### PR TITLE
fix(build): compile src/diagnostic.c whenever the effective MI_DEBUG > 2 (#312)

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -180,6 +180,18 @@ jobs:
             cmake: -DCMAKE_BUILD_TYPE=Release -DMI_DEBUG=OFF -DMI_PPROF=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
             target: mimalloc-static
             kind: lib
+          - config: debug3-extra
+            container: ''
+            python: uv run
+            # #312: MI_DEBUG=3 arriving through MI_EXTRA_CPPDEFS (not the MI_DEBUG_FULL
+            # option) used to leave src/diagnostic.c out of the build while atomic.h
+            # still called its `_mi_lock_debug_*` hooks -- an undefined reference that
+            # only a *test executable* link exposes (a static archive tolerates it),
+            # hence the target. Link-only; debug-full runs the suite for this define.
+            cmake: -DCMAKE_BUILD_TYPE=Debug -DMI_PPROF=ON -DMI_EXTRA_CPPDEFS=MI_DEBUG=3
+            assert_defines: MI_DEBUG=3
+            target: mimalloc-test-api
+            kind: lib
     steps:
       # Before checkout: actions/checkout needs `git` on PATH, which alpine's base image
       # does not carry. `tar` too -- busybox's applet cannot write the gzip archive the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,8 +393,27 @@ elseif(CMAKE_BUILD_TYPE MATCHES "Debug")
 endif()
 
 # Debug-only lock diagnostics (#167). Keep this source out of release libraries
-# entirely; src/static.c includes it under the equivalent preprocessor guard.
-if(MI_DEBUG_FULL)
+# entirely -- ci/verify_local.py's `diag` config (and check_release_equivalence.py)
+# assert it never even reaches compile_commands.json for a MI_DEBUG=0 build, not just
+# that its (self-guarded, `#if MI_DEBUG > 2`) body compiles to nothing -- so this can't
+# be unconditional the way src/static.c's #include of it is.
+#
+# The old gate was just `if(MI_DEBUG_FULL)`, the CMake *option*. That missed every route
+# that sets the effective MI_DEBUG=3 preprocessor value without ever setting that option:
+# -DMI_EXTRA_CPPDEFS=MI_DEBUG=3, or a raw -DMI_DEBUG=3 smuggled into CMAKE_C_FLAGS. Either
+# leaves atomic.h's `#if MI_DEBUG > 2` calls into _mi_lock_debug_* with no definition,
+# undefined at link time (#312). So also scan MI_EXTRA_CPPDEFS/CMAKE_C_FLAGS for a
+# MI_DEBUG=N > 2 and treat that the same as MI_DEBUG_FULL=ON. This is intentionally
+# over-inclusive (it can't replicate the compiler's own "last -D wins" duplicate-macro
+# resolution), never under-inclusive: an MI_DEBUG=0/OFF release build sets neither of
+# these, so the diag gate above is unaffected by this addition.
+set(mi_need_diagnostic_c ${MI_DEBUG_FULL})
+foreach(mi_extra_def IN ITEMS "${MI_EXTRA_CPPDEFS}" "${CMAKE_C_FLAGS}")
+  if(mi_extra_def MATCHES "MI_DEBUG=([0-9]+)" AND CMAKE_MATCH_1 GREATER 2)
+    set(mi_need_diagnostic_c ON)
+  endif()
+endforeach()
+if(mi_need_diagnostic_c)
   list(APPEND mi_sources src/diagnostic.c)
 endif()
 

--- a/ci/tests/test_verify_local.py
+++ b/ci/tests/test_verify_local.py
@@ -226,6 +226,7 @@ class VerifyLocalDriftTests(unittest.TestCase):
             "release",
             "off",
             "debug-full",
+            "debug3-extra",
             "guarded",
             "shared",
             "bundle",

--- a/ci/verify_local.py
+++ b/ci/verify_local.py
@@ -306,6 +306,38 @@ def run_debug_full(ctx: RunCtx) -> bool:
     return ctest_run(ctx, build, config="Debug") == 0
 
 
+def run_debug3_extra(ctx: RunCtx) -> bool:
+    """c-unit.yml `build (debug3-extra)` (#312): MI_DEBUG=3 reaching the compiler via
+    `-DMI_EXTRA_CPPDEFS=MI_DEBUG=3` instead of `-DMI_DEBUG_FULL=ON`. CI only links
+    `mimalloc-test-api` (the failure was an undefined reference at executable link time);
+    this local config additionally runs a small ctest subset.
+
+    Only `test-fork-locks*` and `test-api*` run here (ctest -R 'lock|api'), not the full
+    suite `debug-full` covers -- and notably not #167's `test-lock-reentrancy` /
+    `-uncleared-owner` / `-nonowner-release` / `-destroy-owned` positive controls, which
+    are separately registered under `if(MI_DEBUG_FULL)` in CMakeLists.txt (the same
+    option-vs-effective-value gap this issue is about, but for *test* registration rather
+    than the *source* compiled -- there's no CMake-side way to see a MI_DEBUG=N smuggled
+    into CMAKE_C_FLAGS at the point those tests get registered, so left out of #312's fix).
+    """
+    build = ctx.dir / "build"
+    rc, configure_out = cmake_configure(
+        ctx,
+        build,
+        ["-DCMAKE_BUILD_TYPE=Debug", "-DMI_PPROF=ON", "-DMI_EXTRA_CPPDEFS=MI_DEBUG=3"],
+    )
+    if rc:
+        return False
+    # #312: MI_DEBUG=3 must actually reach the compiler through this route (it collides
+    # with the MI_DEBUG=2 that CMAKE_BUILD_TYPE=Debug also appends; the later -D wins).
+    if not re.search(r"Compiler defines\s*:.*MI_DEBUG=3", configure_out):
+        log_write(ctx.log, "\n[verify_local] FAIL: MI_DEBUG=3 did not reach mi_defines\n")
+        return False
+    if cmake_build(ctx, build, config="Debug"):
+        return False
+    return ctest_run(ctx, build, config="Debug", filter_regex="lock|api") == 0
+
+
 def run_bundle(ctx: RunCtx) -> bool:
     """Bundle/ctest pass-and-fail equivalence: -DMI_PPROF=ON -DMI_DEBUG_FULL=ON, Debug.
 
@@ -865,6 +897,12 @@ CONFIGS: list[ConfigSpec] = [
         "c-unit.yml: build(debug-full)+run-linux",
         "Debug, MI_DEBUG_FULL=ON",
         run_debug_full,
+    ),
+    ConfigSpec(
+        "debug3-extra",
+        "c-unit.yml: build(debug3-extra)+run-linux",
+        "Debug, MI_EXTRA_CPPDEFS=MI_DEBUG=3, lock|api ctest subset",
+        run_debug3_extra,
     ),
     ConfigSpec(
         "guarded",

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -177,7 +177,7 @@ runs no tests. `kind` says what it produces:
 |---|---|---|
 | `bundle` | `release`, `pprof-off`, `debug-full`, `guarded`, `shared`, `musl`, `musl-pprof-off` | a `ci/bundle_tests.py` bundle, tarred, **plus** `show-only-<config>.json` straight from `ctest --show-only=json-v1` |
 | `control` | `memory-gate-leak` (`MI_BENCH_INJECT_LEAK=600000`) | a bundle that is never executed — only its `mimalloc-test-memory-gate` binary is, as the memory gate's positive control |
-| `lib` | `isa-portable`, `isa-arch`, `diag-pprof-on`, `diag-pprof-off` | `libmimalloc*.a` (+ `compile_commands.json`) for the run stage to scan |
+| `lib` | `isa-portable`, `isa-arch`, `diag-pprof-on`, `diag-pprof-off`, `debug3-extra` (#312: `MI_EXTRA_CPPDEFS=MI_DEBUG=3` must link `mimalloc-test-api`) | `libmimalloc*.a` (+ `compile_commands.json`) for the run stage to scan |
 
 The bundles are **tarred**, not uploaded as loose files: `upload-artifact@v4` drops the
 executable bit and flattens the `libmimalloc-debug.so → .so.3` SONAME symlink chain, either


### PR DESCRIPTION
Closes #312.

`-DMI_EXTRA_CPPDEFS=MI_DEBUG=3` (without `-DMI_DEBUG_FULL=ON`) failed to link test executables with `_mi_lock_debug_*` undefined: CMake gated `src/diagnostic.c` on the `MI_DEBUG_FULL` option only, while `include/mimalloc/atomic.h` gates its calls on the effective `MI_DEBUG > 2`.

**Fix (`CMakeLists.txt`):** also scan `MI_EXTRA_CPPDEFS` and `CMAKE_C_FLAGS` for `MI_DEBUG=N` with N > 2 and add `src/diagnostic.c` when found. Over-inclusive by design (a stale duplicate `-D` can't be resolved CMake-side); `MI_DEBUG=0` release builds are unaffected, so the `diag` compile_commands assertion still holds.

**Guards:**
- `c-unit.yml`: new `build (debug3-extra)` lib row: `-DCMAKE_BUILD_TYPE=Debug -DMI_PPROF=ON -DMI_EXTRA_CPPDEFS=MI_DEBUG=3`, `assert_defines: MI_DEBUG=3`, target `mimalloc-test-api` (a static archive tolerates the undefined reference; only an executable link exposes it).
- `ci/verify_local.py --only debug3-extra`: same configure, plus a `lock|api` ctest subset locally.
- `docs/ci-gates.md` lib-row table updated.

**Verification:** negative control on `main` reproduces the three undefined references; on this branch `verify_local --only debug3-extra` passes, `ruff`/`pyright` clean, `pytest ci/tests` 285 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
