### PR TITLE
fix: collect inside the sub-process on _mi_free_subproc_safe (Bun P10a, #316)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,7 +988,7 @@ if (MI_BUILD_TESTS)
   enable_testing()
 
   # static link tests
-  foreach(TEST_NAME api api-fill stress-heaps stress-subprocs stress)
+  foreach(TEST_NAME api api-fill heap-burst-destroy stress-heaps stress-subprocs stress)
     add_executable(mimalloc-test-${TEST_NAME} test/test-${TEST_NAME}.c)
     target_compile_definitions(mimalloc-test-${TEST_NAME} PRIVATE ${mi_defines})
     target_compile_options(mimalloc-test-${TEST_NAME} PRIVATE ${mi_cflags})
@@ -1867,6 +1867,10 @@ endif()
 #     missed deadline is indistinguishable from the regression these tests exist to catch.
 #   * a subprocess-shaped lifecycle -- test-subproc-lifecycle forks/execs and asserts on
 #     what the child does at exit.
+#   * process-wide meta-data bookkeeping under load -- test-heap-burst-destroy measures the
+#     main heap's byte-count and process RSS across 4000 heap creates/destroys (single-
+#     threaded; no race), the same sensitivity class as the RSS-under-pressure tests above: a
+#     parallel wave's memory pressure can move both numbers independently of the allocator.
 #
 # RUN_SERIAL is ctest's own word for this ("do not run any other test concurrently"), so
 # it is set here rather than encoded as a name list inside the CI runner: a new test
@@ -1889,6 +1893,7 @@ set(mi_serial_tests
   test-profile-race
   test-profile-race-scavenger
   test-subproc-lifecycle
+  test-heap-burst-destroy
 )
 # Next candidate if the wave ever goes flaky: test-fork-user-heap. It is not here because
 # nothing has been observed to fail -- it forks, and a fork's cost and timing are the

--- a/include/mimalloc/prim-tls.h
+++ b/include/mimalloc/prim-tls.h
@@ -147,13 +147,24 @@ static inline void* mi_prim_tls_slot(size_t slot) {
     #else
       return mi_prim_thread_pointer()[slot];
     #endif
+  #elif defined(__GNUC__) || defined(__clang__)
+    // The slot lives in the thread's control block, which the OS reuses for a later thread, so the
+    // exiting thread's last store (`_mi_thread_done`) and a new thread's first load touch the same
+    // address from different threads. A relaxed atomic is the same single load/store instruction and
+    // states that this is by design (and keeps TSAN quiet about it). Ported from oven-sh/mimalloc
+    // (issue #316, Bun parity P10a).
+    return __atomic_load_n(&mi_prim_thread_pointer()[slot], __ATOMIC_RELAXED);
   #else
     return mi_prim_thread_pointer()[slot];
   #endif
 }
 
 static inline void mi_prim_tls_slot_set(size_t slot, void* value) {
+  #if defined(__GNUC__) || defined(__clang__)
+  __atomic_store_n(&mi_prim_thread_pointer()[slot], value, __ATOMIC_RELAXED);
+  #else
   mi_prim_thread_pointer()[slot] = value;
+  #endif
 }
 #endif
 

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit efdd4bc1 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit be81f936 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -7965,26 +7965,34 @@ static void mi_stat_free(const mi_page_t* page, const mi_block_t* block) {
   // mi_heap_delete/mi_heap_destroy of page's heap on another thread -- reproduced as a
   // SIGSEGV reading page->heap->subproc here (see memory-events.c's _mi_memevt_on_free
   // provenance comment for the first instance of this class of bug and its fix).
-  // Converged in #316 (Bun parity P10a) onto `mi_page_subproc_unowned` (above), the same
-  // arena-derived read that replaced `page->heap->subproc`: `page->memid` is immutable after
+  // Converged in #316 (Bun parity P10a) onto `mi_page_subproc_unowned` (defined earlier in this
+  // file, called a few lines below in this function), the same arena-derived read that replaced
+  // `page->heap->subproc`: `page->memid` is immutable after
   // page creation, so reading the arena through it never dereferences `page->heap` either, and
   // is strictly more accurate than the previous stand-in of "this (the freeing) thread's own
   // subproc" -- it agrees with that whenever the page is in fact ours (the common case, per the
   // "never collect across subprocesses" assumption a few lines below), and gets the actual
   // owning subproc right in the rare cross-subprocess free the old comment conceded was an
-  // unverified edge case. Not a memory-safety concern either way: `theap_meta`/`theap_meta_lock`
-  // are read off whichever subproc is returned, same as before.
-  mi_subproc_t* const subproc = mi_page_subproc_unowned(page);
-  mi_theap_t* const theap_meta = subproc->theap_meta;
+  // unverified edge case.
+  //
+  // #316 (P10a): the condition below is Bun's original shape, not our prior
+  // `theap_meta != NULL && mi_page_thread_id(page) == theap_meta->tld->thread_id` -- that reads
+  // `theap_meta->tld` unconditionally once `theap_meta != NULL`, but `mi_heap_free_theaps` nulls
+  // a theap's `tld` *before* `mi_subproc_unsafe_destroy` nulls `subproc->theap_meta`, so a
+  // *foreign* subproc mid-teardown (only reachable now that `subproc` need not be our own) can
+  // have `theap_meta != NULL` with `theap_meta->tld == NULL` -- a NULL deref. Every `theap_meta`
+  // shares the same static `mi_tld_detached` (`init.c:101`, `subproc.c:209`'s assert), whose
+  // `thread_id` is the compile-time constant `MI_THREADID_DETACHED`, so
+  // `mi_page_thread_id(page) == theap_meta->tld->thread_id` for the meta theap is equivalent to
+  // `mi_page_thread_id(page) == MI_THREADID_DETACHED` without reading `theap_meta` (let alone its
+  // `tld`) at all in the condition. `subproc`/`theap_meta` are loaded inside the branch instead,
+  // where they are actually needed, and past their own `theap_meta == NULL` guard.
   if mi_unlikely(!mi_theap_is_initialized(theap) || // can happen if free'd after thread_done was called (usually a thread cleanup call by the OS)
-                  // page->theap == subproc->theap_meta  .. but we cannot read `theap` if we don't own the page
-                  (theap_meta != NULL && mi_page_thread_id(page) == theap_meta->tld->thread_id)) {
-    // #316 (P10a): `subproc` can now be a *foreign* subproc (the page's arena's, not
-    // necessarily this thread's own), which the old `_mi_subproc()` could never be mid-teardown
-    // out from under the freeing thread. Ported from Bun's converged `mi_stat_free`: give up the
-    // stat update rather than deref a NULL theap_meta of a subproc that is being destroyed.
-    if (theap_meta == NULL) return;
-    theap = theap_meta;
+                  mi_page_thread_id(page) == MI_THREADID_DETACHED) { // page->theap == subproc->theap_meta .. but we cannot read `theap` if we don't own the page (only the meta theap has the detached thread id)
+    // account on the subproc of the page (we cannot use our own theap here)
+    mi_subproc_t* const subproc = mi_page_subproc_unowned(page);
+    if (subproc->theap_meta == NULL) return;  // give up (the subproc is being destroyed)
+    theap = subproc->theap_meta;
     lock = &subproc->theap_meta_lock;
     mi_lock_acquire(lock);
   }
@@ -11894,13 +11902,13 @@ void _mi_arenas_free(mi_subproc_t* subproc, void* p, size_t size, mi_memid_t mem
     // #316 (P10a): this free now collects in-subproc. No allocation site in this tree
     // currently produces a MI_MEM_MALLOC memid that reaches here -- the producers
     // (`_mi_meta_zalloc`/`_mi_meta_zalloc_aligned`/`_mi_meta_rezalloc`, subproc.c, via
-    // `_mi_memid_create_malloc`) hand it to `_mi_meta_free` (subproc.c), which handles
-    // MI_MEM_MALLOC itself with a plain `mi_free(p)` and only forwards other memkinds to
-    // `_mi_arenas_free`; every caller of `_mi_arenas_free` we audited (heap.c:283/309,
-    // arena.c:794/935/1184) passes an arena- or OS-backed memid. This branch is upstream's
-    // fallback, kept for shape parity; if a future producer reaches it, the collect is guarded
-    // the same way as every other `mi_free_ex` path (`mi_free_try_collect_mt`'s own reclaim
-    // guards, unconditional).
+    // `_mi_memid_create_malloc`) hand it to `_mi_meta_free` (subproc.c:94, the only caller of
+    // `_mi_arenas_free` that matters here), which handles MI_MEM_MALLOC itself with a plain
+    // `mi_free(p)` and only forwards other memkinds to `_mi_arenas_free` (subproc.c:99); the
+    // rest of `_mi_arenas_free`'s callers (arena.c:794/935/1184) pass an arena- or OS-backed
+    // memid. This branch is upstream's fallback, kept for shape parity; if a future producer
+    // reaches it, the collect is guarded the same way as every other `mi_free_ex` path
+    // (`mi_free_try_collect_mt`'s own reclaim guards, unconditional).
     _mi_free_subproc_safe(p);
   }
   else {
@@ -15892,10 +15900,13 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
         mi_arena_pages_t* arena_pages = mi_atomic_load_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i]);
         if (arena_pages!=NULL) {
           mi_atomic_store_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i], NULL);
