### PR TITLE
feat(rust): bind every fork C API and document the C/Rust surface table

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           python3 ci/check_isa_baseline.py --selftest
           python3 ci/check_internal_state.py --selftest
+          # Parses C headers and Rust source with regexes; a regex that matches nothing
+          # reports "clean" exactly as loudly as one that works.
+          python3 ci/check_rust_surface.py --selftest
+          python3 ci/check_rust_surface.py
           # A gate script that imports cleanly but crashes on argv is still broken.
           python3 ci/memory_gate.py 2>&1 | grep -q "Exit codes"
           python3 ci/check_isa_baseline.py --help > /dev/null

--- a/.github/workflows/rust-native.yml
+++ b/.github/workflows/rust-native.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - 'rust/**'
       - 'ci/check_crate_package.py'
+      - 'ci/check_rust_surface.py'
+      # The C headers ARE an input to this job: ci/check_rust_surface.py fails when a
+      # header grows an export or an mi_option_t enumerator that rust/mimalloc-pprof's
+      # hand-written bindings do not mirror. Without these paths a C-only PR could add
+      # an API (or shift the option enum) and this job would never look.
+      - 'include/**'
       - '.github/workflows/rust-native.yml'
 
 concurrency:
@@ -48,6 +54,14 @@ jobs:
       - name: xtask check (vendored C amalgamation must match src/include/)
         if: runner.os != 'Windows'
         run: soldr cargo run -p xtask -- check
+      # The bindings in src/sys.rs are hand written, so nothing in the Rust build notices
+      # when C grows an export or shifts mi_option_t. This is what notices. Run before
+      # `cargo test` so a missing binding is reported as a missing binding rather than as
+      # a compile error three steps later.
+      - name: Rust binding surface covers the fork's C API
+        if: runner.os != 'Windows'
+        shell: bash
+        run: python ../ci/check_rust_surface.py
       - run: soldr cargo test --locked
       - name: cargo publish --dry-run (mimalloc-pprof)
         if: runner.os != 'Windows'

--- a/README.md
+++ b/README.md
@@ -332,8 +332,9 @@ For a measured chart of what this buys on a churn workload, see
 
 Every API this fork adds, in all three places it can be reached from: the C header,
 the crate's raw FFI module (`mimalloc_pprof::sys`, `unsafe`), and the crate's safe
-wrapper. There are no gaps — `ci/check_rust_surface.py` fails the build if a C export
-or an `mi_option_t` enumerator appears without a binding, and
+wrapper. There are no gaps — `ci/check_rust_surface.py` fails the build if a **fork** C export
+or an `mi_option_t` enumerator appears without a binding (upstream's own exports are
+bound opportunistically, not by requirement), and
 `rust/mimalloc-pprof/tests/t19_layout.rs` checks every mirrored struct layout and
 option value against what the C compiler actually laid out.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Three instruments, each shown in Rust and C: **pprof** sampled profiling for
 production, **exact allocator stats** to check a sampled profile against, and
 **DHAT** exact profiling for focused investigations.
 
+In a hurry, or looking for one specific call? [**API surface**](#api-surface) below
+is the whole thing in one table — every C entry point, its raw Rust FFI declaration,
+and its safe Rust wrapper.
+
 ### pprof: sampled heap profiling
 
 #### Rust
@@ -323,6 +327,155 @@ mi_purge_holes_report();        /* per size class: what could NOT be discarded, 
 
 For a measured chart of what this buys on a churn workload, see
 [Bun features: hole purging, measured](#hole-purging-measured).
+
+### API surface
+
+Every API this fork adds, in all three places it can be reached from: the C header,
+the crate's raw FFI module (`mimalloc_pprof::sys`, `unsafe`), and the crate's safe
+wrapper. There are no gaps — `ci/check_rust_surface.py` fails the build if a C export
+or an `mi_option_t` enumerator appears without a binding, and
+`rust/mimalloc-pprof/tests/t19_layout.rs` checks every mirrored struct layout and
+option value against what the C compiler actually laid out.
+
+Where the third column says **sys only**, that is deliberate and the reason is
+recorded in `ci/check_rust_surface.py`'s allowlist.
+
+#### Sampled pprof profiler — `include/mimalloc/profile.h`
+
+| C | Rust FFI (`sys::`) | Rust safe wrapper |
+|---|---|---|
+| `mi_prof_start` | ✅ | `prof::start` |
+| `mi_prof_start_seeded` | ✅ | `prof::start_seeded` |
+| `mi_prof_start_ex`, `mi_prof_config_t` | ✅ | `enable_heap_profiling_with(&ProfConfig)` |
+| `mi_prof_stop` | ✅ | `prof::stop` |
+| `mi_prof_is_enabled` | ✅ | `prof::is_enabled` |
+| `mi_prof_reset` | ✅ | `prof::reset` |
+| `mi_prof_dump` | ✅ | `prof::dump_file` |
+| `mi_prof_dump_writer` | ✅ | `prof::dump_to_vec` |
+| `mi_prof_dump_proto` | ✅ | `prof::dump_proto_file` |
+| `mi_prof_dump_proto_writer` | ✅ | `prof::dump_proto_to_vec` |
+| `mi_prof_stats_get`, `mi_prof_stats_t` | ✅ | `prof::stats() -> ProfStats` |
+| `mi_prof_snapshot_new` / `_visit` / `_free` | ✅ | `prof::samples() -> Vec<Sample>` |
+| `mi_prof_modules_visit` | ✅ | `prof::modules() -> Vec<ModuleInfo>` |
+| `mi_prof_visit` | ✅ | **sys only** — its visitor runs under the profiler lock, where an allocating Rust closure can deadlock; `prof::samples` takes a snapshot first |
+| `mi_prof_debug_stats` | ✅ | **sys only** — deprecated in favour of `mi_prof_stats_get` |
+| _no-code_: `MIMALLOC_PROF`, `MIMALLOC_PROF_DUMP_AT_EXIT`, … | — | see [options](#options--mi_option_t) below |
+
+Compiled out with the crate's `default-features = false` (mirrors `#if MI_PPROF`); the
+Rust API stays present and `prof::start` returns `false`.
+
+#### DHAT exact profiling — `include/mimalloc/dhat.h`
+
+| C | Rust FFI (`sys::`) | Rust safe wrapper |
+|---|---|---|
+| `mi_dhat_start` | ✅ | `dhat::start` |
+| `mi_dhat_stop` | ✅ | `dhat::stop` |
+| `mi_dhat_is_enabled` | ✅ | `dhat::is_enabled` |
+| `mi_dhat_stats_get`, `mi_dhat_stats_t` | ✅ | `dhat::stats() -> dhat::Stats` |
+| `mi_dhat_dump` | ✅ | `dhat::dump_file` |
+
+Independent of `MI_PPROF`: available in both feature modes.
+
+#### Memory events — `include/mimalloc/memory-events.h`
+
+| C | Rust FFI (`sys::`) | Rust safe wrapper |
+|---|---|---|
+| `mi_memory_tracking_set_enabled` | ✅ | `memory_events::set_enabled` |
+| `mi_memory_tracking_is_enabled` | ✅ | `memory_events::is_enabled` |
+| `mi_memory_snapshot`, `mi_memory_snapshot_t` | ✅ | `memory_events::snapshot() -> Snapshot` |
+| `mi_memory_set_callbacks`, `mi_memory_callbacks_t`, `mi_memory_change_t` | ✅ | `memory_events::set_callbacks(&'static Callbacks)` / `clear_callbacks` |
+| `mi_memory_visit_live_allocations` | ✅ | `unsafe memory_events::visit_live_allocations` |
+| `mi_unwrapped_malloc` / `_free` / `_realloc` | ✅ | `unwrapped_malloc` / `unwrapped_free` / `unwrapped_realloc` |
+
+Always compiled in, opt-in at runtime. Off by default, and while it is off every
+allocate/free/realloc pays for one relaxed flag check and nothing else.
+
+#### Exact allocator statistics — `include/mimalloc-stats.h`
+
+Upstream's API, not the fork's, but it is what a sampled profile is checked against —
+so the crate binds all of it.
+
+| C | Rust FFI (`sys::`) | Rust safe wrapper |
+|---|---|---|
+| `mi_stats_get`, `mi_stats_t` | ✅ | `stats::get() -> Stats` (derefs to the full struct) |
+| `mi_stats_get_json` | ✅ | `stats::json` |
+| `mi_stats_as_json` | ✅ | `Stats::to_json` |
+| `mi_stats_print_out` | ✅ | `stats::print` |
+| `mi_stats_get_bin_size` | ✅ | `stats::bin_size` |
+| `mi_subproc_stats_get` | ✅ | `stats::subproc_get` |
+| `mi_subproc_stats_get_exclusive` | ✅ | `stats::subproc_get_exclusive` |
+| `mi_subproc_stats_get_json` | ✅ | `stats::subproc_json` |
+| `mi_subproc_stats_print_out` | ✅ | `stats::subproc_print` |
+| `mi_subproc_heap_stats_print_out` | ✅ | `stats::subproc_heap_print` |
+| `mi_heap_stats_get` / `_get_json` / `_print_out`, `mi_heap_stats_merge_to_subproc` | ✅ | **sys only** — they take a `mi_heap_t*`, and v3 removed `mi_heap_get_default`, so Rust has no safe way to name a heap |
+
+Note what is **not** in `mi_stats_t`: the idle-sweep and hole-purging gauges. They live
+in `mi_purge_holes_stats_t` instead, because the sweep also covers pages no heap owns
+and `mi_stats_t` cannot grow (it is embedded in a theap, at the meta-allocator's 8 KB
+block limit).
+
+#### Heap dump
+
+| C | Rust FFI (`sys::`) | Rust safe wrapper |
+|---|---|---|
+| `mi_heap_dump_json` | ✅ | `heap_dump_json(include_blocks, hash_addresses)` |
+| `mi_heap_get_seq` | ✅ | **sys only** — needs a `mi_heap_t*` (see above); the seq numbers are already in `heap_dump_json`'s output |
+
+#### Thread idle, scavenger and hole purging
+
+A [Bun feature](#bun-features), ported from `oven-sh/mimalloc` — see that section for
+what hole purging buys on a churn workload. There is no single "hole punch" entry point:
+the feature is reached through the idle-sweep calls below, the `purge_holes*` options,
+and the `mi_purge_holes_stats_t` gauges.
+
+| C | Rust FFI (`sys::`) | Rust safe wrapper |
+|---|---|---|
+| `mi_on_thread_idle` | ✅ | `on_thread_idle()` |
+| `mi_on_thread_idle_start` / `_end` | ✅ | `park_while_idle() -> Option<IdlePark>` (ends on drop) |
+| `mi_scavenger_stop` | ✅ | `scavenger_stop()` |
+| `mi_purge_holes_stats_get`, `mi_purge_holes_stats_t` | ✅ | `purge_holes_stats() -> MiPurgeHolesStats` |
+| `mi_purge_holes_report` | ✅ | `purge_holes_report()` |
+
+#### Options — `mi_option_t`
+
+| C | Rust FFI (`sys::`) | Rust safe wrapper |
+|---|---|---|
+| `mi_option_t` (61 enumerators; 13 added by this fork at indices 47–59) | `sys::mi_option_*`, `sys::MI_OPTIONS_IN_ORDER` | `options::Opt` (named constants + range-checked `Opt::from_raw`) |
+| `mi_option_get` / `_get_clamp` / `_get_size` | ✅ | `options::get` / `get_clamp` / `get_size` |
+| `mi_option_set` / `_set_default` | ✅ | `options::set` / `set_default` |
+| `mi_option_is_enabled` / `_enable` / `_disable` / `_set_enabled` / `_set_enabled_default` | ✅ | `options::is_enabled` / `enable` / `disable` / `set_enabled` / `set_enabled_default` |
+| `mi_options_print_out` | ✅ | `options::print` |
+
+The thirteen this fork adds, each also settable as `MIMALLOC_<NAME>` in the environment:
+
+| Option | Default | What it does |
+|---|---|---|
+| `prof` | `0` | start the sampled profiler at process start |
+| `prof_sample_rate` | `524288` | average bytes between samples |
+| `prof_bt_max` | `32` | max captured stack depth |
+| `prof_accum` | `0` | keep cumulative counters until `mi_prof_reset` |
+| `prof_seed` | `0` | sampling PRNG seed; 0 = nondeterministic |
+| `prof_max_bytes` | `0` | budget for profiler-internal arena memory; 0 = unbudgeted |
+| `memory_events` | `0` | enable allocation-change accounting/callbacks |
+| `purge_zeroes` | `0` | **dead** since #80; the slot is kept so nothing renumbers |
+| `scavenger` | `1` | run the background arena-purging thread |
+| `purge_holes` | `1` | discard free blocks inside still-used pages on idle |
+| `purge_holes_eager_zero` | `0` | zero before discarding, so a mis-scoped discard corrupts visibly |
+| `purge_holes_min_interval` | `100` | ms floor between sweeps of one thread's heaps |
+| `purge_holes_full_every` | `64` | every N-th sweep walks every page; 0 disables |
+
+Because they are positional, a stale Rust mirror of this enum would silently set the
+*wrong* option — which is why `tests/t19_layout.rs` checks every value against the C
+compiler and `ci/check_rust_surface.py` checks the whole sequence against the header.
+
+#### Allocation
+
+`MiMalloc` implements `GlobalAlloc`. Beyond that the crate binds `mi_malloc`,
+`mi_zalloc`, `mi_calloc`, `mi_realloc`, `mi_free`, their `_aligned` forms,
+`mi_usable_size`, `mi_expand`, and the zeroing-realloc family (`mi_rezalloc`,
+`mi_recalloc`, and their aligned forms) as `rezalloc` / `recalloc` / `expand` /
+`usable_size` — `GlobalAlloc` has no `grow_zeroed`, so without them a Rust caller would
+grow and `memset` by hand, redoing work mimalloc has already done.
 
 ### Going deeper
 

--- a/ci/check_rust_surface.py
+++ b/ci/check_rust_surface.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# ///
+"""Fail if a C API this fork adds is not reachable from the Rust crate.
+
+The Rust crate is a hand-written binding: `rust/mimalloc-pprof/src/sys.rs` declares each
+C function by hand and mirrors each C enumerator's value by hand. Nothing in the Rust
+build notices when the C side grows a function or an option -- the crate keeps compiling,
+and the new API is simply invisible to every Rust consumer. That is how
+`include/mimalloc/memory-events.h` ended up with no binding at all while the profiler
+next to it was bound completely.
+
+Worse than absent is *wrong*. `mi_option_t` is positional, and this fork inserts thirteen
+enumerators (`prof*`, `memory_events`, `purge_zeroes`, `scavenger`, `purge_holes*`) at
+indices 47..=59, ahead of `_mi_option_last`. A mirror that drifted by one would compile,
+link, run, and set a different option than the caller named, silently and forever. So
+this script does not merely check that each option NAME is present: it checks the whole
+sequence, in order, against the header.
+
+    uv run ci/check_rust_surface.py            # check the tree
+    uv run ci/check_rust_surface.py --selftest # check this script's own parsing
+
+What it checks:
+
+  1. Every `mi_decl_export` prototype in the fork's own headers (`mimalloc/profile.h`,
+     `mimalloc/memory-events.h`, `mimalloc/dhat.h` -- 100% fork) plus the fork's named
+     additions to the two upstream headers is declared in `sys.rs`, or is on
+     `UNBOUND_WITH_REASON` with a reason.
+  2. `MI_OPTIONS_IN_ORDER` in `sys.rs` is exactly the `mi_option_t` enumerator sequence
+     from `include/mimalloc.h`, up to and including `_mi_option_last`.
+  3. Every C function on `WRAPPED_IN_LIB` really does have its safe wrapper named in
+     `src/lib.rs`, and every fork export is either wrapped or on `SYS_ONLY_WITH_REASON`.
+
+What it deliberately does NOT do: diff against the pinned upstream base commit
+(`6def7be9`). `actions/checkout@v4` fetches depth 1, and this fork's history is unrelated
+to upstream's, so that object does not exist in CI. FORK_ADDITIONS_IN_UPSTREAM_HEADERS
+below is the explicit list instead -- and every name on it is verified to still be an
+export in the header it claims, so a rename cannot quietly empty the list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INCLUDE_DIR = REPO_ROOT / "include"
+CRATE_DIR = REPO_ROOT / "rust" / "mimalloc-pprof"
+SYS_RS = CRATE_DIR / "src" / "sys.rs"
+LIB_RS = CRATE_DIR / "src" / "lib.rs"
+
+#: Headers whose every `mi_decl_export` is a fork addition: these three files do not
+#: exist upstream at all.
+FORK_ONLY_HEADERS = (
+    Path("mimalloc/profile.h"),
+    Path("mimalloc/memory-events.h"),
+    Path("mimalloc/dhat.h"),
+)
+
+#: Headers the fork shares with upstream. Only the names listed in
+#: FORK_ADDITIONS_IN_UPSTREAM_HEADERS are this fork's; the rest are upstream's API and are
+#: bound opportunistically, not by requirement.
+SHARED_HEADERS = (Path("mimalloc.h"), Path("mimalloc-stats.h"))
+
+#: The fork's own exports inside the two shared headers. Kept as a literal list rather
+#: than derived from git: see the module docstring.
+FORK_ADDITIONS_IN_UPSTREAM_HEADERS = {
+    # issue #272 / Bun parity P7a -- the idle/scavenger surface
+    "mi_on_thread_idle",
+    "mi_on_thread_idle_start",
+    "mi_on_thread_idle_end",
+    "mi_scavenger_stop",
+    # issue #272 / Bun parity P7b -- hole purging
+    "mi_purge_holes_stats_get",
+    "mi_purge_holes_report",
+    # issue #269 / Bun parity P4 -- the heap dump
+    "mi_heap_dump_json",
+    "mi_heap_get_seq",
+}
+
+#: C functions with no `sys.rs` declaration, and why that is deliberate. Empty today:
+#: every fork export is bound. Kept as the pressure valve so a future omission has to be
+#: written down rather than merely not noticed.
+UNBOUND_WITH_REASON: dict[str, str] = {}
+
+#: Fork exports that are declared in `sys.rs` but deliberately have no safe wrapper in
+#: `lib.rs`, and why.
+SYS_ONLY_WITH_REASON = {
+    "mi_prof_debug_stats": (
+        "deprecated in include/mimalloc/profile.h in favour of mi_prof_stats_get, which "
+        "is wrapped as prof::stats(). Binding it in sys.rs keeps the C surface complete "
+        "without giving the deprecated shape a Rust name."
+    ),
+    "mi_heap_get_seq": (
+        "needs a `mi_heap_t*`, and mimalloc v3 removed `mi_heap_get_default`, so Rust has "
+        "no safe way to name a heap to ask about. The sequence numbers it returns are "
+        "already visible in the JSON from `heap_dump_json`, which is the wrapped route."
+    ),
+    "mi_prof_visit": (
+        "prof::samples() deliberately wraps mi_prof_snapshot_new/_visit/_free instead. "
+        "mi_prof_visit runs its visitor while the profiler lock is held, so a Rust "
+        "closure that allocates -- which collecting into a Vec does -- can deadlock "
+        "against an ordinary mi_malloc on another thread (see profile.h's #270 note)."
+    ),
+}
+
+_EXPORT_RE = re.compile(
+    r"mi_decl_export[^;{]*?\b(mi_[A-Za-z0-9_]+)\s*\(",
+)
+_COMMENT_BLOCK_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_COMMENT_LINE_RE = re.compile(r"//[^\n]*")
+_OPTION_ENUM_RE = re.compile(r"typedef\s+enum\s+mi_option_e\s*\{(.*?)\}\s*mi_option_t", re.DOTALL)
+_SYS_EXTERN_FN_RE = re.compile(r"^\s*pub fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*[(<]", re.MULTILINE)
+_SYS_OPTIONS_BLOCK_RE = re.compile(r"mi_options!\s*\{(.*?)\n\}", re.DOTALL)
+_SYS_OPTION_NAME_RE = re.compile(r"^\s*(_?mi_option_[A-Za-z0-9_]*)\s*=\s*(\d+);", re.MULTILINE)
+
+
+def strip_comments(source: str) -> str:
+    """C source with block and line comments blanked out.
+
+    Load bearing: several prototypes are *described* in neighbouring comments (and
+    `include/mimalloc.h` discusses `mi_heap_visit_blocks` at length), so a regex run over
+    raw text would find exports that are not declared and enumerators that are not there.
+    """
+    return _COMMENT_LINE_RE.sub(" ", _COMMENT_BLOCK_RE.sub(" ", source))
+
+
+def exports_in_source(source: str) -> set[str]:
+    """Every `mi_decl_export`ed function name declared in a chunk of C header text."""
+    return set(_EXPORT_RE.findall(strip_comments(source)))
+
+
+def header_exports(path: Path) -> set[str]:
+    """Every `mi_decl_export`ed function name declared in one header."""
+    return exports_in_source(path.read_text(encoding="utf-8"))
+
+
+def option_enumerators(header: str) -> list[str]:
+    """`mi_option_t`'s enumerators in declaration order, up to `_mi_option_last`.
+
+    The deprecated aliases after the sentinel are excluded: they carry explicit `= other`
+    values rather than positions, so they are not part of the sequence that shifts.
+    """
+    match = _OPTION_ENUM_RE.search(strip_comments(header))
+    if match is None:
+        raise ValueError("could not find `typedef enum mi_option_e { ... } mi_option_t`")
+    names: list[str] = []
+    for token in match.group(1).split(","):
+        name = token.split("=")[0].strip()
+        if not name.startswith(("mi_option_", "_mi_option")):
+            continue
+        names.append(name)
+        if name == "_mi_option_last":
+            break
+    return names
+
+
+def sys_declared_functions(source: str) -> set[str]:
+    """Every function `sys.rs` declares in its `unsafe extern "C"` block."""
+    return set(_SYS_EXTERN_FN_RE.findall(source))
+
+
+def sys_option_mirror(source: str) -> list[tuple[str, int]]:
+    """The `mi_options! { ... }` mirror in `sys.rs`, as `(name, value)` in source order."""
+    match = _SYS_OPTIONS_BLOCK_RE.search(source)
+    if match is None:
+        raise ValueError("could not find the `mi_options! { ... }` block in sys.rs")
+    return [(name, int(value)) for name, value in _SYS_OPTION_NAME_RE.findall(match.group(1))]
+
+
+def option_mirror_problems(header_options: list[str], mirror: list[tuple[str, int]]) -> list[str]:
+    """Everything wrong with `sys.rs`'s `mi_option_t` mirror, as human-readable strings.
+
+    Split out from `check` so the negative control is testable: a mirror that is merely
+    *shifted* still contains every correct name, so a set comparison would call it clean
+    while every option past the shift silently resolves to the wrong one.
+    """
+    problems: list[str] = []
+    mirror_names = [name for name, _ in mirror]
+    if mirror_names != header_options:
+        # Report the first divergence rather than two long lists: that is the enumerator
+        # whose wrong value every later one inherits.
+        for index, expected in enumerate(header_options):
+            actual = mirror_names[index] if index < len(mirror_names) else "<missing>"
+            if actual != expected:
+                problems.append(
+                    f"mi_option_t mirror diverges at index {index}: include/mimalloc.h "
+                    f"has `{expected}`, sys.rs's mi_options! has `{actual}`. Every later "
+                    "option is now off by at least one, which silently sets the WRONG "
+                    "option at runtime."
+                )
+                break
+        else:
+            problems.append(
+                f"mi_option_t mirror has {len(mirror_names)} enumerators, "
+                f"include/mimalloc.h has {len(header_options)}."
+            )
+    for index, (name, value) in enumerate(mirror):
+        if value != index:
+            problems.append(
+                f"sys.rs mirrors `{name}` as {value} but it is at index {index}; "
+                "mi_option_t is a plain sequential C enum."
+            )
+    return problems
+
+
+def _fail(problems: list[str], message: str) -> None:
+    problems.append(message)
+
+
+def check(*, verbose: bool = True) -> int:
+    """Return 0 when the Rust binding surface covers the C surface, 1 otherwise."""
+    problems: list[str] = []
+
+    fork_exports: dict[str, str] = {}
+    for relative in FORK_ONLY_HEADERS:
+        for name in sorted(header_exports(INCLUDE_DIR / relative)):
+            fork_exports[name] = str(relative)
+
+    shared_exports: dict[str, str] = {}
+    for relative in SHARED_HEADERS:
+        for name in header_exports(INCLUDE_DIR / relative):
+            shared_exports[name] = str(relative)
+
+    # A rename upstream (or in the fork) must not quietly shrink the list of things this
+    # script requires, so every literal name is checked against the header it claims.
+    for name in sorted(FORK_ADDITIONS_IN_UPSTREAM_HEADERS):
+        if name not in shared_exports:
+            _fail(
+                problems,
+                f"{name}: listed in FORK_ADDITIONS_IN_UPSTREAM_HEADERS but no longer "
+                f"exported by any of {', '.join(str(h) for h in SHARED_HEADERS)}. If it "
+                "was renamed, update the list; if it was removed, drop it.",
+            )
+        else:
+            fork_exports[name] = shared_exports[name]
+
+    sys_source = SYS_RS.read_text(encoding="utf-8")
+    lib_source = LIB_RS.read_text(encoding="utf-8")
+    declared = sys_declared_functions(sys_source)
+
+    for name, origin in sorted(fork_exports.items()):
+        if name in declared:
+            continue
+        reason = UNBOUND_WITH_REASON.get(name)
+        if reason:
+            if verbose:
+                print(f"  allowed unbound: {name} ({origin}) -- {reason}")
+            continue
+        _fail(
+            problems,
+            f"{name} ({origin}) is exported by C but not declared in "
+            f"rust/mimalloc-pprof/src/sys.rs. Add the `pub fn` declaration, or add it to "
+            "UNBOUND_WITH_REASON in this script with a reason.",
+        )
+
+    # Stale allowlist entries are their own failure: an entry that no longer describes
+    # anything real is a claim nobody checked.
+    for name in sorted(UNBOUND_WITH_REASON):
+        if name in declared:
+            _fail(
+                problems,
+                f"{name} is on UNBOUND_WITH_REASON but IS declared in sys.rs. Remove the "
+                "allowlist entry.",
+            )
+        elif name not in fork_exports:
+            _fail(
+                problems,
+                f"{name} is on UNBOUND_WITH_REASON but is not a fork export at all. "
+                "Remove the allowlist entry.",
+            )
+
+    # --- the positional hazard -------------------------------------------------------
+    header_options = option_enumerators((INCLUDE_DIR / "mimalloc.h").read_text(encoding="utf-8"))
+    problems.extend(option_mirror_problems(header_options, sys_option_mirror(sys_source)))
+
+    # --- safe wrappers ---------------------------------------------------------------
+    for name in sorted(fork_exports):
+        if name not in declared:
+            continue  # already reported (or allowlisted) above
+        if f"sys::{name}" in lib_source:
+            continue
+        reason = SYS_ONLY_WITH_REASON.get(name)
+        if reason:
+            if verbose:
+                print(f"  sys-only: {name} -- {reason}")
+            continue
+        _fail(
+            problems,
+            f"{name} is declared in sys.rs but never called from src/lib.rs, so there is "
+            "no safe wrapper. Add one, or add it to SYS_ONLY_WITH_REASON with a reason.",
+        )
+
+    for name in sorted(SYS_ONLY_WITH_REASON):
+        if name not in fork_exports:
+            _fail(
+                problems,
+                f"{name} is on SYS_ONLY_WITH_REASON but is not a fork export. Remove the "
+                "allowlist entry.",
+            )
+        elif f"sys::{name}" in lib_source:
+            _fail(
+                problems,
+                f"{name} is on SYS_ONLY_WITH_REASON but IS called from lib.rs. Remove the "
+                "allowlist entry.",
+            )
+
+    if problems:
+        print("\ncheck_rust_surface: the Rust binding surface does not cover C.\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        print(
+            f"\n{len(problems)} problem(s). See rust/mimalloc-pprof/src/sys.rs and the "
+            "'API surface' table in README.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"check_rust_surface: {len(fork_exports)} fork exports bound, "
+        f"{len(header_options)} mi_option_t enumerators mirrored in order."
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------------------
+# Self-test: the parsing, on fixtures, so a regex that silently matches nothing (and
+# therefore reports "clean") fails loudly instead. This has already happened twice in
+# this repo's gate scripts -- see .github/workflows/python-lint.yml's header.
+# --------------------------------------------------------------------------------------
+
+_SELFTEST_HEADER = """
+/* mi_decl_export void mi_in_a_comment(void); */
+// mi_decl_export void mi_in_a_line_comment(void);
+mi_decl_export void mi_real_one(void) mi_attr_noexcept;
+mi_decl_nodiscard mi_decl_export bool mi_real_two(size_t n) mi_attr_noexcept;
+
+typedef enum mi_option_e {
+  mi_option_alpha,
+  mi_option_beta,   /* a comment, with a comma, that must not become an enumerator */
+  mi_option_gamma,
+  _mi_option_last,
+  mi_option_alias = mi_option_alpha
+} mi_option_t;
+"""
+
+_SELFTEST_SYS = """
+mi_options! {
+    /// doc
+    mi_option_alpha = 0;
+    mi_option_beta = 1;
+    mi_option_gamma = 2;
+    _mi_option_last = 3;
+}
+
+unsafe extern "C" {
+    pub fn mi_real_one();
+    pub fn mi_real_two(n: usize) -> bool;
+}
+"""
+
+
+def selftest() -> int:
+    """Check the parsers against fixtures; return 0 on success."""
+    failures: list[str] = []
+
+    exports = exports_in_source(_SELFTEST_HEADER)
+    if exports != {"mi_real_one", "mi_real_two"}:
+        failures.append(f"export parsing: expected the two real exports, got {sorted(exports)}")
+
+    options = option_enumerators(_SELFTEST_HEADER)
+    if options != ["mi_option_alpha", "mi_option_beta", "mi_option_gamma", "_mi_option_last"]:
+        failures.append(f"option parsing: got {options}")
+
+    mirror = sys_option_mirror(_SELFTEST_SYS)
+    if mirror != [
+        ("mi_option_alpha", 0),
+        ("mi_option_beta", 1),
+        ("mi_option_gamma", 2),
+        ("_mi_option_last", 3),
+    ]:
+        failures.append(f"sys.rs option mirror parsing: got {mirror}")
+
+    declared = sys_declared_functions(_SELFTEST_SYS)
+    if declared != {"mi_real_one", "mi_real_two"}:
+        failures.append(f"sys.rs extern parsing: got {sorted(declared)}")
+
+    # The parsers must find something real in the actual tree, too: a regex that matches
+    # nothing reports "clean" just as loudly as one that works.
+    for relative in FORK_ONLY_HEADERS:
+        if not header_exports(INCLUDE_DIR / relative):
+            failures.append(f"{relative}: parsed zero exports from a real fork header")
+    if len(sys_declared_functions(SYS_RS.read_text(encoding="utf-8"))) < 20:
+        failures.append("sys.rs: parsed suspiciously few extern declarations")
+
+    if failures:
+        for failure in failures:
+            print(f"check_rust_surface --selftest: {failure}", file=sys.stderr)
+        return 1
+    print("check_rust_surface --selftest: parsers OK")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="check this script's own parsing against fixtures and exit",
+    )
+    parser.add_argument("--quiet", action="store_true", help="only print failures")
+    args = parser.parse_args(argv)
+    if args.selftest:
+        return selftest()
+    return check(verbose=not args.quiet)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check_rust_surface.py
+++ b/ci/check_rust_surface.py
@@ -171,6 +171,20 @@ def sys_option_mirror(source: str) -> list[tuple[str, int]]:
     return [(name, int(value)) for name, value in _SYS_OPTION_NAME_RE.findall(match.group(1))]
 
 
+def is_called_from_lib(name: str, lib_source: str) -> bool:
+    """Whether `src/lib.rs` actually calls `sys::<name>`.
+
+    Word-anchored rather than a plain substring test, because C's names nest:
+    `sys::mi_prof_start_seeded` contains `sys::mi_prof_start`, `sys::mi_option_get_clamp`
+    contains `sys::mi_option_get`, `sys::mi_option_set_default` contains
+    `sys::mi_option_set`. A substring test would report the shorter one as wrapped on the
+    strength of the longer one's call site -- which is precisely the regression this
+    check exists to catch. `\\b` does not match between `t` and `_`, so the longer name
+    no longer covers the shorter.
+    """
+    return re.search(rf"\bsys::{re.escape(name)}\b", lib_source) is not None
+
+
 def option_mirror_problems(header_options: list[str], mirror: list[tuple[str, int]]) -> list[str]:
     """Everything wrong with `sys.rs`'s `mi_option_t` mirror, as human-readable strings.
 
@@ -281,7 +295,7 @@ def check(*, verbose: bool = True) -> int:
     for name in sorted(fork_exports):
         if name not in declared:
             continue  # already reported (or allowlisted) above
-        if f"sys::{name}" in lib_source:
+        if is_called_from_lib(name, lib_source):
             continue
         reason = SYS_ONLY_WITH_REASON.get(name)
         if reason:
@@ -301,7 +315,7 @@ def check(*, verbose: bool = True) -> int:
                 f"{name} is on SYS_ONLY_WITH_REASON but is not a fork export. Remove the "
                 "allowlist entry.",
             )
