### PR TITLE
ci: required checks always report -- no pull_request path filters on the gate workflows (#360)

### DIFF
--- a/.github/workflows/c-unit.yml
+++ b/.github/workflows/c-unit.yml
@@ -44,13 +44,8 @@ on:
   push:
     branches: [main, v4]
   pull_request:
-    paths:
-      - 'src/**'
-      - 'include/**'
-      - 'test/**'
-      - 'CMakeLists.txt'
-      - 'ci/**'
-      - '.github/workflows/c-unit.yml'
+    # No `paths` filter (#360): every job here is a required status check on `main`, and a
+    # filtered workflow never reports on a PR outside its paths, leaving that PR BLOCKED.
 
 concurrency:
   # The macOS/Windows queue hog (#277). A superseded push's ctest result is worthless.

--- a/.github/workflows/macos-bundles.yml
+++ b/.github/workflows/macos-bundles.yml
@@ -49,17 +49,10 @@ on:
   push:
     branches: [main, v4]
   pull_request:
+    # No `paths` filter (#360): every job here is a required status check on `main`, and a
+    # filtered workflow never reports on a PR outside its paths, leaving that PR BLOCKED.
     # `labeled` so adding `needs-macos` to an open PR re-runs `decide` (#339).
     types: [opened, synchronize, reopened, labeled]
-    paths:
-      - 'src/**'
-      - 'include/**'
-      - 'test/**'
-      - 'rust/**'
-      - 'CMakeLists.txt'
-      - 'cmake/toolchains/**'
-      - 'ci/**'
-      - '.github/workflows/macos-bundles.yml'
 
 concurrency:
   # The macOS pool is the scarce one this whole workflow exists to stop wasting (#277).

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -10,17 +10,8 @@ on:
   push:
     branches: [main, v4]
   pull_request:
-    paths:
-      - 'ci/**'
-      - 'pyproject.toml'
-      - '.github/workflows/**'
-      # The feature table renders from docs/allocator-features.json into the README
-      # region and both SVGs. Without these three, an edit to any of them would skip
-      # this job entirely and the `--check` below could not catch the drift it exists
-      # to catch.
-      - 'README.md'
-      - 'docs/allocator-features.json'
-      - '.github/assets/allocator-features-*.svg'
+    # No `paths` filter (#360): every job here is a required status check on `main`, and a
+    # filtered workflow never reports on a PR outside its paths, leaving that PR BLOCKED.
 
 concurrency:
   # Pure verification: a superseded push's answer is worthless.

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -68,16 +68,8 @@ on:
   push:
     branches: [main, v4]
   pull_request:
-    paths:
-      - 'src/**'
-      - 'include/**'
-      - 'test/**'
-      - 'rust/**'
-      - 'bin/**'
-      - 'CMakeLists.txt'
-      - 'cmake/toolchains/**'
-      - 'ci/**'
-      - '.github/workflows/windows-bundles.yml'
+    # No `paths` filter (#360): every job here is a required status check on `main`, and a
+    # filtered workflow never reports on a PR outside its paths, leaving that PR BLOCKED.
 
 concurrency:
   group: windows-bundles-${{ github.ref }}

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -62,14 +62,12 @@ it. `macos-bundles.yml` has two more jobs:
   `CMakeLists.txt`, the lane's own files — or whether the PR carries the `needs-macos`
   label. It always completes, so it is the job branch protection requires; a
   conditional job cannot be.
-- **Branch protection (#352)** requires `decide` plus 13 other checks on `main`. Known
-  hole: `c-unit.yml`, `macos-bundles.yml`, `windows-bundles.yml` and `python-lint.yml`
-  are all `pull_request.paths`-filtered, so a PR that touches none of those paths
-  (docs-only, for instance) never gets its required checks reported and stays BLOCKED.
-  Such PRs are merged with `gh pr merge --admin` (`enforce_admins` is off for exactly
-  this); the proper fix — an always-running workflow that reports the required
-  contexts as success when the filtered paths are untouched — is tracked as a
-  follow-up on #351.
+- **Branch protection (#352)** requires `decide` plus 13 other checks on `main`. Since
+  #360 the four gate workflows (`c-unit.yml`, `macos-bundles.yml`, `windows-bundles.yml`,
+  `python-lint.yml`) have **no `pull_request.paths` filter**: a required check that never
+  reports leaves a PR BLOCKED, which is what happened to docs-only PRs (#359 had to be
+  admin-merged). The price is a full CI run on a docs-only PR; do not put the filters
+  back without also solving the reporting problem. Push triggers keep their filters.
 - **`run-macos-x64-selective`** runs when `decide` says so: the same Recovery guest,
   but `run_test_bundle.py --label macos` on the release and debug-full bundles, judged
   by the same `ci/recovery_expected_failures.py` (a waiver for a test that did not run


### PR DESCRIPTION
Closes #360. Follow-up sub-issue of #351.

Removes `pull_request.paths` from `c-unit.yml`, `macos-bundles.yml`, `windows-bundles.yml` and `python-lint.yml` (push filters untouched, `labeled` type kept on macos-bundles). Rationale in each file and in docs/ci-gates.md: a required status check that never reports leaves the PR BLOCKED, so with #352's rule a docs-only PR could only be admin-merged (#359). Cost: a full CI run on docs-only PRs. Verification: after merge, a docs-only PR must show all 14 required checks without `--admin` — I will open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSkzjDkDvDc2cYu4QLz6A4