### PR TITLE
chore(release): mimalloc-pprof 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Profiling is **opt-in at runtime**: a build with `MI_PPROF=ON` (the default) doe
 not sample until you call a start API or set `MIMALLOC_PROF=1`.
 
 **v3 only.** This fork tracks upstream mimalloc's `dev3` line (crate
-[`mimalloc-pprof` 0.9.x](https://crates.io/crates/mimalloc-pprof)). The legacy v2
+[`mimalloc-pprof` 0.10.x](https://crates.io/crates/mimalloc-pprof)). The legacy v2
 line (0.8.x, upstream `main`) is preserved on the
 [`v2`](https://github.com/zackees/mimalloc-pprof/tree/v2) branch but is not
 maintained going forward. Upstream mimalloc v3 (`dev3`) is itself still a
@@ -978,7 +978,7 @@ Design history and milestone decisions are in
 
 The authoritative release record, with the reasoning behind each fix, is
 [`rust/mimalloc-pprof/CHANGELOG.md`](rust/mimalloc-pprof/CHANGELOG.md). The v3
-line ships as [`mimalloc-pprof` 0.9.x](https://crates.io/crates/mimalloc-pprof);
+line ships as [`mimalloc-pprof` 0.10.x](https://crates.io/crates/mimalloc-pprof);
 the v2 line (0.8.x) is maintained on the
 [`v2`](https://github.com/zackees/mimalloc-pprof/tree/v2) branch.
 

--- a/ci/check_crate_package.py
+++ b/ci/check_crate_package.py
@@ -18,6 +18,18 @@ def member_text(archive: tarfile.TarFile, suffix: str) -> str:
     return stream.read().decode("utf-8")
 
 
+def crate_version(manifest: Path) -> str:
+    in_package = False
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_package = stripped == "[package]"
+            continue
+        if in_package and stripped.startswith("version"):
+            return stripped.split("=", 1)[1].strip().strip('"')
+    raise AssertionError(f"no [package] version in {manifest}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("archive", type=Path)
@@ -25,7 +37,12 @@ def main() -> None:
 
     archive_path = args.archive
     if archive_path.is_dir():
-        matches = list(archive_path.rglob("mimalloc-pprof-0.9.5.crate"))
+        # Resolve the crate version from the manifest instead of hard-coding it, so a
+        # release bump cannot make this check look for an archive that no longer exists.
+        version = crate_version(
+            Path(__file__).resolve().parent.parent / "rust" / "mimalloc-pprof" / "Cargo.toml"
+        )
+        matches = list(archive_path.rglob(f"mimalloc-pprof-{version}.crate"))
         if len(matches) != 1:
             raise AssertionError(f"expected one packaged archive, found {len(matches)}")
         archive_path = matches[0]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "cc",
  "regex",

--- a/rust/mimalloc-pprof/CHANGELOG.md
+++ b/rust/mimalloc-pprof/CHANGELOG.md
@@ -1,6 +1,33 @@
 # Changelog
 
-## Unreleased
+## 0.10.0
+
+The v3 line catches up with everything merged since 0.9.5: full Bun parity through
+oven-sh/mimalloc `b20b60d9`, a Rust binding for every C API this fork adds, and a CI that
+cross-builds every platform from Linux.
+
+- **Bun parity P0–P10** ([#264](https://github.com/zackees/mimalloc-pprof/issues/264),
+  [#315](https://github.com/zackees/mimalloc-pprof/issues/315)): background scavenger and
+  `mi_on_thread_idle*` park protocol, page hole purging (`purge_holes*`), `pthread_atfork`
+  handlers with a runtime lock-order checker, heap delete/destroy teardown protocol,
+  `mi_heap_dump_json`/`mi_heap_get_seq`, `MI_NO_PROCESS_DETACH`, zero-cost-when-off
+  profiler fast path, TLS-slot zeroing, glibc 2.44 `free(NULL)`-before-init fix, Windows
+  PRNG/RAM/NUMA fixes, macOS TLS slots 96/97, collect on sub-process-safe free, lazy
+  per-bin abandoned bitmaps and unmapped abandon on heap release.
+- **Padding and small-free fixes** ([#301](https://github.com/zackees/mimalloc-pprof/issues/301)):
+  `MI_OPT_FREE_SMALL` + `MI_PADDING` misrouting of 1009–1024 B blocks and `realloc` freeing
+  an interior pointer.
+- **Memory-regression gate made deterministic** ([#298](https://github.com/zackees/mimalloc-pprof/issues/298)):
+  a barrier in the churn workload; 5 % tolerance.
+- **`MI_DEBUG=3` via `MI_EXTRA_CPPDEFS` links** ([#312](https://github.com/zackees/mimalloc-pprof/issues/312)).
+- **CI**: every Windows and macOS artifact is cross-built on Linux (soldr); macOS x86_64
+  bundles execute in a macOS Recovery guest on a Linux runner, on demand; build-once /
+  run-all test bundles ([#307](https://github.com/zackees/mimalloc-pprof/issues/307)).
+- **Benchmarks**: Bun's fork is a fifth allocator row in every suite
+  ([#325](https://github.com/zackees/mimalloc-pprof/issues/325)); the idle memory-return
+  chart is measured under jemalloc, upstream mimalloc, Bun and this fork.
+
+### Rust crate
 
 Bind every C API this fork adds, and gate the binding surface so it cannot drift again.
 

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimalloc-pprof"
-version = "0.9.5"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 description = "mimalloc global allocator with pprof-compatible sampled heap profiling"

--- a/rust/mimalloc-pprof/README.md
+++ b/rust/mimalloc-pprof/README.md
@@ -73,13 +73,13 @@ MIMALLOC_PROF=1 MIMALLOC_PROF_DUMP_AT_EXIT=heap.prof ./my_app
 
 | | crate | engine |
 |---|---|---|
-| **0.9.x** — current | `mimalloc-pprof = "0.9"` | mimalloc v3 |
+| **0.10.x** — current | `mimalloc-pprof = "0.10"` | mimalloc v3 |
 | 0.8.x — previous | `mimalloc-pprof = "0.8"` | mimalloc v2 |
 
 The profiler API, environment variables, and output formats are identical in both,
 so moving between them is a version bump rather than a code change.
 
-**0.9.x is recommended.** It has strictly more test coverage, per-heap allocator
+**0.10.x is recommended.** It has strictly more test coverage, per-heap allocator
 statistics, and fixes two upstream mimalloc bugs that 0.8.x still carries —
 including an unbounded memory leak on Windows/MinGW where every exiting thread
 leaked its heap and pages (23.5 GB at 100 stress iterations, versus flat after the
@@ -87,7 +87,7 @@ fix). Note that upstream mimalloc v3 is itself still a pre-release branch.
 
 ## Exact statistics alongside sampled ones
 
-On 0.9.x, `prof::stats()` carries the allocator's **exact** counters next to the
+On 0.10.x, `prof::stats()` carries the allocator's **exact** counters next to the
 sampled ones. A sampled profile alone cannot tell you whether it under-counted;
 comparing the two measures the sampling error directly:
 


### PR DESCRIPTION
Minor version bump 0.9.5 → 0.10.0 (owner request). Tagging `v0.10.0` after merge triggers `auto-release.yml` (build, `xtask check`, `cargo test --locked`, `cargo publish`).

- `rust/mimalloc-pprof/Cargo.toml` + `Cargo.lock`: 0.10.0
- `CHANGELOG.md`: `## Unreleased` → `## 0.10.0` with a summary of everything since 0.9.5 (Bun parity P0–P10, padding fixes, deterministic memory gate, MI_DEBUG=3 link fix, cross-built CI, Bun benchmark row); the Rust-crate section from the API-parity work (#321) is kept under it.
- README (main + crate): 0.9.x → 0.10.x.

`cargo publish --dry-run -p mimalloc-pprof --locked` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S
