### PR TITLE
ci(release): expect synchronization.lib on Windows; version-agnostic crate package check

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -226,7 +226,7 @@ jobs:
           # find_link_library() hands the host's ELF librt.so to a Mach-O link.
           case "${{ matrix.triple }}" in
             *-apple-darwin) want='pthread' ;;
-            *)              want='psapi;shell32;user32;advapi32;bcrypt' ;;
+            *)              want='psapi;shell32;user32;advapi32;bcrypt;synchronization' ;;  # synchronization: WaitOnAddress for the scavenger park protocol (#299)
           esac
           if ! grep -qE "^-- Link libraries *: *${want}\$" configure.log; then
             echo "::error::the ${{ matrix.triple }} link resolved unexpected libraries; expected exactly '${want}'"

--- a/ci/check_crate_package.py
+++ b/ci/check_crate_package.py
@@ -53,7 +53,10 @@ def main() -> None:
         library = member_text(archive, "/src/lib.rs")
         native = member_text(archive, "/vendor/mimalloc-pprof-amalgamated.c")
 
-    required_manifest = ('version = "0.9.5"', 'default = ["pprof"]', "pprof = []")
+    version = crate_version(
+        Path(__file__).resolve().parent.parent / "rust" / "mimalloc-pprof" / "Cargo.toml"
+    )
+    required_manifest = (f'version = "{version}"', 'default = ["pprof"]', "pprof = []")
     for text in required_manifest:
         if text not in manifest:
             raise AssertionError(f"published manifest missing {text!r}")


### PR DESCRIPTION
The v0.10.0 tag run (33828740230) failed its Windows link-list assertion because the scavenger park protocol (#299) added `synchronization` (WaitOnAddress); the list was last updated before that. Same failure hit v0.9.4. Also removes the last hard-coded `0.9.5` in `ci/check_crate_package.py`. After merge the `v0.10.0` tag is moved to the new main head and the release re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S