### PR TITLE
ci(macos): make the Recovery execution job manual-only (workflow_dispatch)

### DIFF
--- a/.github/workflows/macos-bundles.yml
+++ b/.github/workflows/macos-bundles.yml
@@ -34,6 +34,18 @@ env:
   SOLDR_GITHUB_TOKEN: ${{ github.token }}
 
 on:
+  # The Recovery *execution* job (`run-macos-x64-recovery`) is manual-only: a full run is
+  # ~25 min when the guest cooperates and up to the 90-min job timeout when it does not,
+  # which is too slow for a per-PR gate (owner decision, 2026-09-03). Push/PR events still
+  # cross-compile every macOS bundle (both arches) so a build break is caught at once;
+  # trigger this workflow from the Actions tab (or `gh workflow run macos-bundles.yml
+  # --ref <branch>`) to execute the x86_64 bundles inside the Recovery guest.
+  workflow_dispatch:
+    inputs:
+      run-timeout:
+        description: seconds the guest gets to run the bundles
+        default: '3600'
+        required: false
   push:
     branches: [main, v4]
   pull_request:
@@ -417,6 +429,9 @@ jobs:
   run-macos-x64-recovery:
     name: run-macos-x64 (macOS Recovery on Linux)
     needs: [build-macos, build-rust-apple]
+    # Manual only -- see the `on:` block. Not a PR gate; run it before merging changes to
+    # the allocator's macOS-specific paths (prim/osx, interpose, TLS slots) or on demand.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # Emulated guest, everything in it serial, one boot retry budgeted.
     timeout-minutes: 90
@@ -493,7 +508,7 @@ jobs:
           share-dir: share
           collect: /tmp/w/out
           ram: '8'
-          run-timeout: '3600'
+          run-timeout: ${{ inputs.run-timeout || '3600' }}
           # One boot, everything serial inside it. Nothing here may abort the
           # script on a test failure: a red bundle still has to post its JUnit
           # back, and the runner decides pass/fail afterwards.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,13 @@ if the sub-issue conflicts with older prose in #2, the sub-issue + #2's Decision
    `RUN_SERIAL` group in `CMakeLists.txt`, never behind a retry.
    MSVC **and** win-gnu are priority platforms — both, always.
    The **macOS** gate is `macos-bundles.yml` and uses no Apple hardware (#277 phase B2):
-   both Apple arches are cross-built on Linux through soldr, `x86_64` is *executed* inside a
-   macOS Recovery guest on a Linux runner (`run-macos-x64-recovery`), and `aarch64` is
-   **compile-only** — a build plus Mach-O header assertions, with its test-name set checked
-   against the executed x86_64 bundle. Never add a `macos-*` runner label to a workflow or
+   both Apple arches are cross-built on Linux through soldr on every push/PR (that build is
+   the gate), and `aarch64` is **compile-only** — a build plus Mach-O header assertions, with
+   its test-name set checked against the x86_64 bundle. *Executing* the x86_64 bundles inside
+   a macOS Recovery guest on a Linux runner (`run-macos-x64-recovery`) is **manual-only**
+   (`workflow_dispatch`; owner decision 2026-09-03: ~25–90 min per run cannot gate PRs).
+   Run it with `gh workflow run macos-bundles.yml --ref <branch>` before merging changes
+   to macOS-specific allocator paths (prim/osx, interpose, TLS slots), and on demand. Never add a `macos-*` runner label to a workflow or
    to `azure-pipelines.yml`; `ci/lint_no_macos_runners.py` fails `python-lint` if you do.
    The guest boots macOS **Recovery** straight off the image every run via the
    `zackees/docker-mac-x64` action — no golden disk, no Actions cache, nothing to expire

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -34,7 +34,24 @@ verifying nothing**, each discovered by asking "has this ever actually failed?":
 | **zero-tracking** | correctness and footprint of `mi_option_purge_zeroes`, reported as paired interleaved A/B medians with the within-arm spread alongside. Linux runs it in its own path-filtered workflow; Windows runs it as a gated step inside `run-windows` (#277 phase E), and the *correctness* half is unconditional there because `test-zero-tracking*` are ordinary ctest tests carried in every bundle | — |
 | **bun-surface** (`ci/check_bun_surface.py`) | whether `oven-sh/bun`'s exact `scripts/build/deps/mimalloc.ts` DirectBuild (`src/static.c` compiled as C++ with Bun's define set) can actually link against every `mi_*` symbol Bun's Rust FFI and C++ consumers reference, plus `MI_MAX_ALIGN_SIZE` / `mi_heap_area_t` / `mi_option_t` slot-0-42 ABI drift via `test/test-bun-surface.cpp`'s `static_assert`s | the script's own exit code already reflects reality (1 on any missing symbol or failed assert) |
 
-### `bun-surface` is a hard gate
+### macOS execution is manual-only (2026-09-03)
+
+`macos-bundles.yml`'s `run-macos-x64-recovery` job (x86_64 bundles executed inside a macOS
+Recovery guest on a Linux runner, PR #308) takes ~25 min when the guest cooperates and up
+to the 90-min job timeout when it does not, so it is **not** a per-PR gate. It runs only on
+`workflow_dispatch`:
+
+```
+gh workflow run macos-bundles.yml --ref <branch>            # default 3600 s guest run
+gh workflow run macos-bundles.yml --ref <branch> -f run-timeout=1800
+```
+
+Every push/PR still cross-builds all six macOS bundles (both arches) and runs the Mach-O
+and coverage assertions, so a macOS build break is caught immediately; only the execution
+is on demand. Run it before merging changes to macOS-specific paths (`src/prim/osx`,
+interpose, TLS slots) and when a Linux-green change touches the arena/heap lifecycle.
+
+## `bun-surface` is a hard gate
 
 Issue #274 (Bun parity P9a). `mi_on_thread_idle` is part of Bun's linked surface
 (`mimalloc_sys.rs:30`) and merged to `main` with Bun parity P7a (issue #299, `1dbbb8df`).


### PR DESCRIPTION
Owner decision (2026-09-03): the macOS Recovery execution cannot complete in time to gate PRs, so it becomes a real test that is invoked manually.

**Changes**
- `macos-bundles.yml`: `workflow_dispatch` trigger with a `run-timeout` input; `run-macos-x64-recovery` now has `if: github.event_name == 'workflow_dispatch'`. Push/PR still cross-build all six macOS bundles (both arches) and run the Mach-O + coverage assertions; only the guest execution is on demand.
- `CLAUDE.md` rule 3 and `docs/ci-gates.md`: document the manual lane and how to run it (`gh workflow run macos-bundles.yml --ref <branch>`).

**Context**: PR #319's job hung for the full 3600 s guest timeout after the guest reached Terminal (previous head passed in ~130 s); tracked in zackees/docker-mac-x64#1. `ci/lint_no_macos_runners.py` still passes (no Apple hardware anywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
