### PR TITLE
fix(bench-harness): tolerate a child that exits before reading its request (#323)

### DIFF
--- a/rust/bench-harness/src/lib.rs
+++ b/rust/bench-harness/src/lib.rs
@@ -421,12 +421,20 @@ fn run_child_sample(
         .stderr(Stdio::piped())
         .spawn()
         .map_err(BenchError::Spawn)?;
-    process
-        .stdin
-        .take()
-        .expect("child stdin piped")
-        .write_all(&request)
-        .map_err(BenchError::WriteRequest)?;
+    {
+        let mut stdin = process.stdin.take().expect("child stdin piped");
+        // A child that exits before reading its request (a crash, or a deliberately
+        // malformed test child that prints and returns) closes the pipe under us. That
+        // is not a request-delivery failure: fall through and let the child's exit
+        // status and output say what went wrong, so the reported error is the same
+        // whichever side won the race (#323).
+        match stdin.write_all(&request) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(error) => return Err(BenchError::WriteRequest(error)),
+        }
+        // Dropping stdin here closes the write end, so the child sees EOF.
+    }
 
     let started = Instant::now();
     loop {

--- a/rust/bench-harness/tests/rejections.rs
+++ b/rust/bench-harness/tests/rejections.rs
@@ -44,18 +44,21 @@ fn benchmark_rejects_zero_measurement_rounds() {
 
 #[test]
 fn benchmark_rejects_partial_or_extra_child_output() {
-    assert!(matches!(
-        run_benchmark(config(), &child(Some("partial"))),
-        Err(BenchError::InvalidChildResponse(_))
-    ));
-    assert!(matches!(
-        run_benchmark(config(), &child(Some("extra"))),
-        Err(BenchError::InvalidChildResponse(_))
-    ));
-    assert!(matches!(
-        run_benchmark(config(), &child(Some("nonfinite"))),
-        Err(BenchError::InvalidChildResponse(_))
-    ));
+    let result = run_benchmark(config(), &child(Some("partial")));
+    assert!(
+        matches!(result, Err(BenchError::InvalidChildResponse(_))),
+        "partial: expected InvalidChildResponse, got {result:?}"
+    );
+    let result = run_benchmark(config(), &child(Some("extra")));
+    assert!(
+        matches!(result, Err(BenchError::InvalidChildResponse(_))),
+        "extra: expected InvalidChildResponse, got {result:?}"
+    );
+    let result = run_benchmark(config(), &child(Some("nonfinite")));
+    assert!(
+        matches!(result, Err(BenchError::InvalidChildResponse(_))),
+        "nonfinite: expected InvalidChildResponse, got {result:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #323 (seen twice today on unrelated PRs #321 and #330, on different assertions of the same test).

**Cause.** `run_child_sample` spawns the child, then writes the JSON request to its stdin and returns `BenchError::WriteRequest` on any write error. The rejection tests' child (`BENCH_HARNESS_TEST_RESPONSE=partial|extra|nonfinite`) prints its bogus response and exits without reading stdin. When the child wins the race the parent's write hits `EPIPE`, so the harness reports `WriteRequest(Broken pipe)` instead of the `InvalidChildResponse` the test expects. Same thing would misreport a real child crash-before-read.

**Fix.** Treat `BrokenPipe` on the request write as "the child has already exited" and fall through to the existing wait/parse path, so the exit status and output determine the error regardless of ordering. Other write errors still return `WriteRequest`. The three rejection assertions now print the actual `Result` on mismatch (the diagnostic step from #323).

**Verification.** `cargo test -p bench-harness` green; the rejections test run 6× consecutively, all green; clippy and fmt clean on the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