-        elif f"sys::{name}" in lib_source:
+        elif is_called_from_lib(name, lib_source):
             _fail(
                 problems,
                 f"{name} is on SYS_ONLY_WITH_REASON but IS called from lib.rs. Remove the "
@@ -387,6 +401,13 @@ def selftest() -> int:
     declared = sys_declared_functions(_SELFTEST_SYS)
     if declared != {"mi_real_one", "mi_real_two"}:
         failures.append(f"sys.rs extern parsing: got {sorted(declared)}")
+
+    # C names nest, and a substring test would call the shorter one wrapped.
+    nested = "let x = unsafe { sys::mi_prof_start_seeded(0, 1) };"
+    if is_called_from_lib("mi_prof_start", nested):
+        failures.append("call-site matching: `mi_prof_start_seeded` satisfied `mi_prof_start`")
+    if not is_called_from_lib("mi_prof_start_seeded", nested):
+        failures.append("call-site matching: missed a real `sys::mi_prof_start_seeded` call")
 
     # The parsers must find something real in the actual tree, too: a regex that matches
     # nothing reports "clean" just as loudly as one that works.

--- a/ci/check_rust_surface.py
+++ b/ci/check_rust_surface.py
@@ -115,6 +115,12 @@ _COMMENT_LINE_RE = re.compile(r"//[^\n]*")
 _OPTION_ENUM_RE = re.compile(r"typedef\s+enum\s+mi_option_e\s*\{(.*?)\}\s*mi_option_t", re.DOTALL)
 _SYS_EXTERN_FN_RE = re.compile(r"^\s*pub fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*[(<]", re.MULTILINE)
 _SYS_OPTIONS_BLOCK_RE = re.compile(r"mi_options!\s*\{(.*?)\n\}", re.DOTALL)
+#: Rust comment shapes, stripped before searching `lib.rs` for a `sys::` call site: a
+#: doc comment that merely NAMES a C function must not count as calling it.
+_RUST_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_RUST_LINE_COMMENT_RE = re.compile(r"^[ \t]*//[^\n]*", re.MULTILINE)
+#: A trailing `// ...`, but not the `//` of a `https://` inside a string or doc link.
+_RUST_TRAILING_COMMENT_RE = re.compile(r"(?<!:)//[^\n]*")
 _SYS_OPTION_NAME_RE = re.compile(r"^\s*(_?mi_option_[A-Za-z0-9_]*)\s*=\s*(\d+);", re.MULTILINE)
 
 
@@ -171,8 +177,25 @@ def sys_option_mirror(source: str) -> list[tuple[str, int]]:
     return [(name, int(value)) for name, value in _SYS_OPTION_NAME_RE.findall(match.group(1))]
 
 
+def strip_rust_comments(source: str) -> str:
+    """Rust source with comments blanked out, for call-site searching.
+
+    `lib.rs` is heavily documented, and its doc comments name the C functions they wrap
+    ("Thin wrapper around `sys::mi_unwrapped_malloc`"). Searching raw text would let a
+    function be *described* rather than *called* and still count as wrapped -- the check
+    would pass on prose.
+
+    The trailing-comment rule requires the `//` not to follow a colon, so the `https://`
+    in a doc link does not truncate the rest of its line. Block comments go first, since
+    a `/* ... */` may span lines.
+    """
+    source = _RUST_BLOCK_COMMENT_RE.sub(" ", source)
+    source = _RUST_LINE_COMMENT_RE.sub(" ", source)
+    return _RUST_TRAILING_COMMENT_RE.sub(" ", source)
+
+
 def is_called_from_lib(name: str, lib_source: str) -> bool:
-    """Whether `src/lib.rs` actually calls `sys::<name>`.
+    """Whether `src/lib.rs` actually calls `sys::<name>` in code (not in a comment).
 
     Word-anchored rather than a plain substring test, because C's names nest:
     `sys::mi_prof_start_seeded` contains `sys::mi_prof_start`, `sys::mi_option_get_clamp`
@@ -181,8 +204,11 @@ def is_called_from_lib(name: str, lib_source: str) -> bool:
     strength of the longer one's call site -- which is precisely the regression this
     check exists to catch. `\\b` does not match between `t` and `_`, so the longer name
     no longer covers the shorter.
+
+    Comments are stripped first for the same reason: a wrapper that was deleted but whose
+    doc comment still mentions the C function must not read as wrapped.
     """
-    return re.search(rf"\bsys::{re.escape(name)}\b", lib_source) is not None
+    return re.search(rf"\bsys::{re.escape(name)}\b", strip_rust_comments(lib_source)) is not None
 
 
 def option_mirror_problems(header_options: list[str], mirror: list[tuple[str, int]]) -> list[str]:
@@ -377,6 +403,19 @@ unsafe extern "C" {
 """
 
 
+#: `mi_prof_stop` is only ever NAMED here (in a doc comment, in a block comment, and in a
+#: trailing comment); `mi_prof_reset` is genuinely called, on a line that also carries a
+#: `https://` the trailing-comment rule must not mistake for a comment.
+_SELFTEST_LIB_COMMENT_ONLY = """
+/// Stops the profiler. Thin wrapper around `sys::mi_prof_stop`.
+//! See sys::mi_prof_stop for the raw declaration.
+/* was: unsafe { sys::mi_prof_stop() } */
+pub fn reset() {
+    let _doc = "https://example.invalid/x"; unsafe { sys::mi_prof_reset() } // sys::mi_prof_stop
+}
+"""
+
+
 def selftest() -> int:
     """Check the parsers against fixtures; return 0 on success."""
     failures: list[str] = []
@@ -408,6 +447,12 @@ def selftest() -> int:
         failures.append("call-site matching: `mi_prof_start_seeded` satisfied `mi_prof_start`")
     if not is_called_from_lib("mi_prof_start_seeded", nested):
         failures.append("call-site matching: missed a real `sys::mi_prof_start_seeded` call")
+
+    # A function that is only *described* is not wrapped.
+    if is_called_from_lib("mi_prof_stop", _SELFTEST_LIB_COMMENT_ONLY):
+        failures.append("call-site matching: a doc comment satisfied the wrapper check")
+    if not is_called_from_lib("mi_prof_reset", _SELFTEST_LIB_COMMENT_ONLY):
+        failures.append("call-site matching: missed a real call on a line that also has a URL")
 
     # The parsers must find something real in the actual tree, too: a regex that matches
     # nothing reports "clean" just as loudly as one that works.

--- a/ci/tests/test_check_rust_surface.py
+++ b/ci/tests/test_check_rust_surface.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import check_rust_surface as surface
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class CheckRustSurfaceTests(unittest.TestCase):
+    def test_the_tree_is_clean(self) -> None:
+        """The gate itself: every fork C API is reachable from the Rust crate."""
+        self.assertEqual(surface.check(verbose=False), 0)
+
+    def test_selftest_passes(self) -> None:
+        self.assertEqual(surface.selftest(), 0)
+
+    def test_comments_do_not_look_like_exports(self) -> None:
+        """include/mimalloc.h discusses prototypes in prose; a raw regex would find them."""
+        source = "/* mi_decl_export void mi_ghost(void); */\nmi_decl_export void mi_real(void);"
+        self.assertEqual(surface.exports_in_source(source), {"mi_real"})
+
+    def test_fork_headers_parse_to_something(self) -> None:
+        """A regex that matches nothing reports 'clean' exactly as loudly as one that works."""
+        for relative in surface.FORK_ONLY_HEADERS:
+            with self.subTest(header=str(relative)):
+                self.assertTrue(surface.header_exports(surface.INCLUDE_DIR / relative))
+
+    def test_the_forks_own_options_are_mirrored_in_order(self) -> None:
+        header = (surface.INCLUDE_DIR / "mimalloc.h").read_text(encoding="utf-8")
+        options = surface.option_enumerators(header)
+        self.assertEqual(options[-1], "_mi_option_last")
+        # The thirteen this fork inserts, contiguously, ahead of the sentinel.
+        fork_block = [
+            "mi_option_prof",
+            "mi_option_prof_sample_rate",
+            "mi_option_prof_bt_max",
+            "mi_option_prof_accum",
+            "mi_option_prof_seed",
+            "mi_option_prof_max_bytes",
+            "mi_option_memory_events",
+            "mi_option_purge_zeroes",
+            "mi_option_scavenger",
+            "mi_option_purge_holes",
+            "mi_option_purge_holes_eager_zero",
+            "mi_option_purge_holes_min_interval",
+            "mi_option_purge_holes_full_every",
+        ]
+        self.assertEqual(options[-len(fork_block) - 1 : -1], fork_block)
+
+    def test_a_shifted_mirror_is_caught(self) -> None:
+        """The negative control that matters.
+
+        A mirror that dropped one enumerator still contains every *name* the header does,
+        so a set comparison would call it clean -- while every option past the drop point
+        resolves to a different option than the caller named. This must fail.
+        """
+        header_options = ["mi_option_a", "mi_option_b", "mi_option_c", "_mi_option_last"]
+        shifted = [("mi_option_a", 0), ("mi_option_c", 1), ("_mi_option_last", 2)]
+        problems = surface.option_mirror_problems(header_options, shifted)
+        self.assertTrue(problems)
+        self.assertIn("diverges at index 1", problems[0])
+
+    def test_a_correct_mirror_is_accepted(self) -> None:
+        header_options = ["mi_option_a", "mi_option_b", "_mi_option_last"]
+        good = [("mi_option_a", 0), ("mi_option_b", 1), ("_mi_option_last", 2)]
+        self.assertEqual(surface.option_mirror_problems(header_options, good), [])
+
+    def test_a_renumbered_mirror_is_caught(self) -> None:
+        """Right names, wrong values: still the wrong option at runtime."""
+        header_options = ["mi_option_a", "mi_option_b", "_mi_option_last"]
+        renumbered = [("mi_option_a", 0), ("mi_option_b", 7), ("_mi_option_last", 2)]
+        problems = surface.option_mirror_problems(header_options, renumbered)
+        self.assertTrue(any("mirrors `mi_option_b` as 7" in p for p in problems))
+
+    def test_every_allowlist_entry_carries_a_reason(self) -> None:
+        for name, reason in {
+            **surface.UNBOUND_WITH_REASON,
+            **surface.SYS_ONLY_WITH_REASON,
+        }.items():
+            with self.subTest(name=name):
+                self.assertGreater(len(reason), 40, f"{name}: the reason is not a reason")
+
+    def test_the_named_fork_additions_are_real_exports(self) -> None:
+        """The literal list stands in for a diff against upstream; keep it honest."""
+        exported: set[str] = set()
+        for relative in surface.SHARED_HEADERS:
+            exported |= surface.header_exports(surface.INCLUDE_DIR / relative)
+        missing = surface.FORK_ADDITIONS_IN_UPSTREAM_HEADERS - exported
+        self.assertEqual(missing, set(), f"no longer exported by C: {sorted(missing)}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tests/test_check_rust_surface.py
+++ b/ci/tests/test_check_rust_surface.py
@@ -49,6 +49,20 @@ class CheckRustSurfaceTests(unittest.TestCase):
         ]
         self.assertEqual(options[-len(fork_block) - 1 : -1], fork_block)
 
+    def test_a_nested_name_does_not_count_as_a_call_site(self) -> None:
+        """C names nest, and a substring test would call the shorter one wrapped.
+
+        `sys::mi_prof_start_seeded` contains `sys::mi_prof_start`, `sys::mi_option_get_clamp`
+        contains `sys::mi_option_get`, and so on -- so a plain `in` test would report an
+        UNwrapped function as wrapped on the strength of its longer sibling's call site.
+        """
+        source = "let x = unsafe { sys::mi_prof_start_seeded(0, 1) };"
+        self.assertFalse(surface.is_called_from_lib("mi_prof_start", source))
+        self.assertTrue(surface.is_called_from_lib("mi_prof_start_seeded", source))
+        clamp = "options::get_clamp(unsafe { sys::mi_option_get_clamp(o, a, b) })"
+        self.assertFalse(surface.is_called_from_lib("mi_option_get", clamp))
+        self.assertTrue(surface.is_called_from_lib("mi_option_get_clamp", clamp))
+
     def test_a_shifted_mirror_is_caught(self) -> None:
         """The negative control that matters.
 

--- a/ci/tests/test_check_rust_surface.py
+++ b/ci/tests/test_check_rust_surface.py
@@ -63,6 +63,27 @@ class CheckRustSurfaceTests(unittest.TestCase):
         self.assertFalse(surface.is_called_from_lib("mi_option_get", clamp))
         self.assertTrue(surface.is_called_from_lib("mi_option_get_clamp", clamp))
 
+    def test_a_doc_comment_mention_is_not_a_call_site(self) -> None:
+        """lib.rs names the C functions it wraps in prose; prose must not count.
+
+        If a wrapper were deleted but its doc comment left behind, a raw text search
+        would still report the function as wrapped -- the gate would pass on a sentence.
+        """
+        described_only = (
+            "/// Stops the profiler. Thin wrapper around `sys::mi_prof_stop`.\n"
+            "//! See sys::mi_prof_stop for the raw declaration.\n"
+            "/* was: unsafe { sys::mi_prof_stop() } */\n"
+        )
+        self.assertFalse(surface.is_called_from_lib("mi_prof_stop", described_only))
+        self.assertTrue(
+            surface.is_called_from_lib("mi_prof_stop", "unsafe { sys::mi_prof_stop() }")
+        )
+
+    def test_a_url_in_source_does_not_swallow_the_rest_of_its_line(self) -> None:
+        """The trailing-comment rule must not treat the `//` of `https://` as a comment."""
+        line = 'let _ = "https://example.invalid/x"; unsafe { sys::mi_prof_reset() }'
+        self.assertTrue(surface.is_called_from_lib("mi_prof_reset", line))
+
     def test_a_shifted_mirror_is_caught(self) -> None:
         """The negative control that matters.
 

--- a/ci/verify_local.py
+++ b/ci/verify_local.py
@@ -641,6 +641,12 @@ def run_rust(ctx: RunCtx) -> bool:
     )
     if rc:
         return False
