### PR TITLE
ci(release): pin setup-soldr to v0.9.11

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -104,6 +104,7 @@ jobs:
         id: setup_soldr
         continue-on-error: true
         with:
+          version: v0.9.11  # pinned: v0.9.12 archive lacks the binary (zackees/soldr#3091)
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target
@@ -113,6 +114,7 @@ jobs:
         if: steps.setup_soldr.outcome == 'failure'
         uses: zackees/setup-soldr@v0
         with:
+          version: v0.9.11  # pinned: v0.9.12 archive lacks the binary (zackees/soldr#3091)
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target
@@ -182,6 +184,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - uses: zackees/setup-soldr@v0
         with:
+          version: v0.9.11  # pinned: v0.9.12 archive lacks the binary (zackees/soldr#3091)
           # This job drives CMake directly; there is no `soldr cargo` for zccache to wrap.
           cache: false
           toolchain-file: rust/rust-toolchain.toml
@@ -400,6 +403,7 @@ jobs:
         id: setup_soldr
         continue-on-error: true
         with:
+          version: v0.9.11  # pinned: v0.9.12 archive lacks the binary (zackees/soldr#3091)
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target
@@ -409,6 +413,7 @@ jobs:
         if: steps.setup_soldr.outcome == 'failure'
         uses: zackees/setup-soldr@v0
         with:
+          version: v0.9.11  # pinned: v0.9.12 archive lacks the binary (zackees/soldr#3091)
           toolchain-file: rust/rust-toolchain.toml
           lockfile: rust/Cargo.lock
           target-dir: rust/target


### PR DESCRIPTION
soldr v0.9.12 (published 02:24Z today) ships an archive without the soldr binary, so every setup-soldr@v0 step with version: latest fails (zackees/soldr#3091); both attempts of the v0.10.0 release run died there. Pins the five setup-soldr steps in auto-release.yml to v0.9.11 until soldr is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4jVokb2gdT8ngFrH8i8S