-          // #316 (P10a): this free now collects in-subproc. Safe here: this thread is deleting
-          // `heap` (mi_heap_free's only caller), so it is not parked, and mi_free_try_collect_mt's
-          // own reclaim guards (_mi_thread_is_initialized, _mi_page_associated_theap_peek refusing
-          // a theap of another heap) apply regardless.
+          // #316 (P10a): this free now collects in-subproc. Safe regardless of whether this
+          // thread is parked: `allow_collect` only reaches `mi_free_block_mt`/
+          // `mi_free_generic_mt` (free.c:mi_free_ex), while `_mi_park_leave_if_parked` lives
+          // only in the separate `mi_free_generic_local` owner-free path (free.c:167) -- so this
+          // can never newly reach the park protocol. `mi_free_try_collect_mt`'s own reclaim
+          // guards (`_mi_thread_is_initialized`, `_mi_page_associated_theap_peek` refusing a
+          // theap of another heap) apply unconditionally.
           _mi_free_subproc_safe(arena_pages);
         }
       }
@@ -15922,8 +15933,8 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
   mi_lock_done(&heap->arena_pages_lock);
   if (!_mi_is_process_heap_main(heap)) {
     _mi_thread_local_free(heap->theap);
-    // #316 (P10a): same audit as the arena_pages free above -- this thread is deleting `heap`
-    // and is not parked; the collect this can now reach is guarded the same way.
+    // #316 (P10a): same audit as the arena_pages free above -- `allow_collect` cannot reach the
+    // park protocol from here either, for the same call-graph reason.
     _mi_free_subproc_safe(heap);
   }
 }
@@ -16144,7 +16155,7 @@ terms of the MIT license. A copy of the license can be found in the file
       -> sp->theap_meta_lock        `mi_heap_free_theaps` (heap.c:174) -> `_mi_theap_decref`
                                     -> `mi_theap_free_mem` -> `_mi_meta_free` (theap.c:363)
                                     ... and, for a page owned by `theap_meta`, `mi_free`
-                                    -> `mi_stat_free` (free.c:741) takes `theap_meta_lock`
+                                    -> `mi_stat_free` (free.c:768) takes `theap_meta_lock`
       -> tld->theaps_lock           `_mi_heap_detach_theaps` -- but `mi_lock_TRY_acquire`
                                     with a back-off retry (theap.c:412), so NOT a blocking
                                     edge; see the Phase 7 gap note below
@@ -16156,7 +16167,7 @@ terms of the MIT license. A copy of the license can be found in the file
                                     `mi_arena_pages_alloc` (arena.c:1544), which runs a FULL
                                     `mi_heap_zalloc_aligned(subproc->heap_main, ...)`
       -> sp->theap_meta_lock        `mi_heap_free` (heap.c:203-208) holds it across
-                                    `_mi_free_subproc_safe` -> `mi_stat_free` (free.c:741)
+                                    `_mi_free_subproc_safe` -> `mi_stat_free` (free.c:768)
       -> heap->os_abandoned_pages_lock   (same free, via `mi_arena_page_abandon`, arena.c:1224)
 
     mi_thread_locals_lock           threadlocal.c    TLS slot bitmap

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 872c37d8 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 0b614bac of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -6470,13 +6470,24 @@ static inline void* mi_prim_tls_slot(size_t slot) {
     #else
       return mi_prim_thread_pointer()[slot];
     #endif
+  #elif defined(__GNUC__) || defined(__clang__)
+    // The slot lives in the thread's control block, which the OS reuses for a later thread, so the
+    // exiting thread's last store (`_mi_thread_done`) and a new thread's first load touch the same
+    // address from different threads. A relaxed atomic is the same single load/store instruction and
+    // states that this is by design (and keeps TSAN quiet about it). Ported from oven-sh/mimalloc
+    // (issue #316, Bun parity P10a).
+    return __atomic_load_n(&mi_prim_thread_pointer()[slot], __ATOMIC_RELAXED);
   #else
     return mi_prim_thread_pointer()[slot];
   #endif
 }
 
 static inline void mi_prim_tls_slot_set(size_t slot, void* value) {
+  #if defined(__GNUC__) || defined(__clang__)
+  __atomic_store_n(&mi_prim_thread_pointer()[slot], value, __ATOMIC_RELAXED);
+  #else
   mi_prim_thread_pointer()[slot] = value;
+  #endif
 }
 #endif
 
@@ -7460,10 +7471,31 @@ void _mi_free_subproc_safe_in_page(void* p, mi_page_t* page) mi_attr_noexcept {
   mi_free_ex(p, page, NULL, false);
 }
 
-// Free a pointer that is potentially allocated in a different sub-process
+// The sub-process of a page we do not own. On a multi-threaded free we cannot go through
+// `page->heap` (`mi_page_heap`): a concurrent `mi_heap_delete` moves the page to the main
+// heap and frees the heap struct. `page->memid` is immutable after page creation, so its
+// arena (`mi_memid_arena`) is a safe read regardless of who owns the page right now -- the
+// same read `_mi_meta_is_meta_page_safe` (internal.h:266) already trusts, with the same
+// provenance. For the (rare) OS-allocated pages, which carry no arena, fall back to our own
+// subproc, as Bun does (issue #316, Bun parity P10a, commit 04ced98d).
+static mi_subproc_t* mi_page_subproc_unowned(const mi_page_t* page) {
+  mi_arena_t* const arena = mi_memid_arena(page->memid);
+  return (arena != NULL ? arena->subproc : _mi_subproc());
+}
+
+// Free a pointer that is potentially allocated in a different sub-process.
+// Collecting an abandoned page (free it, reclaim it, or re-map it) must not cross sub-processes,
+// but inside our own it must still happen: a full page is abandoned and unmapped, and a block
+// freed into it without collecting is never found again and pins the page (`mi_heap_free` frees
+// every `mi_heap_t` and `mi_arena_pages_t` through here; see the call sites for why the park
+// protocol is safe with collecting turned on).
 void _mi_free_subproc_safe(void* p) mi_attr_noexcept {
-  mi_page_t* const page = mi_validate_ptr_page(p,"_mi_free_subproc_safe");  
-  mi_free_ex(p, page, NULL, false);
+  mi_page_t* const page = mi_validate_ptr_page(p,"_mi_free_subproc_safe");
+  if mi_unlikely(page==NULL) return;   // p==NULL, or an invalid pointer already reported by mi_validate_ptr_page;
+                                        // mi_free_ex below guards NULL too, but mi_page_subproc_unowned needs
+                                        // a non-NULL page to read page->memid from.
+  const bool allow_collect = (mi_page_subproc_unowned(page) == _mi_subproc());
+  mi_free_ex(p, page, NULL, allow_collect);
 }
 
 