+    # rust-native.yml's "Rust binding surface covers the fork's C API" step. Cheap, and it
+    # names a missing binding as a missing binding instead of letting it surface (or not
+    # surface at all) three steps later.
+    rc, _ = run_logged(["uv", "run", "ci/check_rust_surface.py"], cwd=ROOT, log=ctx.log)
+    if rc:
+        return False
     rc, _ = run_logged(["cargo", "test", "--workspace"], cwd=rust_dir, log=ctx.log, env=env)
     return rc == 0
 
@@ -672,6 +678,8 @@ def run_lint(ctx: RunCtx) -> bool:
     for cmd in (
         ["uv", "run", "ci/check_isa_baseline.py", "--selftest"],
         ["uv", "run", "ci/check_internal_state.py", "--selftest"],
+        ["uv", "run", "ci/check_rust_surface.py", "--selftest"],
+        ["uv", "run", "ci/check_rust_surface.py"],
         ["uv", "run", "ci/check_isa_baseline.py", "--help"],
         ["uv", "run", "ci/check_release_equivalence.py", "--help"],
     ):

--- a/rust/mimalloc-pprof/CHANGELOG.md
+++ b/rust/mimalloc-pprof/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+Bind every C API this fork adds, and gate the binding surface so it cannot drift again.
+
+- **New: `memory_events`** — the whole of `include/mimalloc/memory-events.h`, which had no
+  Rust binding at all: `set_enabled`/`is_enabled`, `snapshot`, `set_callbacks`/
+  `clear_callbacks` (per-kind `fn` pointers behind a `&'static Callbacks`, so the C side's
+  caller-owned `arg` cannot dangle), and `unsafe fn visit_live_allocations`.
+- **New: `options`** — `mi_option_*` with a range-checked `Opt` newtype and named constants
+  for all thirteen options this fork adds (`prof*`, `memory_events`, `purge_zeroes`,
+  `scavenger`, `purge_holes*`), plus get/set/clamp/size/enable/disable and their `_default`
+  forms.
+- **New: `stats`** — the exact-statistics surface from `include/mimalloc-stats.h`:
+  `mi_stats_t` mirrored field-for-field, `get`, `json`, `print`, `bin_size`, and the
+  subprocess-scoped getters (aggregated, exclusive, JSON, print, per-heap print).
+- **New: `purge_holes_report`** — the last unbound fork export in `mimalloc.h`.
+- **New ABI gate: `layout_probe.c` + `tests/t19_layout.rs`.** The C compiler now publishes
+  `sizeof`/`offsetof` for every mirrored struct and the value of every mirrored
+  `mi_option_t` enumerator; the test compares them by name. This is the hazard that
+  motivated the work: this fork inserts thirteen enumerators at indices 47..=59, so an
+  option mirror copied from upstream would set a *different* option than the caller named,
+  silently and forever. The existing mirrors were checked and were **correct**; they are
+  now checked on every build.
+- `ci/check_rust_surface.py` (new, gated in `python-lint` and `rust-native`) asserts that
+  every fork export and every `mi_option_t` enumerator in the C headers is declared in
+  `src/sys.rs`, with an allowlist that must give a reason for each intentional omission.
+
 ## 0.9.5
 
 - Add a default `pprof` feature so allocator-only consumers can compile sampled

--- a/rust/mimalloc-pprof/README.md
+++ b/rust/mimalloc-pprof/README.md
@@ -99,6 +99,31 @@ println!(
 );
 ```
 
+## The full API
+
+Everything mimalloc-pprof exposes, grouped and shown next to its C counterpart, is in
+one table in the repository README:
+**[API surface](https://github.com/zackees/mimalloc-pprof#api-surface)**. It is not
+duplicated here — one table, kept honest by `ci/check_rust_surface.py`, which fails the
+build if a C export or an `mi_option_t` enumerator has no Rust binding.
+
+The short version. Safe wrappers, all at the crate root unless noted:
+
+| Module | What it covers |
+|---|---|
+| `prof` | sampled pprof profiling: start/stop, text and `profile.proto` dumps, `stats()`, `samples()`, `modules()` |
+| `dhat` | exact DHAT v2 profiling: start/stop, `stats()`, `dump_file()` |
+| `stats` | the allocator's **exact** counters: `get()`, `json()`, `print()`, `bin_size()`, and the subprocess-scoped forms |
+| `memory_events` | opt-in allocation-change accounting: `set_enabled`, `snapshot`, `set_callbacks`, `visit_live_allocations` |
+| `options` | every `mi_option_t`, including the thirteen this fork adds (`Opt::PROF`, `Opt::SCAVENGER`, `Opt::PURGE_HOLES`, …) |
+| crate root | `MiMalloc`, `heap_dump_json`, `on_thread_idle`, `park_while_idle`, `scavenger_stop`, `purge_holes_stats`, `purge_holes_report`, `rezalloc`/`recalloc`/`expand`, `unwrapped_malloc`/`_free`/`_realloc` |
+
+`mimalloc_pprof::sys` holds the raw `unsafe extern "C"` declarations and the `#[repr(C)]`
+struct mirrors behind all of the above. The mirrors are checked field-by-field against
+the C compiler's own layout on every build (`tests/t19_layout.rs`), because
+`mi_option_t` is positional and a mirror that drifted would silently set a different
+option than the caller named.
+
 ## Platforms and cross-compilation
 
 The crate vendors mimalloc as a single amalgamated C translation unit with no

