### PR TITLE
docs: real-Mac leaks/vmmap run becomes a release-checklist step (#353)

### DIFF
--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -62,6 +62,14 @@ it. `macos-bundles.yml` has two more jobs:
   `CMakeLists.txt`, the lane's own files — or whether the PR carries the `needs-macos`
   label. It always completes, so it is the job branch protection requires; a
   conditional job cannot be.
+- **Branch protection (#352)** requires `decide` plus 13 other checks on `main`. Known
+  hole: `c-unit.yml`, `macos-bundles.yml`, `windows-bundles.yml` and `python-lint.yml`
+  are all `pull_request.paths`-filtered, so a PR that touches none of those paths
+  (docs-only, for instance) never gets its required checks reported and stays BLOCKED.
+  Such PRs are merged with `gh pr merge --admin` (`enforce_admins` is off for exactly
+  this); the proper fix — an always-running workflow that reports the required
+  contexts as success when the filtered paths are untouched — is tracked as a
+  follow-up on #351.
 - **`run-macos-x64-selective`** runs when `decide` says so: the same Recovery guest,
   but `run_test_bundle.py --label macos` on the release and debug-full bundles, judged
   by the same `ci/recovery_expected_failures.py` (a waiver for a test that did not run

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -78,8 +78,10 @@ Out-of-process zone enumeration (`test-osx-zone-introspect-remote`) needs `task_
 which Recovery — root, SIP not enforced — may grant. If the guest cannot, the test's
 exit 3 is waived **by name** in `ci/recovery_expected_failures.py`, and that waiver goes
 red the day it starts passing. The `leaks`/`vmmap` CLIs themselves are absent from
-Recovery and are not exercised anywhere automated; the tests drive the `enumerator`
-entry point those tools call.
+Recovery (measured; they are base-OS binaries, not part of the Command Line Tools) and
+are not exercised anywhere automated; the tests drive the `enumerator` entry point those
+tools call, and running the tools once on a real Mac is a release-checklist step in
+[docs/maintainers.md](maintainers.md#manual-macos-check-before-a-release-real-mac-required).
 
 ## `bun-surface` is a hard gate
 

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -38,6 +38,28 @@ soldr cargo run -p xtask -- check
 soldr cargo test --workspace --locked
 ```
 
+## Manual macOS check before a release (real Mac required)
+
+Apple's `leaks`, `vmmap`, `heap` and `malloc_history` are base-OS binaries that the
+macOS Recovery guest CI uses does not carry (measured on #353: none of the five is
+present in a 13.0 Recovery image, and they are not in the Command Line Tools package
+either). CI drives the same `enumerator` entry point those tools call
+(`test-osx-zone-introspect`, `test-osx-zone-introspect-remote`, both in the selective
+Recovery lane), so the residual risk is the tools' own plumbing. Before tagging a
+release that touched `src/prim/osx/**`, run this once on any Mac with a full macOS
+install and paste both outputs in the release PR:
+
+```sh
+cmake -B build -DMI_OVERRIDE=ON -DMI_OSX_ZONE=ON && cmake --build build
+leaks --atExit -- ./build/mimalloc-test-osx-zone-introspect
+./build/mimalloc-test-osx-zone-introspect-remote & vmmap $!
+```
+
+Expected: `leaks` lists a zone named `mimalloc` with non-zero nodes and reports the
+384 live blocks the in-process test still holds at exit; `vmmap` shows the arena as a
+`MALLOC` region attributed to that zone. A zone that reports zero nodes means the
+enumerator regressed to upstream's empty stub.
+
 ## Repository layout
 
 ```text


### PR DESCRIPTION
Closes #353. Sub-issue of #351. Docs only.

Both automation routes were measured dead (see #353): the Recovery guest ships none of `leaks`/`vmmap`/`heap`/`malloc_history`, and Apple's public Command Line Tools package does not contain them (they are base-OS binaries). The check is therefore made a documented pre-tag step in `docs/maintainers.md` for releases that touch `src/prim/osx/**`, with the exact commands and expected output; `docs/ci-gates.md` links to it. CI keeps driving the same `enumerator` entry point through the two zone tests in the selective Recovery lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSkzjDkDvDc2cYu4QLz6A4