@@ -7932,17 +7964,26 @@ static void mi_stat_free(const mi_page_t* page, const mi_block_t* block) {
   // This can run for a cross-thread free (mi_free_block_mt) racing a concurrent
   // mi_heap_delete/mi_heap_destroy of page's heap on another thread -- reproduced as a
   // SIGSEGV reading page->heap->subproc here (see memory-events.c's _mi_memevt_on_free
-  // provenance comment for the first instance of this class of bug and its fix). _mi_subproc()
-  // is this (the freeing) thread's own subproc -- always safe, no dereference of anything
-  // reachable only through `page`. Matches the pre-existing (commented out, "never collect
-  // across subprocesses") assumption a few lines below that the two agree in the normal case;
-  // the rare cross-subprocess free this could get wrong (attributing the stat decrease to the
-  // wrong subproc's theap_meta) was already an unverified edge case, not a memory-safety one.
-  mi_subproc_t* const subproc = _mi_subproc();
+  // provenance comment for the first instance of this class of bug and its fix).
+  // Converged in #316 (Bun parity P10a) onto `mi_page_subproc_unowned` (above), the same
+  // arena-derived read that replaced `page->heap->subproc`: `page->memid` is immutable after
+  // page creation, so reading the arena through it never dereferences `page->heap` either, and
+  // is strictly more accurate than the previous stand-in of "this (the freeing) thread's own
+  // subproc" -- it agrees with that whenever the page is in fact ours (the common case, per the
+  // "never collect across subprocesses" assumption a few lines below), and gets the actual
+  // owning subproc right in the rare cross-subprocess free the old comment conceded was an
+  // unverified edge case. Not a memory-safety concern either way: `theap_meta`/`theap_meta_lock`
+  // are read off whichever subproc is returned, same as before.
+  mi_subproc_t* const subproc = mi_page_subproc_unowned(page);
   mi_theap_t* const theap_meta = subproc->theap_meta;
   if mi_unlikely(!mi_theap_is_initialized(theap) || // can happen if free'd after thread_done was called (usually a thread cleanup call by the OS)
                   // page->theap == subproc->theap_meta  .. but we cannot read `theap` if we don't own the page
-                  (theap_meta != NULL && mi_page_thread_id(page) == theap_meta->tld->thread_id)) { 
+                  (theap_meta != NULL && mi_page_thread_id(page) == theap_meta->tld->thread_id)) {
+    // #316 (P10a): `subproc` can now be a *foreign* subproc (the page's arena's, not
+    // necessarily this thread's own), which the old `_mi_subproc()` could never be mid-teardown
+    // out from under the freeing thread. Ported from Bun's converged `mi_stat_free`: give up the
+    // stat update rather than deref a NULL theap_meta of a subproc that is being destroyed.
+    if (theap_meta == NULL) return;
     theap = theap_meta;
     lock = &subproc->theap_meta_lock;
     mi_lock_acquire(lock);
@@ -11850,6 +11891,14 @@ void _mi_arenas_free(mi_subproc_t* subproc, void* p, size_t size, mi_memid_t mem
     };
   }
   else if (memid.memkind == MI_MEM_MALLOC) {
+    // #316 (P10a): this free now collects in-subproc. No allocation site in this tree
+    // currently produces a MI_MEM_MALLOC memid that reaches here -- `_mi_meta_free` (subproc.c),
+    // the only place that creates one (`_mi_memid_create_malloc`), handles MI_MEM_MALLOC itself
+    // via a plain `mi_free(p)` and only forwards other memkinds to `_mi_arenas_free`; every
+    // caller of `_mi_arenas_free` we audited (heap.c:283/309, arena.c:794/935/1184) passes an
+    // arena- or OS-backed memid. This branch is upstream's fallback, kept for shape parity; if a
+    // future producer reaches it, the collect is guarded the same way as every other
+    // `mi_free_ex` path (`mi_free_try_collect_mt`'s own reclaim guards, unconditional).
     _mi_free_subproc_safe(p);
   }
   else {
@@ -12943,6 +12992,15 @@ mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_heap_delete_claim;  // impor
 // too. This is the same protocol the abandoned-page map already uses
 // (`mi_arena_try_claim_abandoned`).
 //
+// ported from oven-sh/mimalloc commit a26c5de7, MIT (issue #316 / Bun parity P10a): the page
+// struct is only located (`mi_arena_page_at_slice`, which reads `page->block_size` when
+// `MI_PAGE_META_ALIGNED_FREE_SMALL`/`MI_OPT_FREE_SMALL` separates page meta) once the slice is
+// pinned -- before that a concurrent `mi_free` may still be freeing the page and the slice may
+// already be a fresh page of another heap by the time we look. Latent under our default
+// configs (`mi_arena_page_at_slice` is a pure function of `slice_index` there); a correctness
+// fix once `MI_OPT_FREE_SMALL` reads `block_size` off an unpinned slice. Returns the page we
+// now own, or NULL if it is gone.
+//
 // imported from oven-sh/mimalloc @ 942b8342, MIT (issue #271 / Bun parity P6): the
 // `_mi_process_is_forked_child` branch below was originally dropped here with a note to
 // "add it back once #270/PR #289 lands" -- #289 landed a handler-only fork design
@@ -12959,11 +13017,13 @@ static void mi_heap_visit_page_seize(mi_page_t* page) {
   mi_page_set_theap(page, NULL);
 }
 
-static bool mi_heap_visit_page_claim(mi_heap_visit_info_t* vinfo, mi_page_t* page, size_t slice_index) {
+static mi_page_t* mi_heap_visit_page_claim(mi_heap_visit_info_t* vinfo, mi_arena_t* arena, size_t slice_index) {
   mi_bitmap_t* const pages = vinfo->arena_pages->pages;
+  mi_page_t* page = NULL;
   for (;;) {
-    if (!mi_bitmap_clear(pages, slice_index)) return false;   // freed by a concurrent `mi_free`
-    // pinned
+    if (!mi_bitmap_clear(pages, slice_index)) return NULL;   // freed by a concurrent `mi_free`
+    // pinned: now it is a page of this heap and stays one while we hold the bit
+    page = mi_arena_page_at_slice(arena, slice_index);
     #if MI_DEBUG > 0
     if (mi_atomic_load_relaxed(&mi_debug_stall_in_heap_delete_claim) == 1) {
       mi_atomic_store_release(&mi_debug_stall_in_heap_delete_claim, (uintptr_t)2);  // signal: pinned, not yet claimed
@@ -12977,8 +13037,8 @@ static bool mi_heap_visit_page_claim(mi_heap_visit_info_t* vinfo, mi_page_t* pag
       // arena-pages bit propagated but the page-map entry or the owned bit did not, and that
       // thread no longer exists in this process to finish the update. Re-derive what we can
       // and take the page outright; there is nobody left to race.
-      if (mi_page_start(page) == NULL) return false;  // the page struct never made it across: leave it unpublished
-      if (_mi_safe_ptr_page(mi_page_start(page)) != page && !_mi_page_map_register(page)) return false;
+      if (mi_page_start(page) == NULL) return NULL;  // the page struct never made it across: leave it unpublished
+      if (_mi_safe_ptr_page(mi_page_start(page)) != page && !_mi_page_map_register(page)) return NULL;
       mi_page_claim_ownership(page);   // ours now, whether or not the dead thread held it
       mi_bitmap_set(pages, slice_index);
       if (!mi_page_is_abandoned(page)) { mi_heap_visit_page_seize(page); }
@@ -13005,15 +13065,19 @@ static bool mi_heap_visit_page_claim(mi_heap_visit_info_t* vinfo, mi_page_t* pag
   mi_assert_internal(mi_page_is_owned(page) && mi_page_is_abandoned(page));
   mi_assert_internal(mi_bitmap_is_set(pages, slice_index));
   mi_assert_internal(_mi_ptr_page(mi_page_start(page)) == page && mi_page_heap(page) == vinfo->heap);
-  return true;
+  return page;
 }
 
 static bool mi_heap_visit_page_at(size_t slice_index, size_t slice_count, mi_arena_t* arena, void* arg) {
   MI_UNUSED(slice_count);
   mi_heap_visit_info_t* vinfo = (mi_heap_visit_info_t*)arg;
-  mi_page_t* page = mi_arena_page_at_slice(arena, slice_index);
+  mi_page_t* page;
   if (vinfo->claim_pages) {
-    if (!mi_heap_visit_page_claim(vinfo, page, slice_index)) return true;  // gone: skip
+    page = mi_heap_visit_page_claim(vinfo, arena, slice_index);
+    if (page == NULL) return true;  // gone: freed by a concurrent `mi_free`
+  }
+  else {
+    page = mi_arena_page_at_slice(arena, slice_index);
   }
   return mi_heap_visit_page(page, vinfo);
 }
@@ -14764,12 +14828,17 @@ void mi_bitmap_clear_once_set(mi_subproc_t* subproc, mi_bitmap_t* bitmap, size_t
 
 
 // Visit all set bits in a bitmap.
+// The loads are acquire: `mi_heap_delete` walks its `arena_pages->pages` with this and then frees the
+// heap and the bitmap itself (`arena.c:mi_heap_visit_page_claim` against `mi_arenas_page_free_prim`),
+// while a concurrent `mi_free` that frees a page of the heap reads both and then clears the page's bit
+// (release) as its last access. Seeing that bit clear here is what orders those reads before our free
+// of the memory they read (issue #316, Bun parity P10a, commit a26c5de7).
 // todo: optimize further? maybe use avx512 to directly get all indices using a mask_compressstore?
 bool _mi_bitmap_forall_set(mi_bitmap_t* bitmap, mi_forall_set_fun_t* visit, mi_arena_t* arena, void* arg) {
   // for all chunkmap entries
   const size_t chunkmap_max = _mi_divide_up(mi_bitmap_chunk_count(bitmap), MI_BFIELD_BITS);
   for(size_t i = 0; i < chunkmap_max; i++) {
-    mi_bfield_t cmap_entry = mi_atomic_load_relaxed(&bitmap->chunkmap.bfields[i]);
+    mi_bfield_t cmap_entry = mi_atomic_load_acquire(&bitmap->chunkmap.bfields[i]);
     size_t cmap_idx;
     // for each chunk (corresponding to a set bit in a chunkmap entry)
     while (mi_bfield_foreach_bit(&cmap_entry, &cmap_idx)) {
@@ -14778,7 +14847,7 @@ bool _mi_bitmap_forall_set(mi_bitmap_t* bitmap, mi_forall_set_fun_t* visit, mi_a
       mi_bchunk_t* const chunk = &bitmap->chunks[chunk_idx];
       for (size_t j = 0; j < MI_BCHUNK_FIELDS; j++) {
         const size_t base_idx = (chunk_idx*MI_BCHUNK_BITS) + (j*MI_BFIELD_BITS);
-        mi_bfield_t b = mi_atomic_load_relaxed(&chunk->bfields[j]);
+        mi_bfield_t b = mi_atomic_load_acquire(&chunk->bfields[j]);
         size_t bidx;
         while (mi_bfield_foreach_bit(&b, &bidx)) {
           const size_t idx = base_idx + bidx;
@@ -15821,6 +15890,10 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
         mi_arena_pages_t* arena_pages = mi_atomic_load_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i]);
         if (arena_pages!=NULL) {
           mi_atomic_store_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i], NULL);
+          // #316 (P10a): this free now collects in-subproc. Safe here: this thread is deleting
+          // `heap` (mi_heap_free's only caller), so it is not parked, and mi_free_try_collect_mt's
+          // own reclaim guards (_mi_thread_is_initialized, _mi_page_associated_theap_peek refusing
+          // a theap of another heap) apply regardless.
           _mi_free_subproc_safe(arena_pages);
         }
       }
@@ -15845,9 +15918,11 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
   mi_lock_done(&heap->theaps_lock);
   mi_lock_done(&heap->os_abandoned_pages_lock);
   mi_lock_done(&heap->arena_pages_lock);
-  if (!_mi_is_process_heap_main(heap)) { 
+  if (!_mi_is_process_heap_main(heap)) {
     _mi_thread_local_free(heap->theap);
-    _mi_free_subproc_safe(heap); 
+    // #316 (P10a): same audit as the arena_pages free above -- this thread is deleting `heap`
+    // and is not parked; the collect this can now reach is guarded the same way.
+    _mi_free_subproc_safe(heap);
   }
 }
 

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 0b614bac of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit efdd4bc1 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -11892,13 +11892,15 @@ void _mi_arenas_free(mi_subproc_t* subproc, void* p, size_t size, mi_memid_t mem
   }
   else if (memid.memkind == MI_MEM_MALLOC) {
     // #316 (P10a): this free now collects in-subproc. No allocation site in this tree
-    // currently produces a MI_MEM_MALLOC memid that reaches here -- `_mi_meta_free` (subproc.c),
-    // the only place that creates one (`_mi_memid_create_malloc`), handles MI_MEM_MALLOC itself
-    // via a plain `mi_free(p)` and only forwards other memkinds to `_mi_arenas_free`; every
-    // caller of `_mi_arenas_free` we audited (heap.c:283/309, arena.c:794/935/1184) passes an
-    // arena- or OS-backed memid. This branch is upstream's fallback, kept for shape parity; if a
-    // future producer reaches it, the collect is guarded the same way as every other
-    // `mi_free_ex` path (`mi_free_try_collect_mt`'s own reclaim guards, unconditional).
+    // currently produces a MI_MEM_MALLOC memid that reaches here -- the producers
+    // (`_mi_meta_zalloc`/`_mi_meta_zalloc_aligned`/`_mi_meta_rezalloc`, subproc.c, via
+    // `_mi_memid_create_malloc`) hand it to `_mi_meta_free` (subproc.c), which handles
+    // MI_MEM_MALLOC itself with a plain `mi_free(p)` and only forwards other memkinds to
+    // `_mi_arenas_free`; every caller of `_mi_arenas_free` we audited (heap.c:283/309,
+    // arena.c:794/935/1184) passes an arena- or OS-backed memid. This branch is upstream's
+    // fallback, kept for shape parity; if a future producer reaches it, the collect is guarded
+    // the same way as every other `mi_free_ex` path (`mi_free_try_collect_mt`'s own reclaim
+    // guards, unconditional).
     _mi_free_subproc_safe(p);
   }
   else {

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 872c37d8 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 0b614bac of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 0b614bac of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit efdd4bc1 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit efdd4bc1 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit be81f936 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/src/arena.c
+++ b/src/arena.c
@@ -1592,13 +1592,13 @@ void _mi_arenas_free(mi_subproc_t* subproc, void* p, size_t size, mi_memid_t mem
     // #316 (P10a): this free now collects in-subproc. No allocation site in this tree
     // currently produces a MI_MEM_MALLOC memid that reaches here -- the producers
     // (`_mi_meta_zalloc`/`_mi_meta_zalloc_aligned`/`_mi_meta_rezalloc`, subproc.c, via
-    // `_mi_memid_create_malloc`) hand it to `_mi_meta_free` (subproc.c), which handles
-    // MI_MEM_MALLOC itself with a plain `mi_free(p)` and only forwards other memkinds to
-    // `_mi_arenas_free`; every caller of `_mi_arenas_free` we audited (heap.c:283/309,
-    // arena.c:794/935/1184) passes an arena- or OS-backed memid. This branch is upstream's
-    // fallback, kept for shape parity; if a future producer reaches it, the collect is guarded
-    // the same way as every other `mi_free_ex` path (`mi_free_try_collect_mt`'s own reclaim
-    // guards, unconditional).
+    // `_mi_memid_create_malloc`) hand it to `_mi_meta_free` (subproc.c:94, the only caller of
+    // `_mi_arenas_free` that matters here), which handles MI_MEM_MALLOC itself with a plain
+    // `mi_free(p)` and only forwards other memkinds to `_mi_arenas_free` (subproc.c:99); the
+    // rest of `_mi_arenas_free`'s callers (arena.c:794/935/1184) pass an arena- or OS-backed
+    // memid. This branch is upstream's fallback, kept for shape parity; if a future producer
+    // reaches it, the collect is guarded the same way as every other `mi_free_ex` path
+    // (`mi_free_try_collect_mt`'s own reclaim guards, unconditional).
     _mi_free_subproc_safe(p);
   }
   else {

--- a/src/arena.c
+++ b/src/arena.c
@@ -1589,6 +1589,14 @@ void _mi_arenas_free(mi_subproc_t* subproc, void* p, size_t size, mi_memid_t mem
     };
   }
   else if (memid.memkind == MI_MEM_MALLOC) {
+    // #316 (P10a): this free now collects in-subproc. No allocation site in this tree
+    // currently produces a MI_MEM_MALLOC memid that reaches here -- `_mi_meta_free` (subproc.c),
+    // the only place that creates one (`_mi_memid_create_malloc`), handles MI_MEM_MALLOC itself
+    // via a plain `mi_free(p)` and only forwards other memkinds to `_mi_arenas_free`; every
+    // caller of `_mi_arenas_free` we audited (heap.c:283/309, arena.c:794/935/1184) passes an
+    // arena- or OS-backed memid. This branch is upstream's fallback, kept for shape parity; if a
+    // future producer reaches it, the collect is guarded the same way as every other
+    // `mi_free_ex` path (`mi_free_try_collect_mt`'s own reclaim guards, unconditional).
     _mi_free_subproc_safe(p);
   }
   else {
@@ -2682,6 +2690,15 @@ mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_heap_delete_claim;  // impor
 // too. This is the same protocol the abandoned-page map already uses
 // (`mi_arena_try_claim_abandoned`).
 //
+// ported from oven-sh/mimalloc commit a26c5de7, MIT (issue #316 / Bun parity P10a): the page
+// struct is only located (`mi_arena_page_at_slice`, which reads `page->block_size` when
+// `MI_PAGE_META_ALIGNED_FREE_SMALL`/`MI_OPT_FREE_SMALL` separates page meta) once the slice is
+// pinned -- before that a concurrent `mi_free` may still be freeing the page and the slice may
+// already be a fresh page of another heap by the time we look. Latent under our default
+// configs (`mi_arena_page_at_slice` is a pure function of `slice_index` there); a correctness
+// fix once `MI_OPT_FREE_SMALL` reads `block_size` off an unpinned slice. Returns the page we
+// now own, or NULL if it is gone.
+//
 // imported from oven-sh/mimalloc @ 942b8342, MIT (issue #271 / Bun parity P6): the
 // `_mi_process_is_forked_child` branch below was originally dropped here with a note to
 // "add it back once #270/PR #289 lands" -- #289 landed a handler-only fork design
@@ -2698,11 +2715,13 @@ static void mi_heap_visit_page_seize(mi_page_t* page) {
   mi_page_set_theap(page, NULL);
 }
 
-static bool mi_heap_visit_page_claim(mi_heap_visit_info_t* vinfo, mi_page_t* page, size_t slice_index) {
+static mi_page_t* mi_heap_visit_page_claim(mi_heap_visit_info_t* vinfo, mi_arena_t* arena, size_t slice_index) {
   mi_bitmap_t* const pages = vinfo->arena_pages->pages;
+  mi_page_t* page = NULL;
   for (;;) {
-    if (!mi_bitmap_clear(pages, slice_index)) return false;   // freed by a concurrent `mi_free`
-    // pinned
+    if (!mi_bitmap_clear(pages, slice_index)) return NULL;   // freed by a concurrent `mi_free`
+    // pinned: now it is a page of this heap and stays one while we hold the bit
+    page = mi_arena_page_at_slice(arena, slice_index);
     #if MI_DEBUG > 0
     if (mi_atomic_load_relaxed(&mi_debug_stall_in_heap_delete_claim) == 1) {
       mi_atomic_store_release(&mi_debug_stall_in_heap_delete_claim, (uintptr_t)2);  // signal: pinned, not yet claimed
@@ -2716,8 +2735,8 @@ static bool mi_heap_visit_page_claim(mi_heap_visit_info_t* vinfo, mi_page_t* pag
       // arena-pages bit propagated but the page-map entry or the owned bit did not, and that
       // thread no longer exists in this process to finish the update. Re-derive what we can
       // and take the page outright; there is nobody left to race.
-      if (mi_page_start(page) == NULL) return false;  // the page struct never made it across: leave it unpublished
-      if (_mi_safe_ptr_page(mi_page_start(page)) != page && !_mi_page_map_register(page)) return false;
+      if (mi_page_start(page) == NULL) return NULL;  // the page struct never made it across: leave it unpublished
+      if (_mi_safe_ptr_page(mi_page_start(page)) != page && !_mi_page_map_register(page)) return NULL;
       mi_page_claim_ownership(page);   // ours now, whether or not the dead thread held it
       mi_bitmap_set(pages, slice_index);
       if (!mi_page_is_abandoned(page)) { mi_heap_visit_page_seize(page); }
@@ -2744,15 +2763,19 @@ static bool mi_heap_visit_page_claim(mi_heap_visit_info_t* vinfo, mi_page_t* pag
   mi_assert_internal(mi_page_is_owned(page) && mi_page_is_abandoned(page));
   mi_assert_internal(mi_bitmap_is_set(pages, slice_index));
   mi_assert_internal(_mi_ptr_page(mi_page_start(page)) == page && mi_page_heap(page) == vinfo->heap);
-  return true;
+  return page;
 }
 
 static bool mi_heap_visit_page_at(size_t slice_index, size_t slice_count, mi_arena_t* arena, void* arg) {
   MI_UNUSED(slice_count);
   mi_heap_visit_info_t* vinfo = (mi_heap_visit_info_t*)arg;
-  mi_page_t* page = mi_arena_page_at_slice(arena, slice_index);
+  mi_page_t* page;
   if (vinfo->claim_pages) {
-    if (!mi_heap_visit_page_claim(vinfo, page, slice_index)) return true;  // gone: skip
+    page = mi_heap_visit_page_claim(vinfo, arena, slice_index);
+    if (page == NULL) return true;  // gone: freed by a concurrent `mi_free`
+  }
+  else {
+    page = mi_arena_page_at_slice(arena, slice_index);
   }
   return mi_heap_visit_page(page, vinfo);
 }

--- a/src/arena.c
+++ b/src/arena.c
@@ -1590,13 +1590,15 @@ void _mi_arenas_free(mi_subproc_t* subproc, void* p, size_t size, mi_memid_t mem
   }
   else if (memid.memkind == MI_MEM_MALLOC) {
     // #316 (P10a): this free now collects in-subproc. No allocation site in this tree
-    // currently produces a MI_MEM_MALLOC memid that reaches here -- `_mi_meta_free` (subproc.c),
-    // the only place that creates one (`_mi_memid_create_malloc`), handles MI_MEM_MALLOC itself
-    // via a plain `mi_free(p)` and only forwards other memkinds to `_mi_arenas_free`; every
-    // caller of `_mi_arenas_free` we audited (heap.c:283/309, arena.c:794/935/1184) passes an
-    // arena- or OS-backed memid. This branch is upstream's fallback, kept for shape parity; if a
-    // future producer reaches it, the collect is guarded the same way as every other
-    // `mi_free_ex` path (`mi_free_try_collect_mt`'s own reclaim guards, unconditional).
+    // currently produces a MI_MEM_MALLOC memid that reaches here -- the producers
+    // (`_mi_meta_zalloc`/`_mi_meta_zalloc_aligned`/`_mi_meta_rezalloc`, subproc.c, via
+    // `_mi_memid_create_malloc`) hand it to `_mi_meta_free` (subproc.c), which handles
+    // MI_MEM_MALLOC itself with a plain `mi_free(p)` and only forwards other memkinds to
+    // `_mi_arenas_free`; every caller of `_mi_arenas_free` we audited (heap.c:283/309,
+    // arena.c:794/935/1184) passes an arena- or OS-backed memid. This branch is upstream's
+    // fallback, kept for shape parity; if a future producer reaches it, the collect is guarded
+    // the same way as every other `mi_free_ex` path (`mi_free_try_collect_mt`'s own reclaim
+    // guards, unconditional).
     _mi_free_subproc_safe(p);
   }
   else {

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -1433,12 +1433,17 @@ void mi_bitmap_clear_once_set(mi_subproc_t* subproc, mi_bitmap_t* bitmap, size_t
 
 
 // Visit all set bits in a bitmap.
+// The loads are acquire: `mi_heap_delete` walks its `arena_pages->pages` with this and then frees the
+// heap and the bitmap itself (`arena.c:mi_heap_visit_page_claim` against `mi_arenas_page_free_prim`),
+// while a concurrent `mi_free` that frees a page of the heap reads both and then clears the page's bit
+// (release) as its last access. Seeing that bit clear here is what orders those reads before our free
+// of the memory they read (issue #316, Bun parity P10a, commit a26c5de7).
 // todo: optimize further? maybe use avx512 to directly get all indices using a mask_compressstore?
 bool _mi_bitmap_forall_set(mi_bitmap_t* bitmap, mi_forall_set_fun_t* visit, mi_arena_t* arena, void* arg) {
   // for all chunkmap entries
   const size_t chunkmap_max = _mi_divide_up(mi_bitmap_chunk_count(bitmap), MI_BFIELD_BITS);
   for(size_t i = 0; i < chunkmap_max; i++) {
-    mi_bfield_t cmap_entry = mi_atomic_load_relaxed(&bitmap->chunkmap.bfields[i]);
+    mi_bfield_t cmap_entry = mi_atomic_load_acquire(&bitmap->chunkmap.bfields[i]);
     size_t cmap_idx;
     // for each chunk (corresponding to a set bit in a chunkmap entry)
     while (mi_bfield_foreach_bit(&cmap_entry, &cmap_idx)) {
@@ -1447,7 +1452,7 @@ bool _mi_bitmap_forall_set(mi_bitmap_t* bitmap, mi_forall_set_fun_t* visit, mi_a
       mi_bchunk_t* const chunk = &bitmap->chunks[chunk_idx];
       for (size_t j = 0; j < MI_BCHUNK_FIELDS; j++) {
         const size_t base_idx = (chunk_idx*MI_BCHUNK_BITS) + (j*MI_BFIELD_BITS);
-        mi_bfield_t b = mi_atomic_load_relaxed(&chunk->bfields[j]);
+        mi_bfield_t b = mi_atomic_load_acquire(&chunk->bfields[j]);
         size_t bidx;
         while (mi_bfield_foreach_bit(&b, &bidx)) {
           const size_t idx = base_idx + bidx;

--- a/src/fork.c
+++ b/src/fork.c
@@ -134,7 +134,7 @@ terms of the MIT license. A copy of the license can be found in the file
       -> sp->theap_meta_lock        `mi_heap_free_theaps` (heap.c:174) -> `_mi_theap_decref`
                                     -> `mi_theap_free_mem` -> `_mi_meta_free` (theap.c:363)
                                     ... and, for a page owned by `theap_meta`, `mi_free`
-                                    -> `mi_stat_free` (free.c:741) takes `theap_meta_lock`
+                                    -> `mi_stat_free` (free.c:768) takes `theap_meta_lock`
       -> tld->theaps_lock           `_mi_heap_detach_theaps` -- but `mi_lock_TRY_acquire`
                                     with a back-off retry (theap.c:412), so NOT a blocking
                                     edge; see the Phase 7 gap note below
@@ -146,7 +146,7 @@ terms of the MIT license. A copy of the license can be found in the file
                                     `mi_arena_pages_alloc` (arena.c:1544), which runs a FULL
                                     `mi_heap_zalloc_aligned(subproc->heap_main, ...)`
       -> sp->theap_meta_lock        `mi_heap_free` (heap.c:203-208) holds it across
-                                    `_mi_free_subproc_safe` -> `mi_stat_free` (free.c:741)
+                                    `_mi_free_subproc_safe` -> `mi_stat_free` (free.c:768)
       -> heap->os_abandoned_pages_lock   (same free, via `mi_arena_page_abandon`, arena.c:1224)
 
     mi_thread_locals_lock           threadlocal.c    TLS slot bitmap

--- a/src/free.c
+++ b/src/free.c
@@ -280,10 +280,31 @@ void _mi_free_subproc_safe_in_page(void* p, mi_page_t* page) mi_attr_noexcept {
   mi_free_ex(p, page, NULL, false);
 }
 
-// Free a pointer that is potentially allocated in a different sub-process
+// The sub-process of a page we do not own. On a multi-threaded free we cannot go through
+// `page->heap` (`mi_page_heap`): a concurrent `mi_heap_delete` moves the page to the main
+// heap and frees the heap struct. `page->memid` is immutable after page creation, so its
+// arena (`mi_memid_arena`) is a safe read regardless of who owns the page right now -- the
+// same read `_mi_meta_is_meta_page_safe` (internal.h:266) already trusts, with the same
+// provenance. For the (rare) OS-allocated pages, which carry no arena, fall back to our own
+// subproc, as Bun does (issue #316, Bun parity P10a, commit 04ced98d).
+static mi_subproc_t* mi_page_subproc_unowned(const mi_page_t* page) {
+  mi_arena_t* const arena = mi_memid_arena(page->memid);
+  return (arena != NULL ? arena->subproc : _mi_subproc());
+}
+
+// Free a pointer that is potentially allocated in a different sub-process.
+// Collecting an abandoned page (free it, reclaim it, or re-map it) must not cross sub-processes,
+// but inside our own it must still happen: a full page is abandoned and unmapped, and a block
+// freed into it without collecting is never found again and pins the page (`mi_heap_free` frees
+// every `mi_heap_t` and `mi_arena_pages_t` through here; see the call sites for why the park
+// protocol is safe with collecting turned on).
 void _mi_free_subproc_safe(void* p) mi_attr_noexcept {
-  mi_page_t* const page = mi_validate_ptr_page(p,"_mi_free_subproc_safe");  
-  mi_free_ex(p, page, NULL, false);
+  mi_page_t* const page = mi_validate_ptr_page(p,"_mi_free_subproc_safe");
+  if mi_unlikely(page==NULL) return;   // p==NULL, or an invalid pointer already reported by mi_validate_ptr_page;
+                                        // mi_free_ex below guards NULL too, but mi_page_subproc_unowned needs
+                                        // a non-NULL page to read page->memid from.
+  const bool allow_collect = (mi_page_subproc_unowned(page) == _mi_subproc());
+  mi_free_ex(p, page, NULL, allow_collect);
 }
 
 
@@ -752,17 +773,26 @@ static void mi_stat_free(const mi_page_t* page, const mi_block_t* block) {
   // This can run for a cross-thread free (mi_free_block_mt) racing a concurrent
   // mi_heap_delete/mi_heap_destroy of page's heap on another thread -- reproduced as a
   // SIGSEGV reading page->heap->subproc here (see memory-events.c's _mi_memevt_on_free
-  // provenance comment for the first instance of this class of bug and its fix). _mi_subproc()
-  // is this (the freeing) thread's own subproc -- always safe, no dereference of anything
-  // reachable only through `page`. Matches the pre-existing (commented out, "never collect
-  // across subprocesses") assumption a few lines below that the two agree in the normal case;
-  // the rare cross-subprocess free this could get wrong (attributing the stat decrease to the
-  // wrong subproc's theap_meta) was already an unverified edge case, not a memory-safety one.
-  mi_subproc_t* const subproc = _mi_subproc();
+  // provenance comment for the first instance of this class of bug and its fix).
+  // Converged in #316 (Bun parity P10a) onto `mi_page_subproc_unowned` (above), the same
+  // arena-derived read that replaced `page->heap->subproc`: `page->memid` is immutable after
+  // page creation, so reading the arena through it never dereferences `page->heap` either, and
+  // is strictly more accurate than the previous stand-in of "this (the freeing) thread's own
+  // subproc" -- it agrees with that whenever the page is in fact ours (the common case, per the
+  // "never collect across subprocesses" assumption a few lines below), and gets the actual
+  // owning subproc right in the rare cross-subprocess free the old comment conceded was an
+  // unverified edge case. Not a memory-safety concern either way: `theap_meta`/`theap_meta_lock`
+  // are read off whichever subproc is returned, same as before.
+  mi_subproc_t* const subproc = mi_page_subproc_unowned(page);
   mi_theap_t* const theap_meta = subproc->theap_meta;
   if mi_unlikely(!mi_theap_is_initialized(theap) || // can happen if free'd after thread_done was called (usually a thread cleanup call by the OS)
                   // page->theap == subproc->theap_meta  .. but we cannot read `theap` if we don't own the page
-                  (theap_meta != NULL && mi_page_thread_id(page) == theap_meta->tld->thread_id)) { 
+                  (theap_meta != NULL && mi_page_thread_id(page) == theap_meta->tld->thread_id)) {
+    // #316 (P10a): `subproc` can now be a *foreign* subproc (the page's arena's, not
+    // necessarily this thread's own), which the old `_mi_subproc()` could never be mid-teardown
+    // out from under the freeing thread. Ported from Bun's converged `mi_stat_free`: give up the
+    // stat update rather than deref a NULL theap_meta of a subproc that is being destroyed.
+    if (theap_meta == NULL) return;
     theap = theap_meta;
     lock = &subproc->theap_meta_lock;
     mi_lock_acquire(lock);

--- a/src/free.c
+++ b/src/free.c
@@ -774,26 +774,34 @@ static void mi_stat_free(const mi_page_t* page, const mi_block_t* block) {
   // mi_heap_delete/mi_heap_destroy of page's heap on another thread -- reproduced as a
   // SIGSEGV reading page->heap->subproc here (see memory-events.c's _mi_memevt_on_free
   // provenance comment for the first instance of this class of bug and its fix).
-  // Converged in #316 (Bun parity P10a) onto `mi_page_subproc_unowned` (above), the same
-  // arena-derived read that replaced `page->heap->subproc`: `page->memid` is immutable after
+  // Converged in #316 (Bun parity P10a) onto `mi_page_subproc_unowned` (defined earlier in this
+  // file, called a few lines below in this function), the same arena-derived read that replaced
+  // `page->heap->subproc`: `page->memid` is immutable after
   // page creation, so reading the arena through it never dereferences `page->heap` either, and
   // is strictly more accurate than the previous stand-in of "this (the freeing) thread's own
   // subproc" -- it agrees with that whenever the page is in fact ours (the common case, per the
   // "never collect across subprocesses" assumption a few lines below), and gets the actual
   // owning subproc right in the rare cross-subprocess free the old comment conceded was an
-  // unverified edge case. Not a memory-safety concern either way: `theap_meta`/`theap_meta_lock`
-  // are read off whichever subproc is returned, same as before.
-  mi_subproc_t* const subproc = mi_page_subproc_unowned(page);
-  mi_theap_t* const theap_meta = subproc->theap_meta;
+  // unverified edge case.
+  //
+  // #316 (P10a): the condition below is Bun's original shape, not our prior
+  // `theap_meta != NULL && mi_page_thread_id(page) == theap_meta->tld->thread_id` -- that reads
+  // `theap_meta->tld` unconditionally once `theap_meta != NULL`, but `mi_heap_free_theaps` nulls
+  // a theap's `tld` *before* `mi_subproc_unsafe_destroy` nulls `subproc->theap_meta`, so a
+  // *foreign* subproc mid-teardown (only reachable now that `subproc` need not be our own) can
+  // have `theap_meta != NULL` with `theap_meta->tld == NULL` -- a NULL deref. Every `theap_meta`
+  // shares the same static `mi_tld_detached` (`init.c:101`, `subproc.c:209`'s assert), whose
+  // `thread_id` is the compile-time constant `MI_THREADID_DETACHED`, so
+  // `mi_page_thread_id(page) == theap_meta->tld->thread_id` for the meta theap is equivalent to
+  // `mi_page_thread_id(page) == MI_THREADID_DETACHED` without reading `theap_meta` (let alone its
+  // `tld`) at all in the condition. `subproc`/`theap_meta` are loaded inside the branch instead,
+  // where they are actually needed, and past their own `theap_meta == NULL` guard.
   if mi_unlikely(!mi_theap_is_initialized(theap) || // can happen if free'd after thread_done was called (usually a thread cleanup call by the OS)
-                  // page->theap == subproc->theap_meta  .. but we cannot read `theap` if we don't own the page
-                  (theap_meta != NULL && mi_page_thread_id(page) == theap_meta->tld->thread_id)) {
-    // #316 (P10a): `subproc` can now be a *foreign* subproc (the page's arena's, not
-    // necessarily this thread's own), which the old `_mi_subproc()` could never be mid-teardown
-    // out from under the freeing thread. Ported from Bun's converged `mi_stat_free`: give up the
-    // stat update rather than deref a NULL theap_meta of a subproc that is being destroyed.
-    if (theap_meta == NULL) return;
-    theap = theap_meta;
+                  mi_page_thread_id(page) == MI_THREADID_DETACHED) { // page->theap == subproc->theap_meta .. but we cannot read `theap` if we don't own the page (only the meta theap has the detached thread id)
+    // account on the subproc of the page (we cannot use our own theap here)
+    mi_subproc_t* const subproc = mi_page_subproc_unowned(page);
+    if (subproc->theap_meta == NULL) return;  // give up (the subproc is being destroyed)
+    theap = subproc->theap_meta;
     lock = &subproc->theap_meta_lock;
     mi_lock_acquire(lock);
   }

--- a/src/heap.c
+++ b/src/heap.c
@@ -280,6 +280,10 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
         mi_arena_pages_t* arena_pages = mi_atomic_load_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i]);
         if (arena_pages!=NULL) {
           mi_atomic_store_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i], NULL);
+          // #316 (P10a): this free now collects in-subproc. Safe here: this thread is deleting
+          // `heap` (mi_heap_free's only caller), so it is not parked, and mi_free_try_collect_mt's
+          // own reclaim guards (_mi_thread_is_initialized, _mi_page_associated_theap_peek refusing
+          // a theap of another heap) apply regardless.
           _mi_free_subproc_safe(arena_pages);
         }
       }
@@ -304,9 +308,11 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
   mi_lock_done(&heap->theaps_lock);
   mi_lock_done(&heap->os_abandoned_pages_lock);
   mi_lock_done(&heap->arena_pages_lock);
-  if (!_mi_is_process_heap_main(heap)) { 
+  if (!_mi_is_process_heap_main(heap)) {
     _mi_thread_local_free(heap->theap);
-    _mi_free_subproc_safe(heap); 
+    // #316 (P10a): same audit as the arena_pages free above -- this thread is deleting `heap`
+    // and is not parked; the collect this can now reach is guarded the same way.
+    _mi_free_subproc_safe(heap);
   }
 }
 

--- a/src/heap.c
+++ b/src/heap.c
@@ -280,10 +280,13 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
         mi_arena_pages_t* arena_pages = mi_atomic_load_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i]);
         if (arena_pages!=NULL) {
           mi_atomic_store_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i], NULL);
-          // #316 (P10a): this free now collects in-subproc. Safe here: this thread is deleting
-          // `heap` (mi_heap_free's only caller), so it is not parked, and mi_free_try_collect_mt's
-          // own reclaim guards (_mi_thread_is_initialized, _mi_page_associated_theap_peek refusing
-          // a theap of another heap) apply regardless.
+          // #316 (P10a): this free now collects in-subproc. Safe regardless of whether this
+          // thread is parked: `allow_collect` only reaches `mi_free_block_mt`/
+          // `mi_free_generic_mt` (free.c:mi_free_ex), while `_mi_park_leave_if_parked` lives
+          // only in the separate `mi_free_generic_local` owner-free path (free.c:167) -- so this
+          // can never newly reach the park protocol. `mi_free_try_collect_mt`'s own reclaim
+          // guards (`_mi_thread_is_initialized`, `_mi_page_associated_theap_peek` refusing a
+          // theap of another heap) apply unconditionally.
           _mi_free_subproc_safe(arena_pages);
         }
       }
@@ -310,8 +313,8 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
   mi_lock_done(&heap->arena_pages_lock);
   if (!_mi_is_process_heap_main(heap)) {
     _mi_thread_local_free(heap->theap);
-    // #316 (P10a): same audit as the arena_pages free above -- this thread is deleting `heap`
-    // and is not parked; the collect this can now reach is guarded the same way.
+    // #316 (P10a): same audit as the arena_pages free above -- `allow_collect` cannot reach the
+    // park protocol from here either, for the same call-graph reason.
     _mi_free_subproc_safe(heap);
   }
 }

--- a/test/test-heap-burst-destroy.c
+++ b/test/test-heap-burst-destroy.c
@@ -1,0 +1,137 @@
+/* ----------------------------------------------------------------------------
+Copyright (c) 2018-2026, Microsoft Research, Daan Leijen
+This is free software; you can redistribute it and/or modify it under the
+terms of the MIT license.
+-----------------------------------------------------------------------------*/
+
+// ported from oven-sh/mimalloc commit 04ced98d, MIT (issue #316 / Bun parity P10a):
+// "Collect the page when heap meta data is freed into it". Pure public API, so this ports
+// unchanged (no adaptation for our tree's `mi_heap_t`/`mi_theap_t` split was needed).
+
+/* test-heap-burst-destroy.c
+
+   Destroy many heaps at once, round after round, and check that the meta data
+   of a destroyed heap (`mi_heap_t`, `mi_arena_pages_t`) really goes away.
+
+   mimalloc abandons a page once it is full. The only way such a page comes back
+   is a free into it that "collects" the page: frees it when it is empty, reclaims
+   it into the current theap, or re-maps it once enough blocks are free.
+   `mi_heap_free` frees the meta data through `_mi_free_subproc_safe`, which did
+   not collect (a collect must not cross sub-processes). Inside the same
+   sub-process that stranded the block: the page stayed abandoned and resident
+   for good. With enough heaps alive at the same time their meta data fills
+   whole pages of the main heap, so from then on every `mi_heap_destroy` leaked
+   the heap struct and, once the heap had allocated, its arena page bitmaps
+   (about 150 KiB for a 1 GiB arena).
+
+   The test counts the bytes in use in the main heap with `mi_heap_visit_blocks`
+   (that walks every page of the heap, abandoned ones included, so a stranded
+   block is counted) before and after the rounds. Without the fix the count
+   grows by the meta data of every destroyed heap.
+
+   > mimalloc-test-heap-burst-destroy [LIVE_HEAPS] [ROUNDS]
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "mimalloc.h"
+
+static int failed = 0;
+#define EXPECT(what, cond)  do { if (!(cond)) { fprintf(stderr, "\n  FAILED %s: %s (%s:%d)\n", what, #cond, __FILE__, __LINE__); failed++; } } while(0)
+
+static bool count_used_bytes(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, void* arg) {
+  (void)heap; (void)block; (void)block_size;
+  if (area != NULL) {
+    *((size_t*)arg) += area->used * area->block_size;
+  }
+  return true;
+}
+
+// Bytes in use in the main heap, over every page of it (also the abandoned ones).
+static size_t main_heap_used_bytes(void) {
+  size_t used = 0;
+  mi_heap_visit_blocks(mi_heap_main(), false /* pages only */, &count_used_bytes, &used);
+  return used;
+}
+
+static size_t current_rss(void) {
+  size_t elapsed, user, sys, current_rss, peak_rss, current_commit, peak_commit, page_faults;
+  mi_process_info(&elapsed, &user, &sys, &current_rss, &peak_rss, &current_commit, &peak_commit, &page_faults);
+  return current_rss;
+}
+
+// One round: `live` heaps alive at the same time, each with one allocation (so
+// that each heap also has its `mi_arena_pages_t`), then all of them destroyed.
+static void round_of_heaps(mi_heap_t** heaps, int live, bool allocate) {
+  for (int i = 0; i < live; i++) {
+    heaps[i] = mi_heap_new();
+    EXPECT("heap_new", heaps[i] != NULL);
+    if (allocate) {
+      void* p = mi_heap_malloc(heaps[i], 200);
+      EXPECT("heap_malloc", p != NULL);
+      memset(p, (int)(i & 0xFF), 200);
+    }
+  }
+  for (int i = 0; i < live; i++) {
+    mi_heap_destroy(heaps[i]);
+    heaps[i] = NULL;
+  }
+}
+
+int main(int argc, char** argv) {
+  int live   = (argc > 1 ? atoi(argv[1]) : 200);
+  int rounds = (argc > 2 ? atoi(argv[2]) : 20);
+  if (live <= 0) live = 200;
+  if (rounds <= 0) rounds = 20;
+
+  mi_heap_t** heaps = (mi_heap_t**)mi_calloc((size_t)live, sizeof(mi_heap_t*));
+  EXPECT("alloc heaps array", heaps != NULL);
+  if (heaps == NULL) return 1;
+
+  // warm up: the first round pays for thread-local slots, theap meta data, and the like
+  round_of_heaps(heaps, live, true);
+  const size_t used_before = main_heap_used_bytes();
+  const size_t rss_before  = current_rss();
+
+  for (int r = 0; r < rounds; r++) {
+    round_of_heaps(heaps, live, true);
+  }
+  const size_t used_after = main_heap_used_bytes();
+  const size_t rss_after  = current_rss();
+
+  // heaps without any allocation strand only their `mi_heap_t`
+  for (int r = 0; r < rounds; r++) {
+    round_of_heaps(heaps, live, false);
+  }
+  const size_t used_after_empty = main_heap_used_bytes();
+
+  mi_free(heaps);
+
+  const size_t destroyed = (size_t)live * (size_t)rounds;
+  printf("heap-burst-destroy: %d live heaps x %d rounds\n", live, rounds);
+  printf("  main heap in use: %zu KiB before, %zu KiB after (%zu B per destroyed heap)\n",
+         used_before / 1024, used_after / 1024,
+         (used_after > used_before ? (used_after - used_before) / destroyed : 0));
+  printf("  main heap in use after %zu empty heaps: %zu KiB (%zu B per destroyed heap)\n",
+         destroyed, used_after_empty / 1024,
+         (used_after_empty > used_after ? (used_after_empty - used_after) / destroyed : 0));
+  printf("  rss: %zu KiB before, %zu KiB after\n", rss_before / 1024, rss_after / 1024);
+
+  // Without the fix every destroyed heap leaves about 7 KiB (`mi_heap_t`) plus about 150 KiB
+  // (`mi_arena_pages_t`) in use: `destroyed * 157 KiB`. With it the count stays where the warm-up
+  // round left it; allow a few pages of slack for meta data that legitimately grows.
+  const size_t slack = 4 * 64 * 1024;
+  EXPECT("meta data of destroyed heaps is freed", used_after <= used_before + slack);
+  EXPECT("meta data of destroyed empty heaps is freed", used_after_empty <= used_before + slack);
+
+  if (failed > 0) {
+    fprintf(stderr, "test-heap-burst-destroy: %d failure(s)\n", failed);
+    return 1;
+  }
+  printf("test-heap-burst-destroy: ok\n");
+  return 0;
+}


### PR DESCRIPTION
Ports Bun's P10a from the ingest plan in #315 §2.1/§2.7 onto our diverged tree (`git apply` fails on essentially every hunk; ported by anchor, not by patch), per #316.

## What's ported, with our anchors

**`src/free.c` — `04ced98d` "Collect the page when heap meta data is freed into it"**
- New `mi_page_subproc_unowned(page)`, built on our existing `mi_memid_arena(page->memid)` (not a fresh `memid.memkind==MI_MEM_ARENA` test) — the same read `_mi_meta_is_meta_page_safe` (`internal.h:266`) already trusts, with the same provenance: `page->memid` is immutable after page creation, so it never dereferences `page->heap`. Falls back to `_mi_subproc()` for non-arena pages, as Bun does.
- `_mi_free_subproc_safe` now computes `allow_collect = (mi_page_subproc_unowned(page) == _mi_subproc())` and passes it to `mi_free_ex`, and early-returns on `page==NULL` — needed only because `mi_page_subproc_unowned` reads `page->memid` before `mi_free_ex` gets its own NULL guard (`mi_free_ex` already handles `p==NULL` fine on its own).
- **Convergence decision (issue's proposal, taken):** we don't have Bun's `mi_stat_free_subproc` — P6 (#271) had already replaced it with plain `_mi_subproc()` in `mi_stat_free`. Converged `mi_stat_free` onto the new `mi_page_subproc_unowned` too, and rewrote the P6 comment to describe it as the arena-derived replacement for `page->heap->subproc`, not `_mi_subproc()`.
- **Extra fix beyond the issue's literal text, needed by the convergence:** added `if (theap_meta == NULL) return;` inside `mi_stat_free`'s lock-acquire branch. With `_mi_subproc()`, `subproc` was always the freeing thread's own — never mid-teardown out from under it. After convergence `subproc` can be a *foreign* subproc (the page's arena's), which genuinely can be mid-teardown with `theap_meta` already NULL; without the guard that path derefs NULL. Matches Bun's own converged shape (`if (subproc->theap_meta == NULL) return; // give up (the subproc is being destroyed)`).

**Four callers whose behavior changes** (`allow_collect` can now be `true`):
1. `src/heap.c:283` — `_mi_free_subproc_safe(arena_pages)` inside `mi_heap_free`.
2. `src/heap.c:309` — `_mi_free_subproc_safe(heap)`, same function.
3. `src/arena.c:1592` — the `MI_MEM_MALLOC` branch of `_mi_arenas_free`. Audited: no allocation site in this tree currently produces a `MI_MEM_MALLOC` memid that reaches this branch. The producers of that memid (`_mi_meta_zalloc`/`_mi_meta_zalloc_aligned`/`_mi_meta_rezalloc`, `subproc.c`, via `_mi_memid_create_malloc`) hand it to `_mi_meta_free` (`subproc.c:94`, the only caller of `_mi_arenas_free` that matters here), which handles `MI_MEM_MALLOC` itself with a plain `mi_free(p)` and only forwards other memkinds to `_mi_arenas_free` (`subproc.c:99`); the rest of `_mi_arenas_free`'s callers (`arena.c:794/935/1184`) pass an arena- or OS-backed memid. Callers 1-2 above (`heap.c:290/318`, the issue's anchors were `heap.c:283/309` pre-patch) call a *different* function, `_mi_free_subproc_safe`, not `_mi_arenas_free` -- an earlier version of this paragraph conflated the two; fixed in the review round (F2 below).
4. Caller 4 in #315's list (the CAS-loser free in `mi_arena_pages_abandoned_ensure`) doesn't exist in our tree yet — that's P10b, not P10a.

**Park-protocol audit (rule: audit, do not assume).** Traced the call graph rather than reasoning per-caller: `allow_collect` only ever flows into `mi_free_block_mt` (directly, or via `mi_free_generic_mt`) — the two "cross-thread/abandoned page" branches of `mi_free_ex`. `_mi_park_leave_if_parked` (`free.c:167`) lives only in `mi_free_generic_local`, the separate *local-owner* free path, which never receives `allow_collect`. So P10a cannot newly reach the park-leave line from **any** caller — a stronger, caller-independent argument than auditing each of 1–3 individually. `mi_free_try_collect_mt`'s own reclaim guards (`_mi_thread_is_initialized`, and `_mi_page_associated_theap_peek` returning NULL for a theap that doesn't belong to the page's heap) apply unconditionally regardless of caller. One-line comments recording this are at all three call sites.

**`include/mimalloc/prim-tls.h` — relaxed atomics on the TLS slot.** Added a `#elif defined(__GNUC__) || defined(__clang__)` branch using `__atomic_load_n`/`__atomic_store_n(..., __ATOMIC_RELAXED)`, documenting the deliberate exiting-thread/new-thread slot reuse. The `_WIN32` `__readgsqword`/`__readfsdword` branches are untouched and still take priority on MinGW/win-gnu.

**`src/bitmap.c` — `a26c5de7`'s acquire loads, `_mi_bitmap_forall_set` only.** The chunkmap and chunk-field loads become `mi_atomic_load_acquire`, ordering a concurrent `mi_free`'s release-clear of a page's bit (`mi_arenas_page_free_prim`) before `mi_heap_delete` frees the memory it read.

**`src/arena.c` — `a26c5de7`'s `mi_heap_visit_page_claim` reorder.** Signature changed from `(vinfo, page, slice_index) -> bool` to `(vinfo, arena, slice_index) -> mi_page_t*`; `page = mi_arena_page_at_slice(arena, slice_index)` moved inside the retry loop, right after the first successful `mi_bitmap_clear` (i.e. after the slice is pinned), instead of being computed by the caller beforehand. `mi_heap_visit_page_at` updated to match, including the non-claim branch. Our fork-child branch (imported in P6 from oven-sh/mimalloc @ 942b8342, and present unchanged in Bun's `a26c5de7` diff too -- both trees carry it at this point) needed no re-derivation: it already runs after `page = mi_arena_page_at_slice(...)` in the reordered loop, so only its two `return false` -> `return NULL` needed updating to match the new signature, same as the rest of the function. Honest severity, per the issue: latent under our default configs (`mi_arena_page_at_slice` is a pure function of `slice_index` there); a correctness fix only once `MI_OPT_FREE_SMALL` (`MI_PAGE_META_ALIGNED_FREE_SMALL`) reads `page->block_size` off a possibly-unpinned slice. Ported anyway per the issue.

**`test/test-heap-burst-destroy.c` (new).** Body ported unchanged from Bun — pure public API (`mi_heap_new/destroy`, `mi_heap_visit_blocks`, `mi_heap_main`, `mi_process_info`, no `<stdatomic.h>` dependency, so no MSVC fallback was needed here unlike `test-abandoned-lazy.c`, which is P10b); license header and a provenance comment adapted to our convention. Destroys 200 heaps × 20 rounds (default args), asserting the main heap's tracked byte count returns to its warm-up baseline. Registered in `CMakeLists.txt`'s static-link `foreach(TEST_NAME ...)` loop and added to `mi_serial_tests` (RSS/main-heap-byte-count sensitivity to a parallel wave, same class as `test-degenerate`/`test-process-rss`).

**Confirmed RED before / GREEN after**, by temporarily reverting only `src/free.c` and rebuilding:
```
# before (free.c reverted):
main heap in use: 34871 KiB before, 700071 KiB after (170291 B per destroyed heap)
FAILED meta data of destroyed heaps is freed
FAILED meta data of destroyed empty heaps is freed

# after (fix in place):
main heap in use: 1611 KiB before, 1611 KiB after (0 B per destroyed heap)
test-heap-burst-destroy: ok
```
The ~170 KB/heap matches the issue's own estimate ("about 7 KiB `mi_heap_t` plus about 150 KiB `mi_arena_pages_t`").

## Not ported (P10b, per #315 — blocked on this PR, not preference)

`heap->releasing`, the lazy per-bin abandoned bitmaps, `_mi_arena_pages_free`, `test-abandoned-lazy.c`, `test-heap-release-mt.c`, `test-free-before-init.c`'s `.CRT$XCU` hook. None of these are touched here.

## Review round

An Opus review of this PR requested five changes, applied in a follow-up `fix:` + `chore(rust):` commit pair:

- **F1 (MEDIUM):** `mi_stat_free`'s foreign-subproc condition read `theap_meta->tld->thread_id` unconditionally once `theap_meta != NULL`. Since `mi_heap_free_theaps` nulls a theap's `tld` *before* `mi_subproc_unsafe_destroy` nulls `subproc->theap_meta`, a foreign subproc mid-teardown (only reachable now that `subproc` need not be our own) could have `theap_meta != NULL` with `theap_meta->tld == NULL` — a NULL deref my original `theap_meta == NULL` guard (item 1 in "Deviations" below, superseded) didn't cover, because the deref happens while *evaluating the condition*, before that guard's branch body ever runs. Converged onto Bun's original condition shape instead — `mi_page_thread_id(page) == MI_THREADID_DETACHED` — which never reads `theap_meta` in the condition at all (every `theap_meta` shares the static `mi_tld_detached`, whose `thread_id` is that compile-time constant, per `init.c:101`/`subproc.c:209`'s assert).
- **F2 (LOW):** the `arena.c:1592` audit comment cited `heap.c:283/309` as callers of `_mi_arenas_free` (they call `_mi_free_subproc_safe`, a different function) and omitted `subproc.c:99`, the caller that actually matters. Reworded.
- **F3 (LOW):** `heap.c`'s two park-protocol comments claimed "this thread is deleting `heap` so it is not parked" — false, a thread can be parked and still run allocator code. Replaced with the real argument: `allow_collect` only reaches `mi_free_block_mt`/`mi_free_generic_mt`, and `_mi_park_leave_if_parked` lives only in the separate `mi_free_generic_local` owner-free path, so this can never newly reach the park protocol regardless of parked state.
- **F4 (TRIVIAL):** this PR body wrongly claimed the fork-child branch in `mi_heap_visit_page_claim` was "not present in Bun's post-P10 tree" — it is, unchanged, in Bun's own `a26c5de7` diff. Corrected above.
- **F5 (TRIVIAL):** swept a stale line citation in `src/fork.c`'s lock-order table (`mi_stat_free` at `free.c:741` → `free.c:768`, shifted by this series).

## Verification (all on the final HEAD, after both the comment-wording fixup and the review-round fixes)

- `uv run ci/verify_local.py` — all 12 configs PASS (`release`, `off`, `debug-full`, `debug3-extra`, `guarded`, `shared`, `bundle`, `memory-gate`, `diag`, `lint`, `asan`, `rust`), across multiple passes as the tree evolved; the coordinator-specified subset (`release`, `debug-full`, `guarded`, `debug3-extra`, `memory-gate`, `diag`, `lint`) re-run once more on the true final HEAD.
- `uv run ci/verify_local.py --only release,debug-full --slow` — PASS (both new-test-relevant slow tiers, `test-heap-burst-destroy` included).
- `uv run ci/memory_gate.py check` — PASS: `peak_rss 58.2 MB vs baseline 58.0 MB (+0.3%, allowed +5%)`.
- `uv run ci/check_internal_state.py` — `internal-state inventory is complete (31 sites)`; no new site needed (that's a P10b requirement, per the issue).
- `uv run ci/check_bun_surface.py` — PASS, unchanged (no new public symbol).
- `cargo run -p xtask -- check` — `xtask check: vendored amalgamation matches src/include/.`
- Full `ctest` under a hand-built `MI_DEBUG_FULL=ON MI_PPROF=ON` config (56 tests, exercises `mi_stat_free`'s real `MI_STAT>0` body and the lock-order/assertion-heavy paths this PR touches) — 100% pass on every re-run, including `test-lock-reentrancy` and `test-heap-teardown`.
- Manual RED/GREEN proof of `test-heap-burst-destroy`, re-run against `main`'s actual pre-P10a `src/free.c` (not just this branch's own prior commit) on final HEAD:
  ```
  # src/free.c swapped for main's version, rest of the branch unchanged:
  main heap in use: 34871 KiB before, 700071 KiB after (170291 B per destroyed heap)
  FAILED meta data of destroyed heaps is freed
  FAILED meta data of destroyed empty heaps is freed

  # src/free.c restored (final HEAD):
  main heap in use: 1611 KiB before, 1611 KiB after (0 B per destroyed heap)
  test-heap-burst-destroy: ok
  ```
  F1's fix addresses a narrow foreign-subproc-teardown race this single-process test doesn't exercise, so it isn't expected to move this particular test on its own -- confirmed by rebuilding at each of the four HEADs along the way and seeing no change there.

No C-core path is mixed with `rust/` in any commit (rule 2): all three `fix: ...` commits touch only `CMakeLists.txt`/`include/`/`src/`/`test/`; all three `chore(rust): ...` commits touch only the vendored amalgamation.

Not run: `uv run ci/dev_linux.py bench` (the issue's "paste on #10 if it moves" acceptance test) — not required by the coordinator's verification list for this PR, and P10a's only live-by-default code path (`mi_stat_free`'s subproc lookup) only executes when `MI_STAT>0`, which is off in the default release/bench config, so nothing this PR touches is on the bench path in that configuration. Flagging the gap rather than skipping it silently.

## Deviations from the issue's literal text (commented in the diff, raised on #316)

1. Added a guard against `mi_stat_free` dereferencing a NULL `theap_meta` of a foreign subproc mid-teardown, which the issue's `mi_stat_free`-convergence proposal didn't spell out but which the convergence itself requires for safety. Landed in two steps: an initial `theap_meta == NULL` check (insufficient — see F1 above), corrected in the review round to Bun's actual condition shape, which avoids the unsafe read entirely rather than guarding after it.
2. The issue lists `src/arena.c:1592` as one of "four callers whose behavior changes," implying it's live; auditing it found no producer in this tree currently reaches it. Ported the hunk anyway (matches upstream's shape, and the guard is free) and documented the audit instead of silently agreeing with the issue's premise.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S


