### PR TITLE
ci: selective macOS Recovery lane for Darwin-touching PRs (#339, step 1)

### DIFF
--- a/.github/workflows/macos-bundles.yml
+++ b/.github/workflows/macos-bundles.yml
@@ -49,6 +49,8 @@ on:
   push:
     branches: [main, v4]
   pull_request:
+    # `labeled` so adding `needs-macos` to an open PR re-runs `decide` (#339).
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'src/**'
       - 'include/**'
@@ -265,6 +267,10 @@ jobs:
           fi
       - name: Bundle the tests
         run: python3 ci/bundle_tests.py build bundle
+      - name: Every Darwin-only test carries the `macos` label (#339)
+        # The selective lane runs `--label macos`; a `test-osx-*` without the label
+        # would ship in the bundle and never execute anywhere. Red here, on Linux.
+        run: python3 ci/check_macos_labels.py bundle/tests.json
       - name: The manifest must carry no absolute path
         # bundle_tests.py already refuses these; this is the independent check, because
         # the whole portability claim rests on it and this is the first phase where the
@@ -426,6 +432,114 @@ jobs:
   # new failure is red AND one of them starting to pass is also red. 42 of 45 tests in
   # the release bundle execute for real (measured).
   # ---------------------------------------------------------------------------------
+  # ---------------------------------------------------------------------------------
+  # Selective lane (#339). A PR that touches a Darwin-only path, or carries the
+  # `needs-macos` label, boots the same Recovery guest but executes ONLY the tests
+  # labelled `macos` (ci/run_test_bundle.py --label). Boot-to-shell is ~6 min, so this
+  # is a ~10-12 min job and CAN gate a PR; the full run above stays manual.
+  # `decide` always runs and is the required check -- a conditional job cannot be
+  # required by branch protection, so the *decision* is what the rule names.
+  # ---------------------------------------------------------------------------------
+  decide:
+    name: decide (selective macOS lane)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: decide
+        run: |
+          set -euo pipefail
+          python3 ci/macos_lane_decide.py \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --labels "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+      - run: |
+          echo "### selective macOS lane: run=${{ steps.decide.outputs.run }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.decide.outputs.reason }}" >> "$GITHUB_STEP_SUMMARY"
+
+  run-macos-x64-selective:
+    name: run-macos-x64-selective (tests labelled macos, in Recovery)
+    needs: [decide, build-macos]
+    if: needs.decide.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: bundle-macos-x64-*
+          path: artifacts
+      - name: Build the guest payload (x86_64 bundles + relocatable CPython)
+        run: |
+          set -euo pipefail
+          mkdir -p payload share
+          for archive in artifacts/*/*.tar.gz; do
+            name=$(basename "$archive" .tar.gz)
+            mkdir -p "payload/$name"
+            tar -C "payload/$name" -xzf "$archive"
+          done
+          cp ci/run_test_bundle.py payload/
+          # Prove on the runner that the label selects something in BOTH bundles, so a
+          # guest boot is never spent on a run that would refuse to start.
+          python3 ci/check_macos_labels.py payload/macos-x64-release/tests.json payload/macos-x64-debug-full/tests.json
+          curl -fsSL -o cpython.tar.gz \
+            "https://github.com/astral-sh/python-build-standalone/releases/download/20250612/cpython-3.12.11+20250612-x86_64-apple-darwin-install_only.tar.gz"
+          tar -xzf cpython.tar.gz -C payload
+          python3 ci/patch_recovery_python.py payload/python/lib/libpython3.12.dylib
+          tar -czf share/payload.tar.gz -C payload .
+          ls -lh share/payload.tar.gz
+
+      - name: Boot macOS Recovery and run the macos-labelled tests
+        id: macos
+        uses: zackees/docker-mac-x64@main
+        with:
+          share-dir: share
+          collect: /tmp/w/out
+          ram: '8'
+          run-timeout: '1200'
+          run: |
+            set -x
+            mkdir -p /tmp/w/out && cd /tmp/w
+            curl -s -o payload.tar.gz http://10.0.2.2:8000/payload.tar.gz
+            mkdir -p payload && tar -xzf payload.tar.gz -C payload
+            cd payload
+            ./python/bin/python3 -VV || exit 91
+            ./python/bin/python3 run_test_bundle.py macos-x64-release \
+              --label macos --junit /tmp/w/out/sel-release.xml
+            echo $? > /tmp/w/out/release.rc
+            ./python/bin/python3 run_test_bundle.py macos-x64-debug-full \
+              --label macos --junit /tmp/w/out/sel-debug-full.xml
+            echo $? > /tmp/w/out/debug-full.rc
+            echo "guest script complete"
+
+      - name: Test results -- exactly the waived Recovery failures, no others
+        run: |
+          set -euo pipefail
+          C="${{ steps.macos.outputs.workdir }}/collected"
+          ls -l "$C"
+          test -f "$C/sel-release.xml" || { echo "::error::no JUnit came back from the guest"; exit 1; }
+          test -f "$C/sel-debug-full.xml" || { echo "::error::debug-full JUnit missing"; exit 1; }
+          python3 ci/recovery_expected_failures.py "$C/sel-release.xml" "$C/sel-debug-full.xml"
+
+      - if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-selective-results
+          path: ${{ steps.macos.outputs.workdir }}/collected/
+          if-no-files-found: warn
+          retention-days: 7
+      - if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-selective-guest-screens
+          path: ${{ steps.macos.outputs.workdir }}/results/*.ppm
+          if-no-files-found: warn
+
   run-macos-x64-recovery:
     name: run-macos-x64 (macOS Recovery on Linux)
     needs: [build-macos, build-rust-apple]

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -72,6 +72,11 @@ jobs:
       # see the module docstring for why it parses the YAML instead of grepping it.
       - name: No workflow may schedule onto a native macOS runner
         run: python3 ci/lint_no_macos_runners.py
+      - name: Selective macOS lane helpers (#339)
+        run: |
+          set -euo pipefail
+          python3 ci/check_macos_labels.py --selftest
+          python3 ci/macos_lane_decide.py --selftest
 
       # The committed chart SVGs under .github/assets must still re-render
       # byte-for-byte from the committed CSV/JSON they name. `--check` re-renders and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1942,6 +1942,21 @@ foreach(mi_serial_test IN LISTS mi_serial_tests)
   endif()
 endforeach()
 
+# `macos` label (#339): the tests the selective macOS lane executes inside the Recovery
+# guest (`ci/run_test_bundle.py --label macos`). Every `test-osx-*` MUST be here --
+# ci/check_macos_labels.py fails the build otherwise -- and a portable test that is
+# worth re-running on Darwin (the TLS-slot probes: pthread TSD slots are a macOS-only
+# mechanism) may be added too. Appended, so RUN_SERIAL's `serial` label survives.
+set(mi_macos_tests
+  test-tls-slots-heap
+  test-threadlocal-growth
+)
+foreach(mi_macos_test IN LISTS mi_macos_tests)
+  if(mi_macos_test IN_LIST mi_registered_tests)
+    set_property(TEST ${mi_macos_test} APPEND PROPERTY LABELS macos)
+  endif()
+endforeach()
+
 # -----------------------------------------------------------------------------
 # Set override properties
 # -----------------------------------------------------------------------------

--- a/ci/check_macos_labels.py
+++ b/ci/check_macos_labels.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Every Darwin-only test must carry the `macos` ctest label (#339).
+
+The selective macOS lane in `macos-bundles.yml` executes `run_test_bundle.py --label
+macos` inside the Recovery guest, so a test that only means something on macOS but
+forgot its `LABELS macos` would build, ship in the bundle, and never run anywhere --
+the "gate that verifies nothing" shape docs/ci-gates.md exists to prevent. This check
+runs on the bundle manifest (`tests.json`, the same file the guest replays) and makes
+the omission red on the Linux build job, long before a guest boots.
+
+The convention is by name: a test called `test-osx-*` is Darwin-only. Anything else
+may carry the label too (a portable test worth re-running on macOS, e.g. the TLS-slot
+probe), but is not required to.
+
+    python3 ci/check_macos_labels.py bundle-dir/tests.json [...]
+    python3 ci/check_macos_labels.py --selftest
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+MACOS_LABEL = "macos"
+DARWIN_ONLY_PREFIX = "test-osx-"
+
+
+def _entries(manifest: Mapping[str, object]) -> list[tuple[str, list[str]]]:
+    """(name, labels) for every well-formed entry; raises if there is no `tests` array."""
+    tests = manifest.get("tests")
+    if not isinstance(tests, list):
+        raise ValueError("manifest has no `tests` array")
+    out: list[tuple[str, list[str]]] = []
+    for raw in cast("list[object]", tests):
+        if not isinstance(raw, dict):
+            continue
+        entry = cast("dict[str, object]", raw)
+        name = entry.get("name")
+        labels = entry.get("labels")
+        if not isinstance(name, str):
+            continue
+        clean = (
+            [x for x in cast("list[object]", labels) if isinstance(x, str)]
+            if isinstance(labels, list)
+            else []
+        )
+        out.append((name, clean))
+    return out
+
+
+def unlabeled(manifest: Mapping[str, object]) -> list[str]:
+    """Names of `test-osx-*` entries that do not carry the `macos` label."""
+    return sorted(
+        name
+        for name, labels in _entries(manifest)
+        if name.startswith(DARWIN_ONLY_PREFIX) and MACOS_LABEL not in labels
+    )
+
+
+def labeled(manifest: Mapping[str, object]) -> list[str]:
+    return sorted(name for name, labels in _entries(manifest) if MACOS_LABEL in labels)
+
+
+def selftest() -> int:
+    good: dict[str, object] = {"tests": [{"name": "test-osx-zone", "labels": ["macos", "serial"]}]}
+    bad: dict[str, object] = {
+        "tests": [{"name": "test-osx-zone", "labels": []}, {"name": "test-api", "labels": []}]
+    }
+    assert unlabeled(good) == [], unlabeled(good)
+    assert unlabeled(bad) == ["test-osx-zone"], unlabeled(bad)
+    assert labeled(good) == ["test-osx-zone"]
+    try:
+        unlabeled({"nope": 1})
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("a manifest without `tests` must be rejected")
+    print("check_macos_labels selftest OK")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv == ["--selftest"]:
+        return selftest()
+    if not argv:
+        print(__doc__, file=sys.stderr)
+        return 2
+    rc = 0
+    for arg in argv:
+        path = Path(arg)
+        manifest = cast("dict[str, object]", json.loads(path.read_text(encoding="utf-8")))
+        missing = unlabeled(manifest)
+        have = labeled(manifest)
+        print(f"{path}: {len(have)} test(s) labelled `{MACOS_LABEL}`: {have or 'none'}")
+        if missing:
+            print(
+                f"::error::{path}: Darwin-only tests without `LABELS {MACOS_LABEL}` "
+                f"(they would never execute in the selective lane): {missing}"
+            )
+            rc = 1
+        if not have:
+            print(
+                f"::error::{path}: no test carries `{MACOS_LABEL}`; the selective lane "
+                "would refuse to run (run_test_bundle.py --label)"
+            )
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/ci/macos_lane_decide.py
+++ b/ci/macos_lane_decide.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Decide whether a PR gets the selective macOS Recovery lane (#339).
+
+The full Recovery execution stays manual (owner decision 2026-09-03: 25-90 min cannot
+gate a PR). This picks the PRs that get a *selective* run -- boot the guest, execute only
+the tests labelled `macos` -- when either:
+
+  * the diff touches a Darwin-specific path (the same list CLAUDE.md tells humans to run
+    the manual lane for: `src/prim/osx`, interpose, the TLS slots), or
+  * the PR carries the `needs-macos` label (manual opt-in).
+
+Both are dependency-free: the diff comes from `git diff --name-only`, the labels from
+the event payload. Prints `run=true|false` and `reason=...`, and appends them to
+`$GITHUB_OUTPUT` when set.
+
+    python3 ci/macos_lane_decide.py --base <sha> --head <sha> [--labels a,b]
+    python3 ci/macos_lane_decide.py --selftest
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+OPT_IN_LABEL = "needs-macos"
+
+#: Paths whose change means "this is a macOS change". Globs are matched against the
+#: repo-relative path with `fnmatch` (so `*` crosses directory separators).
+MACOS_PATHS: tuple[str, ...] = (
+    "src/prim/osx/*",
+    "test/test-osx-*",
+    "include/mimalloc/prim-tls.h",
+    "cmake/toolchains/*apple*",
+    ".github/workflows/macos-bundles.yml",
+    "ci/recovery_expected_failures.py",
+    "ci/check_macos_labels.py",
+    "ci/macos_lane_decide.py",
+)
+
+#: Substrings that make a CMakeLists.txt change count (the zone/interpose blocks).
+CMAKE_MARKERS: tuple[str, ...] = ("MI_OSX_ZONE", "MI_OSX_INTERPOSE", "alloc-override-zone")
+
+
+def touched_macos_paths(files: list[str]) -> list[str]:
+    return sorted(f for f in files if any(fnmatch.fnmatch(f, g) for g in MACOS_PATHS))
+
+
+def cmake_touches_macos(diff_text: str) -> bool:
+    """True if a changed CMakeLists.txt line mentions the zone/interpose machinery."""
+    for line in diff_text.splitlines():
+        changed = line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+        if changed and any(marker in line for marker in CMAKE_MARKERS):
+            return True
+    return False
+
+
+def decide(files: list[str], labels: list[str], cmake_diff: str = "") -> tuple[bool, str]:
+    if OPT_IN_LABEL in labels:
+        return True, f"label `{OPT_IN_LABEL}`"
+    hits = touched_macos_paths(files)
+    if hits:
+        return True, f"macOS paths changed: {hits}"
+    if "CMakeLists.txt" in files and cmake_touches_macos(cmake_diff):
+        return True, "CMakeLists.txt zone/interpose block changed"
+    return False, "no macOS path or label"
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout
+
+
+def selftest() -> int:
+    assert decide([], [OPT_IN_LABEL]) == (True, f"label `{OPT_IN_LABEL}`")
+    ok, why = decide(["src/prim/osx/alloc-override-zone.c"], [])
+    assert ok and "src/prim/osx" in why, why
+    assert decide(["test/test-osx-zone-introspect.c"], [])[0]
+    assert decide(["include/mimalloc/prim-tls.h"], [])[0]
+    assert not decide(["src/alloc.c", "rust/x.rs"], ["bug"])[0]
+    assert not decide(["CMakeLists.txt"], [], "+set(FOO 1)\n")[0]
+    assert decide(["CMakeLists.txt"], [], "+  list(APPEND x src/prim/osx/alloc-override-zone.c)")[0]
+    assert not decide(["CMakeLists.txt"], [], "--- a\n+++ b\n MI_OSX_ZONE context line")[0]
+    print("macos_lane_decide selftest OK")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--labels", default="", help="comma-separated PR labels")
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+    if args.selftest:
+        return selftest()
+    if not args.base:
+        parser.error("--base is required")
+    base = str(args.base)
+    head = str(args.head)
+    files = [f for f in _git("diff", "--name-only", f"{base}...{head}").splitlines() if f]
+    cmake_diff = (
+        _git("diff", f"{base}...{head}", "--", "CMakeLists.txt")
+        if "CMakeLists.txt" in files
+        else ""
+    )
+    labels = [x.strip() for x in str(args.labels).split(",") if x.strip()]
+    run, reason = decide(files, labels, cmake_diff)
+    print(f"run={'true' if run else 'false'}")
+    print(f"reason={reason}")
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with Path(out).open("a", encoding="utf-8") as fh:
+            fh.write(f"run={'true' if run else 'false'}\nreason={reason}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/ci/run_test_bundle.py
+++ b/ci/run_test_bundle.py
@@ -560,11 +560,26 @@ def parse_variants(raw: Sequence[Sequence[str]]) -> list[Variant]:
     return variants
 
 
-def select(specs: Sequence[TestSpec], only: Sequence[str] | None) -> list[TestSpec]:
-    if only is None:
-        return list(specs)
-    wanted = set(only)
-    return [spec for spec in specs if spec.name in wanted]
+def select(
+    specs: Sequence[TestSpec],
+    only: Sequence[str] | None,
+    labels: Sequence[str] | None = None,
+) -> list[TestSpec]:
+    """The tests `--only` / `--label` ask for; both given means both must match.
+
+    `--label` selects by the ctest LABELS the manifest carries (`ci/bundle_tests.py`
+    lowers them verbatim). It exists for the selective macOS lane (#339): a PR that
+    touches a Darwin-only path executes just the tests labelled `macos` inside the
+    Recovery guest instead of the full ~25-minute bundle.
+    """
+    chosen = list(specs)
+    if only is not None:
+        wanted = set(only)
+        chosen = [spec for spec in chosen if spec.name in wanted]
+    if labels is not None:
+        needed = set(labels)
+        chosen = [spec for spec in chosen if needed & set(spec.labels)]
+    return chosen
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -590,6 +605,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         "manifest marks `serial` always run alone, after the parallel wave.",
     )
     parser.add_argument("--only", nargs="+", default=None, metavar="NAME", help="run these tests")
+    parser.add_argument(
+        "--label",
+        nargs="+",
+        default=None,
+        metavar="LABEL",
+        help="run only tests carrying at least one of these ctest labels (e.g. `macos`, "
+        "the selective macOS lane of #339). A bundle in which nothing carries the label "
+        "is an error, not an empty green run.",
+    )
     parser.add_argument(
         "--env", nargs="+", default=None, metavar="K=V", help="extra environment for every test"
     )
@@ -657,6 +681,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     only = cast("list[str] | None", args.only)
+    labels = cast("list[str] | None", args.label)
     loaded: list[tuple[str, Path, Sequence[TestSpec]]] = []
     for raw_path in paths:
         bundle = Path(raw_path).resolve()
@@ -670,7 +695,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             if missing and not multi:
                 print(f"no such test(s) in the bundle: {missing}", file=sys.stderr)
                 return 1
-        loaded.append((bundle.name, bundle, select(specs, only)))
+        chosen = select(specs, only, labels)
+        if labels is not None and not chosen and not multi:
+            # `--label macos` against a bundle where no test carries the label would
+            # otherwise fall through to "no tests selected" -- true, but the useful
+            # fact is that the label is unknown to this bundle (a typo, or a test that
+            # forgot its LABELS), so say that.
+            print(
+                f"no test in {bundle.name} carries any of the labels {sorted(labels)}",
+                file=sys.stderr,
+            )
+            return 1
+        loaded.append((bundle.name, bundle, chosen))
 
     # A `--env-variant guarded:...` whose bundle name is a typo would silently drop the
     # second pass and still report green -- the "gate that verifies nothing" shape. Refuse.

--- a/ci/tests/test_test_bundles.py
+++ b/ci/tests/test_test_bundles.py
@@ -591,6 +591,38 @@ class RunnerTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stdout)
         self.assertIn("out of 1", proc.stdout)
 
+    def test_label_selects_by_manifest_labels(self) -> None:
+        """#339: `--label macos` runs exactly the tests whose LABELS carry `macos`."""
+        self.write_manifest(
+            [
+                self.spec("t-mac", "ok", labels=["macos"]),
+                self.spec("t-mac-serial", "ok", labels=["serial", "macos"]),
+                self.spec("t-linux", "boom"),
+            ]
+        )
+        proc = self.run_bundle("--label", "macos")
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+        self.assertIn("out of 2", proc.stdout)
+
+    def test_label_and_only_intersect(self) -> None:
+        self.write_manifest(
+            [
+                self.spec("t-mac", "ok", labels=["macos"]),
+                self.spec("t-mac2", "boom", labels=["macos"]),
+            ]
+        )
+        proc = self.run_bundle("--label", "macos", "--only", "t-mac")
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+        self.assertIn("out of 1", proc.stdout)
+
+    def test_label_nobody_carries_is_an_error_not_an_empty_green(self) -> None:
+        """The 'gate that verifies nothing' shape: a mistyped label, or a macOS-only test
+        that forgot its LABELS, must be red -- never a 100% pass of zero tests."""
+        self.write_manifest([self.spec("t-ok", "ok")])
+        proc = self.run_bundle("--label", "macos")
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("carries any of the labels", proc.stderr)
+
     def test_only_with_an_unknown_name_is_an_error(self) -> None:
         self.write_manifest([self.spec("t-ok", "ok")])
         proc = self.run_bundle("--only", "t-nope")

--- a/ci/verify_local.py
+++ b/ci/verify_local.py
@@ -694,6 +694,10 @@ def run_lint(ctx: RunCtx) -> bool:
         # render from docs/allocator-features.json, and `--check` fails if any of the
         # three has drifted from it.
         ["uv", "run", "ci/render_feature_table.py", "--check"],
+        # Selective macOS lane helpers (#339): the label check that runs on every
+        # cross-built bundle and the PR-diff decision that picks the lane.
+        ["uv", "run", "ci/check_macos_labels.py", "--selftest"],
+        ["uv", "run", "ci/macos_lane_decide.py", "--selftest"],
     ):
         rc, _ = run_logged(cmd, cwd=ROOT, log=ctx.log)
         ok = ok and rc == 0


### PR DESCRIPTION
Step 1 of the verification plan on #339 (comment 5548131760): the CI plumbing and the workflow, proven here by labelling two existing TLS-slot tests `macos` and opting this PR in with `needs-macos`.

## What
- `ci/run_test_bundle.py --label LABEL` — select by the ctest `LABELS` the manifest already carries. Nothing matching is an error, never an empty green. Unit tests added.
- `ci/check_macos_labels.py` — every `test-osx-*` must carry `macos`; runs on each cross-built bundle's `tests.json` in `build-macos`, so a forgotten label is red on Linux before any guest boots.
- `ci/macos_lane_decide.py` — `run=true` when the PR diff touches `src/prim/osx`, `test/test-osx-*`, `prim-tls.h`, the zone/interpose CMake block, or the PR carries the new `needs-macos` label. Selftested.
- `macos-bundles.yml`: `decide` (runs on every PR; **this is the check to require in branch protection**, a conditional job cannot be) and `run-macos-x64-selective` (same Recovery guest, `--label macos` on the release + debug-full bundles, 30-min cap, judged by the same `recovery_expected_failures.py`). The full `run-macos-x64-recovery` stays `workflow_dispatch`-only per the 2026-09-03 decision.
- `CMakeLists.txt`: `macos` label appended on `test-tls-slots-heap` and `test-threadlocal-growth`.

## Verified locally
- `pytest ci/tests`: 375 passed.
- Linux build → `bundle_tests.py` → `check_macos_labels.py` OK → `run_test_bundle.py --label macos` runs exactly the 2 labelled tests.
- ruff/pyright (pinned versions) clean; `lint_no_macos_runners` clean.

## What this PR proves in CI
`decide` → `run=true` (label) → the selective job boots Recovery and runs the two tests. The job's wall-clock is the number that justifies making it a PR gate.

Step 2 (the `intro_enumerator` port + `test-osx-zone-introspect*`) follows on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSkzjDkDvDc2cYu4QLz6A4