### PR TITLE
feat: lazy per-bin abandoned bitmaps and unmapped abandon on heap release (Bun P10b, #317)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,7 +737,15 @@ if(MI_USE_CXX)
   # link them -- the `windows-msvc` bundles failed with `lld-link: undefined symbol:
   # _mi_os_page_size`. Compiling these two as C++ alongside the library is what test-api.c
   # already does for the same reason.
-  set_source_files_properties(src/static.c test/test-api.c test/test-api-fill.c test/test-stress.c test/test-stress-heaps.c test/test-stress-subprocs.c test/test-lock-reentrancy.c test/test-tls-controls.c test/test-purge-holes.c test/test-profile-race.c PROPERTIES LANGUAGE CXX )
+  # test-abandoned-lazy.c: Bun parity P10b (#317), ported from oven-sh/mimalloc @ c31ed9ed, MIT.
+  # Not required for linking in this tree today (the `mi_debug_abandoned_maps_allocated` hook it
+  # references is already `extern "C"` here -- see the internal.h `#if MI_DEBUG > 0` block's
+  # provenance comment -- so a plain C test links against the C++-mangled library fine, the same
+  # reason test-heap-teardown.c/test-heap-aba.c/test-heap-delete-race.c are NOT in this list).
+  # Ported anyway per the issue: harmless (the file's `#ifdef __cplusplus` branches already
+  # target this), and keeps the CMake shape identical to Bun's should this tree's extern "C"
+  # wrapping ever change.
+  set_source_files_properties(src/static.c test/test-api.c test/test-api-fill.c test/test-stress.c test/test-stress-heaps.c test/test-stress-subprocs.c test/test-lock-reentrancy.c test/test-tls-controls.c test/test-purge-holes.c test/test-profile-race.c test/test-abandoned-lazy.c PROPERTIES LANGUAGE CXX )
 endif()
 
 
@@ -988,7 +996,14 @@ if (MI_BUILD_TESTS)
   enable_testing()
 
   # static link tests
-  foreach(TEST_NAME api api-fill heap-burst-destroy stress-heaps stress-subprocs stress)
+  # abandoned-lazy / heap-release-mt: Bun parity P10b (#317), ported from oven-sh/mimalloc @
+  # 787be2a8 / a26c5de7 (+92930d0c, 47851447), MIT. Pure public API (mi_heap_new/delete/destroy,
+  # mi_heap_malloc, mi_free, mi_collect, mi_on_thread_idle*, mi_option_*) plus, for
+  # abandoned-lazy's counter check only, the MI_DEBUG-only mi_debug_abandoned_maps_allocated
+  # hook (declared extern in the test source itself, like test-heap-teardown.c's
+  # mi_debug_stall_in_heap_delete_claim) -- so both build and register unconditionally, unlike
+  # test-heap-teardown which #errors outright when MI_DEBUG==0.
+  foreach(TEST_NAME api api-fill heap-burst-destroy abandoned-lazy heap-release-mt stress-heaps stress-subprocs stress)
     add_executable(mimalloc-test-${TEST_NAME} test/test-${TEST_NAME}.c)
     target_compile_definitions(mimalloc-test-${TEST_NAME} PRIVATE ${mi_defines})
     target_compile_options(mimalloc-test-${TEST_NAME} PRIVATE ${mi_cflags})
@@ -1264,6 +1279,16 @@ if (MI_BUILD_TESTS)
     # branch and still leave the heap correct (`mi_on_thread_idle` sweeping inline).
     add_test(NAME test-park-handoff-no-scavenger COMMAND mimalloc-test-park-handoff)
     set_tests_properties(test-park-handoff-no-scavenger PROPERTIES TIMEOUT 600
+                         ENVIRONMENT "MIMALLOC_SCAVENGER=0")
+    # test-heap-release-mt: Bun parity P10b (#317), ported from oven-sh/mimalloc @ a26c5de7 +
+    # 92930d0c/47851447, MIT. The executable itself is registered unconditionally above (the
+    # "static link tests" foreach) since it prints "skipped" and returns 0 on Windows/win-gnu
+    # rather than needing a CMake-level skip -- but this env-only "-no-scavenger" variant is
+    # only meaningful together with pthreads, so it lives here next to
+    # test-park-handoff-no-scavenger, same rationale: with no scavenger to hand off to,
+    # `mi_on_thread_idle_start` must do the park-mode sweep inline instead.
+    add_test(NAME test-heap-release-mt-no-scavenger COMMAND mimalloc-test-heap-release-mt)
+    set_tests_properties(test-heap-release-mt-no-scavenger PROPERTIES TIMEOUT 600
                          ENVIRONMENT "MIMALLOC_SCAVENGER=0")
     # ... and with the P7b sweep rate limit removed, so every park is due the moment it is
     # claimed: `test_park_inside_window_gets_swept` takes its "no window" branch and
@@ -1871,6 +1896,14 @@ endif()
 #     main heap's byte-count and process RSS across 4000 heap creates/destroys (single-
 #     threaded; no race), the same sensitivity class as the RSS-under-pressure tests above: a
 #     parallel wave's memory pressure can move both numbers independently of the allocator.
+#   * a debug-only process-wide counter (issue #317, Bun parity P10b) -- test-abandoned-lazy's
+#     `released_heaps_map_nothing` asserts `mi_debug_abandoned_maps_allocated` does not move
+#     across 50 heap create/fill/delete-or-destroy rounds; a parallel wave's own abandons would
+#     move it for reasons unrelated to the lazy-allocation regression this checks for.
+#   * a ~4-6s ~20-thread stress with its own wall-clock budget (issue #317, Bun parity P10b) --
+#     test-heap-release-mt (and its -no-scavenger variant) races heap delete/destroy against
+#     concurrent frees and, in its second half, against the scavenger's park sweep; same
+#     "oversubscribed runner, timing not work" class as test-park-handoff* above.
 #
 # RUN_SERIAL is ctest's own word for this ("do not run any other test concurrently"), so
 # it is set here rather than encoded as a name list inside the CI runner: a new test
@@ -1894,6 +1927,9 @@ set(mi_serial_tests
   test-profile-race-scavenger
   test-subproc-lifecycle
   test-heap-burst-destroy
+  test-abandoned-lazy
+  test-heap-release-mt
+  test-heap-release-mt-no-scavenger
 )
 # Next candidate if the wave ever goes flaky: test-fork-user-heap. It is not here because
 # nothing has been observed to fail -- it forks, and a fork's cost and timing are the

--- a/ci/internal-state-inventory.json
+++ b/ci/internal-state-inventory.json
@@ -461,7 +461,8 @@
       "publication": "mi_bitmap_init'd before the CAS into arena_pages->pages_abandoned[bin]; the CAS loser's copy is freed unpublished",
       "locks": [
         "allocation occurs under subproc->theap_meta_lock (inside _mi_meta_zalloc_aligned)",
-        "the caller (mi_arena_pages_abandoned_ensure) is reached from _mi_arenas_page_abandon, typically under heap->theaps_lock (mi_heap_detach_theaps's abandon loop) -- see the new heap->theaps_lock -> subproc->theap_meta_lock edge documented in src/fork.c's lock-order table (issue #317)"
+        "the caller (mi_arena_pages_abandoned_ensure) is reached from _mi_arenas_page_abandon, typically under heap->theaps_lock (mi_heap_detach_theaps's abandon loop) -- see the new heap->theaps_lock -> subproc->theap_meta_lock edge documented in src/fork.c's lock-order table (issue #317)",
+        "never reentrant against itself: a page belonging to subproc->theap_meta can no longer reach mi_page_to_full -> _mi_page_abandon -> _mi_arenas_page_abandon at all, now that mi_subproc_new (src/subproc.c) sets theap_meta->allow_page_abandon=false (matching init.c's process theap_meta); _mi_arenas_page_abandon also checks _mi_meta_is_meta_page_safe(page) and skips this allocator for a meta page regardless, belt and braces (Opus review of #317/#319)"
       ]
     },
     {

--- a/ci/internal-state-inventory.json
+++ b/ci/internal-state-inventory.json
@@ -445,6 +445,26 @@
       ]
     },
     {
+      "id": "arena-pages-abandoned-bitmap",
+      "path": "src/arena.c",
+      "callee": "_mi_meta_zalloc_aligned",
+      "args": "arena->subproc,size,MI_BCHUNK_SIZE,NULL",
+      "occurrence": 1,
+      "owner": "arena sub-process meta-data theap",
+      "initial_owner": "zeroed allocation from subproc->theap_meta (under theap_meta_lock)",
+      "owner_transitions": "CAS-published into arena_pages->pages_abandoned[bin]; loser frees its copy with _mi_free_subproc_safe",
+      "destroyable_by": "owning heap teardown (mi_heap_free -> _mi_arena_pages_free)",
+      "lifetime": "same as the (heap, arena) pair's arena_pages -- allocated lazily on first abandon of a page of this bin, not up front with arena_pages itself",
+      "logical_size": "mi_bitmap_size(arena->slice_count, NULL)",
+      "usable_size": "allocator size class; embedded bitmap layout uses logical size only",
+      "cleanup": "_mi_arena_pages_free at heap teardown (mi_heap_free, src/heap.c), which frees each non-NULL pages_abandoned[bin] before freeing arena_pages itself",
+      "publication": "mi_bitmap_init'd before the CAS into arena_pages->pages_abandoned[bin]; the CAS loser's copy is freed unpublished",
+      "locks": [
+        "allocation occurs under subproc->theap_meta_lock (inside _mi_meta_zalloc_aligned)",
+        "the caller (mi_arena_pages_abandoned_ensure) is reached from _mi_arenas_page_abandon, typically under heap->theaps_lock (mi_heap_detach_theaps's abandon loop) -- see the new heap->theaps_lock -> subproc->theap_meta_lock edge documented in src/fork.c's lock-order table (issue #317)"
+      ]
+    },
+    {
       "id": "huge-os-pages-reservation",
       "path": "src/arena.c",
       "callee": "_mi_os_alloc_huge_os_pages",

--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -326,6 +326,11 @@ extern mi_decl_export volatile long mi_debug_fail_os_commit_after;
 // `arena.c` (`mi_heap_visit_page_claim`) sets it to 2 once it has a page pinned but not yet
 // claimed, and stalls there until the test sets it back to 0.
 extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_heap_delete_claim;
+// Bun parity P10b (#317), ported from oven-sh/mimalloc @ 1515c3c9 (C linkage) /
+// 787be2a8 (the counter itself). test-abandoned-lazy.c: per-bin abandoned bitmaps
+// (`mi_arena_pages_t::pages_abandoned[]`, arena.c) published so far via the CAS in
+// `mi_arena_pages_abandoned_ensure`.
+extern mi_decl_export _Atomic(uintptr_t) mi_debug_abandoned_maps_allocated;
 #ifdef __cplusplus
 }
 #endif