--- a/rust/mimalloc-pprof/build.rs
+++ b/rust/mimalloc-pprof/build.rs
@@ -11,11 +11,17 @@ fn main() {
     println!("cargo:rerun-if-changed=vendor/mimalloc-pprof-amalgamated.h");
     println!("cargo:rerun-if-changed=vendor/mimalloc.h");
     println!("cargo:rerun-if-changed=vendor/mimalloc-stats.h");
+    // The ABI layout probe (see layout_probe.c) is compiled into the same static
+    // library. It is referenced only from tests/t19_layout.rs, so the linker drops it
+    // from ordinary consumers; keeping it in this one `cc::Build` means it always sees
+    // exactly the defines the library itself was built with.
+    println!("cargo:rerun-if-changed=layout_probe.c");
 
     let mut build = cc::Build::new();
     build
         .include("vendor")
         .file("vendor/mimalloc-pprof-amalgamated.c")
+        .file("layout_probe.c")
         .define("MI_STATIC_LIB", None)
         // Preserve the crate's default profiler-enabled behavior, while
         // allowing allocator-only consumers to compile hooks out with

--- a/rust/mimalloc-pprof/layout_probe.c
+++ b/rust/mimalloc-pprof/layout_probe.c
@@ -1,0 +1,267 @@
+/* ABI layout probe for the Rust mirrors in src/sys.rs (issue: C/Rust API parity).
+
+   Every `#[repr(C)]` struct in `src/sys.rs` is a hand-written mirror of a C struct, and
+   every `mi_option_*` constant there is a hand-written mirror of an enumerator whose
+   value is positional. Both are silent-corruption hazards: a mirror that drifts writes
+   the wrong field, or sets the wrong option, with no diagnostic anywhere.
+
+   So the C side publishes what it actually laid out. This file exports a name/value
+   table -- `sizeof:<type>`, `offset:<type>.<field>`, `option:<enumerator>`, and the
+   versioned/sentinel constants -- which `tests/t19_layout.rs` looks up BY NAME and
+   compares against `core::mem::size_of` / `core::mem::offset_of!` and the Rust
+   constants. Lookup by name (rather than by index) is deliberate: a field renamed or
+   dropped on either side fails as "missing key", never as a coincidentally-equal number.
+
+   This file lives under rust/ on purpose: it is a binding-verification artifact, not
+   part of the C library, so it never enters the CMake build or the amalgamation. It is
+   compiled into the crate's static library but referenced only from the test, so the
+   linker drops it from ordinary consumers.
+
+   Nothing here is gated on MI_PPROF: the profiler's public *types* are declared
+   unconditionally in include/mimalloc/profile.h (only the implementation is gated), so
+   the layout the mirrors must match is the same in both feature modes. */
+
+#include <stddef.h>
+
+#include "mimalloc-pprof-amalgamated.h"
+#include "mimalloc-stats.h"
+
+typedef struct mi_rs_layout_entry_s {
+  const char* name;
+  size_t      value;
+} mi_rs_layout_entry_t;
+
+#define MI_RS_SIZEOF(T)      { "sizeof:" #T, sizeof(T) },
+#define MI_RS_OFFSET(T, F)   { "offset:" #T "." #F, offsetof(T, F) },
+#define MI_RS_CONST(N)       { "const:" #N, (size_t)(N) },
+#define MI_RS_OPTION(N)      { "option:" #N, (size_t)(N) },
+
+static const mi_rs_layout_entry_t mi_rs_layout_entries[] = {
+  /* ---- include/mimalloc/profile.h ---- */
+  MI_RS_SIZEOF(mi_prof_stats_t)
+  MI_RS_OFFSET(mi_prof_stats_t, size)
+  MI_RS_OFFSET(mi_prof_stats_t, version)
+  MI_RS_OFFSET(mi_prof_stats_t, enabled)
+  MI_RS_OFFSET(mi_prof_stats_t, accum)
+  MI_RS_OFFSET(mi_prof_stats_t, sample_rate)
+  MI_RS_OFFSET(mi_prof_stats_t, live_samples)
+  MI_RS_OFFSET(mi_prof_stats_t, live_bytes)
+  MI_RS_OFFSET(mi_prof_stats_t, accum_samples)
+  MI_RS_OFFSET(mi_prof_stats_t, accum_bytes)
+  MI_RS_OFFSET(mi_prof_stats_t, unique_stacks)
+  MI_RS_OFFSET(mi_prof_stats_t, arena_committed)
+  MI_RS_OFFSET(mi_prof_stats_t, stack_table_overflows)
+  MI_RS_OFFSET(mi_prof_stats_t, dropped_samples)
+  MI_RS_OFFSET(mi_prof_stats_t, heap_committed)
+  MI_RS_OFFSET(mi_prof_stats_t, heap_reserved)
+  MI_RS_OFFSET(mi_prof_stats_t, heap_malloc_requested)
+  MI_RS_OFFSET(mi_prof_stats_t, heap_pages)
+  MI_RS_OFFSET(mi_prof_stats_t, heap_pages_abandoned)
+  MI_RS_OFFSET(mi_prof_stats_t, heap_count)
+  MI_RS_OFFSET(mi_prof_stats_t, theap_count)
+  MI_RS_OFFSET(mi_prof_stats_t, heap_purged)
+  MI_RS_OFFSET(mi_prof_stats_t, heap_stats_detailed)
+
+  MI_RS_SIZEOF(mi_prof_config_t)
+  MI_RS_OFFSET(mi_prof_config_t, size)
+  MI_RS_OFFSET(mi_prof_config_t, version)
+  MI_RS_OFFSET(mi_prof_config_t, mode)
+  MI_RS_OFFSET(mi_prof_config_t, sample_interval)
+  MI_RS_OFFSET(mi_prof_config_t, max_profiler_bytes)
+  MI_RS_OFFSET(mi_prof_config_t, seed)
+  MI_RS_OFFSET(mi_prof_config_t, accum)
+  MI_RS_OFFSET(mi_prof_config_t, max_stack_depth)
+  MI_RS_OFFSET(mi_prof_config_t, dump_at_exit)
+  MI_RS_OFFSET(mi_prof_config_t, dump_format)
+
+  MI_RS_SIZEOF(mi_prof_sample_info_t)
+  MI_RS_OFFSET(mi_prof_sample_info_t, stack)
+  MI_RS_OFFSET(mi_prof_sample_info_t, depth)
+  MI_RS_OFFSET(mi_prof_sample_info_t, live_objects)
+  MI_RS_OFFSET(mi_prof_sample_info_t, live_bytes)
+  MI_RS_OFFSET(mi_prof_sample_info_t, accum_objects)
+  MI_RS_OFFSET(mi_prof_sample_info_t, accum_bytes)
+
+  MI_RS_SIZEOF(mi_prof_module_info_t)
+  MI_RS_OFFSET(mi_prof_module_info_t, path)
+  MI_RS_OFFSET(mi_prof_module_info_t, base)
+  MI_RS_OFFSET(mi_prof_module_info_t, size)
+
+  MI_RS_CONST(MI_PROF_STAT_VERSION)
+  MI_RS_CONST(MI_PROF_CONFIG_VERSION)
+  MI_RS_CONST(MI_PROF_FORMAT_TEXT)
+  MI_RS_CONST(MI_PROF_FORMAT_PROTO)
+  MI_RS_CONST(MI_PROF_CONFIG_FALLBACK)
+  MI_RS_CONST(MI_PROF_CONFIG_OVERRIDE)
+
+  /* ---- include/mimalloc/dhat.h ---- */
+  MI_RS_SIZEOF(mi_dhat_stats_t)
+  MI_RS_OFFSET(mi_dhat_stats_t, size)
+  MI_RS_OFFSET(mi_dhat_stats_t, version)
+  MI_RS_OFFSET(mi_dhat_stats_t, enabled)
+  MI_RS_OFFSET(mi_dhat_stats_t, incomplete)
+  MI_RS_OFFSET(mi_dhat_stats_t, total_bytes)
+  MI_RS_OFFSET(mi_dhat_stats_t, total_blocks)
+  MI_RS_OFFSET(mi_dhat_stats_t, live_bytes)
+  MI_RS_OFFSET(mi_dhat_stats_t, live_blocks)
+  MI_RS_OFFSET(mi_dhat_stats_t, peak_bytes)
+  MI_RS_OFFSET(mi_dhat_stats_t, peak_blocks)
+  MI_RS_OFFSET(mi_dhat_stats_t, dropped)
+  MI_RS_OFFSET(mi_dhat_stats_t, internal_bytes)
+  MI_RS_CONST(MI_DHAT_STATS_VERSION)
+
+  /* ---- include/mimalloc/memory-events.h ---- */
+  MI_RS_SIZEOF(mi_memory_change_t)
+  MI_RS_OFFSET(mi_memory_change_t, kind)
+  MI_RS_OFFSET(mi_memory_change_t, total_bytes)
+  MI_RS_OFFSET(mi_memory_change_t, delta_bytes)
+  MI_RS_OFFSET(mi_memory_change_t, request_size)
+
+  MI_RS_SIZEOF(mi_memory_callbacks_t)
+  MI_RS_OFFSET(mi_memory_callbacks_t, handlers)
+  MI_RS_OFFSET(mi_memory_callbacks_t, args)
+
+  MI_RS_SIZEOF(mi_memory_snapshot_t)
+  MI_RS_OFFSET(mi_memory_snapshot_t, size)
+  MI_RS_OFFSET(mi_memory_snapshot_t, version)
+  MI_RS_OFFSET(mi_memory_snapshot_t, live_bytes)
+  MI_RS_OFFSET(mi_memory_snapshot_t, accum_bytes)
+  MI_RS_OFFSET(mi_memory_snapshot_t, live_count)
+  MI_RS_OFFSET(mi_memory_snapshot_t, accum_count)
+
+  MI_RS_CONST(MI_MEMORY_SNAPSHOT_VERSION)
+  MI_RS_CONST(MI_MEMORY_ALLOCATE)
+  MI_RS_CONST(MI_MEMORY_FREE)
+  MI_RS_CONST(MI_MEMORY_RESIZE)
+  MI_RS_CONST(MI_MEMORY_CHANGE_COUNT)
+
+  /* ---- include/mimalloc.h: hole purging (issue #272, Bun parity P7b) ---- */
+  MI_RS_SIZEOF(mi_purge_holes_stats_t)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, purged_bytes)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, purged_blocks)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, purged_bytes_total)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, discard_calls)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, reuse_calls)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, pages_freed)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, ineligible_pages)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, ineligible_bytes)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, ineligible_free_bytes)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, unformed_bytes)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, unformed_bytes_total)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, unformed_discard_calls)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, unformed_reuse_calls)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, pages_skipped)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, blocks_visited)
+  MI_RS_OFFSET(mi_purge_holes_stats_t, full_sweeps)
+
+  /* ---- include/mimalloc-stats.h ---- */
+  MI_RS_SIZEOF(mi_stat_count_t)
+  MI_RS_OFFSET(mi_stat_count_t, total)
+  MI_RS_OFFSET(mi_stat_count_t, peak)
+  MI_RS_OFFSET(mi_stat_count_t, current)
+  MI_RS_SIZEOF(mi_stat_counter_t)
+  MI_RS_OFFSET(mi_stat_counter_t, total)
+
+  MI_RS_SIZEOF(mi_stats_t)
+  MI_RS_OFFSET(mi_stats_t, size)
+  MI_RS_OFFSET(mi_stats_t, version)
+  /* Generated straight from the header's own field list, so a field added or reordered
+     upstream shows up here without this file being touched -- and then fails the Rust
+     test as a missing/moved key, which is exactly the intent. */
+#define MI_STAT_COUNT(stat)     MI_RS_OFFSET(mi_stats_t, stat)
+#define MI_STAT_COUNTER(stat)   MI_RS_OFFSET(mi_stats_t, stat)
+  MI_STAT_FIELDS()
+#undef MI_STAT_COUNT
+#undef MI_STAT_COUNTER
+  MI_RS_OFFSET(mi_stats_t, _stat_reserved)
+  MI_RS_OFFSET(mi_stats_t, _stat_counter_reserved)
+  MI_RS_OFFSET(mi_stats_t, malloc_bins)
+  MI_RS_OFFSET(mi_stats_t, page_bins)
+  MI_RS_OFFSET(mi_stats_t, chunk_bins)
+  MI_RS_CONST(MI_STAT_VERSION)
+  MI_RS_CONST(MI_BIN_HUGE)
+  MI_RS_CONST(MI_CBIN_COUNT)
+
+  MI_RS_SIZEOF(mi_subproc_id_t)
+
+  /* ---- include/mimalloc.h: mi_option_t ----
+     Positional and silently wrong when mirrored stale: the fork inserted thirteen
+     enumerators (prof_*, memory_events, purge_zeroes, scavenger, purge_holes*) BEFORE
+     `_mi_option_last`, so any Rust mirror copied from upstream sets a different option
+     than the caller named. Every enumerator the Rust side mirrors is listed here. */
+  MI_RS_OPTION(mi_option_show_errors)
+  MI_RS_OPTION(mi_option_show_stats)
+  MI_RS_OPTION(mi_option_verbose)
+  MI_RS_OPTION(mi_option_deprecated_eager_commit)
+  MI_RS_OPTION(mi_option_arena_eager_commit)
+  MI_RS_OPTION(mi_option_purge_decommits)
+  MI_RS_OPTION(mi_option_allow_large_os_pages)
+  MI_RS_OPTION(mi_option_reserve_huge_os_pages)
+  MI_RS_OPTION(mi_option_reserve_huge_os_pages_at)
+  MI_RS_OPTION(mi_option_reserve_os_memory)
+  MI_RS_OPTION(mi_option_deprecated_segment_cache)
+  MI_RS_OPTION(mi_option_deprecated_page_reset)
+  MI_RS_OPTION(mi_option_deprecated_abandoned_page_purge)
+  MI_RS_OPTION(mi_option_deprecated_segment_reset)
+  MI_RS_OPTION(mi_option_deprecated_eager_commit_delay)
+  MI_RS_OPTION(mi_option_purge_delay)
+  MI_RS_OPTION(mi_option_use_numa_nodes)
+  MI_RS_OPTION(mi_option_disallow_os_alloc)
+  MI_RS_OPTION(mi_option_os_tag)
+  MI_RS_OPTION(mi_option_max_errors)
+  MI_RS_OPTION(mi_option_max_warnings)
+  MI_RS_OPTION(mi_option_deprecated_max_segment_reclaim)
+  MI_RS_OPTION(mi_option_destroy_on_exit)
+  MI_RS_OPTION(mi_option_arena_reserve)
+  MI_RS_OPTION(mi_option_arena_purge_mult)
+  MI_RS_OPTION(mi_option_deprecated_purge_extend_delay)
+  MI_RS_OPTION(mi_option_disallow_arena_alloc)
+  MI_RS_OPTION(mi_option_retry_on_oom)
+  MI_RS_OPTION(mi_option_deprecated_visit_abandoned)
+  MI_RS_OPTION(mi_option_guarded_min)
+  MI_RS_OPTION(mi_option_guarded_max)
+  MI_RS_OPTION(mi_option_guarded_precise)
+  MI_RS_OPTION(mi_option_guarded_sample_rate)
+  MI_RS_OPTION(mi_option_guarded_sample_seed)
+  MI_RS_OPTION(mi_option_generic_collect)
+  MI_RS_OPTION(mi_option_page_reclaim_on_free)
+  MI_RS_OPTION(mi_option_page_full_retain)
+  MI_RS_OPTION(mi_option_page_max_candidates)
+  MI_RS_OPTION(mi_option_max_vabits)
+  MI_RS_OPTION(mi_option_pagemap_commit)
+  MI_RS_OPTION(mi_option_page_commit_on_demand)
+  MI_RS_OPTION(mi_option_page_max_reclaim)
+  MI_RS_OPTION(mi_option_page_cross_thread_max_reclaim)
+  MI_RS_OPTION(mi_option_allow_thp)
+  MI_RS_OPTION(mi_option_minimal_purge_size)
+  MI_RS_OPTION(mi_option_arena_max_object_size)
+  MI_RS_OPTION(mi_option_arena_is_numa_local)
+  /* fork additions start here (indices 47..59) */
+  MI_RS_OPTION(mi_option_prof)
+  MI_RS_OPTION(mi_option_prof_sample_rate)
+  MI_RS_OPTION(mi_option_prof_bt_max)
+  MI_RS_OPTION(mi_option_prof_accum)
+  MI_RS_OPTION(mi_option_prof_seed)
+  MI_RS_OPTION(mi_option_prof_max_bytes)
+  MI_RS_OPTION(mi_option_memory_events)
+  MI_RS_OPTION(mi_option_purge_zeroes)
+  MI_RS_OPTION(mi_option_scavenger)
+  MI_RS_OPTION(mi_option_purge_holes)
+  MI_RS_OPTION(mi_option_purge_holes_eager_zero)
+  MI_RS_OPTION(mi_option_purge_holes_min_interval)
+  MI_RS_OPTION(mi_option_purge_holes_full_every)
+  MI_RS_OPTION(_mi_option_last)
+  /* deprecated aliases, defined after the sentinel with explicit values */
+  MI_RS_OPTION(mi_option_large_os_pages)
+  MI_RS_OPTION(mi_option_eager_region_commit)
+  MI_RS_OPTION(mi_option_reset_decommits)
+  MI_RS_OPTION(mi_option_reset_delay)
+  MI_RS_OPTION(mi_option_limit_os_alloc)
+};
+
+/* Returns the entry table and writes its length to `*count`. The table is static
+   `const` data with static-string names; the caller never frees anything. */
+mi_decl_export const mi_rs_layout_entry_t* mi_rs_layout_table(size_t* count) mi_attr_noexcept {
+  if (count != NULL) { *count = sizeof(mi_rs_layout_entries) / sizeof(mi_rs_layout_entries[0]); }
+  return mi_rs_layout_entries;
+}

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -1470,6 +1470,12 @@ pub mod memory_events {
     ///   is active — that includes anything that allocates indirectly, such as `println!`,
     ///   growing a `Vec`, or formatting. Collect into a fixed-size buffer, or into
     ///   [`crate::unwrapped_malloc`] memory, and process it after this returns.
+    /// - `visitor` must not panic. Raising a panic allocates its payload and its message
+    ///   through the global allocator, which reenters mimalloc in the middle of the walk
+    ///   -- the very thing the bullet above forbids. The `catch_unwind` inside the
+    ///   trampoline stops the unwind from crossing the C frame; it does **not** and
+    ///   cannot prevent that allocation, which has already happened by the time it runs.
+    ///   Report failures by setting a flag the caller reads after the walk returns.
     /// - The pointers handed to `visitor` must not be dereferenced, retained, or freed:
     ///   they may already be dead. Treat them as addresses, not as references.
     /// - No other thread may be freeing into the heaps being walked (the

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -885,10 +885,10 @@ pub mod prof {
 /// Print, per size class, what hole purging leaves behind (issue #272, Bun parity P7b).
 ///
 /// Read-only: it purges nothing and mutates no free list. The report goes to mimalloc's
-/// own output sink (stderr by default, or whatever `mi_register_output` installed), not
-/// to a returned `String` — building a `String` here would allocate from inside a walk
-/// over the very free lists being reported. Pass a custom sink through
-/// [`sys::mi_purge_holes_report`]'s C counterpart if you need to capture it.
+/// own output sink (stderr by default), not to a returned `String` — building a `String`
+/// here would allocate from inside a walk over the very free lists being reported.
+/// `mi_purge_holes_report` takes no sink argument at all; to capture the text, install a
+/// process-wide sink with C's `mi_register_output` (not bound by this crate).
 ///
 /// Like the idle sweep it only covers what the calling thread may safely read: its own
 /// theaps, plus the abandoned pages of the heaps behind them. Call it right after an

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -882,6 +882,611 @@ pub mod prof {
     }
 }
 
+/// Print, per size class, what hole purging leaves behind (issue #272, Bun parity P7b).
+///
+/// Read-only: it purges nothing and mutates no free list. The report goes to mimalloc's
+/// own output sink (stderr by default, or whatever `mi_register_output` installed), not
+/// to a returned `String` — building a `String` here would allocate from inside a walk
+/// over the very free lists being reported. Pass a custom sink through
+/// [`sys::mi_purge_holes_report`]'s C counterpart if you need to capture it.
+///
+/// Like the idle sweep it only covers what the calling thread may safely read: its own
+/// theaps, plus the abandoned pages of the heaps behind them. Call it right after an
+/// [`on_thread_idle`] sweep, when the numbers still describe that sweep.
+pub fn purge_holes_report() {
+    unsafe { sys::mi_purge_holes_report() }
+}
+
+/// mimalloc's `mi_option_*` settings: the runtime knobs behind every `MIMALLOC_*`
+/// environment variable.
+///
+/// Options are read once, lazily, the first time the allocator needs them, so setting one
+/// after the allocation it governs has already happened has no effect. In particular
+/// [`Opt::SCAVENGER`] and the profiler options must be set before the first allocation to
+/// matter; [`Opt::PURGE_HOLES`] and its companions are re-read per sweep and can be
+/// changed at any time.
+///
+/// ```
+/// use mimalloc_pprof::options::{self, Opt};
+/// let previous = options::get(Opt::PURGE_HOLES_MIN_INTERVAL);
+/// options::set(Opt::PURGE_HOLES_MIN_INTERVAL, 0); // sweep on every idle call
+/// mimalloc_pprof::on_thread_idle();
+/// options::set(Opt::PURGE_HOLES_MIN_INTERVAL, previous);
+/// ```
+pub mod options {
+    use core::ffi::c_long;
+
+    use crate::sys;
+
+    /// One `mi_option_t` setting.
+    ///
+    /// The associated constants name this fork's own options plus the handful of upstream
+    /// ones that interact with them; [`Opt::from_raw`] reaches any other enumerator in
+    /// [`sys`] — it range-checks against `_mi_option_last`, because the C side indexes an
+    /// array with this value and an out-of-range option would read out of bounds.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct Opt(sys::mi_option_t);
+
+    impl Opt {
+        /// **Fork addition.** Enable the sampled profiler at process start (`MIMALLOC_PROF`).
+        pub const PROF: Self = Self(sys::mi_option_prof);
+        /// **Fork addition.** Average byte interval between profiler samples.
+        pub const PROF_SAMPLE_RATE: Self = Self(sys::mi_option_prof_sample_rate);
+        /// **Fork addition.** Maximum captured stack depth for the profiler.
+        pub const PROF_BT_MAX: Self = Self(sys::mi_option_prof_bt_max);
+        /// **Fork addition.** Keep cumulative profiler counters until [`crate::prof::reset`].
+        pub const PROF_ACCUM: Self = Self(sys::mi_option_prof_accum);
+        /// **Fork addition.** Profiler sampling PRNG seed; 0 = nondeterministic.
+        pub const PROF_SEED: Self = Self(sys::mi_option_prof_seed);
+        /// **Fork addition.** Budget in bytes for profiler-internal arena memory.
+        pub const PROF_MAX_BYTES: Self = Self(sys::mi_option_prof_max_bytes);
+        /// **Fork addition.** Enable [`crate::memory_events`] accounting
+        /// (`MIMALLOC_MEMORY_EVENTS`).
+        pub const MEMORY_EVENTS: Self = Self(sys::mi_option_memory_events);
+        /// **Fork addition, dead since #80.** Parses, but has no effect. Kept so nothing
+        /// renumbers; unrelated to [`Opt::PURGE_HOLES_EAGER_ZERO`].
+        pub const PURGE_ZEROES: Self = Self(sys::mi_option_purge_zeroes);
+        /// **Fork addition (Bun).** Run the background scavenger thread.
+        pub const SCAVENGER: Self = Self(sys::mi_option_scavenger);
+        /// **Fork addition (Bun).** Discard free blocks inside still-used pages on
+        /// [`crate::on_thread_idle`].
+        pub const PURGE_HOLES: Self = Self(sys::mi_option_purge_holes);
+        /// **Fork addition (Bun).** Zero a range before discarding it, so a mis-scoped
+        /// discard corrupts visibly. Forced on in debug builds.
+        pub const PURGE_HOLES_EAGER_ZERO: Self = Self(sys::mi_option_purge_holes_eager_zero);
+        /// **Fork addition (Bun).** Minimum milliseconds between sweeps of one thread's heaps.
+        pub const PURGE_HOLES_MIN_INTERVAL: Self = Self(sys::mi_option_purge_holes_min_interval);
+        /// **Fork addition (Bun).** Every N-th sweep walks every page; 0 disables.
+        pub const PURGE_HOLES_FULL_EVERY: Self = Self(sys::mi_option_purge_holes_full_every);
+
+        /// Upstream: milliseconds to delay purging, which the scavenger also honours.
+        pub const PURGE_DELAY: Self = Self(sys::mi_option_purge_delay);
+        /// Upstream: print statistics on process termination.
+        pub const SHOW_STATS: Self = Self(sys::mi_option_show_stats);
+        /// Upstream: print error messages.
+        pub const SHOW_ERRORS: Self = Self(sys::mi_option_show_errors);
+        /// Upstream: print verbose messages.
+        pub const VERBOSE: Self = Self(sys::mi_option_verbose);
+
+        /// Wrap a raw `mi_option_t` from [`sys`], or `None` if it is not a real option.
+        ///
+        /// The range check is load bearing: the C implementation indexes its option table
+        /// with this value, so an out-of-range option is an out-of-bounds read.
+        #[must_use]
+        pub fn from_raw(raw: sys::mi_option_t) -> Option<Self> {
+            if (0..sys::_mi_option_last).contains(&raw) {
+                Some(Self(raw))
+            } else {
+                None
+            }
+        }
+
+        /// The raw `mi_option_t` value.
+        #[must_use]
+        pub fn as_raw(self) -> sys::mi_option_t {
+            self.0
+        }
+
+        /// The C enumerator's name, e.g. `mi_option_purge_holes`.
+        #[must_use]
+        pub fn name(self) -> &'static str {
+            sys::MI_OPTIONS_IN_ORDER
+                .get(self.0 as usize)
+                .map_or("<unknown>", |(name, _)| *name)
+        }
+    }
+
+    /// Read an option's value.
+    ///
+    /// Note the width: mimalloc stores option values in a C `long`, which is 32-bit on
+    /// Windows and 64-bit on Linux/macOS. Use [`get_size`] for byte counts.
+    #[must_use]
+    pub fn get(option: Opt) -> c_long {
+        unsafe { sys::mi_option_get(option.as_raw()) }
+    }
+
+    /// Read an option's value, clamped into `min..=max`.
+    #[must_use]
+    pub fn get_clamp(option: Opt, min: c_long, max: c_long) -> c_long {
+        unsafe { sys::mi_option_get_clamp(option.as_raw(), min, max) }
+    }
+
+    /// Read an option's value as a `size_t`, for options that count bytes.
+    #[must_use]
+    pub fn get_size(option: Opt) -> usize {
+        unsafe { sys::mi_option_get_size(option.as_raw()) }
+    }
+
+    /// Set an option's value, overriding both the default and the environment.
+    pub fn set(option: Opt, value: c_long) {
+        unsafe { sys::mi_option_set(option.as_raw(), value) }
+    }
+
+    /// Set an option's value only if the environment did not already set it.
+    pub fn set_default(option: Opt, value: c_long) {
+        unsafe { sys::mi_option_set_default(option.as_raw(), value) }
+    }
+
+    /// Whether a boolean option is on.
+    #[must_use]
+    pub fn is_enabled(option: Opt) -> bool {
+        unsafe { sys::mi_option_is_enabled(option.as_raw()) }
+    }
+
+    /// Turn a boolean option on.
+    pub fn enable(option: Opt) {
+        unsafe { sys::mi_option_enable(option.as_raw()) }
+    }
+
+    /// Turn a boolean option off.
+    pub fn disable(option: Opt) {
+        unsafe { sys::mi_option_disable(option.as_raw()) }
+    }
+
+    /// Turn a boolean option on or off.
+    pub fn set_enabled(option: Opt, enabled: bool) {
+        unsafe { sys::mi_option_set_enabled(option.as_raw(), enabled) }
+    }
+
+    /// Set a boolean option's default, which the environment still overrides.
+    pub fn set_enabled_default(option: Opt, enabled: bool) {
+        unsafe { sys::mi_option_set_enabled_default(option.as_raw(), enabled) }
+    }
+
+    /// Print every option's current value to mimalloc's output sink.
+    ///
+    /// Goes to the sink rather than to a returned `String` for the same reason as
+    /// [`crate::purge_holes_report`]: capturing it would mean allocating from inside a
+    /// callback the allocator drives.
+    pub fn print() {
+        unsafe { sys::mi_options_print_out(None, core::ptr::null_mut()) }
+    }
+
+    /// Every option this build knows about, in C declaration order, as
+    /// `(name, value)` pairs — including the ones without an [`Opt`] constant.
+    #[must_use]
+    pub fn all() -> &'static [(&'static str, sys::mi_option_t)] {
+        sys::MI_OPTIONS_IN_ORDER
+    }
+}
+
+/// The allocator's own **exact** statistics, as opposed to the sampled numbers
+/// [`crate::prof::stats`] reports.
+///
+/// This is upstream mimalloc's `mimalloc-stats.h` surface. Note what is *not* here:
+/// hole-purging and idle-sweep gauges are **not** part of `mi_stats_t` — they live in
+/// [`crate::purge_holes_stats`], because the sweep also covers pages that no heap owns
+/// and `mi_stats_t` cannot grow (it is embedded in a theap, at the meta-allocator's 8 KB
+/// block limit).
+///
+/// `malloc_requested` is only maintained when the C library was built with `MI_STAT >= 2`
+/// (upstream enables that for debug builds only); a default release build reports 0 for
+/// it and for nothing else.
+pub mod stats {
+    use core::ops::Deref;
+    use std::ffi::CStr;
+
+    use crate::sys;
+
+    /// An owned copy of `mi_stats_t`, boxed because it is ~4 KB.
+    ///
+    /// Deref to reach every counter, e.g. `stats.committed.current`.
+    #[derive(Clone, Debug)]
+    pub struct Stats(Box<sys::mi_stats_t>);
+
+    impl Deref for Stats {
+        type Target = sys::mi_stats_t;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl Stats {
+        /// Render these counters as mimalloc's statistics JSON.
+        ///
+        /// Returns `None` on allocation failure. Wraps `mi_stats_as_json`.
+        #[must_use]
+        pub fn to_json(&self) -> Option<String> {
+            // `mi_stats_as_json` takes a non-const pointer but only reads through it.
+            let mut copy = self.0.clone();
+            let ptr = unsafe { sys::mi_stats_as_json(&raw mut *copy, 0, core::ptr::null_mut()) };
+            take_c_string(ptr)
+        }
+
+        /// The raw C struct.
+        #[must_use]
+        pub fn as_raw(&self) -> &sys::mi_stats_t {
+            &self.0
+        }
+    }
+
+    /// A zeroed `mi_stats_t` with its `size`/`version` header filled in, which every
+    /// `*_stats_get` entry point checks before writing a single counter.
+    fn empty() -> Box<sys::mi_stats_t> {
+        let mut raw: Box<sys::mi_stats_t> = Box::new(unsafe { core::mem::zeroed() });
+        raw.size = size_of::<sys::mi_stats_t>();
+        raw.version = sys::MI_STAT_VERSION;
+        raw
+    }
+
+    /// Copy a `mi_malloc`-family C string out and release it with `mi_free`.
+    fn take_c_string(ptr: *mut core::ffi::c_char) -> Option<String> {
+        if ptr.is_null() {
+            return None;
+        }
+        let owned = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { sys::mi_free(ptr.cast()) };
+        Some(owned)
+    }
+
+    /// Which subprocess a subprocess-scoped call refers to.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub enum Subproc {
+        /// The process-wide default subprocess (`mi_subproc_main`).
+        #[default]
+        Main,
+        /// The subprocess this thread belongs to (`mi_subproc_current`).
+        Current,
+    }
+
+    impl Subproc {
+        fn id(self) -> sys::mi_subproc_id_t {
+            unsafe {
+                match self {
+                    Self::Main => sys::mi_subproc_main(),
+                    Self::Current => sys::mi_subproc_current(),
+                }
+            }
+        }
+    }
+
+    /// Statistics for the current subprocess and all its heaps, aggregated.
+    ///
+    /// Wraps `mi_stats_get`. Returns `None` only if the C library rejects the struct
+    /// header, which would mean this crate's `mi_stats_t` mirror has drifted from the
+    /// library it is linked against (`tests/t19_layout.rs` gates exactly that).
+    #[must_use]
+    pub fn get() -> Option<Stats> {
+        let mut raw = empty();
+        unsafe { sys::mi_stats_get(&raw mut *raw) }.then_some(Stats(raw))
+    }
+
+    /// The same statistics as [`get`], rendered as JSON by the C library.
+    ///
+    /// Wraps `mi_stats_get_json`; returns `None` on allocation failure.
+    #[must_use]
+    pub fn json() -> Option<String> {
+        take_c_string(unsafe { sys::mi_stats_get_json(0, core::ptr::null_mut()) })
+    }
+
+    /// Print the current subprocess's statistics to mimalloc's output sink.
+    ///
+    /// Wraps `mi_stats_print_out(NULL, NULL)`. Use [`json`] to capture them instead:
+    /// routing the sink through a Rust closure would allocate from inside a callback the
+    /// allocator drives.
+    pub fn print() {
+        unsafe { sys::mi_stats_print_out(None, core::ptr::null_mut()) }
+    }
+
+    /// The block size served by size bin `bin` (`0..=`[`sys::MI_BIN_HUGE`]), matching the
+    /// `malloc_bins`/`page_bins` indices.
+    #[must_use]
+    pub fn bin_size(bin: usize) -> usize {
+        unsafe { sys::mi_stats_get_bin_size(bin) }
+    }
+
+    /// Statistics for one subprocess and all its heaps, aggregated.
+    #[must_use]
+    pub fn subproc_get(which: Subproc) -> Option<Stats> {
+        let mut raw = empty();
+        unsafe { sys::mi_subproc_stats_get(which.id(), &raw mut *raw) }.then_some(Stats(raw))
+    }
+
+    /// Statistics for one subprocess **without** aggregating its heaps.
+    #[must_use]
+    pub fn subproc_get_exclusive(which: Subproc) -> Option<Stats> {
+        let mut raw = empty();
+        unsafe { sys::mi_subproc_stats_get_exclusive(which.id(), &raw mut *raw) }
+            .then_some(Stats(raw))
+    }
+
+    /// One subprocess's aggregated statistics as JSON.
+    #[must_use]
+    pub fn subproc_json(which: Subproc) -> Option<String> {
+        take_c_string(unsafe {
+            sys::mi_subproc_stats_get_json(which.id(), 0, core::ptr::null_mut())
+        })
+    }
+
+    /// Print one subprocess's aggregated statistics to mimalloc's output sink.
+    pub fn subproc_print(which: Subproc) {
+        unsafe { sys::mi_subproc_stats_print_out(which.id(), None, core::ptr::null_mut()) }
+    }
+
+    /// Print one subprocess **and each of its heaps separately** to mimalloc's output sink.
+    pub fn subproc_heap_print(which: Subproc) {
+        unsafe {
+            sys::mi_subproc_heap_stats_print_out(which.id(), None, core::ptr::null_mut());
+        }
+    }
+}
+
+/// Opt-in allocation-change accounting and callbacks (`include/mimalloc/memory-events.h`).
+///
+/// Independent of the sampled profiler: this module is compiled into the C library in
+/// every configuration, including `default-features = false`. Tracking is **off** by
+/// default; while it is off every allocate/free/realloc pays for exactly one relaxed flag
+/// check and nothing else.
+///
+/// ```
+/// use mimalloc_pprof::{memory_events, MiMalloc};
+///
+/// // The counters only move for allocations that actually reach mimalloc, so this
+/// // example is only meaningful once mimalloc is the global allocator.
+/// #[global_allocator]
+/// static ALLOCATOR: MiMalloc = MiMalloc;
+///
+/// fn main() {
+///     memory_events::set_enabled(true);
+///     let before = memory_events::snapshot().expect("snapshot").accum_count;
+///     let v = vec![0_u8; 4096];
+///     std::hint::black_box(&v);
+///     let after = memory_events::snapshot().expect("snapshot").accum_count;
+///     assert!(after > before);
+///     memory_events::set_enabled(false);
+/// }
+/// ```
+pub mod memory_events {
+    use core::ffi::c_void;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    use crate::sys;
+
+    /// Which kind of change a [`Change`] describes.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub enum ChangeKind {
+        /// A successful allocation.
+        Allocate,
+        /// A successful free.
+        Free,
+        /// A successful realloc, whether it grew or shrank.
+        Resize,
+    }
+
+    impl ChangeKind {
+        fn from_raw(raw: sys::mi_memory_change_kind_t) -> Option<Self> {
+            match raw {
+                sys::MI_MEMORY_ALLOCATE => Some(Self::Allocate),
+                sys::MI_MEMORY_FREE => Some(Self::Free),
+                sys::MI_MEMORY_RESIZE => Some(Self::Resize),
+                _ => None,
+            }
+        }
+
+        fn slot(self) -> usize {
+            match self {
+                Self::Allocate => sys::MI_MEMORY_ALLOCATE as usize,
+                Self::Free => sys::MI_MEMORY_FREE as usize,
+                Self::Resize => sys::MI_MEMORY_RESIZE as usize,
+            }
+        }
+    }
+
+    /// One observed allocation change, copied out of `mi_memory_change_t`.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct Change {
+        /// What happened.
+        pub kind: ChangeKind,
+        /// Tracked global live usable bytes after this operation.
+        pub total_bytes: u64,
+        /// Signed change in tracked live usable bytes: positive for allocation/growth,
+        /// negative for free/shrink, zero for a same-size-class resize.
+        pub delta_bytes: i64,
+        /// Caller-requested size for allocate and resize; zero for free.
+        pub request_size: u64,
+    }
+
+    /// Running totals maintained while tracking is enabled.
+    ///
+    /// Counters are **not** reconstructed for time spent with tracking off: a total is
+    /// exact only if tracking was enabled before the first allocation and never disabled.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct Snapshot {
+        /// Tracked live usable bytes right now.
+        pub live_bytes: u64,
+        /// Cumulative usable bytes ever allocated.
+        pub accum_bytes: u64,
+        /// Tracked live allocation count right now.
+        pub live_count: u64,
+        /// Cumulative count of successful allocate events.
+        pub accum_count: u64,
+    }
+
+    /// Enable or disable tracking; returns the previous state.
+    ///
+    /// An explicit call is always authoritative over the `MIMALLOC_MEMORY_EVENTS`
+    /// environment read: called before the first allocation it *replaces* that read;
+    /// called after, it overrides the cached flag. Re-enabling does not reconstruct what
+    /// happened while tracking was off.
+    pub fn set_enabled(enabled: bool) -> bool {
+        unsafe { sys::mi_memory_tracking_set_enabled(enabled) }
+    }
+
+    /// Whether tracking is on.
+    #[must_use]
+    pub fn is_enabled() -> bool {
+        unsafe { sys::mi_memory_tracking_is_enabled() }
+    }
+
+    /// Read the running totals.
+    ///
+    /// Returns `None` only if the C library rejects the struct header, which would mean
+    /// this crate's mirror has drifted from the library (`tests/t19_layout.rs` gates that).
+    #[must_use]
+    pub fn snapshot() -> Option<Snapshot> {
+        let mut raw: sys::mi_memory_snapshot_t = unsafe { core::mem::zeroed() };
+        raw.size = size_of::<sys::mi_memory_snapshot_t>();
+        raw.version = sys::MI_MEMORY_SNAPSHOT_VERSION;
+        if !unsafe { sys::mi_memory_snapshot(&raw mut raw) } {
+            return None;
+        }
+        Some(Snapshot {
+            live_bytes: raw.live_bytes,
+            accum_bytes: raw.accum_bytes,
+            live_count: raw.live_count,
+            accum_count: raw.accum_count,
+        })
+    }
+
+    /// Handlers to install with [`set_callbacks`], one per [`ChangeKind`].
+    ///
+    /// Plain `fn` pointers rather than closures on purpose: the C side keeps the
+    /// registration until it is replaced, so anything captured would have to outlive the
+    /// process. Route per-instance state through a `static` (an atomic counter, a channel
+    /// sender in a `OnceLock`) instead.
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct Callbacks {
+        /// Called after each successful allocation.
+        pub allocate: Option<fn(&Change)>,
+        /// Called after each successful free.
+        pub free: Option<fn(&Change)>,
+        /// Called after each successful realloc.
+        pub resize: Option<fn(&Change)>,
+    }
+
+    impl Callbacks {
+        fn handler(&self, kind: ChangeKind) -> Option<fn(&Change)> {
+            match kind {
+                ChangeKind::Allocate => self.allocate,
+                ChangeKind::Free => self.free,
+                ChangeKind::Resize => self.resize,
+            }
+        }
+    }
+
+    /// The single C-ABI entry point for all three slots. `arg` is the `&'static Callbacks`
+    /// the caller handed to [`set_callbacks`]; the kind comes out of the change record, so
+    /// one trampoline serves every slot.
+    unsafe extern "C" fn dispatch(change: *const sys::mi_memory_change_t, arg: *mut c_void) {
+        if change.is_null() || arg.is_null() {
+            return;
+        }
+        let raw = unsafe { &*change };
+        let callbacks = unsafe { &*(arg as *const Callbacks) };
+        // An unknown kind means the C enum grew: ignore it rather than guessing.
+        let Some(kind) = ChangeKind::from_raw(raw.kind) else {
+            return;
+        };
+        let Some(handler) = callbacks.handler(kind) else {
+            return;
+        };
+        let change = Change {
+            kind,
+            total_bytes: raw.total_bytes,
+            delta_bytes: raw.delta_bytes,
+            request_size: raw.request_size,
+        };
+        // A panic must not unwind across the C frame that called us.
+        let _ = catch_unwind(AssertUnwindSafe(|| handler(&change)));
+    }
+
+    /// Install `callbacks`, replacing any previous table. Returns `false` if the C library
+    /// refused the table.
+    ///
+    /// `'static` is what makes this safe: the C side keeps the pointer until the table is
+    /// replaced or cleared, which is exactly the header's "`arg` pointers are caller-owned
+    /// and must stay valid" requirement.
+    ///
+    /// Callbacks run with no allocator locks held and **may** allocate, but a hook that
+    /// fires while another hook's callback is running on the same thread is suppressed —
+    /// so bytes a callback itself allocates never reach the running totals. Keep them
+    /// short, and let them return normally: a panic is caught and swallowed here, but a
+    /// C `longjmp` out of one is unsupported.
+    pub fn set_callbacks(callbacks: &'static Callbacks) -> bool {
+        let mut raw = sys::mi_memory_callbacks_t {
+            handlers: [None; sys::MI_MEMORY_CHANGE_COUNT],
+            args: [core::ptr::null_mut(); sys::MI_MEMORY_CHANGE_COUNT],
+        };
+        let arg = (callbacks as *const Callbacks).cast_mut().cast::<c_void>();
+        for kind in [ChangeKind::Allocate, ChangeKind::Free, ChangeKind::Resize] {
+            if callbacks.handler(kind).is_some() {
+                raw.handlers[kind.slot()] = Some(dispatch);
+                raw.args[kind.slot()] = arg;
+            }
+        }
+        unsafe { sys::mi_memory_set_callbacks(&raw const raw) }
+    }
+
+    /// Remove every installed callback. Accounting (and [`snapshot`]) keeps working.
+    pub fn clear_callbacks() -> bool {
+        unsafe { sys::mi_memory_set_callbacks(core::ptr::null()) }
+    }
+
+    unsafe extern "C" fn visit_trampoline<F>(
+        allocation: *mut c_void,
+        usable_size: usize,
+        arg: *mut c_void,
+    ) -> bool
+    where
+        F: FnMut(*mut u8, usize) -> bool,
+    {
+        let visitor = unsafe { &mut *(arg as *mut F) };
+        catch_unwind(AssertUnwindSafe(|| visitor(allocation.cast(), usable_size))).unwrap_or(false)
+    }
+
+    /// Walk the live allocations this thread may safely observe, calling `visitor` with
+    /// each one's address and usable size. Return `false` from `visitor` to stop early.
+    ///
+    /// Diagnostics only. This is **not** a consistent global snapshot: it is built on
+    /// `mi_heap_visit_blocks`, so another thread may free a reported allocation the
+    /// instant the callback begins.
+    ///
+    /// # Safety
+    ///
+    /// - `visitor` must not allocate, free, or otherwise reenter mimalloc while the walk
+    ///   is active — that includes anything that allocates indirectly, such as `println!`,
+    ///   growing a `Vec`, or formatting. Collect into a fixed-size buffer, or into
+    ///   [`crate::unwrapped_malloc`] memory, and process it after this returns.
+    /// - The pointers handed to `visitor` must not be dereferenced, retained, or freed:
+    ///   they may already be dead. Treat them as addresses, not as references.
+    /// - No other thread may be freeing into the heaps being walked (the
+    ///   `mi_heap_visit_blocks` precondition; see `include/mimalloc.h`).
+    pub unsafe fn visit_live_allocations<F>(mut visitor: F) -> bool
+    where
+        F: FnMut(*mut u8, usize) -> bool,
+    {
+        unsafe {
+            sys::mi_memory_visit_live_allocations(
+                visit_trampoline::<F>,
+                (&raw mut visitor).cast::<c_void>(),
+            )
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/mimalloc-pprof/src/sys.rs
+++ b/rust/mimalloc-pprof/src/sys.rs
@@ -158,6 +158,425 @@ pub struct MiPurgeHolesStats {
     pub full_sweeps: usize,
 }
 
+// ---------------------------------------------------------------------------------------
+// include/mimalloc-stats.h -- exact allocator statistics (upstream API)
+// ---------------------------------------------------------------------------------------
+
+/// Mirrors `MI_STAT_VERSION` in `include/mimalloc-stats.h`.
+pub const MI_STAT_VERSION: usize = 5;
+
+/// Mirrors `MI_BIN_HUGE` in `include/mimalloc-stats.h`; the bin arrays below hold
+/// `MI_BIN_HUGE + 1` entries.
+pub const MI_BIN_HUGE: usize = 73;
+
+/// Mirrors `MI_CBIN_COUNT` (`mi_chunkbin_t`) in `include/mimalloc-stats.h`.
+pub const MI_CBIN_COUNT: usize = 6;
+
+/// Mirrors `mi_stat_count_t`: a quantity tracked over time.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct mi_stat_count_t {
+    /// Total ever allocated.
+    pub total: i64,
+    /// Peak simultaneous value.
+    pub peak: i64,
+    /// Value right now.
+    pub current: i64,
+}
+
+/// Mirrors `mi_stat_counter_t`: a monotonically increasing counter.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct mi_stat_counter_t {
+    /// Total count.
+    pub total: i64,
+}
+
+/// Mirrors `mi_stats_t` (include/mimalloc-stats.h) field-for-field, including the
+/// reserved-for-future-use arrays and the three size-segregated bin arrays.
+///
+/// This is upstream's struct, unchanged by the fork -- in particular it carries **no**
+/// hole-purging or idle-sweep gauges. Those live in [`MiPurgeHolesStats`], because the
+/// sweep also covers pages no heap owns and `mi_stats_t` cannot grow (it is embedded in
+/// a theap, at the meta-allocator's 8 KB block limit).
+///
+/// Field order, offsets and total size are checked against the C library at test time by
+/// `tests/t19_layout.rs` (see `layout_probe.c`), which walks the header's own
+/// `MI_STAT_FIELDS` list -- so an upstream reordering fails loudly instead of silently
+/// reading the wrong counter.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+#[allow(non_camel_case_types)]
+pub struct mi_stats_t {
+    /// `sizeof(mi_stats_t)` as the C library sees it.
+    pub size: usize,
+    /// [`MI_STAT_VERSION`] as the C library sees it.
+    pub version: usize,
+    /// Count of mimalloc pages.
+    pub pages: mi_stat_count_t,
+    /// Reserved memory bytes.
+    pub reserved: mi_stat_count_t,
+    /// Committed bytes.
+    pub committed: mi_stat_count_t,
+    /// Reset bytes.
+    pub reset: mi_stat_counter_t,
+    /// Purged bytes.
+    pub purged: mi_stat_counter_t,
+    /// Committed memory inside pages.
+    pub page_committed: mi_stat_count_t,
+    /// Abandoned page count.
+    pub pages_abandoned: mi_stat_count_t,
+    /// Number of threads.
+    pub threads: mi_stat_count_t,
+    /// Allocated bytes `<= MI_LARGE_OBJ_SIZE_MAX`.
+    pub malloc_normal: mi_stat_count_t,
+    /// Allocated bytes in huge pages.
+    pub malloc_huge: mi_stat_count_t,
+    /// Bytes the application actually asked for; only maintained at `MI_STAT >= 2`.
+    pub malloc_requested: mi_stat_count_t,
+    /// `mmap`/`VirtualAlloc` calls.
+    pub mmap_calls: mi_stat_counter_t,
+    /// Commit calls.
+    pub commit_calls: mi_stat_counter_t,
+    /// Reset calls.
+    pub reset_calls: mi_stat_counter_t,
+    /// Purge calls.
+    pub purge_calls: mi_stat_counter_t,
+    /// Number of memory arenas.
+    pub arena_count: mi_stat_counter_t,
+    /// Number of blocks `<= MI_LARGE_OBJ_SIZE_MAX`.
+    pub malloc_normal_count: mi_stat_counter_t,
+    /// Number of huge blocks.
+    pub malloc_huge_count: mi_stat_counter_t,
+    /// Number of allocations with guard pages.
+    pub malloc_guarded_count: mi_stat_counter_t,
+    /// Internal: arena rollbacks.
+    pub arena_rollback_count: mi_stat_counter_t,
+    /// Internal: arena purges.
+    pub arena_purges: mi_stat_counter_t,
+    /// Internal: page extensions.
+    pub pages_extended: mi_stat_counter_t,
+    /// Internal: retired pages.
+    pub pages_retire: mi_stat_counter_t,
+    /// Internal: total pages searched for a fresh page.
+    pub page_searches: mi_stat_counter_t,
+    /// Internal: searched count for a fresh page.
+    pub page_searches_count: mi_stat_counter_t,
+    /// v1/v2 only; always zero on this v3 line.
+    pub segments: mi_stat_count_t,
+    /// v1/v2 only; always zero on this v3 line.
+    pub segments_abandoned: mi_stat_count_t,
+    /// v1/v2 only; always zero on this v3 line.
+    pub segments_cache: mi_stat_count_t,
+    /// v1/v2 only; always zero on this v3 line.
+    pub _segments_reserved: mi_stat_count_t,
+    /// v3 only: first-class heaps.
+    pub heaps: mi_stat_count_t,
+    /// v3 only: thread-local heaps (`mi_theap_t`).
+    pub theaps: mi_stat_count_t,
+    /// v3 only: pages reclaimed on allocation.
+    pub pages_reclaim_on_alloc: mi_stat_counter_t,
+    /// v3 only: pages reclaimed on free.
+    pub pages_reclaim_on_free: mi_stat_counter_t,
+    /// v3 only: full pages re-abandoned.
+    pub pages_reabandon_full: mi_stat_counter_t,
+    /// v3 only: busy waits while unabandoning a page.
+    pub pages_unabandon_busy_wait: mi_stat_counter_t,
+    /// v3 only: waits while deleting a heap.
+    pub heaps_delete_wait: mi_stat_counter_t,
+    /// Upstream's future-extension padding; do not read.
+    pub _stat_reserved: [mi_stat_count_t; 4],
+    /// Upstream's future-extension padding; do not read.
+    pub _stat_counter_reserved: [mi_stat_counter_t; 4],
+    /// Allocation per size bin.
+    pub malloc_bins: [mi_stat_count_t; MI_BIN_HUGE + 1],
+    /// Pages allocated per size bin.
+    pub page_bins: [mi_stat_count_t; MI_BIN_HUGE + 1],
+    /// Chunks per page size (`mi_chunkbin_t`).
+    pub chunk_bins: [mi_stat_count_t; MI_CBIN_COUNT],
+}
+
+/// Mirrors `mi_subproc_id_t` (include/mimalloc.h): an abstract, pointer-sized handle.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct mi_subproc_id_t {
+    /// The opaque identifier. Only ever produced by `mi_subproc_main`/`mi_subproc_current`.
+    pub _mi_subproc_id: *mut c_void,
+}
+
+/// Mirrors `mi_output_fun` (include/mimalloc.h): mimalloc's text output sink.
+#[allow(non_camel_case_types)]
+pub type mi_output_fun = unsafe extern "C" fn(msg: *const c_char, arg: *mut c_void);
+
+// ---------------------------------------------------------------------------------------
+// include/mimalloc/memory-events.h -- allocation-change accounting (always compiled in)
+// ---------------------------------------------------------------------------------------
+
+/// Mirrors `MI_MEMORY_SNAPSHOT_VERSION` in `include/mimalloc/memory-events.h`.
+pub const MI_MEMORY_SNAPSHOT_VERSION: c_int = 1;
+
+/// Mirrors `mi_memory_change_kind_t`. Declared as a plain `c_int` rather than a Rust
+/// `enum` on purpose: the value is produced by C, and materialising an out-of-range
+/// discriminant into a `#[repr(i32)]` enum would be undefined behaviour.
+#[allow(non_camel_case_types)]
+pub type mi_memory_change_kind_t = c_int;
+
+/// Mirrors `MI_MEMORY_ALLOCATE`.
+pub const MI_MEMORY_ALLOCATE: mi_memory_change_kind_t = 0;
+/// Mirrors `MI_MEMORY_FREE`.
+pub const MI_MEMORY_FREE: mi_memory_change_kind_t = 1;
+/// Mirrors `MI_MEMORY_RESIZE`.
+pub const MI_MEMORY_RESIZE: mi_memory_change_kind_t = 2;
+/// Mirrors `MI_MEMORY_CHANGE_COUNT`: the number of callback slots, not a kind.
+pub const MI_MEMORY_CHANGE_COUNT: usize = 3;
+
+/// Mirrors `mi_memory_change_t` (include/mimalloc/memory-events.h) field-for-field.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct mi_memory_change_t {
+    /// One of [`MI_MEMORY_ALLOCATE`] / [`MI_MEMORY_FREE`] / [`MI_MEMORY_RESIZE`].
+    pub kind: mi_memory_change_kind_t,
+    /// Tracked global live usable bytes after this operation.
+    pub total_bytes: u64,
+    /// Signed change in tracked live usable bytes caused by this operation.
+    pub delta_bytes: i64,
+    /// Caller-requested size for allocation and resize; zero for free.
+    pub request_size: u64,
+}
+
+/// Mirrors `mi_memory_change_fun` (include/mimalloc/memory-events.h).
+#[allow(non_camel_case_types)]
+pub type mi_memory_change_fun =
+    unsafe extern "C" fn(change: *const mi_memory_change_t, arg: *mut c_void);
+
+/// Mirrors `mi_memory_callbacks_t` (include/mimalloc/memory-events.h): one handler and
+/// one caller-owned `arg` per [`mi_memory_change_kind_t`], indexed by the kind.
+#[repr(C)]
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub struct mi_memory_callbacks_t {
+    /// Handler per change kind; `None` leaves that kind unobserved.
+    pub handlers: [Option<mi_memory_change_fun>; MI_MEMORY_CHANGE_COUNT],
+    /// Caller-owned context per change kind, passed back to the matching handler.
+    pub args: [*mut c_void; MI_MEMORY_CHANGE_COUNT],
+}
+
+/// Mirrors `mi_memory_snapshot_t` (include/mimalloc/memory-events.h) field-for-field.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub struct mi_memory_snapshot_t {
+    /// `sizeof(mi_memory_snapshot_t)`; fill in before calling `mi_memory_snapshot`.
+    pub size: usize,
+    /// [`MI_MEMORY_SNAPSHOT_VERSION`]; fill in before calling `mi_memory_snapshot`.
+    pub version: c_int,
+    /// Tracked live usable bytes right now.
+    pub live_bytes: u64,
+    /// Cumulative usable bytes ever allocated.
+    pub accum_bytes: u64,
+    /// Tracked live allocation count right now.
+    pub live_count: u64,
+    /// Cumulative count of successful allocate events.
+    pub accum_count: u64,
+}
+
+/// Mirrors `mi_memory_allocation_visit_fun` (include/mimalloc/memory-events.h).
+#[allow(non_camel_case_types)]
+pub type mi_memory_allocation_visit_fun =
+    unsafe extern "C" fn(allocation: *mut c_void, usable_size: usize, arg: *mut c_void) -> bool;
+
+// ---------------------------------------------------------------------------------------
+// include/mimalloc.h -- mi_option_t
+// ---------------------------------------------------------------------------------------
+
+/// Mirrors `mi_option_t` (include/mimalloc.h).
+///
+/// **Positional, and silently wrong if it drifts.** This fork inserts thirteen
+/// enumerators (`mi_option_prof*`, `mi_option_memory_events`, `mi_option_purge_zeroes`,
+/// `mi_option_scavenger`, `mi_option_purge_holes*`) at indices 47..=59, immediately
+/// before `_mi_option_last` -- so a mirror copied from upstream mimalloc would set a
+/// *different* option than the caller named, with no diagnostic. Every value below is
+/// checked against the C enum at test time by `tests/t19_layout.rs`, and the ordering is
+/// checked against `include/mimalloc.h` by `ci/check_rust_surface.py`.
+#[allow(non_camel_case_types)]
+pub type mi_option_t = c_int;
+
+macro_rules! mi_options {
+    ($($(#[$attr:meta])* $name:ident = $value:expr;)*) => {
+        $(
+            $(#[$attr])*
+            #[allow(non_upper_case_globals)]
+            pub const $name: mi_option_t = $value;
+        )*
+        /// Every enumerator of `mi_option_t` up to and including `_mi_option_last`, in C
+        /// declaration order, as `(name, value)` pairs. Used by `tests/t19_layout.rs` to
+        /// check this mirror against the C enum, and by `ci/check_rust_surface.py` to
+        /// check it against `include/mimalloc.h`.
+        pub const MI_OPTIONS_IN_ORDER: &[(&str, mi_option_t)] = &[$((stringify!($name), $name)),*];
+    };
+}
+
+mi_options! {
+    /// Print error messages.
+    mi_option_show_errors = 0;
+    /// Print statistics on termination.
+    mi_option_show_stats = 1;
+    /// Print verbose messages.
+    mi_option_verbose = 2;
+    /// Deprecated; kept for numbering.
+    mi_option_deprecated_eager_commit = 3;
+    /// Eagerly commit arena memory.
+    mi_option_arena_eager_commit = 4;
+    /// Purge decommits rather than resets.
+    mi_option_purge_decommits = 5;
+    /// Allow large (2 MiB) OS pages.
+    mi_option_allow_large_os_pages = 6;
+    /// Reserve N huge OS pages at startup.
+    mi_option_reserve_huge_os_pages = 7;
+    /// Reserve huge OS pages at a specific NUMA node.
+    mi_option_reserve_huge_os_pages_at = 8;
+    /// Reserve N KiB of OS memory at startup.
+    mi_option_reserve_os_memory = 9;
+    /// Deprecated; kept for numbering.
+    mi_option_deprecated_segment_cache = 10;
+    /// Deprecated; kept for numbering.
+    mi_option_deprecated_page_reset = 11;
+    /// Deprecated; kept for numbering.
+    mi_option_deprecated_abandoned_page_purge = 12;
+    /// Deprecated; kept for numbering.
+    mi_option_deprecated_segment_reset = 13;
+    /// Deprecated; kept for numbering.
+    mi_option_deprecated_eager_commit_delay = 14;
+    /// Milliseconds to delay purging.
+    mi_option_purge_delay = 15;
+    /// Number of NUMA nodes to use.
+    mi_option_use_numa_nodes = 16;
+    /// Refuse to allocate from the OS.
+    mi_option_disallow_os_alloc = 17;
+    /// Tag passed to the OS allocator.
+    mi_option_os_tag = 18;
+    /// Maximum error messages printed.
+    mi_option_max_errors = 19;
+    /// Maximum warning messages printed.
+    mi_option_max_warnings = 20;
+    /// Deprecated; kept for numbering.
+    mi_option_deprecated_max_segment_reclaim = 21;
+    /// Release all memory on process exit.
+    mi_option_destroy_on_exit = 22;
+    /// Bytes to reserve per new arena.
+    mi_option_arena_reserve = 23;
+    /// Multiplier on the arena purge delay.
+    mi_option_arena_purge_mult = 24;
+    /// Deprecated; kept for numbering.
+    mi_option_deprecated_purge_extend_delay = 25;
+    /// Refuse to allocate from arenas.
+    mi_option_disallow_arena_alloc = 26;
+    /// Retry count on OS out-of-memory.
+    mi_option_retry_on_oom = 27;
+    /// Deprecated; kept for numbering.
+    mi_option_deprecated_visit_abandoned = 28;
+    /// Minimum size for guard-page allocation.
+    mi_option_guarded_min = 29;
+    /// Maximum size for guard-page allocation.
+    mi_option_guarded_max = 30;
+    /// Place guard pages precisely after the block.
+    mi_option_guarded_precise = 31;
+    /// Sample every N-th allocation for guard pages.
+    mi_option_guarded_sample_rate = 32;
+    /// Seed for guard-page sampling.
+    mi_option_guarded_sample_seed = 33;
+    /// Collect generically every N-th generic allocation.
+    mi_option_generic_collect = 34;
+    /// Reclaim abandoned pages on free.
+    mi_option_page_reclaim_on_free = 35;
+    /// Number of full pages to retain per bin.
+    mi_option_page_full_retain = 36;
+    /// Candidate pages searched per allocation.
+    mi_option_page_max_candidates = 37;
+    /// Maximum virtual address bits to assume.
+    mi_option_max_vabits = 38;
+    /// Commit the page map eagerly.
+    mi_option_pagemap_commit = 39;
+    /// Commit page memory on demand.
+    mi_option_page_commit_on_demand = 40;
+    /// Maximum pages reclaimed at once.
+    mi_option_page_max_reclaim = 41;
+    /// Maximum cross-thread pages reclaimed at once.
+    mi_option_page_cross_thread_max_reclaim = 42;
+    /// Allow transparent huge pages.
+    mi_option_allow_thp = 43;
+    /// Smallest range worth purging.
+    mi_option_minimal_purge_size = 44;
+    /// Largest object served from an arena.
+    mi_option_arena_max_object_size = 45;
+    /// Treat arenas as NUMA local.
+    mi_option_arena_is_numa_local = 46;
+    /// **Fork addition.** Enable the allocation sampling profiler at process start
+    /// (`MIMALLOC_PROF`).
+    mi_option_prof = 47;
+    /// **Fork addition.** Average byte interval between profiler samples.
+    mi_option_prof_sample_rate = 48;
+    /// **Fork addition.** Maximum captured stack depth for the profiler.
+    mi_option_prof_bt_max = 49;
+    /// **Fork addition.** Keep cumulative profiler counters until `mi_prof_reset`.
+    mi_option_prof_accum = 50;
+    /// **Fork addition.** Profiler sampling PRNG seed; 0 = nondeterministic.
+    mi_option_prof_seed = 51;
+    /// **Fork addition.** Budget in bytes for profiler-internal arena memory.
+    mi_option_prof_max_bytes = 52;
+    /// **Fork addition.** Enable allocation-change accounting/callbacks
+    /// (`MIMALLOC_MEMORY_EVENTS`).
+    mi_option_memory_events = 53;
+    /// **Fork addition, dead since #80.** The slot is kept so nothing renumbers; setting
+    /// it parses but has no effect. Unrelated to `mi_option_purge_holes_eager_zero`.
+    mi_option_purge_zeroes = 54;
+    /// **Fork addition (Bun).** Run a background thread that purges scheduled arena memory.
+    mi_option_scavenger = 55;
+    /// **Fork addition (Bun).** Discard the memory of free blocks inside still-used pages
+    /// on `mi_on_thread_idle`.
+    mi_option_purge_holes = 56;
+    /// **Fork addition (Bun).** Zero a range before discarding it, so a mis-scoped discard
+    /// corrupts visibly.
+    mi_option_purge_holes_eager_zero = 57;
+    /// **Fork addition (Bun).** Minimum milliseconds between sweeps of one thread's heaps.
+    mi_option_purge_holes_min_interval = 58;
+    /// **Fork addition (Bun).** Every N-th sweep walks every page, ignoring the per-page
+    /// skip check; 0 disables.
+    mi_option_purge_holes_full_every = 59;
+    /// Sentinel: one past the last real option.
+    _mi_option_last = 60;
+}
+
+/// Deprecated upstream alias for [`mi_option_allow_large_os_pages`].
+#[allow(non_upper_case_globals)]
+pub const mi_option_large_os_pages: mi_option_t = mi_option_allow_large_os_pages;
+/// Deprecated upstream alias for [`mi_option_arena_eager_commit`].
+#[allow(non_upper_case_globals)]
+pub const mi_option_eager_region_commit: mi_option_t = mi_option_arena_eager_commit;
+/// Deprecated upstream alias for [`mi_option_purge_decommits`].
+#[allow(non_upper_case_globals)]
+pub const mi_option_reset_decommits: mi_option_t = mi_option_purge_decommits;
+/// Deprecated upstream alias for [`mi_option_purge_delay`].
+#[allow(non_upper_case_globals)]
+pub const mi_option_reset_delay: mi_option_t = mi_option_purge_delay;
+/// Deprecated upstream alias for [`mi_option_disallow_os_alloc`].
+#[allow(non_upper_case_globals)]
+pub const mi_option_limit_os_alloc: mi_option_t = mi_option_disallow_os_alloc;
+
+/// One entry of the ABI layout table published by [`mi_rs_layout_table`].
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MiRsLayoutEntry {
+    /// NUL-terminated static key, e.g. `sizeof:mi_stats_t` or `option:mi_option_prof`.
+    pub name: *const c_char,
+    /// The value the C compiler computed for that key.
+    pub value: usize,
+}
+
 unsafe extern "C" {
     pub fn mi_malloc(size: usize) -> *mut c_void;
     pub fn mi_zalloc(size: usize) -> *mut c_void;
@@ -251,4 +670,124 @@ unsafe extern "C" {
     pub fn mi_scavenger_stop();
     /// Mirrors `mi_purge_holes_stats_get` (issue #272, Bun parity P7b).
     pub fn mi_purge_holes_stats_get(stats: *mut MiPurgeHolesStats);
+
+    /// Mirrors `mi_purge_holes_report` (issue #272, Bun parity P7b): prints, per size
+    /// class, the free bytes hole purging could NOT discard. Read-only; purges nothing.
+    pub fn mi_purge_holes_report();
+
+    // ---- include/mimalloc.h: options ----
+    /// Mirrors `mi_option_is_enabled`.
+    pub fn mi_option_is_enabled(option: mi_option_t) -> bool;
+    /// Mirrors `mi_option_enable`.
+    pub fn mi_option_enable(option: mi_option_t);
+    /// Mirrors `mi_option_disable`.
+    pub fn mi_option_disable(option: mi_option_t);
+    /// Mirrors `mi_option_set_enabled`.
+    pub fn mi_option_set_enabled(option: mi_option_t, enable: bool);
+    /// Mirrors `mi_option_set_enabled_default`.
+    pub fn mi_option_set_enabled_default(option: mi_option_t, enable: bool);
+    /// Mirrors `mi_option_get`.
+    pub fn mi_option_get(option: mi_option_t) -> core::ffi::c_long;
+    /// Mirrors `mi_option_get_clamp`.
+    pub fn mi_option_get_clamp(
+        option: mi_option_t,
+        min: core::ffi::c_long,
+        max: core::ffi::c_long,
+    ) -> core::ffi::c_long;
+    /// Mirrors `mi_option_get_size`.
+    pub fn mi_option_get_size(option: mi_option_t) -> usize;
+    /// Mirrors `mi_option_set`.
+    pub fn mi_option_set(option: mi_option_t, value: core::ffi::c_long);
+    /// Mirrors `mi_option_set_default`.
+    pub fn mi_option_set_default(option: mi_option_t, value: core::ffi::c_long);
+    /// Mirrors `mi_options_print_out`: prints every option's current value.
+    pub fn mi_options_print_out(out: Option<mi_output_fun>, arg: *mut c_void);
+
+    // ---- include/mimalloc-stats.h: exact statistics ----
+    /// Mirrors `mi_stats_get`: aggregated stats for the current subprocess and its heaps.
+    pub fn mi_stats_get(stats: *mut mi_stats_t) -> bool;
+    /// Mirrors `mi_stats_get_json`. With `buf == NULL` the result is `mi_malloc`-family
+    /// memory the caller must release with [`mi_free`].
+    pub fn mi_stats_get_json(buf_size: usize, buf: *mut c_char) -> *mut c_char;
+    /// Mirrors `mi_stats_as_json`: render an already-captured [`mi_stats_t`].
+    pub fn mi_stats_as_json(
+        stats: *mut mi_stats_t,
+        buf_size: usize,
+        buf: *mut c_char,
+    ) -> *mut c_char;
+    /// Mirrors `mi_stats_print_out`.
+    pub fn mi_stats_print_out(out: Option<mi_output_fun>, arg: *mut c_void);
+    /// Mirrors `mi_stats_get_bin_size`: the block size served by size bin `bin`.
+    pub fn mi_stats_get_bin_size(bin: usize) -> usize;
+    /// Mirrors `mi_heap_stats_get`.
+    pub fn mi_heap_stats_get(heap: *mut mi_heap_t, stats: *mut mi_stats_t) -> bool;
+    /// Mirrors `mi_heap_stats_get_json`.
+    pub fn mi_heap_stats_get_json(
+        heap: *mut mi_heap_t,
+        buf_size: usize,
+        buf: *mut c_char,
+    ) -> *mut c_char;
+    /// Mirrors `mi_heap_stats_print_out`.
+    pub fn mi_heap_stats_print_out(
+        heap: *mut mi_heap_t,
+        out: Option<mi_output_fun>,
+        arg: *mut c_void,
+    );
+    /// Mirrors `mi_heap_stats_merge_to_subproc`: fold a heap's stats into its subprocess
+    /// and clear the heap's own.
+    pub fn mi_heap_stats_merge_to_subproc(heap: *mut mi_heap_t);
+    /// Mirrors `mi_subproc_stats_get`.
+    pub fn mi_subproc_stats_get(subproc_id: mi_subproc_id_t, stats: *mut mi_stats_t) -> bool;
+    /// Mirrors `mi_subproc_stats_get_exclusive`: the subprocess's own stats, without
+    /// aggregating its heaps.
+    pub fn mi_subproc_stats_get_exclusive(
+        subproc_id: mi_subproc_id_t,
+        stats: *mut mi_stats_t,
+    ) -> bool;
+    /// Mirrors `mi_subproc_stats_get_json`.
+    pub fn mi_subproc_stats_get_json(
+        subproc_id: mi_subproc_id_t,
+        buf_size: usize,
+        buf: *mut c_char,
+    ) -> *mut c_char;
+    /// Mirrors `mi_subproc_stats_print_out`.
+    pub fn mi_subproc_stats_print_out(
+        subproc_id: mi_subproc_id_t,
+        out: Option<mi_output_fun>,
+        arg: *mut c_void,
+    );
+    /// Mirrors `mi_subproc_heap_stats_print_out`: the subprocess and each of its heaps,
+    /// printed separately.
+    pub fn mi_subproc_heap_stats_print_out(
+        subproc_id: mi_subproc_id_t,
+        out: Option<mi_output_fun>,
+        arg: *mut c_void,
+    );
+    /// Mirrors `mi_subproc_main`: the process-wide default subprocess.
+    pub fn mi_subproc_main() -> mi_subproc_id_t;
+    /// Mirrors `mi_subproc_current`: the subprocess this thread belongs to.
+    pub fn mi_subproc_current() -> mi_subproc_id_t;
+
+    // ---- include/mimalloc/memory-events.h ----
+    /// Mirrors `mi_memory_tracking_set_enabled`; returns the previous state. An explicit
+    /// call is always authoritative over the `MIMALLOC_MEMORY_EVENTS` environment read.
+    pub fn mi_memory_tracking_set_enabled(enabled: bool) -> bool;
+    /// Mirrors `mi_memory_tracking_is_enabled`.
+    pub fn mi_memory_tracking_is_enabled() -> bool;
+    /// Mirrors `mi_memory_set_callbacks`. `callbacks == NULL` clears the table. The `arg`
+    /// pointers are caller-owned and must stay valid until replaced or cleared.
+    pub fn mi_memory_set_callbacks(callbacks: *const mi_memory_callbacks_t) -> bool;
+    /// Mirrors `mi_memory_snapshot`; fill `size`/`version` in before calling.
+    pub fn mi_memory_snapshot(out: *mut mi_memory_snapshot_t) -> bool;
+    /// Mirrors `mi_memory_visit_live_allocations`. Best effort, not a consistent global
+    /// snapshot; the visitor must not allocate, free, or reenter mimalloc.
+    pub fn mi_memory_visit_live_allocations(
+        visitor: mi_memory_allocation_visit_fun,
+        arg: *mut c_void,
+    ) -> bool;
+
+    /// Publishes what the C compiler laid out for every mirrored type, constant and
+    /// option in this module. Defined by `layout_probe.c` (a rust/-side verification
+    /// artifact, not part of the C library) and consumed by `tests/t19_layout.rs`.
+    pub fn mi_rs_layout_table(count: *mut usize) -> *const MiRsLayoutEntry;
 }

--- a/rust/mimalloc-pprof/tests/t19_layout.rs
+++ b/rust/mimalloc-pprof/tests/t19_layout.rs
@@ -1,0 +1,494 @@
+//! ABI layout gate for every hand-written mirror in `src/sys.rs`.
+//!
+//! `src/sys.rs` mirrors C structs field-for-field and C enumerators value-for-value by
+//! hand. Both drift silently: a mirrored struct whose fields moved writes the wrong
+//! field, and a mirrored `mi_option_t` whose values shifted sets a *different* option
+//! than the caller named. Neither produces a diagnostic — this fork inserts thirteen
+//! enumerators mid-enum (indices 47..=59), which is exactly the shape of bug that
+//! silently misconfigures an allocator.
+//!
+//! So the C compiler publishes what it actually laid out (`../layout_probe.c`) and this
+//! test compares it, **by name**, against what Rust laid out. A field renamed or dropped
+//! on either side fails as a missing key rather than as a coincidentally-equal number.
+//!
+//! Runs in both feature modes: the public *types* in `include/mimalloc/profile.h` are
+//! declared unconditionally, so the layout the mirrors must match is the same whether or
+//! not `MI_PPROF` is on.
+
+use std::collections::BTreeMap;
+use std::ffi::CStr;
+
+use mimalloc_pprof::sys;
+
+/// The C-side layout table, keyed by the names `layout_probe.c` publishes.
+fn c_layout() -> BTreeMap<String, usize> {
+    let mut count = 0_usize;
+    let table = unsafe { sys::mi_rs_layout_table(&raw mut count) };
+    assert!(!table.is_null(), "mi_rs_layout_table returned NULL");
+    assert!(count > 0, "mi_rs_layout_table published an empty table");
+    let mut map = BTreeMap::new();
+    for i in 0..count {
+        let entry = unsafe { &*table.add(i) };
+        let name = unsafe { CStr::from_ptr(entry.name) }
+            .to_str()
+            .expect("layout keys are ASCII")
+            .to_owned();
+        assert!(
+            map.insert(name.clone(), entry.value).is_none(),
+            "duplicate layout key {name}"
+        );
+    }
+    map
+}
+
+/// Collect `sizeof` plus one `offset_of` per named field, using the C spelling of the
+/// type so the keys line up with `layout_probe.c`'s `MI_RS_SIZEOF`/`MI_RS_OFFSET`.
+macro_rules! layout {
+    ($c_name:literal, $rust_ty:ty $(, $field:ident)* $(,)?) => {{
+        // `mut` is unused for a size-only invocation (a type with no named fields).
+        #[allow(unused_mut)]
+        let mut v: Vec<(String, usize)> =
+            vec![(format!("sizeof:{}", $c_name), size_of::<$rust_ty>())];
+        $(
+            v.push((
+                format!("offset:{}.{}", $c_name, stringify!($field)),
+                core::mem::offset_of!($rust_ty, $field),
+            ));
+        )*
+        v
+    }};
+}
+
+fn check(c: &BTreeMap<String, usize>, expected: Vec<(String, usize)>) {
+    for (key, rust_value) in expected {
+        let c_value = c
+            .get(&key)
+            .copied()
+            .unwrap_or_else(|| panic!("{key}: the C layout table has no such key"));
+        assert_eq!(
+            c_value, rust_value,
+            "{key}: C says {c_value}, the Rust mirror in src/sys.rs says {rust_value}"
+        );
+    }
+}
+
+#[test]
+fn profiler_structs_match_c() {
+    let c = c_layout();
+    check(
+        &c,
+        layout!(
+            "mi_prof_stats_t",
+            sys::mi_prof_stats_t,
+            size,
+            version,
+            enabled,
+            accum,
+            sample_rate,
+            live_samples,
+            live_bytes,
+            accum_samples,
+            accum_bytes,
+            unique_stacks,
+            arena_committed,
+            stack_table_overflows,
+            dropped_samples,
+            heap_committed,
+            heap_reserved,
+            heap_malloc_requested,
+            heap_pages,
+            heap_pages_abandoned,
+            heap_count,
+            theap_count,
+            heap_purged,
+            heap_stats_detailed,
+        ),
+    );
+    check(
+        &c,
+        layout!(
+            "mi_prof_config_t",
+            sys::mi_prof_config_t,
+            size,
+            version,
+            mode,
+            sample_interval,
+            max_profiler_bytes,
+            seed,
+            accum,
+            max_stack_depth,
+            dump_at_exit,
+            dump_format,
+        ),
+    );
+    check(
+        &c,
+        layout!(
+            "mi_prof_sample_info_t",
+            sys::mi_prof_sample_info_t,
+            stack,
+            depth,
+            live_objects,
+            live_bytes,
+            accum_objects,
+            accum_bytes,
+        ),
+    );
+    check(
+        &c,
+        layout!(
+            "mi_prof_module_info_t",
+            sys::mi_prof_module_info_t,
+            path,
+            base,
+            size,
+        ),
+    );
+}
+
+#[test]
+fn dhat_struct_matches_c() {
+    let c = c_layout();
+    check(
+        &c,
+        layout!(
+            "mi_dhat_stats_t",
+            sys::mi_dhat_stats_t,
+            size,
+            version,
+            enabled,
+            incomplete,
+            total_bytes,
+            total_blocks,
+            live_bytes,
+            live_blocks,
+            peak_bytes,
+            peak_blocks,
+            dropped,
+            internal_bytes,
+        ),
+    );
+}
+
+#[test]
+fn memory_events_structs_match_c() {
+    let c = c_layout();
+    check(
+        &c,
+        layout!(
+            "mi_memory_change_t",
+            sys::mi_memory_change_t,
+            kind,
+            total_bytes,
+            delta_bytes,
+            request_size,
+        ),
+    );
+    check(
+        &c,
+        layout!(
+            "mi_memory_callbacks_t",
+            sys::mi_memory_callbacks_t,
+            handlers,
+            args,
+        ),
+    );
+    check(
+        &c,
+        layout!(
+            "mi_memory_snapshot_t",
+            sys::mi_memory_snapshot_t,
+            size,
+            version,
+            live_bytes,
+            accum_bytes,
+            live_count,
+            accum_count,
+        ),
+    );
+}
+
+#[test]
+fn purge_holes_struct_matches_c() {
+    let c = c_layout();
+    check(
+        &c,
+        layout!(
+            "mi_purge_holes_stats_t",
+            sys::MiPurgeHolesStats,
+            purged_bytes,
+            purged_blocks,
+            purged_bytes_total,
+            discard_calls,
+            reuse_calls,
+            pages_freed,
+            ineligible_pages,
+            ineligible_bytes,
+            ineligible_free_bytes,
+            unformed_bytes,
+            unformed_bytes_total,
+            unformed_discard_calls,
+            unformed_reuse_calls,
+            pages_skipped,
+            blocks_visited,
+            full_sweeps,
+        ),
+    );
+}
+
+#[test]
+fn stats_struct_matches_c() {
+    let c = c_layout();
+    check(
+        &c,
+        layout!(
+            "mi_stat_count_t",
+            sys::mi_stat_count_t,
+            total,
+            peak,
+            current,
+        ),
+    );
+    check(
+        &c,
+        layout!("mi_stat_counter_t", sys::mi_stat_counter_t, total),
+    );
+    check(
+        &c,
+        layout!(
+            "mi_stats_t",
+            sys::mi_stats_t,
+            size,
+            version,
+            pages,
+            reserved,
+            committed,
+            reset,
+            purged,
+            page_committed,
+            pages_abandoned,
+            threads,
+            malloc_normal,
+            malloc_huge,
+            malloc_requested,
+            mmap_calls,
+            commit_calls,
+            reset_calls,
+            purge_calls,
+            arena_count,
+            malloc_normal_count,
+            malloc_huge_count,
+            malloc_guarded_count,
+            arena_rollback_count,
+            arena_purges,
+            pages_extended,
+            pages_retire,
+            page_searches,
+            page_searches_count,
+            segments,
+            segments_abandoned,
+            segments_cache,
+            _segments_reserved,
+            heaps,
+            theaps,
+            pages_reclaim_on_alloc,
+            pages_reclaim_on_free,
+            pages_reabandon_full,
+            pages_unabandon_busy_wait,
+            heaps_delete_wait,
+            _stat_reserved,
+            _stat_counter_reserved,
+            malloc_bins,
+            page_bins,
+            chunk_bins,
+        ),
+    );
+    check(&c, layout!("mi_subproc_id_t", sys::mi_subproc_id_t));
+}
+
+/// The C layout table lists every `mi_stats_t` field by walking the header's own
+/// `MI_STAT_FIELDS()` macro. So if upstream adds a counter, the table grows a key this
+/// test never asked about — and the Rust mirror is quietly one field short of the C
+/// struct even though every offset it *does* check still matches. Catch that by
+/// requiring the two field sets to be equal, not merely compatible.
+#[test]
+fn stats_struct_has_no_unmirrored_fields() {
+    let c = c_layout();
+    let mirrored: Vec<&str> = vec![
+        "size",
+        "version",
+        "pages",
+        "reserved",
+        "committed",
+        "reset",
+        "purged",
+        "page_committed",
+        "pages_abandoned",
+        "threads",
+        "malloc_normal",
+        "malloc_huge",
+        "malloc_requested",
+        "mmap_calls",
+        "commit_calls",
+        "reset_calls",
+        "purge_calls",
+        "arena_count",
+        "malloc_normal_count",
+        "malloc_huge_count",
+        "malloc_guarded_count",
+        "arena_rollback_count",
+        "arena_purges",
+        "pages_extended",
+        "pages_retire",
+        "page_searches",
+        "page_searches_count",
+        "segments",
+        "segments_abandoned",
+        "segments_cache",
+        "_segments_reserved",
+        "heaps",
+        "theaps",
+        "pages_reclaim_on_alloc",
+        "pages_reclaim_on_free",
+        "pages_reabandon_full",
+        "pages_unabandon_busy_wait",
+        "heaps_delete_wait",
+        "_stat_reserved",
+        "_stat_counter_reserved",
+        "malloc_bins",
+        "page_bins",
+        "chunk_bins",
+    ];
+    let from_c: Vec<String> = c
+        .keys()
+        .filter_map(|k| k.strip_prefix("offset:mi_stats_t.").map(str::to_owned))
+        .collect();
+    for field in &from_c {
+        assert!(
+            mirrored.contains(&field.as_str()),
+            "include/mimalloc-stats.h has a field `{field}` that src/sys.rs's \
+             mi_stats_t does not mirror"
+        );
+    }
+    assert_eq!(
+        from_c.len(),
+        mirrored.len(),
+        "mi_stats_t field count drifted between C and src/sys.rs"
+    );
+}
+
+#[test]
+fn versions_and_constants_match_c() {
+    let c = c_layout();
+    let expected: Vec<(&str, usize)> = vec![
+        (
+            "const:MI_PROF_STAT_VERSION",
+            sys::MI_PROF_STAT_VERSION as usize,
+        ),
+        (
+            "const:MI_PROF_CONFIG_VERSION",
+            sys::MI_PROF_CONFIG_VERSION as usize,
+        ),
+        (
+            "const:MI_PROF_FORMAT_TEXT",
+            sys::MI_PROF_FORMAT_TEXT as usize,
+        ),
+        (
+            "const:MI_PROF_FORMAT_PROTO",
+            sys::MI_PROF_FORMAT_PROTO as usize,
+        ),
+        (
+            "const:MI_PROF_CONFIG_FALLBACK",
+            sys::MI_PROF_CONFIG_FALLBACK as usize,
+        ),
+        (
+            "const:MI_PROF_CONFIG_OVERRIDE",
+            sys::MI_PROF_CONFIG_OVERRIDE as usize,
+        ),
+        (
+            "const:MI_DHAT_STATS_VERSION",
+            sys::MI_DHAT_STATS_VERSION as usize,
+        ),
+        (
+            "const:MI_MEMORY_SNAPSHOT_VERSION",
+            sys::MI_MEMORY_SNAPSHOT_VERSION as usize,
+        ),
+        ("const:MI_MEMORY_ALLOCATE", sys::MI_MEMORY_ALLOCATE as usize),
+        ("const:MI_MEMORY_FREE", sys::MI_MEMORY_FREE as usize),
+        ("const:MI_MEMORY_RESIZE", sys::MI_MEMORY_RESIZE as usize),
+        ("const:MI_MEMORY_CHANGE_COUNT", sys::MI_MEMORY_CHANGE_COUNT),
+        ("const:MI_STAT_VERSION", sys::MI_STAT_VERSION),
+        ("const:MI_BIN_HUGE", sys::MI_BIN_HUGE),
+        ("const:MI_CBIN_COUNT", sys::MI_CBIN_COUNT),
+    ];
+    check(
+        &c,
+        expected
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v))
+            .collect(),
+    );
+}
+
+/// The hazard this whole file exists for: `mi_option_t` is positional, and this fork
+/// inserted thirteen enumerators before `_mi_option_last`. A mirror copied from upstream
+/// would compile, run, and set the wrong option forever.
+#[test]
+fn option_values_match_c() {
+    let c = c_layout();
+    let expected: Vec<(String, usize)> = sys::MI_OPTIONS_IN_ORDER
+        .iter()
+        .map(|(name, value)| {
+            assert!(*value >= 0, "{name}: negative option value {value}");
+            (format!("option:{name}"), *value as usize)
+        })
+        .collect();
+    check(&c, expected);
+
+    // Sequential from zero, with no gaps: that is what makes an inserted enumerator
+    // shift every later one, and what an upstream merge can quietly break.
+    for (index, (name, value)) in sys::MI_OPTIONS_IN_ORDER.iter().enumerate() {
+        assert_eq!(
+            *value as usize, index,
+            "{name} is at index {index} of MI_OPTIONS_IN_ORDER but has value {value}"
+        );
+    }
+    let (last_name, last_value) = sys::MI_OPTIONS_IN_ORDER
+        .last()
+        .copied()
+        .expect("MI_OPTIONS_IN_ORDER is non-empty");
+    assert_eq!(last_name, "_mi_option_last");
+    assert_eq!(last_value, sys::_mi_option_last);
+}
+
+/// The deprecated upstream aliases resolve to the option they alias, not to a slot of
+/// their own.
+#[test]
+fn deprecated_option_aliases_match_c() {
+    let c = c_layout();
+    check(
+        &c,
+        vec![
+            (
+                "option:mi_option_large_os_pages".to_owned(),
+                sys::mi_option_large_os_pages as usize,
+            ),
+            (
+                "option:mi_option_eager_region_commit".to_owned(),
+                sys::mi_option_eager_region_commit as usize,
+            ),
+            (
+                "option:mi_option_reset_decommits".to_owned(),
+                sys::mi_option_reset_decommits as usize,
+            ),
+            (
+                "option:mi_option_reset_delay".to_owned(),
+                sys::mi_option_reset_delay as usize,
+            ),
+            (
+                "option:mi_option_limit_os_alloc".to_owned(),
+                sys::mi_option_limit_os_alloc as usize,
+            ),
+        ],
+    );
+}

--- a/rust/mimalloc-pprof/tests/t20_memory_events.rs
+++ b/rust/mimalloc-pprof/tests/t20_memory_events.rs
@@ -1,0 +1,183 @@
+//! Opt-in allocation-change accounting (`include/mimalloc/memory-events.h`).
+//!
+//! Independent of `MI_PPROF`: `src/memory-events.c` is compiled in every configuration,
+//! so this file carries no `required-features` and runs on both `rust-native` rows.
+//!
+//! Everything here is one `#[test]`, run in sections, and that is not laziness. Tracking,
+//! the callback table and the running totals are all **process**-global, and cargo runs
+//! the tests of one binary on several threads at once — so a second test allocating on
+//! another thread lands in the very counters the first is asserting deltas on. One test
+//! per binary is the only way these assertions mean anything.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use mimalloc_pprof::memory_events::{self, Callbacks, Change, ChangeKind};
+
+#[global_allocator]
+static ALLOCATOR: mimalloc_pprof::MiMalloc = mimalloc_pprof::MiMalloc;
+
+#[test]
+fn memory_events_end_to_end() {
+    enabling_is_authoritative_and_reversible();
+    snapshot_counts_allocations_while_enabled();
+    tracking_off_records_nothing();
+    unwrapped_allocations_are_excluded_from_accounting();
+    callbacks_observe_every_kind();
+}
+
+fn enabling_is_authoritative_and_reversible() {
+    let previous = memory_events::set_enabled(true);
+    assert!(memory_events::is_enabled());
+    memory_events::set_enabled(false);
+    assert!(!memory_events::is_enabled());
+    memory_events::set_enabled(previous);
+}
+
+fn snapshot_counts_allocations_while_enabled() {
+    let previous = memory_events::set_enabled(true);
+
+    let before = memory_events::snapshot().expect("snapshot while enabled");
+    let held: Vec<Vec<u8>> = (0..64).map(|_| vec![0_u8; 4096]).collect();
+    std::hint::black_box(&held);
+    let during = memory_events::snapshot().expect("snapshot while enabled");
+
+    assert!(
+        during.accum_count >= before.accum_count + 64,
+        "64 allocations should raise accum_count by at least 64: {} -> {}",
+        before.accum_count,
+        during.accum_count
+    );
+    assert!(
+        during.accum_bytes >= before.accum_bytes + 64 * 4096,
+        "accum_bytes should grow by at least the requested bytes: {} -> {}",
+        before.accum_bytes,
+        during.accum_bytes
+    );
+    assert!(
+        during.live_bytes >= 64 * 4096,
+        "live_bytes = {}",
+        during.live_bytes
+    );
+
+    drop(held);
+    let after = memory_events::snapshot().expect("snapshot while enabled");
+    assert!(
+        after.live_count < during.live_count,
+        "freeing 64 blocks should lower live_count: {} -> {}",
+        during.live_count,
+        after.live_count
+    );
+    // Cumulative counters never go backwards, even as live ones fall.
+    assert!(after.accum_count >= during.accum_count);
+
+    memory_events::set_enabled(previous);
+}
+
+fn tracking_off_records_nothing() {
+    let previous = memory_events::set_enabled(false);
+    let before = memory_events::snapshot().expect("snapshot while disabled");
+    let held: Vec<Vec<u8>> = (0..32).map(|_| vec![0_u8; 8192]).collect();
+    std::hint::black_box(&held);
+    let after = memory_events::snapshot().expect("snapshot while disabled");
+    assert_eq!(
+        before.accum_count, after.accum_count,
+        "accounting must stop dead while tracking is off"
+    );
+    drop(held);
+    memory_events::set_enabled(previous);
+}
+
+fn unwrapped_allocations_are_excluded_from_accounting() {
+    let previous = memory_events::set_enabled(true);
+    let before = memory_events::snapshot().expect("snapshot while enabled");
+
+    // The unwrapped path is backed straight by the OS layer, never by the hooked
+    // mi_malloc family, so it must not move the accounting counters at all.
+    let p = unsafe { mimalloc_pprof::unwrapped_malloc(64 * 1024, 4096) };
+    assert!(!p.is_null(), "unwrapped_malloc returned NULL");
+    let after = memory_events::snapshot().expect("snapshot while enabled");
+    unsafe { mimalloc_pprof::unwrapped_free(p) };
+
+    assert_eq!(before.accum_count, after.accum_count);
+    assert_eq!(before.accum_bytes, after.accum_bytes);
+
+    memory_events::set_enabled(previous);
+}
+
+static ALLOCATES: AtomicU64 = AtomicU64::new(0);
+static FREES: AtomicU64 = AtomicU64::new(0);
+static RESIZES: AtomicU64 = AtomicU64::new(0);
+
+/// A panic inside a callback is caught and swallowed at the C boundary (it must not
+/// unwind across a C frame), so a failed `assert!` in one of these would silently pass
+/// the test. Record contract violations in a counter and check it from the test body.
+static VIOLATIONS: AtomicU64 = AtomicU64::new(0);
+
+fn record(condition: bool) {
+    if !condition {
+        VIOLATIONS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn on_allocate(change: &Change) {
+    record(change.kind == ChangeKind::Allocate && change.delta_bytes >= 0);
+    ALLOCATES.fetch_add(1, Ordering::Relaxed);
+}
+
+fn on_free(change: &Change) {
+    // "Caller-requested size for allocation and resize; zero for free."
+    record(change.kind == ChangeKind::Free && change.delta_bytes <= 0 && change.request_size == 0);
+    FREES.fetch_add(1, Ordering::Relaxed);
+}
+
+fn on_resize(change: &Change) {
+    record(change.kind == ChangeKind::Resize);
+    RESIZES.fetch_add(1, Ordering::Relaxed);
+}
+
+/// `&'static` is the API's answer to the header's "`arg` pointers are caller-owned and
+/// must stay valid": the C side keeps this pointer until the table is replaced.
+static CALLBACKS: Callbacks = Callbacks {
+    allocate: Some(on_allocate),
+    free: Some(on_free),
+    resize: Some(on_resize),
+};
+
+fn callbacks_observe_every_kind() {
+    let previous = memory_events::set_enabled(true);
+    assert!(memory_events::set_callbacks(&CALLBACKS));
+
+    let mut grown: Vec<u8> = Vec::with_capacity(64);
+    grown.resize(64, 1);
+    grown.reserve(64 * 1024); // realloc -> RESIZE
+    std::hint::black_box(&grown);
+    drop(grown);
+
+    assert!(memory_events::clear_callbacks());
+    memory_events::set_enabled(previous);
+
+    assert_eq!(
+        VIOLATIONS.load(Ordering::Relaxed),
+        0,
+        "a callback saw a change record that contradicts memory-events.h"
+    );
+    assert!(
+        ALLOCATES.load(Ordering::Relaxed) > 0,
+        "no ALLOCATE callbacks fired"
+    );
+    assert!(FREES.load(Ordering::Relaxed) > 0, "no FREE callbacks fired");
+    assert!(
+        RESIZES.load(Ordering::Relaxed) > 0,
+        "no RESIZE callbacks fired"
+    );
+
+    // Cleared means cleared: nothing fires after this point.
+    let allocates = ALLOCATES.load(Ordering::Relaxed);
+    let noise: Vec<u8> = vec![3_u8; 32 * 1024];
+    std::hint::black_box(&noise);
+    assert_eq!(
+        allocates,
+        ALLOCATES.load(Ordering::Relaxed),
+        "a callback fired after clear_callbacks"
+    );
+}

--- a/rust/mimalloc-pprof/tests/t20_memory_events.rs
+++ b/rust/mimalloc-pprof/tests/t20_memory_events.rs
@@ -88,6 +88,11 @@ fn tracking_off_records_nothing() {
 }
 
 fn unwrapped_allocations_are_excluded_from_accounting() {
+    // This section asserts strict equality across a window, so nothing else may allocate
+    // through mimalloc inside it. The background scavenger runs on a timer and can, so
+    // quiesce it first -- same reason t23_purge_holes_report.rs does.
+    mimalloc_pprof::scavenger_stop();
+
     let previous = memory_events::set_enabled(true);
     let before = memory_events::snapshot().expect("snapshot while enabled");
 

--- a/rust/mimalloc-pprof/tests/t21_visit_live.rs
+++ b/rust/mimalloc-pprof/tests/t21_visit_live.rs
@@ -1,0 +1,65 @@
+//! `mi_memory_visit_live_allocations` (include/mimalloc/memory-events.h).
+//!
+//! Deliberately the only test in its own binary. The walk is built on
+//! `mi_heap_visit_blocks`, whose documented precondition is that no other thread is
+//! freeing into the heaps being walked — and cargo's harness runs the tests of one
+//! binary on several threads at once. One test, one thread, no precondition to violate.
+
+use std::cell::Cell;
+
+#[global_allocator]
+static ALLOCATOR: mimalloc_pprof::MiMalloc = mimalloc_pprof::MiMalloc;
+
+#[test]
+fn visits_live_allocations_without_allocating_in_the_visitor() {
+    let held: Vec<Vec<u8>> = (0..48).map(|_| vec![0xAB_u8; 3000]).collect();
+    std::hint::black_box(&held);
+
+    // Fixed, pre-allocated state only: the visitor must not allocate, free, or reenter
+    // mimalloc, so it counts into `Cell`s that already exist.
+    let seen = Cell::new(0_usize);
+    let bytes = Cell::new(0_usize);
+    let big_enough = Cell::new(0_usize);
+
+    let ok = unsafe {
+        mimalloc_pprof::memory_events::visit_live_allocations(|_allocation, usable_size| {
+            seen.set(seen.get() + 1);
+            bytes.set(bytes.get() + usable_size);
+            if usable_size >= 3000 {
+                big_enough.set(big_enough.get() + 1);
+            }
+            true
+        })
+    };
+
+    assert!(ok, "mi_memory_visit_live_allocations reported failure");
+    assert!(seen.get() > 0, "the walk visited nothing at all");
+    assert!(
+        bytes.get() >= seen.get(),
+        "every allocation has a usable size"
+    );
+    assert!(
+        big_enough.get() >= 48,
+        "the 48 live 3000-byte vectors should all be visible; saw {} blocks >= 3000 bytes \
+         out of {} total",
+        big_enough.get(),
+        seen.get()
+    );
+
+    // Returning `false` stops the walk early.
+    let counted = Cell::new(0_usize);
+    let ok = unsafe {
+        mimalloc_pprof::memory_events::visit_live_allocations(|_, _| {
+            counted.set(counted.get() + 1);
+            counted.get() < 5
+        })
+    };
+    assert!(ok || counted.get() == 5);
+    assert_eq!(
+        counted.get(),
+        5,
+        "the visitor's `false` did not stop the walk"
+    );
+
+    drop(held);
+}

--- a/rust/mimalloc-pprof/tests/t22_options_stats.rs
+++ b/rust/mimalloc-pprof/tests/t22_options_stats.rs
@@ -1,0 +1,174 @@
+//! `mi_option_*` and the exact-statistics surface (`include/mimalloc-stats.h`),
+//! plus `mi_purge_holes_report`.
+//!
+//! No `required-features`: options and statistics are part of the allocator, not of the
+//! profiler, so this runs in both `rust-native` feature modes.
+//!
+//! Options are process-global, so the tests that change one take a lock and put it back.
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use mimalloc_pprof::options::{self, Opt};
+use mimalloc_pprof::stats::{self, Subproc};
+use mimalloc_pprof::sys;
+
+#[global_allocator]
+static ALLOCATOR: mimalloc_pprof::MiMalloc = mimalloc_pprof::MiMalloc;
+
+fn lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// The hazard the mirror exists for: this fork inserts thirteen enumerators mid-enum, so
+/// a Rust constant that drifted would name a *different* option and misconfigure the
+/// allocator in silence. `tests/t19_layout.rs` checks the values against the C compiler;
+/// this checks that the named [`Opt`] constants still point at the fork's own options.
+#[test]
+fn fork_option_constants_name_the_fork_options() {
+    assert_eq!(Opt::PROF.name(), "mi_option_prof");
+    assert_eq!(Opt::PROF_SAMPLE_RATE.name(), "mi_option_prof_sample_rate");
+    assert_eq!(Opt::PROF_BT_MAX.name(), "mi_option_prof_bt_max");
+    assert_eq!(Opt::PROF_ACCUM.name(), "mi_option_prof_accum");
+    assert_eq!(Opt::PROF_SEED.name(), "mi_option_prof_seed");
+    assert_eq!(Opt::PROF_MAX_BYTES.name(), "mi_option_prof_max_bytes");
+    assert_eq!(Opt::MEMORY_EVENTS.name(), "mi_option_memory_events");
+    assert_eq!(Opt::PURGE_ZEROES.name(), "mi_option_purge_zeroes");
+    assert_eq!(Opt::SCAVENGER.name(), "mi_option_scavenger");
+    assert_eq!(Opt::PURGE_HOLES.name(), "mi_option_purge_holes");
+    assert_eq!(
+        Opt::PURGE_HOLES_EAGER_ZERO.name(),
+        "mi_option_purge_holes_eager_zero"
+    );
+    assert_eq!(
+        Opt::PURGE_HOLES_MIN_INTERVAL.name(),
+        "mi_option_purge_holes_min_interval"
+    );
+    assert_eq!(
+        Opt::PURGE_HOLES_FULL_EVERY.name(),
+        "mi_option_purge_holes_full_every"
+    );
+}
+
+/// `Opt::from_raw` range-checks because the C side indexes an array with the value.
+#[test]
+fn from_raw_rejects_non_options() {
+    assert!(Opt::from_raw(sys::mi_option_purge_holes).is_some());
+    assert!(Opt::from_raw(sys::_mi_option_last).is_none());
+    assert!(Opt::from_raw(-1).is_none());
+    assert!(Opt::from_raw(sys::_mi_option_last + 1000).is_none());
+    assert_eq!(
+        Opt::from_raw(sys::mi_option_scavenger).map(Opt::as_raw),
+        Some(sys::mi_option_scavenger)
+    );
+}
+
+#[test]
+fn options_listing_is_dense_and_ends_at_the_sentinel() {
+    let all = options::all();
+    assert_eq!(all.len(), sys::_mi_option_last as usize + 1);
+    assert_eq!(all.last().map(|(name, _)| *name), Some("_mi_option_last"));
+}
+
+#[test]
+fn numeric_option_round_trips() {
+    let _guard = lock();
+    let previous = options::get(Opt::PURGE_HOLES_MIN_INTERVAL);
+    options::set(Opt::PURGE_HOLES_MIN_INTERVAL, 1234);
+    assert_eq!(options::get(Opt::PURGE_HOLES_MIN_INTERVAL), 1234);
+    assert_eq!(
+        options::get_clamp(Opt::PURGE_HOLES_MIN_INTERVAL, 0, 100),
+        100
+    );
+    assert_eq!(options::get_size(Opt::PURGE_HOLES_MIN_INTERVAL), 1234);
+    options::set(Opt::PURGE_HOLES_MIN_INTERVAL, previous);
+    assert_eq!(options::get(Opt::PURGE_HOLES_MIN_INTERVAL), previous);
+}
+
+#[test]
+fn boolean_option_round_trips() {
+    let _guard = lock();
+    let previous = options::is_enabled(Opt::PURGE_HOLES);
+    options::disable(Opt::PURGE_HOLES);
+    assert!(!options::is_enabled(Opt::PURGE_HOLES));
+    options::enable(Opt::PURGE_HOLES);
+    assert!(options::is_enabled(Opt::PURGE_HOLES));
+    options::set_enabled(Opt::PURGE_HOLES, previous);
+    assert_eq!(options::is_enabled(Opt::PURGE_HOLES), previous);
+}
+
+#[test]
+fn exact_stats_are_populated() {
+    let held: Vec<Vec<u8>> = (0..32).map(|_| vec![0_u8; 64 * 1024]).collect();
+    std::hint::black_box(&held);
+
+    let s = stats::get().expect("mi_stats_get accepted the mirrored struct header");
+    assert_eq!(s.size, size_of::<sys::mi_stats_t>());
+    assert_eq!(s.version, sys::MI_STAT_VERSION);
+    assert!(s.committed.current > 0, "committed = {:?}", s.committed);
+    assert!(
+        s.reserved.current >= s.committed.current,
+        "reserved {} < committed {}",
+        s.reserved.current,
+        s.committed.current
+    );
+    assert!(s.pages.current > 0, "pages = {:?}", s.pages);
+
+    let json = s.to_json().expect("mi_stats_as_json");
+    assert!(
+        json.starts_with('{'),
+        "not JSON: {}",
+        &json[..json.len().min(60)]
+    );
+    assert!(json.contains("committed"), "no committed counter in {json}");
+
+    drop(held);
+}
+
+#[test]
+fn stats_json_matches_the_struct_getter() {
+    let json = stats::json().expect("mi_stats_get_json");
+    assert!(json.contains("committed"));
+    assert!(json.contains("reserved"));
+    // The bin arrays the struct mirrors are what the JSON reports per size class.
+    assert!(stats::bin_size(1) > 0);
+    assert!(stats::bin_size(1) <= stats::bin_size(sys::MI_BIN_HUGE));
+}
+
+#[test]
+fn subprocess_stats_are_reachable() {
+    for which in [Subproc::Main, Subproc::Current] {
+        // Deliberately no cross-snapshot comparison (e.g. aggregated >= exclusive):
+        // although that holds at any single instant, the two are separate reads and the
+        // other tests in this binary allocate on other threads in between. Assert what is
+        // true *within* one snapshot instead.
+        let aggregated = stats::subproc_get(which).expect("mi_subproc_stats_get");
+        assert_eq!(aggregated.version, sys::MI_STAT_VERSION);
+        assert!(
+            aggregated.reserved.current >= aggregated.committed.current,
+            "{which:?}: reserved {} < committed {}",
+            aggregated.reserved.current,
+            aggregated.committed.current
+        );
+        assert!(aggregated.committed.current > 0);
+
+        let exclusive =
+            stats::subproc_get_exclusive(which).expect("mi_subproc_stats_get_exclusive");
+        assert_eq!(exclusive.size, size_of::<sys::mi_stats_t>());
+
+        assert!(stats::subproc_json(which).is_some());
+    }
+}
+
+/// The print entry points write to mimalloc's own output sink rather than returning a
+/// `String` (building one would allocate from inside a callback the allocator drives).
+/// There is nothing to assert but that they run and do not reenter fatally.
+#[test]
+fn print_entry_points_run() {
+    stats::print();
+    stats::subproc_print(Subproc::Main);
+    stats::subproc_heap_print(Subproc::Current);
+    options::print();
+}

--- a/rust/mimalloc-pprof/tests/t23_purge_holes_report.rs
+++ b/rust/mimalloc-pprof/tests/t23_purge_holes_report.rs
@@ -1,0 +1,42 @@
+//! `mi_purge_holes_report` (include/mimalloc.h, issue #272 / Bun parity P7b).
+//!
+//! Its contract is that it is **read-only**: it reports what the last idle sweep could
+//! not discard, and purges nothing itself. Proving that means comparing hole-purging
+//! counters across the call — which only works if nothing else is sweeping. The
+//! background scavenger sweeps on a timer, and cargo runs the tests of one binary
+//! concurrently, so this is deliberately the only test in its own binary, and it stops
+//! the scavenger before it measures.
+
+#[global_allocator]
+static ALLOCATOR: mimalloc_pprof::MiMalloc = mimalloc_pprof::MiMalloc;
+
+#[test]
+fn report_is_read_only() {
+    // Churn first, so the sweep below has holes to find and to report on, and so every
+    // theap this thread needs already exists.
+    let mut held: Vec<Vec<u8>> = (0..512).map(|_| vec![0_u8; 512]).collect();
+    // scattered survivors: exactly the case hole purging exists for
+    held.retain(|v| (v.as_ptr() as usize).is_multiple_of(3));
+    std::hint::black_box(&held);
+
+    mimalloc_pprof::on_thread_idle();
+
+    // Only now: a later allocation can bring the scavenger back, so stopping it has to be
+    // the last thing before the measurement.
+    mimalloc_pprof::scavenger_stop();
+
+    let before = mimalloc_pprof::purge_holes_stats();
+    mimalloc_pprof::purge_holes_report();
+    let after = mimalloc_pprof::purge_holes_stats();
+
+    assert_eq!(
+        before.purged_bytes_total, after.purged_bytes_total,
+        "mi_purge_holes_report discarded memory; it is documented read-only"
+    );
+    assert_eq!(before.discard_calls, after.discard_calls);
+    assert_eq!(before.reuse_calls, after.reuse_calls);
+    assert_eq!(before.blocks_visited, after.blocks_visited);
+    assert_eq!(before.pages_freed, after.pages_freed);
+
+    drop(held);
+}


### PR DESCRIPTION
Answers "does the hole-punch API — and every other API — exist in Rust?", closes the gaps it found, and adds the two gates that stop them reopening.

## The answer, short

The hole-punch API **was** in Rust, all of it except `mi_purge_holes_report`. Three other areas were not:

| Area | Before | After |
|---|---|---|
| `include/mimalloc/memory-events.h` | **nothing bound** except the three `mi_unwrapped_*` | fully bound + `memory_events` safe module |
| `mi_option_*` (incl. all 13 fork options) | **nothing bound**, no `mi_option_t` mirror | fully bound + `options` safe module |
| `include/mimalloc-stats.h` exact stats | reachable only as `prof::stats().heap.*` | fully bound + `stats` safe module |
| `mi_purge_holes_report` | not declared | bound + `purge_holes_report()` |

38 fork C exports, 61 `mi_option_t` enumerators — all now bound, and checked on every build.

## Hazards checked (task step 4)

**(a) `mi_option_t` mirror.** There was no Rust mirror at all, so nothing was stale — but *adding* one creates the hazard, so it ships with its verifier. This fork inserts thirteen enumerators at indices **47..=59**, ahead of `_mi_option_last`; a mirror copied from upstream would compile, link, run, and set a *different* option than the caller named, forever, with no diagnostic. Two gates now:

- `tests/t19_layout.rs` compares every mirrored value against what the C compiler computed;
- `ci/check_rust_surface.py` compares the whole enumerator **sequence** against `include/mimalloc.h`. Sequence, not set: a mirror that merely dropped one enumerator still contains every correct *name*, and a set comparison would call it clean. `test_a_shifted_mirror_is_caught` is the negative control for exactly that.

**(b) Struct mirrors.** All six pre-existing mirrors (`mi_prof_stats_t`, `mi_prof_config_t`, `mi_prof_sample_info_t`, `mi_prof_module_info_t`, `mi_dhat_stats_t`, `mi_purge_holes_stats_t`) were audited field-by-field and were **correct — no mismatch found, no UB to fix**. They are now checked mechanically instead of by eye.

The mechanism: `rust/mimalloc-pprof/layout_probe.c` (a rust/-side verification artifact — not in the CMake build, not in the amalgamation, compiled by the crate's existing `cc::Build` so it always sees the library's own defines) publishes a name→value table of `sizeof`/`offsetof` for every mirrored struct plus the value of every mirrored enumerator and version constant. `tests/t19_layout.rs` looks each up **by name**: a field renamed or dropped on either side fails as a missing key, never as a coincidentally-equal number. The `mi_stats_t` entries are generated from the header's own `MI_STAT_FIELDS()` macro, so an upstream field addition fails the test without `layout_probe.c` changing — and a separate test asserts the C and Rust field *sets* are equal, so a mirror that is one field short cannot pass just because every offset it does check still matches.

**One correction to the task brief:** there are no idle-sweep gauges in `mi_stats_t`. It is byte-identical to upstream's. The gauges are in `mi_purge_holes_stats_t` (already bound as `MiPurgeHolesStats`), because the sweep also covers pages no heap owns and `mi_stats_t` cannot grow — it is embedded in a theap, at the meta-allocator's 8 KB block limit. Said so in the README table.

## API surface

The full three-column table is in [README.md → API surface](https://github.com/zackees/mimalloc-pprof/blob/feat/rust-api-parity/README.md#api-surface); condensed here.

### Sampled pprof profiler — `include/mimalloc/profile.h`

| C | Rust FFI (`sys::`) | Rust safe wrapper |
|---|---|---|
| `mi_prof_start` | ✅ | `prof::start` |
| `mi_prof_start_seeded` | ✅ | `prof::start_seeded` |
| `mi_prof_start_ex`, `mi_prof_config_t` | ✅ | `enable_heap_profiling_with(&ProfConfig)` |
| `mi_prof_stop` | ✅ | `prof::stop` |
| `mi_prof_is_enabled` | ✅ | `prof::is_enabled` |
| `mi_prof_reset` | ✅ | `prof::reset` |
| `mi_prof_dump` | ✅ | `prof::dump_file` |
| `mi_prof_dump_writer` | ✅ | `prof::dump_to_vec` |
| `mi_prof_dump_proto` | ✅ | `prof::dump_proto_file` |
| `mi_prof_dump_proto_writer` | ✅ | `prof::dump_proto_to_vec` |
| `mi_prof_stats_get`, `mi_prof_stats_t` | ✅ | `prof::stats() -> ProfStats` |
| `mi_prof_snapshot_new` / `_visit` / `_free` | ✅ | `prof::samples() -> Vec<Sample>` |
| `mi_prof_modules_visit` | ✅ | `prof::modules() -> Vec<ModuleInfo>` |
| `mi_prof_visit` | ✅ | **sys only** — visitor runs under the profiler lock; an allocating Rust closure can deadlock |
| `mi_prof_debug_stats` | ✅ | **sys only** — deprecated |

### DHAT — `include/mimalloc/dhat.h`

| C | Rust FFI (`sys::`) | Rust safe wrapper |
|---|---|---|
| `mi_dhat_start` / `_stop` / `_is_enabled` | ✅ | `dhat::start` / `stop` / `is_enabled` |
| `mi_dhat_stats_get`, `mi_dhat_stats_t` | ✅ | `dhat::stats() -> dhat::Stats` |
| `mi_dhat_dump` | ✅ | `dhat::dump_file` |

### Memory events — `include/mimalloc/memory-events.h` — **was entirely unbound**

| C | Rust FFI (`sys::`) | Rust safe wrapper |
|---|---|---|
| `mi_memory_tracking_set_enabled` | ✅ **new** | `memory_events::set_enabled` **new** |
| `mi_memory_tracking_is_enabled` | ✅ **new** | `memory_events::is_enabled` **new** |
| `mi_memory_snapshot`, `mi_memory_snapshot_t` | ✅ **new** | `memory_events::snapshot()` **new** |
| `mi_memory_set_callbacks`, `mi_memory_callbacks_t`, `mi_memory_change_t` | ✅ **new** | `memory_events::set_callbacks(&'static Callbacks)` / `clear_callbacks` **new** |
| `mi_memory_visit_live_allocations` | ✅ **new** | `unsafe memory_events::visit_live_allocations` **new** |
| `mi_unwrapped_malloc` / `_free` / `_realloc` | ✅ | `unwrapped_malloc` / `unwrapped_free` / `unwrapped_realloc` |

### Exact allocator statistics — `include/mimalloc-stats.h` (upstream API)

| C | Rust FFI (`sys::`) | Rust safe wrapper |
|---|---|---|
| `mi_stats_get`, `mi_stats_t` | ✅ **new** | `stats::get() -> Stats` **new** |
| `mi_stats_get_json` / `mi_stats_as_json` | ✅ **new** | `stats::json` / `Stats::to_json` **new** |
| `mi_stats_print_out` | ✅ **new** | `stats::print` **new** |
| `mi_stats_get_bin_size` | ✅ **new** | `stats::bin_size` **new** |
| `mi_subproc_stats_get` / `_get_exclusive` / `_get_json` / `_print_out` | ✅ **new** | `stats::subproc_get` / `subproc_get_exclusive` / `subproc_json` / `subproc_print` **new** |
| `mi_subproc_heap_stats_print_out` | ✅ **new** | `stats::subproc_heap_print` **new** |
| `mi_heap_stats_get` / `_get_json` / `_print_out`, `mi_heap_stats_merge_to_subproc` | ✅ **new** | **sys only** — take a `mi_heap_t*`, and v3 removed `mi_heap_get_default` |

### Heap dump

| C | Rust FFI (`sys::`) | Rust safe wrapper |
|---|---|---|
| `mi_heap_dump_json` | ✅ | `heap_dump_json(include_blocks, hash_addresses)` |
| `mi_heap_get_seq` | ✅ | **sys only** — needs a `mi_heap_t*`; the seq numbers are already in `heap_dump_json`'s output |

### Thread idle, scavenger and hole purging — a [Bun feature](https://github.com/zackees/mimalloc-pprof#bun-features)

There is no single "hole punch" function: the feature is reached through the idle-sweep calls, the `purge_holes*` options, and the `mi_purge_holes_stats_t` gauges.

| C | Rust FFI (`sys::`) | Rust safe wrapper |
|---|---|---|
| `mi_on_thread_idle` | ✅ | `on_thread_idle()` |
| `mi_on_thread_idle_start` / `_end` | ✅ | `park_while_idle() -> Option<IdlePark>` (ends on drop) |
| `mi_scavenger_stop` | ✅ | `scavenger_stop()` |
| `mi_purge_holes_stats_get`, `mi_purge_holes_stats_t` | ✅ | `purge_holes_stats()` |
| `mi_purge_holes_report` | ✅ **new** | `purge_holes_report()` **new** |

### Options — `mi_option_t` — **was entirely unbound**

| C | Rust FFI (`sys::`) | Rust safe wrapper |
|---|---|---|
| `mi_option_t`, 61 enumerators (13 fork, indices 47–59) | `sys::mi_option_*`, `sys::MI_OPTIONS_IN_ORDER` **new** | `options::Opt` **new** |
| `mi_option_get` / `_get_clamp` / `_get_size` | ✅ **new** | `options::get` / `get_clamp` / `get_size` **new** |
| `mi_option_set` / `_set_default` | ✅ **new** | `options::set` / `set_default` **new** |
| `mi_option_is_enabled` / `_enable` / `_disable` / `_set_enabled` / `_set_enabled_default` | ✅ **new** | same names under `options::` **new** |
| `mi_options_print_out` | ✅ **new** | `options::print` **new** |

Fork options with `Opt` constants: `PROF`, `PROF_SAMPLE_RATE`, `PROF_BT_MAX`, `PROF_ACCUM`, `PROF_SEED`, `PROF_MAX_BYTES`, `MEMORY_EVENTS`, `PURGE_ZEROES`, `SCAVENGER`, `PURGE_HOLES`, `PURGE_HOLES_EAGER_ZERO`, `PURGE_HOLES_MIN_INTERVAL`, `PURGE_HOLES_FULL_EVERY`.

## Design notes worth reviewing

- **`memory_events::set_callbacks` takes `&'static Callbacks`** of plain `fn` pointers, not closures. `memory-events.h` says the `arg` pointers are caller-owned and must stay valid until replaced; `'static` is the type system saying the same thing. One `extern "C"` trampoline serves all three slots (the kind is in the record) and catches unwinds, since a panic must not cross the C frame.
- **`mi_memory_change_kind_t` is mirrored as `c_int`, not a Rust `enum`.** The value comes from C, and materialising an out-of-range discriminant into a `#[repr(i32)]` enum is UB. `ChangeKind::from_raw` returns `Option` and the trampoline ignores an unknown kind.
- **`visit_live_allocations` is `unsafe`**, with the visitor's no-allocation / no-reentry contract in its `# Safety` block. `mi_heap_visit_blocks`'s own precondition (no concurrent frees into the walked heaps) is genuinely a soundness condition, not just a deadlock risk.
- **The print entry points return `()`, not `String`.** Routing mimalloc's output sink through a Rust closure would allocate from inside a callback the allocator drives — including, for `mi_purge_holes_report`, from inside a walk over the free lists being reported. `json()` is the capture route.
- **Nothing is feature-gated.** `src/memory-events.c`, the option table and the statistics compile into the C library in every configuration, so gating them on `pprof` would be wrong. All new tests run in both feature modes.
- **Test layout.** Memory-events tracking, the callback table and the running totals are process-global, and cargo runs one binary's tests on several threads — so a second test allocating on another thread lands in the counters the first is asserting deltas on. `t20` is therefore one test in sections, and the two tests with a real quiescence precondition (the `mi_heap_visit_blocks` walk; the read-only proof for `mi_purge_holes_report`, which the background scavenger would otherwise race) each get their own binary. This was found empirically — both flaked before being split.

## Gate: `ci/check_rust_surface.py`

Parses the C headers and `sys.rs`/`lib.rs`; fails when a fork export has no `sys.rs` declaration, when a bound export has no `lib.rs` call site, or when the option sequence diverges. Allowlists carry a reason each and a **stale entry is itself a failure** — an allowlist entry that no longer describes anything real is a claim nobody checked. Three entries today, all sys-only-by-design.

Deliberately **no `git show 6def7be9`** to separate fork additions from upstream: `actions/checkout@v4` is depth 1 and this fork's history is unrelated to upstream's, so that object does not exist in CI. The eight fork additions inside the two shared headers are a literal list — and every name on it is verified to still be an export, so a rename cannot quietly empty it.

Wired into `python-lint.yml` (with `--selftest`) and `rust-native.yml`, plus `ci/verify_local.py`'s `lint` and `rust` configs. `rust-native.yml`'s path filter gains `include/**`: without it a C-only PR could shift the option enum and no Rust job would look.

## Verification

```
cargo test -p mimalloc-pprof                       # green x9 (25 binaries + 6 doctests)
cargo test -p mimalloc-pprof --no-default-features # green (11 binaries + 6 doctests)
cargo clippy -p mimalloc-pprof --all-targets       # clean
cargo run -p xtask -- check                        # vendored amalgamation matches src/include/
cargo publish --dry-run -p mimalloc-pprof --locked # green
python ci/check_crate_package.py target/package    # verified publish archive
cargo package -p mimalloc-pprof --list             # layout_probe.c ships with the crate

uv run ci/check_rust_surface.py
  -> 38 fork exports bound, 61 mi_option_t enumerators mirrored in order
uv run ci/check_rust_surface.py --selftest         -> parsers OK
uv run ci/check_doc_snippets.py                    -> PASS: 9 blocks checked, 3 skipped
uv run --with ruff==0.12.10 ruff check ci          -> All checks passed
uv run --with ruff==0.12.10 ruff format --check ci -> 43 files already formatted
uv run --with pyright[nodejs]==1.1.411 pyright     -> 0 errors, 0 warnings
uv run --with pytest==8.3.4 --with pyyaml==6.0.2 -m pytest ci/tests -q  -> 298 passed

uv run ci/verify_local.py --only rust,lint
  rust | PASS | 103.1s
  lint | PASS |  49.0s
```

No C-core paths touched, so no amalgamation re-run and no `release`/`off`/`debug-full` configs needed. Commits are split `feat(rust):` / `ci:` / `docs:` per the repo rules; version deliberately not bumped (this repo bumps in a dedicated release PR), and a `## Unreleased` CHANGELOG section was added instead.

## Post-review fixes (in this PR)

- `ci:` **the wrapper check was substring-matched**, and C's names nest — `sys::mi_prof_start_seeded` contains `sys::mi_prof_start`, `sys::mi_option_get_clamp` contains `sys::mi_option_get`. An unwrapped function would have been reported as wrapped on the strength of its longer sibling's call site, i.e. exactly the regression the gate exists to catch. Now word-anchored, with the negative control in both the pytest suite and the script's `--selftest`. Nothing in the tree was actually unwrapped, so this closed a hole in the gate, not in the bindings.
- `fix(rust):` `purge_holes_report`'s doc comment invented a sink argument. `mi_purge_holes_report(void)` has none; the sink is process-wide (`mi_register_output`, unbound).
- Also verified the two rust-native steps `verify_local` does not cover: `cargo publish --dry-run -p mimalloc-pprof --locked` and `ci/check_crate_package.py target/package` — both green, and `layout_probe.c` ships in the archive.
- `## Unreleased` is new to this CHANGELOG; nothing in `.github/workflows`, `ci/` or `rust/xtask` parses that file, so no release tooling is affected.

## Second review round (applied)

- `ci:` **a doc comment naming a C function is not a call to it.** `lib.rs` documents each wrapper by naming the function it wraps, so the raw-text search would have kept reporting a *deleted* wrapper as wrapped. Comments are stripped first now — block, whole-line `//`/`///`/`//!`, and trailing `//` — with the trailing rule refusing to fire after a colon so `https://` in a doc link does not swallow the rest of its line. Both halves have fixtures, in `--selftest` and in ci/tests. The full check still passes afterwards, which is the useful part: every wrapped export has a real call site, not merely a mention.
- `fix(rust):` **`visit_live_allocations`' `# Safety` now forbids panicking.** Raising a panic allocates its payload and message through the global allocator, reentering mimalloc mid-walk — exactly what the no-allocation bullet forbids. `catch_unwind` stops the unwind crossing the C frame; it does not, and cannot, prevent that allocation, which has already happened by the time it runs.
- `fix(rust):` `t20`'s unwrapped-allocation section calls `scavenger_stop()` before its strict-equality window, the way `t23` already does — the background scavenger runs on a timer and could allocate inside it. Verified over 5 consecutive runs of t20/t21/t23 and 9 of the full suite.
- `docs:` the gate requires an unbound **fork** export to fail; upstream's exports are bound opportunistically. README no longer promises the stronger guarantee.

Follow-up filed as an issue rather than fixed here: `layout_probe.c` gates struct *layouts* but not function *signatures*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