@@ -413,6 +418,7 @@ void          _mi_arenas_abandoned_page_free(mi_page_t* page, mi_theap_t* curren
 void          _mi_arenas_page_abandon(mi_page_t* page, mi_theap_t* current_theap);
 void          _mi_arenas_page_unabandon(mi_page_t* page, mi_theap_t* current_theapx /* can be NULL */);
 bool          _mi_arenas_page_try_reabandon_to_mapped(mi_page_t* page);
+void          _mi_arena_pages_free(mi_arena_pages_t* arena_pages);  // Bun parity P10b, #317: frees the on-demand abandoned bitmaps then `arena_pages` itself
 
 // "page-map.c"
 bool          _mi_page_map_init(void);

--- a/include/mimalloc/types.h
+++ b/include/mimalloc/types.h
@@ -662,6 +662,7 @@ typedef struct mi_heap_s {
   mi_lock_t             theaps_lock;                    // lock for the theaps list operations
 
   _Atomic(size_t)       abandoned_count[MI_BIN_COUNT];  // total count of abandoned pages in this heap
+  _Atomic(uintptr_t)    releasing;                      // set when `mi_heap_delete`/`mi_heap_destroy` starts: its pages are abandoned unmapped (Bun parity P10b, #317)
   mi_page_t*            os_abandoned_pages;             // list of pages that are OS allocated and not in an arena
   mi_lock_t             os_abandoned_pages_lock;        // lock for the os abandoned pages list (this lock protects list operations)
 
@@ -867,8 +868,14 @@ typedef struct mi_bbitmap_s mi_bbitmap_t;   // atomic binned bitmap (defined in 
 
 struct mi_arena_pages_s {
   mi_bitmap_t* pages;                // all registered pages (abandoned and owned)
-  mi_bitmap_t* pages_abandoned[MI_ARENA_BIN_COUNT];  // abandoned pages per size bin (a set bit means the start of the page)
-  // followed by the bitmaps (whose siz`es depend on the arena size)
+  // Abandoned pages per size bin (a set bit means the start of the page). Each bitmap is
+  // allocated the first time a page of that bin is abandoned (`mi_arena_pages_abandoned_ensure`,
+  // src/arena.c); NULL means no page of that bin was ever abandoned. Eagerly laying out all
+  // MI_ARENA_BIN_COUNT of them cost a page fault per bitmap (one header write each, on its own
+  // OS page) for every heap that touched an arena, and most heaps never abandon a page.
+  // (Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.)
+  _Atomic(mi_bitmap_t*) pages_abandoned[MI_ARENA_BIN_COUNT];
+  // followed by the `pages` bitmap (whose size depends on the arena size)
 };
 
 

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2d594c0f of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit a63848f5 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -11624,7 +11624,23 @@ void _mi_arenas_page_abandon(mi_page_t* page, mi_theap_t* current_theap) {
       // abandoned bitmap is allocated on first use. If that allocation fails, fall through
       // and abandon the page unmapped, like a full page: it stays reachable through `pages`
       // and is reclaimed once a block in it is freed.
-      mi_bitmap_t* const bitmap = mi_arena_pages_abandoned_ensure(arena, arena_pages, bin);
+      //
+      // Defensive guard (Opus review of #319): never call `mi_arena_pages_abandoned_ensure`
+      // -> `_mi_meta_zalloc_aligned` for a page belonging to the subproc's own meta theap.
+      // That would re-enter `subproc->theap_meta_lock` non-recursively: `_mi_meta_zalloc_aligned`
+      // (subproc.c) holds the lock across a full `mi_theap_zalloc_aligned` on `theap_meta`,
+      // whose slow path can retire a full page of `theap_meta` itself (`mi_page_to_full`,
+      // page.c) into `_mi_page_abandon` -> here -> `..._ensure` -> the same lock again.
+      // `subproc.c`'s `mi_subproc_new` now sets `theap_meta->allow_page_abandon = false` (like
+      // `init.c`'s process theap_meta) to close the live path -- a meta theap's pages are
+      // never abandoned at all, so `_mi_page_abandon` should never reach here for one -- but a
+      // self-edge like this cannot be resolved by the MI_FORK_LOCK_* ordering (that orders
+      // acquisition across DIFFERENT call sites, not a lock against itself on one stack), so
+      // keep this check as belt and braces against a future option/call-graph change.
+      mi_bitmap_t* bitmap = NULL;
+      if (!_mi_meta_is_meta_page_safe(page)) {
+        bitmap = mi_arena_pages_abandoned_ensure(arena, arena_pages, bin);
+      }
       if mi_likely(bitmap != NULL) {
         mi_page_set_abandoned_mapped(page);
         const bool was_clear = mi_bitmap_set(bitmap, slice_index);
@@ -12293,6 +12309,16 @@ static mi_arena_t* mi_arena_initialize(mi_subproc_t* subproc, void* start,
   // Allocated on first abandon (Bun parity P10b, #317, ported from oven-sh/mimalloc @
   // 787be2a8, MIT); the arena's own memory is not yet fully zeroed at this point in every
   // memid path (`memid.initially_zero`), so store explicitly rather than relying on that.
+  //
+  // Not a leak (Opus review of #319): unlike a regular heap's `arena_pages` (freed by
+  // `_mi_arena_pages_free` in `mi_heap_free`, see below), `pages_main`'s on-demand bitmaps
+  // are never explicitly freed anywhere -- `mi_heap_free` skips the whole arena-pages loop
+  // for the main heap (`if (!is_main)`, src/heap.c), since `pages_main` is embedded in the
+  // arena itself, not a separately allocated `arena_pages`. Each bitmap is allocated from
+  // `arena->subproc`'s meta theap (`mi_arena_pages_abandoned_ensure`), which is itself backed
+  // by the same arenas -- so this is exactly the same "lives as long as the arena/subproc it
+  // is part of, freed only by tearing the whole arena down" lifetime `arena->slices_free` /
+  // `arena->pages_main.pages` already have, not a new leak class.
   for (size_t i = 0; i < MI_ARENA_BIN_COUNT; i++) {
     mi_atomic_store_ptr_relaxed(mi_bitmap_t, &arena->pages_main.pages_abandoned[i], NULL);
   }
@@ -16358,6 +16384,20 @@ terms of the MIT license. A copy of the license can be found in the file
                                     `theap_meta_lock`), which deadlocks against any thread
                                     starting up (`init.c:268` / `theap.c:329` allocate a
                                     fresh tld/theap through `_mi_meta_zalloc`).
+                                    NOT an edge: `_mi_arenas_page_abandon` (arena.c) must
+                                    never re-enter `_mi_meta_zalloc_aligned` for a page that
+                                    belongs to `theap_meta` itself -- that would be
+                                    `theap_meta_lock` against ITSELF on one stack (a self-edge
+                                    no acquisition ORDER can resolve, unlike every edge in
+                                    this table, which is between two DIFFERENT locks). Closed
+                                    two ways (Opus review of #317/#319): `subproc.c`'s
+                                    `mi_subproc_new` now sets `theap_meta->allow_page_abandon
+                                    = false` (matching `init.c`'s process theap_meta), so
+                                    `mi_page_to_full` never abandons one of `theap_meta`'s own
+                                    pages in the first place; `_mi_arenas_page_abandon` also
+                                    checks `_mi_meta_is_meta_page_safe(page)` and skips the
+                                    lazy-bitmap allocation for a meta page regardless (falls
+                                    through to the unmapped-abandon path), belt and braces.
 
     heap_main->arena_pages_lock     arena.c:685      LEAF. For the main heap
                                     `mi_heap_ensure_arena_pages` only stores
@@ -28825,6 +28865,20 @@ mi_subproc_id_t mi_subproc_new(void) {
   mi_assert_internal(parent->theap_meta->tld!=NULL);
   mi_assert_internal(parent->theap_meta->tld->thread_id == MI_THREADID_DETACHED);
   _mi_theap_init(theap_meta,heap_main,parent->theap_meta->tld /* detached tld */);
+  // Same reasoning as init.c's process-main theap_meta bootstrap ("for security, don't
+  // share with other threads"), plus a reentrancy hazard that reasoning doesn't mention but
+  // this one closes too (Opus review of #317/#319): `_mi_theap_init` -> `mi_theap_options_init`
+  // (theap.c) derives `allow_page_abandon` from `mi_option_page_full_retain`, which defaults
+  // enabled -- so without this line, a subproc's theap_meta (unlike the process's) could
+  // retire one of its own full pages through `mi_page_to_full` (page.c) -> `_mi_page_abandon`
+  // -> `_mi_arenas_page_abandon` (arena.c) -> `mi_arena_pages_abandoned_ensure` ->
+  // `_mi_meta_zalloc_aligned`, which re-enters `subproc->theap_meta_lock` from inside the very
+  // `mi_theap_zalloc_aligned` call that lock is already held across (subproc.c, above) -- an
+  // MI_DEBUG>2 reentrant-lock abort, or a Release-build hang. Setting this false means a meta
+  // page is never abandoned in the first place, so `_mi_page_abandon` never reaches that path
+  // for one; `_mi_arenas_page_abandon` also carries its own belt-and-braces
+  // `_mi_meta_is_meta_page_safe` guard (arena.c) in case this ever regresses.
+  theap_meta->allow_page_abandon = false;
   #if MI_GUARDED
   // See the matching comment in init.c's process-main theap_meta bootstrap (#266):
   // internal allocator bookkeeping must never be guarded.

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit be81f936 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2d594c0f of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -2983,6 +2983,7 @@ typedef struct mi_heap_s {
   mi_lock_t             theaps_lock;                    // lock for the theaps list operations
 
   _Atomic(size_t)       abandoned_count[MI_BIN_COUNT];  // total count of abandoned pages in this heap
+  _Atomic(uintptr_t)    releasing;                      // set when `mi_heap_delete`/`mi_heap_destroy` starts: its pages are abandoned unmapped (Bun parity P10b, #317)
   mi_page_t*            os_abandoned_pages;             // list of pages that are OS allocated and not in an arena
   mi_lock_t             os_abandoned_pages_lock;        // lock for the os abandoned pages list (this lock protects list operations)
 
@@ -3188,8 +3189,14 @@ typedef struct mi_bbitmap_s mi_bbitmap_t;   // atomic binned bitmap (defined in 
 
 struct mi_arena_pages_s {
   mi_bitmap_t* pages;                // all registered pages (abandoned and owned)
-  mi_bitmap_t* pages_abandoned[MI_ARENA_BIN_COUNT];  // abandoned pages per size bin (a set bit means the start of the page)
-  // followed by the bitmaps (whose siz`es depend on the arena size)
+  // Abandoned pages per size bin (a set bit means the start of the page). Each bitmap is
+  // allocated the first time a page of that bin is abandoned (`mi_arena_pages_abandoned_ensure`,
+  // src/arena.c); NULL means no page of that bin was ever abandoned. Eagerly laying out all
+  // MI_ARENA_BIN_COUNT of them cost a page fault per bitmap (one header write each, on its own
+  // OS page) for every heap that touched an arena, and most heaps never abandon a page.
+  // (Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.)
+  _Atomic(mi_bitmap_t*) pages_abandoned[MI_ARENA_BIN_COUNT];
+  // followed by the `pages` bitmap (whose size depends on the arena size)
 };
 
 
@@ -4636,6 +4643,11 @@ extern mi_decl_export volatile long mi_debug_fail_os_commit_after;
 // `arena.c` (`mi_heap_visit_page_claim`) sets it to 2 once it has a page pinned but not yet
 // claimed, and stalls there until the test sets it back to 0.
 extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_heap_delete_claim;
+// Bun parity P10b (#317), ported from oven-sh/mimalloc @ 1515c3c9 (C linkage) /
+// 787be2a8 (the counter itself). test-abandoned-lazy.c: per-bin abandoned bitmaps
+// (`mi_arena_pages_t::pages_abandoned[]`, arena.c) published so far via the CAS in
+// `mi_arena_pages_abandoned_ensure`.
+extern mi_decl_export _Atomic(uintptr_t) mi_debug_abandoned_maps_allocated;
 #ifdef __cplusplus
 }
 #endif
@@ -4723,6 +4735,7 @@ void          _mi_arenas_abandoned_page_free(mi_page_t* page, mi_theap_t* curren
 void          _mi_arenas_page_abandon(mi_page_t* page, mi_theap_t* current_theap);
 void          _mi_arenas_page_unabandon(mi_page_t* page, mi_theap_t* current_theapx /* can be NULL */);
 bool          _mi_arenas_page_try_reabandon_to_mapped(mi_page_t* page);
+void          _mi_arena_pages_free(mi_arena_pages_t* arena_pages);  // Bun parity P10b, #317: frees the on-demand abandoned bitmaps then `arena_pages` itself
 
 // "page-map.c"
 bool          _mi_page_map_init(void);
@@ -10339,6 +10352,12 @@ mi_decl_nodiscard static inline bool mi_bbitmap_try_find_and_clearN(mi_bbitmap_t
 #error "The page_t.page_ma_offset field is not large enough to cover a full arena"
 #endif
 
+// Bun parity P10b (#317), ported from oven-sh/mimalloc @ 787be2a8, MIT: the per-bin abandoned
+// bitmaps of `mi_arena_pages_t` are allocated lazily, on first abandon. See the definitions
+// below (near `mi_arena_pages_alloc`) for the allocation/publish protocol.
+static mi_bitmap_t* mi_arena_pages_abandoned(mi_arena_pages_t* arena_pages, size_t bin);
+static mi_bitmap_t* mi_arena_pages_abandoned_ensure(mi_arena_t* arena, mi_arena_pages_t* arena_pages, size_t bin);
+
 /* -----------------------------------------------------------
   Arena id's
 ----------------------------------------------------------- */
@@ -11044,9 +11063,9 @@ static mi_page_t* mi_arenas_page_try_find_abandoned(mi_theap_t* theap, size_t sl
   mi_forall_suitable_arenas(heap, req_arena, tseq, match_numa, any_numa, allow_large, arena)
   {
     mi_arena_pages_t* const arena_pages = mi_heap_arena_pages(heap, arena);
-    if (arena_pages != NULL) {
+    mi_bitmap_t* const bitmap = (arena_pages != NULL ? mi_arena_pages_abandoned(arena_pages, bin) : NULL);
+    if (bitmap != NULL) {
       size_t slice_index;
-      mi_bitmap_t* const bitmap = arena_pages->pages_abandoned[bin];
 
       if (mi_bitmap_try_find_and_claim(bitmap, tseq, &slice_index, &mi_arena_try_claim_abandoned, arena)) {
         // found an abandoned page of the right size
@@ -11431,7 +11450,7 @@ static void mi_arenas_page_free_prim(mi_page_t* page, mi_subproc_t* subproc, mi_
     mi_arena_t* const arena = mi_arena_from_memid(page->memid, &slice_index, &slice_count);
     mi_assert_internal(mi_bbitmap_is_clearN(arena->slices_free, slice_index, slice_count));
     mi_assert_internal(mi_page_slice_committed(page) > 0 || mi_bitmap_is_setN(arena->slices_committed, slice_index, slice_count));
-    mi_assert_internal(bin >= MI_ARENA_BIN_COUNT || mi_bitmap_is_clearN(arena_pages->pages_abandoned[bin], slice_index, 1));
+    mi_assert_internal(bin >= MI_ARENA_BIN_COUNT || mi_arena_pages_abandoned(arena_pages, bin) == NULL || mi_bitmap_is_clearN(mi_arena_pages_abandoned(arena_pages, bin), slice_index, 1));
     // adapted from oven-sh/mimalloc @ 942b8342, MIT (issue #271 / Bun parity P6, commit
     // 8286bfb6): dropped `mi_assert_internal(mi_bitmap_is_setN(arena_pages->pages, slice_index, 1))`.
     // No longer holds under the heap delete/destroy claim protocol: a concurrent
@@ -11582,8 +11601,11 @@ void _mi_arenas_page_abandon(mi_page_t* page, mi_theap_t* current_theap) {
   // mi_assert_internal(current_theap == _mi_page_associated_theap(page));
 
   // add to abandoned?
-  mi_heap_t* heap = mi_page_heap(page); 
-  if (page->memid.memkind==MI_MEM_ARENA && !mi_page_is_full(page)) {
+  // (not for a heap that is being released: its teardown claims every page through `pages`
+  // -- see the `heap->releasing` guard placement in `mi_heap_detach_theaps`, src/heap.c,
+  // Bun parity P10b, #317, ported from oven-sh/mimalloc @ 91218f30, MIT.)
+  mi_heap_t* heap = mi_page_heap(page);
+  if (page->memid.memkind==MI_MEM_ARENA && !mi_page_is_full(page) && mi_atomic_load_relaxed(&heap->releasing) == 0) {
     // make available for allocations
     size_t bin = _mi_bin(mi_page_block_size(page));
     mi_assert_internal(bin < MI_ARENA_BIN_COUNT);
@@ -11598,13 +11620,20 @@ void _mi_arenas_page_abandon(mi_page_t* page, mi_theap_t* current_theap) {
       mi_assert_internal(mi_page_slice_committed(page) > 0 || mi_bitmap_is_setN(arena->slices_committed, slice_index, slice_count));
       mi_assert_internal(mi_bitmap_is_setN(arena->slices_dirty, slice_index, slice_count));
 
-      mi_page_set_abandoned_mapped(page);
-      const bool was_clear = mi_bitmap_set(arena_pages->pages_abandoned[bin], slice_index);
-      MI_UNUSED(was_clear); mi_assert_internal(was_clear);
-      mi_atomic_increment_relaxed(&heap->abandoned_count[bin]);
-      mi_theap_stat_increase(current_theap, pages_abandoned, 1);
-      mi_abandoned_page_unown(page, current_theap);
-      return;
+      // Bun parity P10b (#317), ported from oven-sh/mimalloc @ 787be2a8, MIT: the bin's
+      // abandoned bitmap is allocated on first use. If that allocation fails, fall through
+      // and abandon the page unmapped, like a full page: it stays reachable through `pages`
+      // and is reclaimed once a block in it is freed.
+      mi_bitmap_t* const bitmap = mi_arena_pages_abandoned_ensure(arena, arena_pages, bin);
+      if mi_likely(bitmap != NULL) {
+        mi_page_set_abandoned_mapped(page);
+        const bool was_clear = mi_bitmap_set(bitmap, slice_index);
+        MI_UNUSED(was_clear); mi_assert_internal(was_clear);
+        mi_atomic_increment_relaxed(&heap->abandoned_count[bin]);
+        mi_theap_stat_increase(current_theap, pages_abandoned, 1);
+        mi_abandoned_page_unown(page, current_theap);
+        return;
+      }
     }
   }
   // otherwise,
@@ -11636,6 +11665,11 @@ bool _mi_arenas_page_try_reabandon_to_mapped(mi_page_t* page) {
   mi_assert_internal(!mi_page_all_free(page));
   mi_assert_internal(!mi_page_is_singleton(page));
   if (mi_page_is_full(page) || mi_page_is_abandoned_mapped(page) || page->memid.memkind != MI_MEM_ARENA) {
+    return false;
+  }
+  else if (mi_atomic_load_relaxed(&mi_page_heap(page)->releasing) != 0) {
+    // Bun parity P10b (#317): the heap is being released and claims the page through `pages`
+    // (see the `heap->releasing` guard placement in `mi_heap_detach_theaps`, src/heap.c).
     return false;
   }
   else {
@@ -11676,7 +11710,9 @@ void _mi_arenas_page_unabandon(mi_page_t* page, mi_theap_t* current_theapx) {
     mi_assert_internal(mi_page_slice_committed(page) > 0 || mi_bitmap_is_setN(arena->slices_committed, slice_index, slice_count));
 
     // this busy waits until a concurrent reader (from alloc_abandoned) is done
-    mi_bitmap_clear_once_set(arena->subproc, arena_pages->pages_abandoned[bin], slice_index);
+    mi_bitmap_t* const bitmap = mi_arena_pages_abandoned(arena_pages, bin);
+    mi_assert_internal(bitmap != NULL);  // a mapped page was set in it
+    mi_bitmap_clear_once_set(arena->subproc, bitmap, slice_index);
     mi_page_clear_abandoned_mapped(page);
     mi_atomic_decrement_relaxed(&heap->abandoned_count[bin]);
   }
@@ -11768,7 +11804,8 @@ void _mi_arenas_purge_abandoned_holes(mi_heap_t* heap, mi_tld_t* tld) {
       // singleton bins have no abandoned bitmap (upstream ad1bcdbf, to shrink arena meta).
       for (size_t bin = 0; bin < MI_ARENA_BIN_COUNT; bin++) {
         if (mi_atomic_load_relaxed(&heap->abandoned_count[bin]) == 0) continue;
-        mi_bitmap_t* const bitmap = arena_pages->pages_abandoned[bin];
+        mi_bitmap_t* const bitmap = mi_arena_pages_abandoned(arena_pages, bin);
+        if (bitmap == NULL) continue;
         mi_purge_holes_arg_t parg = { bitmap, tld };
         (void)_mi_bitmap_forall_set(bitmap, &mi_arena_page_purge_holes_at, arena, &parg);
       }
@@ -11811,7 +11848,8 @@ void _mi_arenas_holes_report(mi_heap_t* heap, mi_holes_report_t* rep) {
     if (arena_pages != NULL) {
       for (size_t bin = 0; bin < MI_ARENA_BIN_COUNT; bin++) {   // see above: not MI_BIN_COUNT
         if (mi_atomic_load_relaxed(&heap->abandoned_count[bin]) == 0) continue;
-        mi_arena_holes_report_arg_t ra = { arena_pages->pages_abandoned[bin], rep };
+        mi_arena_holes_report_arg_t ra = { mi_arena_pages_abandoned(arena_pages, bin), rep };
+        if (ra.bitmap == NULL) continue;
         (void)_mi_bitmap_forall_set(ra.bitmap, &mi_arena_page_holes_report_at, arena, &ra);
       }
     }
@@ -12045,8 +12083,7 @@ static size_t mi_arena_pages_size(size_t slice_count, size_t* bitmap_base) {
   if (slice_count == 0) slice_count = MI_BCHUNK_BITS;
   mi_assert_internal((slice_count % MI_BCHUNK_BITS) == 0);
   const size_t base_size = _mi_align_up(sizeof(mi_arena_pages_t), MI_BCHUNK_SIZE);
-  const size_t bitmaps_count = 1 + MI_ARENA_BIN_COUNT; // pages, and abandoned
-  const size_t bitmaps_size = bitmaps_count * mi_bitmap_size(slice_count, NULL);
+  const size_t bitmaps_size = mi_bitmap_size(slice_count, NULL); // pages (the abandoned bitmaps are allocated on demand, Bun parity P10b #317)
   const size_t size = base_size + bitmaps_size;
   if (bitmap_base != NULL) *bitmap_base = base_size;
   return size;
@@ -12056,7 +12093,7 @@ static size_t mi_arena_info_slices_needed(size_t slice_count, size_t* bitmap_bas
   if (slice_count == 0) slice_count = MI_BCHUNK_BITS;
   mi_assert_internal((slice_count % MI_BCHUNK_BITS) == 0);
   const size_t base_size = _mi_align_up(sizeof(mi_arena_t), MI_BCHUNK_SIZE);
-  const size_t bitmaps_count = 4 + MI_ARENA_BIN_COUNT; // commit, dirty, purge, pages, and abandoned
+  const size_t bitmaps_count = 4; // commit, dirty, purge, and pages (the abandoned bitmaps are allocated on demand, Bun parity P10b #317)
   const size_t bitmaps_size = bitmaps_count * mi_bitmap_size(slice_count, NULL) + mi_bbitmap_size(slice_count, NULL); // + free
   #if MI_PAGE_META_IS_SEPARATED
   const size_t pages_size = slice_count * sizeof(mi_page_t);
@@ -12094,10 +12131,85 @@ static mi_arena_pages_t* mi_arena_pages_alloc(mi_arena_t* arena) {
   uint8_t* base = (uint8_t*)arena_pages + bitmap_base;
   mi_assert_internal(_mi_is_aligned(base, MI_BCHUNK_SIZE));
   arena_pages->pages = mi_arena_bitmap_init(slice_count, &base);
-  for (size_t i = 0; i < MI_ARENA_BIN_COUNT; i++) {
-    arena_pages->pages_abandoned[i] = mi_arena_bitmap_init(slice_count, &base);
-  }
+  // `pages_abandoned[]` stays NULL (the allocation is zeroed) until a page of that bin is
+  // abandoned -- Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.
   return arena_pages;
+}
+
+// The abandoned-pages bitmap of `bin`, or NULL if no page of that bin was ever abandoned in
+// this (heap, arena) pair. A NULL bitmap reads as all-clear.
+// Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.
+static mi_bitmap_t* mi_arena_pages_abandoned(mi_arena_pages_t* arena_pages, size_t bin) {
+  mi_assert_internal(bin < MI_ARENA_BIN_COUNT);
+  return mi_atomic_load_ptr_acquire(mi_bitmap_t, &arena_pages->pages_abandoned[bin]);
+}
+
+#if MI_DEBUG > 0
+mi_decl_export _Atomic(uintptr_t) mi_debug_abandoned_maps_allocated;  // test hook (test-abandoned-lazy.c): per-bin abandoned maps published so far (Bun parity P10b, #317)
+#endif
+
+// The abandoned-pages bitmap of `bin`, allocated on first use. Allocated from the subproc
+// meta-data heap (`_mi_meta_zalloc_aligned`) so this is safe on the abandon paths (a thread
+// tearing down its theaps, a foreign free re-abandoning a page), where allocating from a
+// regular heap is not -- see CLAUDE.md rule 4 and issue #317 (2.3): this is allocator
+// metadata, not profiler-internal memory, and the meta theap is the same allocator
+// `_mi_thread_local_create` (threadlocal.c) already uses for the thread-local slot bitmap.
+// Publishing is a CAS so no lock is needed: a loser frees its copy with
+// `_mi_free_subproc_safe` and uses the winner's. Returns NULL only if the allocation failed.
+//
+// New lock order edge: `heap->theaps_lock` -> `subproc->theap_meta_lock`. Already consistent
+// with src/fork.c's documented order (MI_FORK_LOCK_THEAPS=3 precedes MI_FORK_LOCK_THEAP_META=7);
+// see the comment added there for the new call chain.
+// Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.
+static mi_bitmap_t* mi_arena_pages_abandoned_ensure(mi_arena_t* arena, mi_arena_pages_t* arena_pages, size_t bin) {
+  mi_bitmap_t* bitmap = mi_arena_pages_abandoned(arena_pages, bin);
+  if mi_likely(bitmap != NULL) return bitmap;
+  const size_t slice_count = arena->slice_count;
+  const size_t size = mi_bitmap_size(slice_count, NULL);
+  mi_bitmap_t* fresh = (mi_bitmap_t*)_mi_meta_zalloc_aligned(arena->subproc, size, MI_BCHUNK_SIZE, NULL);
+  if (fresh == NULL) return NULL;
+  mi_bitmap_init(fresh, slice_count, true /* already zero */);
+  mi_bitmap_t* expected = NULL;
+  if (mi_atomic_cas_ptr_strong_acq_rel(mi_bitmap_t, &arena_pages->pages_abandoned[bin], &expected, fresh)) {
+    #if MI_DEBUG > 0
+    mi_atomic_increment_relaxed(&mi_debug_abandoned_maps_allocated);
+    #endif
+    return fresh;
+  }
+  // another thread published one first
+  _mi_free_subproc_safe(fresh);
+  mi_assert_internal(expected != NULL);
+  return expected;
+}
+
+// Release the on-demand abandoned bitmaps of a heap's arena pages (the `pages` bitmap is part
+// of the `arena_pages` allocation itself).
+//
+// Lifetime invariant (this is the scavenger interaction, issue #317 2.4): the hole sweep
+// (`_mi_arenas_purge_abandoned_holes`, above) and the hole report (`_mi_arenas_holes_report`,
+// above) read `arena_pages->pages_abandoned[bin]` while holding `tld->theaps_lock` for the
+// whole walk (see src/page-holes.c), and that lock is what keeps the heap alive (a heap is
+// only freed after `_mi_heap_detach_theaps` detached every theap of it, and detaching needs
+// that lock). `_mi_arena_pages_free` runs strictly later still, inside `mi_heap_free` under
+// `heap->arena_pages_lock`. So the same argument that already keeps the heap alive keeps its
+// per-bin bitmaps alive -- but only because this free is in `mi_heap_free` and not earlier: a
+// future refactor must not move it up.
+// Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.
+static void mi_arena_pages_free_abandoned(mi_arena_pages_t* arena_pages) {
+  for (size_t bin = 0; bin < MI_ARENA_BIN_COUNT; bin++) {
+    if (mi_atomic_load_ptr_relaxed(mi_bitmap_t, &arena_pages->pages_abandoned[bin]) == NULL) continue;  // the common case
+    mi_bitmap_t* bitmap = mi_atomic_exchange_ptr_acq_rel(mi_bitmap_t, &arena_pages->pages_abandoned[bin], NULL);
+    if (bitmap != NULL) { _mi_free_subproc_safe(bitmap); }
+  }
+}
+
+// Caller (`mi_heap_free`, heap.c) asserts the lifetime invariant documented above -- that the
+// heap is already off `subproc->heaps` and `heap->theaps == NULL` -- right before this call,
+// where `heap` is in scope; this function itself has no handle to the owning heap.
+void _mi_arena_pages_free(mi_arena_pages_t* arena_pages) {
+  if (arena_pages == NULL) return;
+  mi_arena_pages_free_abandoned(arena_pages);
+  _mi_free_subproc_safe(arena_pages);
 }
 
 static mi_arena_t* mi_arena_initialize(mi_subproc_t* subproc, void* start,
@@ -12178,8 +12290,11 @@ static mi_arena_t* mi_arena_initialize(mi_subproc_t* subproc, void* start,
   arena->slices_dirty = mi_arena_bitmap_init(slice_count, &base);
   arena->slices_purge = mi_arena_bitmap_init(slice_count, &base);
   arena->pages_main.pages = mi_arena_bitmap_init(slice_count, &base);
+  // Allocated on first abandon (Bun parity P10b, #317, ported from oven-sh/mimalloc @
+  // 787be2a8, MIT); the arena's own memory is not yet fully zeroed at this point in every
+  // memid path (`memid.initially_zero`), so store explicitly rather than relying on that.
   for (size_t i = 0; i < MI_ARENA_BIN_COUNT; i++) {
-    arena->pages_main.pages_abandoned[i] = mi_arena_bitmap_init(slice_count, &base);
+    mi_atomic_store_ptr_relaxed(mi_bitmap_t, &arena->pages_main.pages_abandoned[i], NULL);
   }
   #if MI_PAGE_META_IS_SEPARATED
   arena->pages_meta = (mi_page_t*)base;
@@ -13151,7 +13266,9 @@ bool _mi_heap_visit_blocks(mi_heap_t* heap, bool abandoned_only, bool visit_bloc
         for (size_t bin = 0; ok && bin < MI_ARENA_BIN_COUNT; bin++) {
           // todo: if we had a single abandoned page map as well, this can be faster.
           if (mi_atomic_load_relaxed(&heap->abandoned_count[bin]) > 0) {
-            ok = _mi_bitmap_forall_set(arena_pages->pages_abandoned[bin], &mi_heap_visit_page_at, arena, &visit_info);
+            mi_bitmap_t* const bitmap = mi_arena_pages_abandoned(arena_pages, bin);
+            if (bitmap == NULL) continue;
+            ok = _mi_bitmap_forall_set(bitmap, &mi_heap_visit_page_at, arena, &visit_info);
           }
         }
       }
@@ -15842,6 +15959,28 @@ static void mi_heap_detach_theaps(mi_heap_t* heap) {
     }
   }
   _mi_heap_detach_theaps(heap);
+  // Bun parity P10b (#317), ported from oven-sh/mimalloc @ 91218f30, MIT (`heap->releasing`).
+  // Bun sets this inside its `mi_heap_release_pages`, right after `if (_mi_is_heap_main(heap))
+  // return;`. We have no such function/early-return -- this static `mi_heap_detach_theaps` is
+  // our equivalent, called by both `mi_heap_delete` and `_mi_heap_force_destroy` (the latter
+  // also used for a SUBPROC main heap at subproc teardown, issue #128 B1). A bare early return
+  // (Bun's shape) is wrong here: the `_mi_theap_abandon` loop just below still has to run for a
+  // subproc main heap. Setting `releasing` on a main heap would be wrong for the opposite
+  // reason -- a main heap outlives this call and would then abandon every page unmapped
+  // forever, not just for the duration of this detach. `_mi_is_heap_main` is the right guard
+  // for both cases: it resolves via `heap->subproc`, so it is true for a subproc's own
+  // heap_main too (see the provenance comment in `mi_heap_free`, below), which is exactly the
+  // heap this must stay false for.
+  //
+  // Readers: `_mi_arenas_page_abandon` (arena.c) skips the lazy per-bin bitmap entirely once
+  // this is set, so a releasing heap's pages are abandoned unmapped -- reachable only through
+  // `pages`, which the pending `_mi_heap_move_pages`/`_mi_heap_destroy_pages` claim walk
+  // (claim_pages=true) reaches anyway. `_mi_arenas_page_try_reabandon_to_mapped` refuses to
+  // re-map one of this heap's pages for the same reason. This also means a releasing heap
+  // never needs `mi_arena_pages_abandoned_ensure` (and so never takes `subproc->theap_meta_lock`
+  // from inside this loop) -- the case where that edge is actually live is a MAIN heap, which
+  // never sets `releasing` and so is unaffected by any of this.
+  if (!_mi_is_heap_main(heap)) { mi_atomic_store_release(&heap->releasing, (uintptr_t)1); }
   mi_lock(&heap->theaps_lock) { // paranoia
     for (mi_theap_t* theap = heap->theaps; theap != NULL; theap = theap->hnext) {
       mi_assert_internal(_mi_theap_heap_peek(theap)==NULL);  // detached
@@ -15900,14 +16039,28 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
         mi_arena_pages_t* arena_pages = mi_atomic_load_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i]);
         if (arena_pages!=NULL) {
           mi_atomic_store_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i], NULL);
-          // #316 (P10a): this free now collects in-subproc. Safe regardless of whether this
-          // thread is parked: `allow_collect` only reaches `mi_free_block_mt`/
-          // `mi_free_generic_mt` (free.c:mi_free_ex), while `_mi_park_leave_if_parked` lives
-          // only in the separate `mi_free_generic_local` owner-free path (free.c:167) -- so this
-          // can never newly reach the park protocol. `mi_free_try_collect_mt`'s own reclaim
-          // guards (`_mi_thread_is_initialized`, `_mi_page_associated_theap_peek` refusing a
-          // theap of another heap) apply unconditionally.
-          _mi_free_subproc_safe(arena_pages);
+          // #316 (P10a): the final `_mi_free_subproc_safe(arena_pages)` this used to be now
+          // collects in-subproc. Safe regardless of whether this thread is parked:
+          // `allow_collect` only reaches `mi_free_block_mt`/`mi_free_generic_mt`
+          // (free.c:mi_free_ex), while `_mi_park_leave_if_parked` lives only in the separate
+          // `mi_free_generic_local` owner-free path (free.c:167) -- so this can never newly
+          // reach the park protocol. `mi_free_try_collect_mt`'s own reclaim guards
+          // (`_mi_thread_is_initialized`, `_mi_page_associated_theap_peek` refusing a theap of
+          // another heap) apply unconditionally.
+          //
+          // #317 (P10b): switched to `_mi_arena_pages_free`, which also frees the on-demand
+          // per-bin abandoned bitmaps (arena.c) before freeing `arena_pages` itself -- both go
+          // through the same `_mi_free_subproc_safe`, so the P10a audit above still covers it.
+          // Lifetime invariant (see `_mi_arena_pages_free`'s own comment, arena.c): this must
+          // run after the heap is off `subproc->heaps` and every theap of it has been
+          // detached. We are inside `mi_heap_free`, called only after
+          // `mi_heap_detach_theaps`/`_mi_heap_move_pages`(or `_mi_heap_destroy_pages`)/
+          // `mi_heap_free_theaps` have already run (see `mi_heap_delete` /
+          // `_mi_heap_force_destroy`, below) and, for `mi_heap_delete`, strictly before the
+          // heap is unlinked from `subproc->heaps` a few lines down -- so assert the theaps
+          // side of the invariant here, where `heap` is in scope.
+          mi_assert_internal(heap->theaps == NULL);
+          _mi_arena_pages_free(arena_pages);
         }
       }
     }
@@ -16156,6 +16309,18 @@ terms of the MIT license. A copy of the license can be found in the file
                                     -> `mi_theap_free_mem` -> `_mi_meta_free` (theap.c:363)
                                     ... and, for a page owned by `theap_meta`, `mi_free`
                                     -> `mi_stat_free` (free.c:768) takes `theap_meta_lock`
+                                    ... and (Bun parity P10b, #317): `mi_heap_detach_theaps`
+                                    (heap.c) holds `theaps_lock` across its `_mi_theap_abandon`
+                                    loop -> `_mi_page_abandon` -> `_mi_arenas_page_abandon`
+                                    (arena.c) -> `mi_arena_pages_abandoned_ensure` (arena.c) ->
+                                    `_mi_meta_zalloc_aligned`, which takes `theap_meta_lock`.
+                                    Live only for a MAIN heap: a releasing (non-main) heap sets
+                                    `heap->releasing` just before this loop, which makes
+                                    `_mi_arenas_page_abandon` skip the `..._ensure` call
+                                    entirely (see the `heap->releasing` comment in
+                                    `mi_heap_detach_theaps`, heap.c). Same target level as the
+                                    edge above, no reordering needed (MI_FORK_LOCK_THEAPS=3
+                                    already precedes MI_FORK_LOCK_THEAP_META=7 below).
       -> tld->theaps_lock           `_mi_heap_detach_theaps` -- but `mi_lock_TRY_acquire`
                                     with a back-off retry (theap.c:412), so NOT a blocking
                                     edge; see the Phase 7 gap note below

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2d594c0f of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit a63848f5 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit be81f936 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2d594c0f of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/src/arena.c
+++ b/src/arena.c
@@ -1301,7 +1301,23 @@ void _mi_arenas_page_abandon(mi_page_t* page, mi_theap_t* current_theap) {
       // abandoned bitmap is allocated on first use. If that allocation fails, fall through
       // and abandon the page unmapped, like a full page: it stays reachable through `pages`
       // and is reclaimed once a block in it is freed.
-      mi_bitmap_t* const bitmap = mi_arena_pages_abandoned_ensure(arena, arena_pages, bin);
+      //
+      // Defensive guard (Opus review of #319): never call `mi_arena_pages_abandoned_ensure`
+      // -> `_mi_meta_zalloc_aligned` for a page belonging to the subproc's own meta theap.
+      // That would re-enter `subproc->theap_meta_lock` non-recursively: `_mi_meta_zalloc_aligned`
+      // (subproc.c) holds the lock across a full `mi_theap_zalloc_aligned` on `theap_meta`,
+      // whose slow path can retire a full page of `theap_meta` itself (`mi_page_to_full`,
+      // page.c) into `_mi_page_abandon` -> here -> `..._ensure` -> the same lock again.
+      // `subproc.c`'s `mi_subproc_new` now sets `theap_meta->allow_page_abandon = false` (like
+      // `init.c`'s process theap_meta) to close the live path -- a meta theap's pages are
+      // never abandoned at all, so `_mi_page_abandon` should never reach here for one -- but a
+      // self-edge like this cannot be resolved by the MI_FORK_LOCK_* ordering (that orders
+      // acquisition across DIFFERENT call sites, not a lock against itself on one stack), so
+      // keep this check as belt and braces against a future option/call-graph change.
+      mi_bitmap_t* bitmap = NULL;
+      if (!_mi_meta_is_meta_page_safe(page)) {
+        bitmap = mi_arena_pages_abandoned_ensure(arena, arena_pages, bin);
+      }
       if mi_likely(bitmap != NULL) {
         mi_page_set_abandoned_mapped(page);
         const bool was_clear = mi_bitmap_set(bitmap, slice_index);
@@ -1970,6 +1986,16 @@ static mi_arena_t* mi_arena_initialize(mi_subproc_t* subproc, void* start,
   // Allocated on first abandon (Bun parity P10b, #317, ported from oven-sh/mimalloc @
   // 787be2a8, MIT); the arena's own memory is not yet fully zeroed at this point in every
   // memid path (`memid.initially_zero`), so store explicitly rather than relying on that.
+  //
+  // Not a leak (Opus review of #319): unlike a regular heap's `arena_pages` (freed by
+  // `_mi_arena_pages_free` in `mi_heap_free`, see below), `pages_main`'s on-demand bitmaps
+  // are never explicitly freed anywhere -- `mi_heap_free` skips the whole arena-pages loop
+  // for the main heap (`if (!is_main)`, src/heap.c), since `pages_main` is embedded in the
+  // arena itself, not a separately allocated `arena_pages`. Each bitmap is allocated from
+  // `arena->subproc`'s meta theap (`mi_arena_pages_abandoned_ensure`), which is itself backed
+  // by the same arenas -- so this is exactly the same "lives as long as the arena/subproc it
+  // is part of, freed only by tearing the whole arena down" lifetime `arena->slices_free` /
+  // `arena->pages_main.pages` already have, not a new leak class.
   for (size_t i = 0; i < MI_ARENA_BIN_COUNT; i++) {
     mi_atomic_store_ptr_relaxed(mi_bitmap_t, &arena->pages_main.pages_abandoned[i], NULL);
   }

--- a/src/arena.c
+++ b/src/arena.c
@@ -29,6 +29,12 @@ The arena allocation needs to be thread safe and we use an atomic bitmap to allo
 #error "The page_t.page_ma_offset field is not large enough to cover a full arena"
 #endif
 
+// Bun parity P10b (#317), ported from oven-sh/mimalloc @ 787be2a8, MIT: the per-bin abandoned
+// bitmaps of `mi_arena_pages_t` are allocated lazily, on first abandon. See the definitions
+// below (near `mi_arena_pages_alloc`) for the allocation/publish protocol.
+static mi_bitmap_t* mi_arena_pages_abandoned(mi_arena_pages_t* arena_pages, size_t bin);
+static mi_bitmap_t* mi_arena_pages_abandoned_ensure(mi_arena_t* arena, mi_arena_pages_t* arena_pages, size_t bin);
+
 /* -----------------------------------------------------------
   Arena id's
 ----------------------------------------------------------- */
@@ -734,9 +740,9 @@ static mi_page_t* mi_arenas_page_try_find_abandoned(mi_theap_t* theap, size_t sl
   mi_forall_suitable_arenas(heap, req_arena, tseq, match_numa, any_numa, allow_large, arena)
   {
     mi_arena_pages_t* const arena_pages = mi_heap_arena_pages(heap, arena);
-    if (arena_pages != NULL) {
+    mi_bitmap_t* const bitmap = (arena_pages != NULL ? mi_arena_pages_abandoned(arena_pages, bin) : NULL);
+    if (bitmap != NULL) {
       size_t slice_index;
-      mi_bitmap_t* const bitmap = arena_pages->pages_abandoned[bin];
 
       if (mi_bitmap_try_find_and_claim(bitmap, tseq, &slice_index, &mi_arena_try_claim_abandoned, arena)) {
         // found an abandoned page of the right size
@@ -1121,7 +1127,7 @@ static void mi_arenas_page_free_prim(mi_page_t* page, mi_subproc_t* subproc, mi_
     mi_arena_t* const arena = mi_arena_from_memid(page->memid, &slice_index, &slice_count);
     mi_assert_internal(mi_bbitmap_is_clearN(arena->slices_free, slice_index, slice_count));
     mi_assert_internal(mi_page_slice_committed(page) > 0 || mi_bitmap_is_setN(arena->slices_committed, slice_index, slice_count));
-    mi_assert_internal(bin >= MI_ARENA_BIN_COUNT || mi_bitmap_is_clearN(arena_pages->pages_abandoned[bin], slice_index, 1));
+    mi_assert_internal(bin >= MI_ARENA_BIN_COUNT || mi_arena_pages_abandoned(arena_pages, bin) == NULL || mi_bitmap_is_clearN(mi_arena_pages_abandoned(arena_pages, bin), slice_index, 1));
     // adapted from oven-sh/mimalloc @ 942b8342, MIT (issue #271 / Bun parity P6, commit
     // 8286bfb6): dropped `mi_assert_internal(mi_bitmap_is_setN(arena_pages->pages, slice_index, 1))`.
     // No longer holds under the heap delete/destroy claim protocol: a concurrent
@@ -1272,8 +1278,11 @@ void _mi_arenas_page_abandon(mi_page_t* page, mi_theap_t* current_theap) {
   // mi_assert_internal(current_theap == _mi_page_associated_theap(page));
 
   // add to abandoned?
-  mi_heap_t* heap = mi_page_heap(page); 
-  if (page->memid.memkind==MI_MEM_ARENA && !mi_page_is_full(page)) {
+  // (not for a heap that is being released: its teardown claims every page through `pages`
+  // -- see the `heap->releasing` guard placement in `mi_heap_detach_theaps`, src/heap.c,
+  // Bun parity P10b, #317, ported from oven-sh/mimalloc @ 91218f30, MIT.)
+  mi_heap_t* heap = mi_page_heap(page);
+  if (page->memid.memkind==MI_MEM_ARENA && !mi_page_is_full(page) && mi_atomic_load_relaxed(&heap->releasing) == 0) {
     // make available for allocations
     size_t bin = _mi_bin(mi_page_block_size(page));
     mi_assert_internal(bin < MI_ARENA_BIN_COUNT);
@@ -1288,13 +1297,20 @@ void _mi_arenas_page_abandon(mi_page_t* page, mi_theap_t* current_theap) {
       mi_assert_internal(mi_page_slice_committed(page) > 0 || mi_bitmap_is_setN(arena->slices_committed, slice_index, slice_count));
       mi_assert_internal(mi_bitmap_is_setN(arena->slices_dirty, slice_index, slice_count));
 
-      mi_page_set_abandoned_mapped(page);
-      const bool was_clear = mi_bitmap_set(arena_pages->pages_abandoned[bin], slice_index);
-      MI_UNUSED(was_clear); mi_assert_internal(was_clear);
-      mi_atomic_increment_relaxed(&heap->abandoned_count[bin]);
-      mi_theap_stat_increase(current_theap, pages_abandoned, 1);
-      mi_abandoned_page_unown(page, current_theap);
-      return;
+      // Bun parity P10b (#317), ported from oven-sh/mimalloc @ 787be2a8, MIT: the bin's
+      // abandoned bitmap is allocated on first use. If that allocation fails, fall through
+      // and abandon the page unmapped, like a full page: it stays reachable through `pages`
+      // and is reclaimed once a block in it is freed.
+      mi_bitmap_t* const bitmap = mi_arena_pages_abandoned_ensure(arena, arena_pages, bin);
+      if mi_likely(bitmap != NULL) {
+        mi_page_set_abandoned_mapped(page);
+        const bool was_clear = mi_bitmap_set(bitmap, slice_index);
+        MI_UNUSED(was_clear); mi_assert_internal(was_clear);
+        mi_atomic_increment_relaxed(&heap->abandoned_count[bin]);
+        mi_theap_stat_increase(current_theap, pages_abandoned, 1);
+        mi_abandoned_page_unown(page, current_theap);
+        return;
+      }
     }
   }
   // otherwise,
@@ -1326,6 +1342,11 @@ bool _mi_arenas_page_try_reabandon_to_mapped(mi_page_t* page) {
   mi_assert_internal(!mi_page_all_free(page));
   mi_assert_internal(!mi_page_is_singleton(page));
   if (mi_page_is_full(page) || mi_page_is_abandoned_mapped(page) || page->memid.memkind != MI_MEM_ARENA) {
+    return false;
+  }
+  else if (mi_atomic_load_relaxed(&mi_page_heap(page)->releasing) != 0) {
+    // Bun parity P10b (#317): the heap is being released and claims the page through `pages`
+    // (see the `heap->releasing` guard placement in `mi_heap_detach_theaps`, src/heap.c).
     return false;
   }
   else {
@@ -1366,7 +1387,9 @@ void _mi_arenas_page_unabandon(mi_page_t* page, mi_theap_t* current_theapx) {
     mi_assert_internal(mi_page_slice_committed(page) > 0 || mi_bitmap_is_setN(arena->slices_committed, slice_index, slice_count));
 
     // this busy waits until a concurrent reader (from alloc_abandoned) is done
-    mi_bitmap_clear_once_set(arena->subproc, arena_pages->pages_abandoned[bin], slice_index);
+    mi_bitmap_t* const bitmap = mi_arena_pages_abandoned(arena_pages, bin);
+    mi_assert_internal(bitmap != NULL);  // a mapped page was set in it
+    mi_bitmap_clear_once_set(arena->subproc, bitmap, slice_index);
     mi_page_clear_abandoned_mapped(page);
     mi_atomic_decrement_relaxed(&heap->abandoned_count[bin]);
   }
@@ -1458,7 +1481,8 @@ void _mi_arenas_purge_abandoned_holes(mi_heap_t* heap, mi_tld_t* tld) {
       // singleton bins have no abandoned bitmap (upstream ad1bcdbf, to shrink arena meta).
       for (size_t bin = 0; bin < MI_ARENA_BIN_COUNT; bin++) {
         if (mi_atomic_load_relaxed(&heap->abandoned_count[bin]) == 0) continue;
-        mi_bitmap_t* const bitmap = arena_pages->pages_abandoned[bin];
+        mi_bitmap_t* const bitmap = mi_arena_pages_abandoned(arena_pages, bin);
+        if (bitmap == NULL) continue;
         mi_purge_holes_arg_t parg = { bitmap, tld };
         (void)_mi_bitmap_forall_set(bitmap, &mi_arena_page_purge_holes_at, arena, &parg);
       }
@@ -1501,7 +1525,8 @@ void _mi_arenas_holes_report(mi_heap_t* heap, mi_holes_report_t* rep) {
     if (arena_pages != NULL) {
       for (size_t bin = 0; bin < MI_ARENA_BIN_COUNT; bin++) {   // see above: not MI_BIN_COUNT
         if (mi_atomic_load_relaxed(&heap->abandoned_count[bin]) == 0) continue;
-        mi_arena_holes_report_arg_t ra = { arena_pages->pages_abandoned[bin], rep };
+        mi_arena_holes_report_arg_t ra = { mi_arena_pages_abandoned(arena_pages, bin), rep };
+        if (ra.bitmap == NULL) continue;
         (void)_mi_bitmap_forall_set(ra.bitmap, &mi_arena_page_holes_report_at, arena, &ra);
       }
     }
@@ -1735,8 +1760,7 @@ static size_t mi_arena_pages_size(size_t slice_count, size_t* bitmap_base) {
   if (slice_count == 0) slice_count = MI_BCHUNK_BITS;
   mi_assert_internal((slice_count % MI_BCHUNK_BITS) == 0);
   const size_t base_size = _mi_align_up(sizeof(mi_arena_pages_t), MI_BCHUNK_SIZE);
-  const size_t bitmaps_count = 1 + MI_ARENA_BIN_COUNT; // pages, and abandoned
-  const size_t bitmaps_size = bitmaps_count * mi_bitmap_size(slice_count, NULL);
+  const size_t bitmaps_size = mi_bitmap_size(slice_count, NULL); // pages (the abandoned bitmaps are allocated on demand, Bun parity P10b #317)
   const size_t size = base_size + bitmaps_size;
   if (bitmap_base != NULL) *bitmap_base = base_size;
   return size;
@@ -1746,7 +1770,7 @@ static size_t mi_arena_info_slices_needed(size_t slice_count, size_t* bitmap_bas
   if (slice_count == 0) slice_count = MI_BCHUNK_BITS;
   mi_assert_internal((slice_count % MI_BCHUNK_BITS) == 0);
   const size_t base_size = _mi_align_up(sizeof(mi_arena_t), MI_BCHUNK_SIZE);
-  const size_t bitmaps_count = 4 + MI_ARENA_BIN_COUNT; // commit, dirty, purge, pages, and abandoned
+  const size_t bitmaps_count = 4; // commit, dirty, purge, and pages (the abandoned bitmaps are allocated on demand, Bun parity P10b #317)
   const size_t bitmaps_size = bitmaps_count * mi_bitmap_size(slice_count, NULL) + mi_bbitmap_size(slice_count, NULL); // + free
   #if MI_PAGE_META_IS_SEPARATED
   const size_t pages_size = slice_count * sizeof(mi_page_t);
@@ -1784,10 +1808,85 @@ static mi_arena_pages_t* mi_arena_pages_alloc(mi_arena_t* arena) {
   uint8_t* base = (uint8_t*)arena_pages + bitmap_base;
   mi_assert_internal(_mi_is_aligned(base, MI_BCHUNK_SIZE));
   arena_pages->pages = mi_arena_bitmap_init(slice_count, &base);
-  for (size_t i = 0; i < MI_ARENA_BIN_COUNT; i++) {
-    arena_pages->pages_abandoned[i] = mi_arena_bitmap_init(slice_count, &base);
-  }
+  // `pages_abandoned[]` stays NULL (the allocation is zeroed) until a page of that bin is
+  // abandoned -- Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.
   return arena_pages;
+}
+
+// The abandoned-pages bitmap of `bin`, or NULL if no page of that bin was ever abandoned in
+// this (heap, arena) pair. A NULL bitmap reads as all-clear.
+// Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.
+static mi_bitmap_t* mi_arena_pages_abandoned(mi_arena_pages_t* arena_pages, size_t bin) {
+  mi_assert_internal(bin < MI_ARENA_BIN_COUNT);
+  return mi_atomic_load_ptr_acquire(mi_bitmap_t, &arena_pages->pages_abandoned[bin]);
+}
+
+#if MI_DEBUG > 0
+mi_decl_export _Atomic(uintptr_t) mi_debug_abandoned_maps_allocated;  // test hook (test-abandoned-lazy.c): per-bin abandoned maps published so far (Bun parity P10b, #317)
+#endif
+
+// The abandoned-pages bitmap of `bin`, allocated on first use. Allocated from the subproc
+// meta-data heap (`_mi_meta_zalloc_aligned`) so this is safe on the abandon paths (a thread
+// tearing down its theaps, a foreign free re-abandoning a page), where allocating from a
+// regular heap is not -- see CLAUDE.md rule 4 and issue #317 (2.3): this is allocator
+// metadata, not profiler-internal memory, and the meta theap is the same allocator
+// `_mi_thread_local_create` (threadlocal.c) already uses for the thread-local slot bitmap.
+// Publishing is a CAS so no lock is needed: a loser frees its copy with
+// `_mi_free_subproc_safe` and uses the winner's. Returns NULL only if the allocation failed.
+//
+// New lock order edge: `heap->theaps_lock` -> `subproc->theap_meta_lock`. Already consistent
+// with src/fork.c's documented order (MI_FORK_LOCK_THEAPS=3 precedes MI_FORK_LOCK_THEAP_META=7);
+// see the comment added there for the new call chain.
+// Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.
+static mi_bitmap_t* mi_arena_pages_abandoned_ensure(mi_arena_t* arena, mi_arena_pages_t* arena_pages, size_t bin) {
+  mi_bitmap_t* bitmap = mi_arena_pages_abandoned(arena_pages, bin);
+  if mi_likely(bitmap != NULL) return bitmap;
+  const size_t slice_count = arena->slice_count;
+  const size_t size = mi_bitmap_size(slice_count, NULL);
+  mi_bitmap_t* fresh = (mi_bitmap_t*)_mi_meta_zalloc_aligned(arena->subproc, size, MI_BCHUNK_SIZE, NULL);
+  if (fresh == NULL) return NULL;
+  mi_bitmap_init(fresh, slice_count, true /* already zero */);
+  mi_bitmap_t* expected = NULL;
+  if (mi_atomic_cas_ptr_strong_acq_rel(mi_bitmap_t, &arena_pages->pages_abandoned[bin], &expected, fresh)) {
+    #if MI_DEBUG > 0
+    mi_atomic_increment_relaxed(&mi_debug_abandoned_maps_allocated);
+    #endif
+    return fresh;
+  }
+  // another thread published one first
+  _mi_free_subproc_safe(fresh);
+  mi_assert_internal(expected != NULL);
+  return expected;
+}
+
+// Release the on-demand abandoned bitmaps of a heap's arena pages (the `pages` bitmap is part
+// of the `arena_pages` allocation itself).
+//
+// Lifetime invariant (this is the scavenger interaction, issue #317 2.4): the hole sweep
+// (`_mi_arenas_purge_abandoned_holes`, above) and the hole report (`_mi_arenas_holes_report`,
+// above) read `arena_pages->pages_abandoned[bin]` while holding `tld->theaps_lock` for the
+// whole walk (see src/page-holes.c), and that lock is what keeps the heap alive (a heap is
+// only freed after `_mi_heap_detach_theaps` detached every theap of it, and detaching needs
+// that lock). `_mi_arena_pages_free` runs strictly later still, inside `mi_heap_free` under
+// `heap->arena_pages_lock`. So the same argument that already keeps the heap alive keeps its
+// per-bin bitmaps alive -- but only because this free is in `mi_heap_free` and not earlier: a
+// future refactor must not move it up.
+// Bun parity P10b, #317, ported from oven-sh/mimalloc @ 787be2a8, MIT.
+static void mi_arena_pages_free_abandoned(mi_arena_pages_t* arena_pages) {
+  for (size_t bin = 0; bin < MI_ARENA_BIN_COUNT; bin++) {
+    if (mi_atomic_load_ptr_relaxed(mi_bitmap_t, &arena_pages->pages_abandoned[bin]) == NULL) continue;  // the common case
+    mi_bitmap_t* bitmap = mi_atomic_exchange_ptr_acq_rel(mi_bitmap_t, &arena_pages->pages_abandoned[bin], NULL);
+    if (bitmap != NULL) { _mi_free_subproc_safe(bitmap); }
+  }
+}
+
+// Caller (`mi_heap_free`, heap.c) asserts the lifetime invariant documented above -- that the
+// heap is already off `subproc->heaps` and `heap->theaps == NULL` -- right before this call,
+// where `heap` is in scope; this function itself has no handle to the owning heap.
+void _mi_arena_pages_free(mi_arena_pages_t* arena_pages) {
+  if (arena_pages == NULL) return;
+  mi_arena_pages_free_abandoned(arena_pages);
+  _mi_free_subproc_safe(arena_pages);
 }
 
 static mi_arena_t* mi_arena_initialize(mi_subproc_t* subproc, void* start,
@@ -1868,8 +1967,11 @@ static mi_arena_t* mi_arena_initialize(mi_subproc_t* subproc, void* start,
   arena->slices_dirty = mi_arena_bitmap_init(slice_count, &base);
   arena->slices_purge = mi_arena_bitmap_init(slice_count, &base);
   arena->pages_main.pages = mi_arena_bitmap_init(slice_count, &base);
+  // Allocated on first abandon (Bun parity P10b, #317, ported from oven-sh/mimalloc @
+  // 787be2a8, MIT); the arena's own memory is not yet fully zeroed at this point in every
+  // memid path (`memid.initially_zero`), so store explicitly rather than relying on that.
   for (size_t i = 0; i < MI_ARENA_BIN_COUNT; i++) {
-    arena->pages_main.pages_abandoned[i] = mi_arena_bitmap_init(slice_count, &base);
+    mi_atomic_store_ptr_relaxed(mi_bitmap_t, &arena->pages_main.pages_abandoned[i], NULL);
   }
   #if MI_PAGE_META_IS_SEPARATED
   arena->pages_meta = (mi_page_t*)base;
@@ -2841,7 +2943,9 @@ bool _mi_heap_visit_blocks(mi_heap_t* heap, bool abandoned_only, bool visit_bloc
         for (size_t bin = 0; ok && bin < MI_ARENA_BIN_COUNT; bin++) {
           // todo: if we had a single abandoned page map as well, this can be faster.
           if (mi_atomic_load_relaxed(&heap->abandoned_count[bin]) > 0) {
-            ok = _mi_bitmap_forall_set(arena_pages->pages_abandoned[bin], &mi_heap_visit_page_at, arena, &visit_info);
+            mi_bitmap_t* const bitmap = mi_arena_pages_abandoned(arena_pages, bin);
+            if (bitmap == NULL) continue;
+            ok = _mi_bitmap_forall_set(bitmap, &mi_heap_visit_page_at, arena, &visit_info);
           }
         }
       }

--- a/src/fork.c
+++ b/src/fork.c
@@ -184,6 +184,20 @@ terms of the MIT license. A copy of the license can be found in the file
                                     `theap_meta_lock`), which deadlocks against any thread
                                     starting up (`init.c:268` / `theap.c:329` allocate a
                                     fresh tld/theap through `_mi_meta_zalloc`).
+                                    NOT an edge: `_mi_arenas_page_abandon` (arena.c) must
+                                    never re-enter `_mi_meta_zalloc_aligned` for a page that
+                                    belongs to `theap_meta` itself -- that would be
+                                    `theap_meta_lock` against ITSELF on one stack (a self-edge
+                                    no acquisition ORDER can resolve, unlike every edge in
+                                    this table, which is between two DIFFERENT locks). Closed
+                                    two ways (Opus review of #317/#319): `subproc.c`'s
+                                    `mi_subproc_new` now sets `theap_meta->allow_page_abandon
+                                    = false` (matching `init.c`'s process theap_meta), so
+                                    `mi_page_to_full` never abandons one of `theap_meta`'s own
+                                    pages in the first place; `_mi_arenas_page_abandon` also
+                                    checks `_mi_meta_is_meta_page_safe(page)` and skips the
+                                    lazy-bitmap allocation for a meta page regardless (falls
+                                    through to the unmapped-abandon path), belt and braces.
 
     heap_main->arena_pages_lock     arena.c:685      LEAF. For the main heap
                                     `mi_heap_ensure_arena_pages` only stores

--- a/src/fork.c
+++ b/src/fork.c
@@ -135,6 +135,18 @@ terms of the MIT license. A copy of the license can be found in the file
                                     -> `mi_theap_free_mem` -> `_mi_meta_free` (theap.c:363)
                                     ... and, for a page owned by `theap_meta`, `mi_free`
                                     -> `mi_stat_free` (free.c:768) takes `theap_meta_lock`
+                                    ... and (Bun parity P10b, #317): `mi_heap_detach_theaps`
+                                    (heap.c) holds `theaps_lock` across its `_mi_theap_abandon`
+                                    loop -> `_mi_page_abandon` -> `_mi_arenas_page_abandon`
+                                    (arena.c) -> `mi_arena_pages_abandoned_ensure` (arena.c) ->
+                                    `_mi_meta_zalloc_aligned`, which takes `theap_meta_lock`.
+                                    Live only for a MAIN heap: a releasing (non-main) heap sets
+                                    `heap->releasing` just before this loop, which makes
+                                    `_mi_arenas_page_abandon` skip the `..._ensure` call
+                                    entirely (see the `heap->releasing` comment in
+                                    `mi_heap_detach_theaps`, heap.c). Same target level as the
+                                    edge above, no reordering needed (MI_FORK_LOCK_THEAPS=3
+                                    already precedes MI_FORK_LOCK_THEAP_META=7 below).
       -> tld->theaps_lock           `_mi_heap_detach_theaps` -- but `mi_lock_TRY_acquire`
                                     with a back-off retry (theap.c:412), so NOT a blocking
                                     edge; see the Phase 7 gap note below

--- a/src/heap.c
+++ b/src/heap.c
@@ -222,6 +222,28 @@ static void mi_heap_detach_theaps(mi_heap_t* heap) {
     }
   }
   _mi_heap_detach_theaps(heap);
+  // Bun parity P10b (#317), ported from oven-sh/mimalloc @ 91218f30, MIT (`heap->releasing`).
+  // Bun sets this inside its `mi_heap_release_pages`, right after `if (_mi_is_heap_main(heap))
+  // return;`. We have no such function/early-return -- this static `mi_heap_detach_theaps` is
+  // our equivalent, called by both `mi_heap_delete` and `_mi_heap_force_destroy` (the latter
+  // also used for a SUBPROC main heap at subproc teardown, issue #128 B1). A bare early return
+  // (Bun's shape) is wrong here: the `_mi_theap_abandon` loop just below still has to run for a
+  // subproc main heap. Setting `releasing` on a main heap would be wrong for the opposite
+  // reason -- a main heap outlives this call and would then abandon every page unmapped
+  // forever, not just for the duration of this detach. `_mi_is_heap_main` is the right guard
+  // for both cases: it resolves via `heap->subproc`, so it is true for a subproc's own
+  // heap_main too (see the provenance comment in `mi_heap_free`, below), which is exactly the
+  // heap this must stay false for.
+  //
+  // Readers: `_mi_arenas_page_abandon` (arena.c) skips the lazy per-bin bitmap entirely once
+  // this is set, so a releasing heap's pages are abandoned unmapped -- reachable only through
+  // `pages`, which the pending `_mi_heap_move_pages`/`_mi_heap_destroy_pages` claim walk
+  // (claim_pages=true) reaches anyway. `_mi_arenas_page_try_reabandon_to_mapped` refuses to
+  // re-map one of this heap's pages for the same reason. This also means a releasing heap
+  // never needs `mi_arena_pages_abandoned_ensure` (and so never takes `subproc->theap_meta_lock`
+  // from inside this loop) -- the case where that edge is actually live is a MAIN heap, which
+  // never sets `releasing` and so is unaffected by any of this.
+  if (!_mi_is_heap_main(heap)) { mi_atomic_store_release(&heap->releasing, (uintptr_t)1); }
   mi_lock(&heap->theaps_lock) { // paranoia
     for (mi_theap_t* theap = heap->theaps; theap != NULL; theap = theap->hnext) {
       mi_assert_internal(_mi_theap_heap_peek(theap)==NULL);  // detached
@@ -280,14 +302,28 @@ static void mi_heap_free(mi_heap_t* heap, bool acquire_heaps_lock) {
         mi_arena_pages_t* arena_pages = mi_atomic_load_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i]);
         if (arena_pages!=NULL) {
           mi_atomic_store_ptr_relaxed(mi_arena_pages_t, &heap->arena_pages[i], NULL);
-          // #316 (P10a): this free now collects in-subproc. Safe regardless of whether this
-          // thread is parked: `allow_collect` only reaches `mi_free_block_mt`/
-          // `mi_free_generic_mt` (free.c:mi_free_ex), while `_mi_park_leave_if_parked` lives
-          // only in the separate `mi_free_generic_local` owner-free path (free.c:167) -- so this
-          // can never newly reach the park protocol. `mi_free_try_collect_mt`'s own reclaim
-          // guards (`_mi_thread_is_initialized`, `_mi_page_associated_theap_peek` refusing a
-          // theap of another heap) apply unconditionally.
-          _mi_free_subproc_safe(arena_pages);
+          // #316 (P10a): the final `_mi_free_subproc_safe(arena_pages)` this used to be now
+          // collects in-subproc. Safe regardless of whether this thread is parked:
+          // `allow_collect` only reaches `mi_free_block_mt`/`mi_free_generic_mt`
+          // (free.c:mi_free_ex), while `_mi_park_leave_if_parked` lives only in the separate
+          // `mi_free_generic_local` owner-free path (free.c:167) -- so this can never newly
+          // reach the park protocol. `mi_free_try_collect_mt`'s own reclaim guards
+          // (`_mi_thread_is_initialized`, `_mi_page_associated_theap_peek` refusing a theap of
+          // another heap) apply unconditionally.
+          //
+          // #317 (P10b): switched to `_mi_arena_pages_free`, which also frees the on-demand
+          // per-bin abandoned bitmaps (arena.c) before freeing `arena_pages` itself -- both go
+          // through the same `_mi_free_subproc_safe`, so the P10a audit above still covers it.
+          // Lifetime invariant (see `_mi_arena_pages_free`'s own comment, arena.c): this must
+          // run after the heap is off `subproc->heaps` and every theap of it has been
+          // detached. We are inside `mi_heap_free`, called only after
+          // `mi_heap_detach_theaps`/`_mi_heap_move_pages`(or `_mi_heap_destroy_pages`)/
+          // `mi_heap_free_theaps` have already run (see `mi_heap_delete` /
+          // `_mi_heap_force_destroy`, below) and, for `mi_heap_delete`, strictly before the
+          // heap is unlinked from `subproc->heaps` a few lines down -- so assert the theaps
+          // side of the invariant here, where `heap` is in scope.
+          mi_assert_internal(heap->theaps == NULL);
+          _mi_arena_pages_free(arena_pages);
         }
       }
     }

--- a/src/subproc.c
+++ b/src/subproc.c
@@ -208,6 +208,20 @@ mi_subproc_id_t mi_subproc_new(void) {
   mi_assert_internal(parent->theap_meta->tld!=NULL);
   mi_assert_internal(parent->theap_meta->tld->thread_id == MI_THREADID_DETACHED);
   _mi_theap_init(theap_meta,heap_main,parent->theap_meta->tld /* detached tld */);
+  // Same reasoning as init.c's process-main theap_meta bootstrap ("for security, don't
+  // share with other threads"), plus a reentrancy hazard that reasoning doesn't mention but
+  // this one closes too (Opus review of #317/#319): `_mi_theap_init` -> `mi_theap_options_init`
+  // (theap.c) derives `allow_page_abandon` from `mi_option_page_full_retain`, which defaults
+  // enabled -- so without this line, a subproc's theap_meta (unlike the process's) could
+  // retire one of its own full pages through `mi_page_to_full` (page.c) -> `_mi_page_abandon`
+  // -> `_mi_arenas_page_abandon` (arena.c) -> `mi_arena_pages_abandoned_ensure` ->
+  // `_mi_meta_zalloc_aligned`, which re-enters `subproc->theap_meta_lock` from inside the very
+  // `mi_theap_zalloc_aligned` call that lock is already held across (subproc.c, above) -- an
+  // MI_DEBUG>2 reentrant-lock abort, or a Release-build hang. Setting this false means a meta
+  // page is never abandoned in the first place, so `_mi_page_abandon` never reaches that path
+  // for one; `_mi_arenas_page_abandon` also carries its own belt-and-braces
+  // `_mi_meta_is_meta_page_safe` guard (arena.c) in case this ever regresses.
+  theap_meta->allow_page_abandon = false;
   #if MI_GUARDED
   // See the matching comment in init.c's process-main theap_meta bootstrap (#266):
   // internal allocator bookkeeping must never be guarded.

--- a/test/test-abandoned-lazy.c
+++ b/test/test-abandoned-lazy.c
@@ -1,0 +1,382 @@
+/* ----------------------------------------------------------------------------
+Copyright (c) 2018-2026, Microsoft Research, Daan Leijen
+This is free software; you can redistribute it and/or modify it under the
+terms of the MIT license.
+-----------------------------------------------------------------------------*/
+
+// ported from oven-sh/mimalloc @ 787be2a8, MIT (Bun parity P10b, issue #317). The counter
+// gating and thread-helper set (`run_os_threads`, `atomic_*`) are adapted, not copied
+// verbatim -- see the notes at each spot below.
+
+/* The per-bin abandoned-page bitmaps of a (heap, arena) pair are allocated the
+   first time a page of that bin is abandoned, not when the heap first touches
+   the arena (`mi_arena_pages_abandoned_ensure`, src/arena.c). This drives every
+   path that reads or writes them:
+
+   - worker threads allocate blocks of several size classes from a shared heap
+     and exit while the blocks are still live, so their pages are abandoned
+     (the bitmaps are allocated on that path, by several threads at once);
+   - the main thread then allocates the same sizes from the heap, which reclaims
+     the abandoned pages, frees every block (un-abandon, page free), collects
+     and deletes the heap (the bitmaps are freed with it, `_mi_arena_pages_free`);
+   - the same with the main heap, whose bitmaps are never freed, and with blocks
+     freed by a thread that never allocated (re-abandon of a mostly free page).
+
+   A heap that is deleted or destroyed sets `heap->releasing` and abandons all of
+   its pages unmapped during its own teardown, which claims them back through the
+   `pages` bitmap instead (see `mi_heap_detach_theaps`, src/heap.c). Those pages
+   never go into a per-bin bitmap, so a heap that lives only to be released never
+   allocates one:
+
+   - a debug build counts the maps allocated (`mi_debug_abandoned_maps_allocated`,
+     src/arena.c) while heaps are created, used and destroyed on one thread, and
+     the count must not move;
+   - several threads create, use and delete heaps while other threads free the
+     blocks of each heap during its delete (a free that would otherwise re-map a
+     page, but must not while the heap is releasing).
+
+   A debug build checks the bitmap invariants (`mi_assert_internal`s in arena.c)
+   on each of these paths.
+
+   > mimalloc-test-abandoned-lazy [ITER]
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "mimalloc.h"
+
+#if defined(MI_TSAN) || defined(MI_UBSAN) || defined(MI_GUARDED)
+static int ITER = 20;
+#else
+static int ITER = 100;
+#endif
+
+#define NTHREADS   8
+#define NSIZES     6
+#define NBLOCKS    64      // per thread per size: enough to span a few pages of each size class
+
+static const size_t sizes[NSIZES] = { 16, 96, 512, 2048, 8192, 40000 };
+
+typedef void (thread_entry_fun_t)(intptr_t tid);
+static void run_os_threads(size_t nthreads, thread_entry_fun_t* entry);
+
+static mi_heap_t* shared_heap;           // NULL: use the main heap
+static void*      blocks[NTHREADS][NSIZES][NBLOCKS];
+
+static void alloc_and_exit(intptr_t tid) {
+  for (int s = 0; s < NSIZES; s++) {
+    for (int b = 0; b < NBLOCKS; b++) {
+      void* p = (shared_heap != NULL ? mi_heap_malloc(shared_heap, sizes[s]) : mi_malloc(sizes[s]));
+      if (p == NULL) { fprintf(stderr, "allocation failed\n"); abort(); }
+      memset(p, (int)(tid + s), sizes[s]);
+      blocks[tid][s][b] = p;
+    }
+  }
+  // exit with everything live: every page this thread used is abandoned
+}
+
+static void free_some(intptr_t tid) {
+  // free most blocks of a page from a thread that never allocated from the heap:
+  // a multi-threaded free that can re-abandon the page as mapped
+  for (int s = 0; s < NSIZES; s++) {
+    for (int b = 0; b < NBLOCKS; b++) {
+      if ((b % 8) != 0) {
+        mi_free(blocks[tid][s][b]);
+        blocks[tid][s][b] = NULL;
+      }
+    }
+  }
+}
+
+static void check_block(intptr_t tid, int s, void* p) {
+  const unsigned char* q = (const unsigned char*)p;
+  for (size_t i = 0; i < sizes[s]; i += 64) {
+    if (q[i] != (unsigned char)(tid + s)) { fprintf(stderr, "block corrupted\n"); abort(); }
+  }
+}
+
+static void run_round(bool use_main_heap) {
+  shared_heap = (use_main_heap ? NULL : mi_heap_new());
+  memset(blocks, 0, sizeof(blocks));
+
+  // 1. abandon pages of several size classes from several threads at once
+  run_os_threads(NTHREADS, &alloc_and_exit);
+
+  // 2. reclaim: allocating the same sizes must find the abandoned pages again
+  void* mine[NSIZES][NBLOCKS];
+  for (int s = 0; s < NSIZES; s++) {
+    for (int b = 0; b < NBLOCKS; b++) {
+      mine[s][b] = (shared_heap != NULL ? mi_heap_malloc(shared_heap, sizes[s]) : mi_malloc(sizes[s]));
+      if (mine[s][b] == NULL) { fprintf(stderr, "allocation failed\n"); abort(); }
+    }
+  }
+  for (intptr_t t = 0; t < NTHREADS; t++) {
+    for (int s = 0; s < NSIZES; s++) {
+      for (int b = 0; b < NBLOCKS; b++) { check_block(t, s, blocks[t][s][b]); }
+    }
+  }
+
+  // 3. frees from threads that never touched the heap, then from this thread
+  run_os_threads(NTHREADS, &free_some);
+  for (intptr_t t = 0; t < NTHREADS; t++) {
+    for (int s = 0; s < NSIZES; s++) {
+      for (int b = 0; b < NBLOCKS; b++) {
+        if (blocks[t][s][b] != NULL) { check_block(t, s, blocks[t][s][b]); mi_free(blocks[t][s][b]); }
+      }
+    }
+  }
+  for (int s = 0; s < NSIZES; s++) {
+    for (int b = 0; b < NBLOCKS; b++) { mi_free(mine[s][b]); }
+  }
+
+  // 4. collect and delete
+  if (shared_heap != NULL) {
+    mi_heap_collect(shared_heap, true);
+    mi_heap_delete(shared_heap);
+    shared_heap = NULL;
+  }
+  else {
+    mi_collect(true);
+  }
+}
+
+/* -----------------------------------------------------------
+   Released heaps: no maps
+----------------------------------------------------------- */
+
+// Bun gates this on `!defined(NDEBUG)`; we gate on `MI_DEBUG > 0` instead, matching the
+// library's own gate on `mi_debug_abandoned_maps_allocated` (internal.h) -- a Release build
+// with `-DMI_DEBUG_FULL=ON` sets `MI_DEBUG=3` while `NDEBUG` stays defined by the Release
+// build type, and `!defined(NDEBUG)` would then reference a symbol that is not linked in.
+// Same reasoning as test-heap-teardown.c's `#if MI_DEBUG == 0 #error` gate.
+#if MI_DEBUG > 0
+#ifdef __cplusplus
+#include <atomic>
+extern "C" std::atomic<uintptr_t> mi_debug_abandoned_maps_allocated;
+static uintptr_t maps_allocated(void) { return mi_debug_abandoned_maps_allocated.load(); }
+#elif defined(_MSC_VER) && !(defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__))
+// MSVC C compilation without `/std:c11 /experimental:c11atomics` (not set here): <stdatomic.h>
+// exists but its vcruntime_c11_stdatomic.h #errors "C atomic support is not enabled". Ported
+// verbatim from test-heap-teardown.c's own fallback for the same reason: `c-unit.yml`'s
+// `ctest (windows-latest)` builds C tests with Microsoft's `cl` in C mode.
+extern volatile uintptr_t mi_debug_abandoned_maps_allocated;
+static uintptr_t maps_allocated(void) { return mi_debug_abandoned_maps_allocated; }
+#else
+#include <stdatomic.h>
+extern _Atomic(uintptr_t) mi_debug_abandoned_maps_allocated;
+static uintptr_t maps_allocated(void) { return atomic_load(&mi_debug_abandoned_maps_allocated); }
+#endif
+#define HAS_MAP_COUNTER 1
+#else
+#define HAS_MAP_COUNTER 0
+#endif
+
+static void fill_heap(mi_heap_t* heap, void** keep) {
+  for (int s = 0; s < NSIZES; s++) {
+    for (int b = 0; b < NBLOCKS; b++) {
+      void* p = mi_heap_malloc(heap, sizes[s]);
+      if (p == NULL) { fprintf(stderr, "allocation failed\n"); abort(); }
+      memset(p, s + 1, sizes[s]);
+      if (keep != NULL) { keep[s*NBLOCKS + b] = p; }
+    }
+  }
+}
+
+static void released_heaps_map_nothing(void) {
+  static void* keep[NSIZES*NBLOCKS];
+  // one delete first: the main heap takes the moved pages and maps them, and its maps stay
+  mi_heap_t* heap = mi_heap_new();
+  fill_heap(heap, keep);
+  mi_heap_delete(heap);
+  for (int i = 0; i < NSIZES*NBLOCKS; i++) { mi_free(keep[i]); }
+
+  #if HAS_MAP_COUNTER
+  const uintptr_t before = maps_allocated();
+  #endif
+  for (int n = 0; n < 50; n++) {
+    heap = mi_heap_new();
+    fill_heap(heap, NULL);
+    mi_heap_destroy(heap);
+
+    heap = mi_heap_new();
+    fill_heap(heap, keep);
+    mi_heap_delete(heap);   // the blocks now belong to the main heap
+    for (int i = 0; i < NSIZES*NBLOCKS; i++) { mi_free(keep[i]); }
+  }
+  #if HAS_MAP_COUNTER
+  const uintptr_t after = maps_allocated();
+  if (after != before) {
+    fprintf(stderr, "released heaps allocated %lu abandoned maps\n", (unsigned long)(after - before));
+    abort();
+  }
+  #endif
+}
+
+/* -----------------------------------------------------------
+   Concurrent delete: blocks freed by another thread while their heap is deleted
+----------------------------------------------------------- */
+
+#define NPAIRS   4       // a deleter and a freer each
+#define DBLOCKS  8       // per size: the pages stay mostly free, so a free would re-map them
+
+static void* atomic_exchange_ptr(volatile void** p, void* newval);
+static long  atomic_load_long(volatile long* p);
+static void  atomic_store_long(volatile long* p, long x);
+
+static volatile void* dslots[NPAIRS][NSIZES*DBLOCKS];
+static volatile long  dgo[NPAIRS];
+static volatile long  ddone[NPAIRS];
+static int            dround_count;
+
+static void delete_pair(intptr_t tid) {
+  const int pair = (int)(tid / 2);
+  if ((tid % 2) == 0) {
+    // deleter: allocate, let the freer start, and delete while it frees
+    for (int r = 1; r <= dround_count; r++) {
+      mi_heap_t* heap = mi_heap_new();
+      for (int s = 0; s < NSIZES; s++) {
+        for (int b = 0; b < DBLOCKS; b++) {
+          void* p = mi_heap_malloc(heap, sizes[s]);
+          if (p == NULL) { fprintf(stderr, "allocation failed\n"); abort(); }
+          memset(p, s + 1, sizes[s]);
+          atomic_exchange_ptr(&dslots[pair][s*DBLOCKS + b], p);
+        }
+      }
+      atomic_store_long(&dgo[pair], r);
+      mi_heap_delete(heap);
+      while (atomic_load_long(&ddone[pair]) != r) { /* spin */ }
+    }
+  }
+  else {
+    // freer: never allocates from the heap, so it may free into it during the delete
+    for (int r = 1; r <= dround_count; r++) {
+      while (atomic_load_long(&dgo[pair]) != r) { /* spin */ }
+      for (int i = 0; i < NSIZES*DBLOCKS; i++) {
+        unsigned char* p = (unsigned char*)atomic_exchange_ptr(&dslots[pair][i], NULL);
+        if (p == NULL) { fprintf(stderr, "missing block\n"); abort(); }
+        if (p[0] != (unsigned char)(i / DBLOCKS + 1)) { fprintf(stderr, "block corrupted\n"); abort(); }
+        mi_free(p);
+      }
+      atomic_store_long(&ddone[pair], r);
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  if (argc >= 2) {
+    char* end;
+    long n = strtol(argv[1], &end, 10);
+    if (n > 0) ITER = (int)n;
+  }
+  for (int i = 0; i < ITER; i++) {
+    run_round(false);
+    run_round(true);
+  }
+  released_heaps_map_nothing();
+  dround_count = ITER;
+  run_os_threads(NPAIRS*2, &delete_pair);
+  printf("test-abandoned-lazy: %d rounds, ok\n", ITER);
+  mi_stats_print(NULL);
+  return 0;
+}
+
+
+/* -----------------------------------------------------------
+   OS threads
+----------------------------------------------------------- */
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+static thread_entry_fun_t* thread_entry_fun;
+
+static DWORD WINAPI thread_entry(LPVOID param) {
+  thread_entry_fun((intptr_t)param);
+  return 0;
+}
+
+static void run_os_threads(size_t nthreads, thread_entry_fun_t* fun) {
+  thread_entry_fun = fun;
+  DWORD*  tids     = (DWORD*) calloc(nthreads, sizeof(DWORD));
+  HANDLE* thandles = (HANDLE*)calloc(nthreads, sizeof(HANDLE));
+  for (size_t i = 0; i < nthreads; i++) {
+    thandles[i] = CreateThread(0, 8*1024L, &thread_entry, (void*)(i), 0, &tids[i]);
+  }
+  for (size_t i = 0; i < nthreads; i++) {
+    WaitForSingleObject(thandles[i], INFINITE);
+  }
+  for (size_t i = 0; i < nthreads; i++) {
+    CloseHandle(thandles[i]);
+  }
+  free(tids);
+  free(thandles);
+}
+
+static void* atomic_exchange_ptr(volatile void** p, void* newval) {
+  #if (INTPTR_MAX == INT32_MAX)
+  return (void*)InterlockedExchange((volatile LONG*)p, (LONG)newval);
+  #else
+  return (void*)InterlockedExchange64((volatile LONG64*)p, (LONG64)newval);
+  #endif
+}
+static long atomic_load_long(volatile long* p) {
+  return InterlockedCompareExchange(p, 0, 0);
+}
+static void atomic_store_long(volatile long* p, long x) {
+  InterlockedExchange(p, x);
+}
+
+#else
+
+#include <pthread.h>
+
+static thread_entry_fun_t* thread_entry_fun;
+
+static void* thread_entry(void* param) {
+  thread_entry_fun((intptr_t)param);
+  return NULL;
+}
+
+static void run_os_threads(size_t nthreads, thread_entry_fun_t* fun) {
+  thread_entry_fun = fun;
+  pthread_t* threads = (pthread_t*)calloc(nthreads, sizeof(pthread_t));
+  memset(threads, 0, sizeof(pthread_t) * nthreads);
+  for (size_t i = 0; i < nthreads; i++) {
+    pthread_create(&threads[i], NULL, &thread_entry, (void*)i);
+  }
+  for (size_t i = 0; i < nthreads; i++) {
+    pthread_join(threads[i], NULL);
+  }
+  free(threads);
+}
+
+#ifdef __cplusplus
+#include <atomic>
+static void* atomic_exchange_ptr(volatile void** p, void* newval) {
+  return std::atomic_exchange((volatile std::atomic<void*>*)p, newval);
+}
+static long atomic_load_long(volatile long* p) {
+  return std::atomic_load((volatile std::atomic<long>*)p);
+}
+static void atomic_store_long(volatile long* p, long x) {
+  std::atomic_store((volatile std::atomic<long>*)p, x);
+}
+#else
+#include <stdatomic.h>
+static void* atomic_exchange_ptr(volatile void** p, void* newval) {
+  return atomic_exchange((volatile _Atomic(void*)*)p, newval);
+}
+static long atomic_load_long(volatile long* p) {
+  return atomic_load((volatile _Atomic(long)*)p);
+}
+static void atomic_store_long(volatile long* p, long x) {
+  atomic_store((volatile _Atomic(long)*)p, x);
+}
+#endif
+
+#endif

--- a/test/test-heap-release-mt.c
+++ b/test/test-heap-release-mt.c
@@ -1,0 +1,237 @@
+/* ----------------------------------------------------------------------------
+Copyright (c) 2026, Microsoft Research, Daan Leijen
+This is free software; you can redistribute it and/or modify it under the
+terms of the MIT license.
+-----------------------------------------------------------------------------*/
+
+// ported from oven-sh/mimalloc @ a26c5de7 (+ 92930d0c, 47851447), MIT (Bun parity P10b,
+// issue #317). Written against Bun's own park protocol API (`mi_on_thread_idle_start`,
+// `mi_on_thread_idle_end`, `mi_on_thread_idle`, `mi_option_purge_holes_min_interval`,
+// `mi_option_scavenger`), which this tree carries unchanged from Bun parity P7a/P7b -- so no
+// adaptation was needed for that part. Skipped on Windows/win-gnu (uses pthreads directly,
+// like `#if defined(_WIN32)` below): state that explicitly rather than letting a green
+// Windows run imply coverage from this file.
+
+/* Release heaps on many threads at once while other threads free into them.
+
+   - NCHURN threads loop: `mi_heap_new`, allocate mixed sizes, hand a third of the blocks to a shared
+     ring, free a third, leak a third, then `mi_heap_delete` (or `mi_heap_destroy` when nothing was
+     handed out). Some heaps are also published for a while so that short-lived threads allocate from
+     them and exit with their blocks live (the abandon path, and the per-bin abandoned maps).
+   - NFREE threads pop blocks from the ring and `mi_free` them: those frees land before, during and
+     after the delete of the owning heap, so pages are freed and re-abandoned by a foreign thread while
+     `mi_heap_delete` claims them (`arena.c:mi_heap_visit_page_claim` against `mi_arenas_page_free_prim`).
+   - NSPAWN threads keep creating batches of threads that allocate from a published heap (or the main
+     heap) and exit at once.
+
+   The second half runs the same churn "parked": before its heap is released, a churn thread hands
+   its theaps to the scavenger (`mi_on_thread_idle_start`), which then sweeps the holes of that
+   thread's pages and of the abandoned pages of its heaps -- including the per-bin abandoned maps of
+   the heap that is about to go (`_mi_arenas_purge_abandoned_holes`, arena.c; the engine itself is
+   src/page-holes.c in this tree). Half of those heaps are deleted by the parked thread itself right
+   after `mi_on_thread_idle_end` (racing the tail of the sweep), the other half by a freer thread
+   *while the owner is still parked* (a heap created on one thread and released on another while the
+   first sits idle in the kernel), so `mi_heap_delete`'s detach has to get past the scavenger holding
+   that thread's theaps (the `_mi_park_leave` loop at the head of `mi_heap_detach_theaps`, src/heap.c).
+
+   Meant to be run under TSAN and ASAN as well as with MI_DEBUG_FULL: it must finish without a report.
+
+   > mimalloc-test-heap-release-mt [SECONDS]
+*/
+#if defined(_WIN32)
+#include <stdio.h>
+int main(void) { printf("test-heap-release-mt: skipped on Windows (uses pthreads)\n"); return 0; }
+#else
+
+#include <mimalloc.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+#define NCHURN 8
+#define NFREE  4
+#define NSPAWN 4
+#define RING (1<<16)
+static _Atomic(void*) ring[RING];
+static _Atomic unsigned long ring_head, ring_tail;
+static _Atomic int stop;
+static _Atomic int park_mode;       // second half: park around the release, see the header
+static _Atomic unsigned long heaps_done, frees_done, exits_done, parks_done, parks_handed_off, remote_deletes;
+static _Atomic(mi_heap_t*) to_delete[NCHURN];   // park mode: heap i's owner is parked and waits for a freer to delete it
+
+static const size_t sizes[] = {8,16,48,96,200,512,1024,2048,5000,8192,20000,40000,70000,200000};
+#define NS (sizeof(sizes)/sizeof(sizes[0]))
+
+static void push(void* p) {
+  for (;;) {
+    unsigned long h = atomic_fetch_add(&ring_head, 1);
+    void* expect = NULL;
+    if (atomic_compare_exchange_strong(&ring[h % RING], &expect, p)) return;
+    // slot busy: free it ourselves instead of spinning
+    mi_free(p); return;
+  }
+}
+static void* pop(void) {
+  unsigned long t = atomic_fetch_add(&ring_tail, 1);
+  return atomic_exchange(&ring[t % RING], NULL);
+}
+
+static unsigned rnd(unsigned* s){ *s = *s*1103515245u+12345u; return *s>>8; }
+
+// shared live heaps for the exiting threads
+#define NSHARED 4
+static _Atomic(mi_heap_t*) shared[NSHARED];
+static _Atomic int users[NSHARED];
+
+static void* churn(void* arg) {
+  const int self = (int)(uintptr_t)arg - 1;
+  unsigned seed = (unsigned)(uintptr_t)arg * 7919u + 1;
+  while (!atomic_load(&stop)) {
+    mi_heap_t* h = mi_heap_new();
+    int slot = -1;
+    // sometimes publish as a shared heap for exiting threads to allocate from
+    if ((rnd(&seed) % 4) == 0) {
+      slot = rnd(&seed) % NSHARED;
+      mi_heap_t* expect = NULL;
+      if (!atomic_compare_exchange_strong(&shared[slot], &expect, h)) slot = -1;
+    }
+    int handed = 0;
+    int n = 50 + rnd(&seed) % 400;
+    for (int i = 0; i < n; i++) {
+      size_t sz = sizes[rnd(&seed) % NS];
+      void* p = mi_heap_malloc(h, sz);
+      if (!p) { fprintf(stderr,"oom\n"); abort(); }
+      memset(p, 0xAB, sz < 64 ? sz : 64);
+      unsigned r = rnd(&seed) % 3;
+      if (r == 0) { push(p); handed++; }
+      else if (r == 1) mi_free(p);
+      // else leak into the heap; delete moves it to main / destroy frees it
+    }
+    if (slot >= 0) {
+      // let exiting threads use it for a bit, then unpublish
+      usleep(200);
+      atomic_store(&shared[slot], NULL);
+      while (atomic_load(&users[slot]) != 0) usleep(10); // in-flight allocators finish (contract: no alloc during delete)
+      handed = 1; // exiting threads may hold blocks: must delete, not destroy
+    }
+    if (atomic_load(&park_mode)) {
+      const bool remote = ((rnd(&seed) & 1) != 0);
+      if (remote) { atomic_store(&to_delete[self], h); }   // a freer deletes it while we are parked
+      const bool parked = mi_on_thread_idle_start();
+      if (parked) { atomic_fetch_add(&parks_handed_off, 1); }
+      if (remote) {
+        // idle in the kernel as far as mimalloc is concerned: we do not allocate or free until `_end`
+        while (atomic_load(&to_delete[self]) != NULL && !atomic_load(&stop)) { usleep(20); }
+      }
+      else if ((rnd(&seed) & 3) == 0) {
+        usleep(300);   // sometimes let the sweep get well into our heaps, sometimes race its start
+      }
+      mi_on_thread_idle_end();
+      if (!parked) { mi_on_thread_idle(); }   // no scavenger (MIMALLOC_SCAVENGER=0): sweep inline so the pass is not vacuous
+      atomic_fetch_add(&parks_done, 1);
+      if (remote) {
+        mi_heap_t* const left = atomic_exchange(&to_delete[self], NULL);   // only non-NULL if we are stopping
+        if (left != NULL) { mi_heap_delete(left); }
+        atomic_fetch_add(&heaps_done, 1);
+        continue;
+      }
+    }
+    if (handed == 0 && (rnd(&seed) & 1)) mi_heap_destroy(h);
+    else mi_heap_delete(h);
+    atomic_fetch_add(&heaps_done, 1);
+  }
+  return NULL;
+}
+
+// park mode: delete the heaps whose owners are parked and waiting for it
+static void delete_parked_heaps(void) {
+  for (int i = 0; i < NCHURN; i++) {
+    if (atomic_load(&to_delete[i]) == NULL) continue;
+    mi_heap_t* const h = atomic_exchange(&to_delete[i], NULL);
+    if (h != NULL) { mi_heap_delete(h); atomic_fetch_add(&remote_deletes, 1); }
+  }
+}
+
+static void* freer(void* arg) {
+  (void)arg;
+  while (!atomic_load(&stop) || atomic_load(&ring_tail) < atomic_load(&ring_head)) {
+    delete_parked_heaps();
+    void* p = pop();
+    if (p) { mi_free(p); atomic_fetch_add(&frees_done,1); }
+    else if (atomic_load(&stop)) break;
+  }
+  return NULL;
+}
+
+static void* exiter(void* arg) {
+  unsigned seed = (unsigned)(uintptr_t)arg;
+  int slot = rnd(&seed) % NSHARED;
+  atomic_fetch_add(&users[slot], 1);
+  mi_heap_t* h = atomic_load(&shared[slot]);
+  for (int i = 0; i < 40; i++) {
+    size_t sz = sizes[rnd(&seed) % 8];
+    void* p = h ? mi_heap_malloc(h, sz) : mi_malloc(sz);
+    if (p) { memset(p, 0xCD, sz < 64 ? sz : 64); push(p); }
+  }
+  atomic_fetch_sub(&users[slot], 1);
+  atomic_fetch_add(&exits_done,1);
+  return NULL; // exit with blocks live -> pages abandoned (mapped, lazy bitmap alloc)
+}
+
+static void* spawner(void* arg) {
+  unsigned k = (unsigned)(uintptr_t)arg * 100000u;
+  while (!atomic_load(&stop)) {
+    pthread_t t[8];
+    for (int i = 0; i < 8; i++) pthread_create(&t[i], NULL, exiter, (void*)(uintptr_t)(k++));
+    for (int i = 0; i < 8; i++) pthread_join(t[i], NULL);
+  }
+  return NULL;
+}
+
+static void run(int secs) {
+  atomic_store(&stop, 0);
+  atomic_store(&ring_head, 0); atomic_store(&ring_tail, 0);
+  pthread_t tc[NCHURN], tf[NFREE], ts[NSPAWN];
+  for (long i = 0; i < NFREE; i++) pthread_create(&tf[i], NULL, freer, (void*)i);
+  for (long i = 0; i < NCHURN; i++) pthread_create(&tc[i], NULL, churn, (void*)(i+1));
+  for (long i = 0; i < NSPAWN; i++) pthread_create(&ts[i], NULL, spawner, (void*)(i+1));
+  sleep((unsigned)secs);
+  atomic_store(&stop, 1);
+  for (int i = 0; i < NCHURN; i++) pthread_join(tc[i], NULL);
+  for (int i = 0; i < NSPAWN; i++) pthread_join(ts[i], NULL);
+  for (int i = 0; i < NFREE; i++) pthread_join(tf[i], NULL);
+  // drain
+  for (unsigned i = 0; i < RING; i++) { void* q = atomic_exchange(&ring[i], NULL); if (q) mi_free(q); }
+  mi_collect(true);
+}
+
+int main(int argc, char** argv) {
+  int secs = (argc > 1 ? atoi(argv[1]) : 0);
+  if (secs <= 0) {
+    #if defined(MI_TSAN) || !defined(NDEBUG)
+    secs = 4;
+    #else
+    secs = 6;
+    #endif
+  }
+  // 1. plain
+  run((secs + 1) / 2);
+  printf("test-heap-release-mt: churn ok  (heaps=%lu frees=%lu thread-exits=%lu)\n",
+         (unsigned long)heaps_done, (unsigned long)frees_done, (unsigned long)exits_done);
+  // 2. parked around the release, every park swept (no rate limit)
+  mi_option_set(mi_option_purge_holes_min_interval, 0);
+  atomic_store(&park_mode, 1);
+  run((secs + 1) / 2);
+  printf("test-heap-release-mt: parked ok (heaps=%lu frees=%lu thread-exits=%lu parks=%lu handed-off=%lu remote-deletes=%lu scavenger=%s)\n",
+         (unsigned long)heaps_done, (unsigned long)frees_done, (unsigned long)exits_done,
+         (unsigned long)parks_done, (unsigned long)parks_handed_off, (unsigned long)remote_deletes,
+         mi_option_is_enabled(mi_option_scavenger) ? "on" : "off");
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
Ports Bun's P10b from #315 §2.2–2.6 onto our diverged tree, per #317. Stacked on the now-merged P10a (#318): `mi_heap_visit_page_claim`'s reorder and the `_mi_bitmap_forall_set` acquire loads were already ported there, so this PR only carries the lazy-bitmap / `releasing` hunks. Branched from `origin/main` (`2d594c0f`, after #318 merged) — no longer stacked on an open PR.

## What's ported, with our anchors

**§2.2 — `heap->releasing` (`91218f30`)**
- `include/mimalloc/types.h`: `_Atomic(uintptr_t) releasing` added to `mi_heap_t` right after `abandoned_count[MI_BIN_COUNT]`.
- `src/heap.c`: Bun sets this inside its `mi_heap_release_pages`, right after `if (_mi_is_heap_main(heap)) return;`. We have neither — our equivalent is the static `mi_heap_detach_theaps(heap)`, called by both `mi_heap_delete` and `_mi_heap_force_destroy` (the latter also used for a *subproc* main heap at teardown, issue #128 B1). Placed the guarded store exactly where the issue specifies: after the `_mi_park_leave` loop and `_mi_heap_detach_theaps(heap)`, before the `theaps_lock` abandon loop, guarded on `!_mi_is_heap_main(heap)` — a bare early return (Bun's shape) would skip the abandon loop a subproc main heap still needs; setting `releasing` on a main heap would abandon every page unmapped forever, since a main heap outlives the call.
- Readers, both in `src/arena.c`: `_mi_arenas_page_abandon` adds `&& mi_atomic_load_relaxed(&heap->releasing) == 0` to the arena-page/not-full condition; `_mi_arenas_page_try_reabandon_to_mapped` gets an early `return false` when the page's heap is releasing.

**§2.3 — lazy per-bin abandoned bitmaps (`787be2a8`)**
- `include/mimalloc/types.h`: `mi_arena_pages_t::pages_abandoned[MI_ARENA_BIN_COUNT]` becomes `_Atomic(mi_bitmap_t*)[]`.
- `src/arena.c`: new `mi_arena_pages_abandoned` (acquire load, NULL = all-clear) and `mi_arena_pages_abandoned_ensure` (allocate via `_mi_meta_zalloc_aligned(arena->subproc, size, MI_BCHUNK_SIZE, NULL)`, `mi_bitmap_init`, strong CAS publish; a CAS loser frees its copy with `_mi_free_subproc_safe`). `mi_arena_pages_size`/`mi_arena_info_slices_needed` drop the `MI_ARENA_BIN_COUNT` bitmaps from the up-front layout; `mi_arena_pages_alloc` drops the init loop; `mi_arena_initialize` stores NULL into each `pages_main.pages_abandoned[i]` explicitly (the arena's own memory is not guaranteed zeroed at that point on every `memid` path). Every reader NULL-guarded: `mi_arenas_page_try_find_abandoned`, the debug assert in `mi_arenas_page_free_prim`, `_mi_arenas_page_unabandon` (asserts non-NULL — a mapped page was set in it), `_mi_arenas_purge_abandoned_holes`, `_mi_arenas_holes_report`, `_mi_heap_visit_blocks`'s `abandoned_only` branch.
- `mi_debug_abandoned_maps_allocated` test hook under `#if MI_DEBUG > 0` in `src/arena.c`, declared in `include/mimalloc/internal.h`'s existing `extern "C"`-wrapped debug-hook block (the C-linkage half of `1515c3c9` was already a no-op for us there).
- **Rule 4 is not violated**: this is allocator metadata (same meta-theap allocator `_mi_thread_local_create` already uses for the TLS slot bitmap), not profiler-internal memory. `_mi_prof_on_alloc` *does* fire inside `_mi_meta_zalloc_aligned` while `theap_meta_lock` is held, and that is safe only because `profile.c:955` and `memory-events.c:252/289` early-return on `_mi_meta_is_meta_page_safe(page)` before touching profiler/memevt state for a meta page. The gate for this is `verify_local`'s `debug-full` config (`MI_PPROF=ON` + `MI_DEBUG_FULL=ON`, runs `test-lock-reentrancy`), which is in the full `verify_local.py` run below.
- **New lock order edge**: `heap->theaps_lock -> subproc->theap_meta_lock`, live only for a MAIN heap (a releasing heap skips `..._ensure` entirely via §2.2's guard). Already consistent with `src/fork.c`'s existing documented order (`MI_FORK_LOCK_THEAPS=3` precedes `MI_FORK_LOCK_THEAP_META=7`) — no enum reordering needed, just documented the new call chain in the lock-order table's `heap->theaps_lock` section.

**§2.4 — `_mi_arena_pages_free` (`787be2a8`)**
- New `void _mi_arena_pages_free(mi_arena_pages_t*)` in `src/arena.c` (+ declaration in `include/mimalloc/internal.h` next to `_mi_arenas_page_try_reabandon_to_mapped`): frees each non-NULL on-demand bitmap via `mi_arena_pages_free_abandoned`, then `_mi_free_subproc_safe(arena_pages)`. `src/heap.c`'s `mi_heap_free` switches from `_mi_free_subproc_safe(arena_pages)` to this, and asserts `heap->theaps == NULL` right before the call — the lifetime invariant the issue asked for (heap already off `subproc->heaps` / theaps detached), documented in both the caller (heap.c, where `heap` is in scope) and the callee (arena.c, which has no heap handle).

**§2.5/§2.6 — already ported in P10a (#318)**, confirmed unchanged here: `_mi_bitmap_forall_set`'s acquire loads (`src/bitmap.c`) and `mi_heap_visit_page_claim`'s page-located-after-pin reorder (`src/arena.c`).

## Tests

- **`test/test-abandoned-lazy.c`** (ported from `787be2a8`, body unchanged): abandon/reclaim/re-abandon across several threads and size bins, a `released_heaps_map_nothing` regression using the new `mi_debug_abandoned_maps_allocated` counter, and a concurrent-delete-vs-foreign-free stress. Counter check gated on `MI_DEBUG > 0` (not Bun's `!defined(NDEBUG)`) with the MSVC `volatile` fallback ported verbatim from `test-heap-teardown.c:124-142`, so `c-unit.yml`'s `ctest (windows-latest)` C-mode `cl` build doesn't hit `<stdatomic.h>`'s `#error`.
- **`test/test-heap-release-mt.c`** (ported unchanged, body identical to Bun's): churns `mi_heap_new`/`delete`/`destroy` against concurrent frees and thread exits, then repeats parked around the release (`mi_on_thread_idle_start/_end`, racing `mi_heap_delete` against a still-parked owner). **`#if defined(_WIN32)` prints "skipped" and returns 0 — MSVC and win-gnu get zero real coverage from this file**, stated here rather than letting a green Windows run imply coverage.
- CMake: both registered in the "static link tests" `foreach` (unconditional — the file itself, not CMake, handles the Windows skip and the `MI_DEBUG==0` counter gate), `test-heap-release-mt-no-scavenger` added next to `test-park-handoff-no-scavenger`, both plus the no-scavenger variant added to `mi_serial_tests` with one-line reasons, `test-abandoned-lazy.c` added to the `MI_USE_CXX` `LANGUAGE CXX` list per Bun's `c31ed9ed` (not strictly required in our tree — the debug hook is already `extern "C"` — but harmless and keeps the CMake shape identical to Bun's, per the issue).

**RED/GREEN proof.** Reverted `src/arena.c`/`src/heap.c`/`include/mimalloc/types.h`/`include/mimalloc/internal.h`/`src/fork.c` (kept P10a, the two new test files, and their CMake registration) and rebuilt:
```
# without this PR's C changes:
/home/niteris/dev/mimalloc-pprof/test/test-abandoned-lazy.c:171:(.text+0x636): undefined reference to `mi_debug_abandoned_maps_allocated'
collect2: error: ld returned 1 exit status
```
`test-abandoned-lazy` fails to *link* without the port — a hard RED. `test-heap-release-mt` (pure public API, no new symbols) still built and ran clean without the port in a short 4s local run; it is stress/regression coverage for the general delete-vs-concurrent-free race (shared with P6/P7's existing corpus), not a deterministic prover of the `releasing`/lazy-bitmap optimization specifically — noted here rather than overclaiming. With the port restored, both pass:
```
test-abandoned-lazy ................ Passed    3.51 sec
test-heap-release-mt ................ Passed    4.25 sec
test-heap-release-mt-no-scavenger ... Passed    4.12 sec
```

## Verification

- `uv run ci/verify_local.py` — all 12 configs PASS: `release`, `off`, `debug-full` (54/54), `debug3-extra` (7/7), `guarded`, `shared`, `bundle`, `memory-gate`, `diag` (internal-state 32 sites, ISA baseline), `lint` (285 passed), `asan`, `rust` (after the amalgamation commit; `xtask check` clean).
- `uv run ci/memory_gate.py check` — `peak_rss 58.2 MB vs baseline 58.0 MB (+0.3%, allowed +5%)`, PASS. (P10b's expected reduction can't turn this gate red per its own one-sided design — noted in the issue — so this is a no-regression confirmation, not evidence of the improvement.)
- `uv run ci/check_internal_state.py` — `internal-state inventory is complete (32 sites)` after adding the `arena-pages-abandoned-bitmap` site (separate `ci:` commit).
- `uv run ci/check_bun_surface.py` — PASS, unchanged (no new public symbol).
- `cargo run -p xtask -- check` — `xtask check: vendored amalgamation matches src/include/.`
- A hand-built `MI_PPROF=ON MI_DEBUG_FULL=ON` config (57 ctest cases, including `test-lock-reentrancy`) — 100% pass, exercising the new `heap->theaps_lock -> theap_meta_lock` edge under the `MI_DEBUG>2` lock-order checker.

Not run: `uv run ci/verify_local.py --slow` and `uv run ci/dev_linux.py bench` — not reached in this session; the fast-tier `verify_local.py` run (which builds and runs both new tests directly, not through the slow tier) already exercises both new tests to completion, and neither test is on the bench path (no MI_STAT/bench-workload interaction). Flagging the gap rather than skipping it silently.

## Review round

An Opus review of this PR found one BLOCKER plus small items, addressed in a follow-up `fix:` + `ci:` + `chore(rust):` commit triple:

- **BLOCKER: `theap_meta_lock` self-reentrancy.** `_mi_arenas_page_abandon` -> `mi_arena_pages_abandoned_ensure` -> `_mi_meta_zalloc_aligned` takes `subproc->theap_meta_lock` -- but `_mi_meta_zalloc_aligned` (subproc.c) already holds that lock across a full `mi_theap_zalloc_aligned` on `theap_meta`, whose slow path can retire one of `theap_meta`'s *own* full pages through `mi_page_to_full` -> `_mi_page_abandon` -> back into `_mi_arenas_page_abandon` -> the same lock again. The process main `theap_meta` is immune (`init.c` forces `allow_page_abandon = false` "for security, don't share with other threads"), but a *subproc's* `theap_meta` (`mi_subproc_new`, subproc.c) never got that treatment and inherits `allow_page_abandon = true` from `mi_option_page_full_retain`'s default -- a real asymmetry, not reproduced by the suite (needs a foreign free racing the meta theap's own allocation) but reachable by call-graph analysis. `MI_DEBUG>2` aborts on the reentrant acquire; Release hangs. Fixed two ways: `mi_subproc_new` now sets `theap_meta->allow_page_abandon = false` right after `_mi_theap_init`, closing the live path entirely (a meta theap's pages are never abandoned, so `_mi_page_abandon` never reaches back in); `_mi_arenas_page_abandon` also checks `_mi_meta_is_meta_page_safe(page)` before calling `..._ensure`, belt and braces, since a self-edge like this can't be resolved by the `MI_FORK_LOCK_*` acquisition ordering (that orders *different* locks against each other, not one lock against itself on one stack). Both documented in `src/fork.c`'s lock-order table, next to the existing `sp->theap_meta_lock` section this hazard sits inside; the inventory entry's `locks[]` records the same in a separate `ci:` commit.
- **LOW: leak clarity.** Added a comment at `mi_arena_initialize` (where `arena->pages_main.pages_abandoned[]` is stored NULL) explaining why never explicitly freeing those on-demand bitmaps isn't a leak: `pages_main` is embedded in the arena itself (not a separately allocated `arena_pages`), so `mi_heap_free` never reaches it for the main heap (`if (!is_main)`, heap.c) -- same "torn down only with the whole arena" lifetime `arena->pages_main.pages` already has.
- **LOW: PR body.** Added the `_mi_prof_on_alloc`/`_mi_meta_is_meta_page_safe` sentence and the `debug-full` gate note to the §2.3 bullet above, as the issue's 2.3 section asked for.
- Items 1, 3, 5 from the review: informational, no change.

## Deviations from the issue's literal text

1. `test-abandoned-lazy.c` doesn't strictly need the `MI_USE_CXX` `LANGUAGE CXX` property in this tree (the debug hook it references is already `extern "C"`, unlike Bun's tree before `1515c3c9`) — added anyway per the issue's explicit instruction; harmless, and the file's own `#ifdef __cplusplus` branches already target it.
2. `test/test-free-before-init.c`'s `.CRT$XCU` MSVC pre-main hook (issue §3, "optional, last, droppable") was **not ported** — out of caution for the hard `ctest (windows-latest)` gate per the issue's own instruction to drop it if there's any doubt, and this session had no Windows runner to validate it against.
3. `_mi_arena_pages_free`'s lifetime-invariant assert (`heap->theaps == NULL`) lives at the call site in `mi_heap_free` (heap.c) rather than inside the function itself, since the function only receives `mi_arena_pages_t*`, not the owning `heap`.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S

