### PR TITLE
chore(release): mimalloc-pprof 0.11.0

### DIFF
--- a/.github/assets/allocator-features-dark.svg
+++ b/.github/assets/allocator-features-dark.svg
@@ -7,7 +7,7 @@
 <text x="24" y="46" font-size="11" fill="#8b949e">Sourced cell by cell in docs/allocator-features.json. Upstream and Bun are the exact commits this fork pins to and ports from; jemalloc is the build in the benchmark lockfile. The measured row is the committed churn benchmark,</text>
 <text x="24" y="61" font-size="11" fill="#8b949e">whose upstream arm is v3.4.3 (bcee5a88).</text>
 <text x="432.0" y="93" font-size="12.5" font-weight="700" fill="#e6edf3">mimalloc-pprof</text>
-<text x="432.0" y="108" font-size="10" fill="#8b949e">this fork, 0.9.x</text>
+<text x="432.0" y="108" font-size="10" fill="#8b949e">this fork, 0.11.x</text>
 <text x="642.0" y="93" font-size="12.5" font-weight="600" fill="#8b949e">Microsoft MiMalloc-V3</text>
 <text x="642.0" y="108" font-size="10" fill="#8b949e">v3 dev3 @ 6def7be9</text>
 <text x="852.0" y="93" font-size="12.5" font-weight="600" fill="#8b949e">Bun mimalloc</text>

--- a/.github/assets/allocator-features-light.svg
+++ b/.github/assets/allocator-features-light.svg
@@ -7,7 +7,7 @@
 <text x="24" y="46" font-size="11" fill="#59636e">Sourced cell by cell in docs/allocator-features.json. Upstream and Bun are the exact commits this fork pins to and ports from; jemalloc is the build in the benchmark lockfile. The measured row is the committed churn benchmark,</text>
 <text x="24" y="61" font-size="11" fill="#59636e">whose upstream arm is v3.4.3 (bcee5a88).</text>
 <text x="432.0" y="93" font-size="12.5" font-weight="700" fill="#1f2328">mimalloc-pprof</text>
-<text x="432.0" y="108" font-size="10" fill="#59636e">this fork, 0.9.x</text>
+<text x="432.0" y="108" font-size="10" fill="#59636e">this fork, 0.11.x</text>
 <text x="642.0" y="93" font-size="12.5" font-weight="600" fill="#59636e">Microsoft MiMalloc-V3</text>
 <text x="642.0" y="108" font-size="10" fill="#59636e">v3 dev3 @ 6def7be9</text>
 <text x="852.0" y="93" font-size="12.5" font-weight="600" fill="#59636e">Bun mimalloc</text>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ if the sub-issue conflicts with older prose in #2, the sub-issue + #2's Decision
 
 ## Repo facts
 
-- Branch layout: `main` is the **v3** line (crate 0.9.x, overlay pinned to `upstream/dev3`
+- Branch layout: `main` is the **v3** line (crate 0.11.x, overlay pinned to `upstream/dev3`
   commit `6def7be9`; was `bcee5a88` before the #266 bump, and `579f8c0e` before that (#80)).
   The previous v2 line is preserved on the **`v2`** branch and is what
   crates.io still serves as 0.8.x. Do not move the v3 overlay to a newer `dev3` without

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Profiling is **opt-in at runtime**: a build with `MI_PPROF=ON` (the default) doe
 not sample until you call a start API or set `MIMALLOC_PROF=1`.
 
 **v3 only.** This fork tracks upstream mimalloc's `dev3` line (crate
-[`mimalloc-pprof` 0.10.x](https://crates.io/crates/mimalloc-pprof)). The legacy v2
+[`mimalloc-pprof` 0.11.x](https://crates.io/crates/mimalloc-pprof)). The legacy v2
 line (0.8.x, upstream `main`) is preserved on the
 [`v2`](https://github.com/zackees/mimalloc-pprof/tree/v2) branch but is not
 maintained going forward. Upstream mimalloc v3 (`dev3`) is itself still a
@@ -93,7 +93,7 @@ image and the table below are rendered from.
 
 | Feature | **mimalloc-pprof** | Microsoft MiMalloc-V3 | Bun mimalloc | jemalloc |
 |---|:--|:--|:--|:--|
-|  | this fork, 0.9.x | v3 dev3 @ 6def7be9 | oven-sh @ b20b60d9 | 5.3.1 @ 81034ce1 |
+|  | this fork, 0.11.x | v3 dev3 @ 6def7be9 | oven-sh @ b20b60d9 | 5.3.1 @ 81034ce1 |
 | **Memory return** | | | | |
 | Process-wide eager purge, from any thread | ✅ gated 72 %, default parked | ❌ mi_collect is caller-only | ❌ mi_collect is caller-only | ✅ MALLCTL_ARENAS_ALL, 74 % |
 | Purge the calling thread's own memory | ✅ mi_collect, idle hook | ✅ mi_collect | ✅ mi_collect, idle hook | ✅ tcache.flush + arena.i.purge |
@@ -336,7 +336,7 @@ and its safe Rust wrapper.
 
 ```toml
 [dependencies]
-mimalloc-pprof = "0.9"
+mimalloc-pprof = "0.11"
 
 [profile.release]
 debug = "line-tables-only"
@@ -1167,7 +1167,7 @@ Design history and milestone decisions are in
 
 The authoritative release record, with the reasoning behind each fix, is
 [`rust/mimalloc-pprof/CHANGELOG.md`](rust/mimalloc-pprof/CHANGELOG.md). The v3
-line ships as [`mimalloc-pprof` 0.10.x](https://crates.io/crates/mimalloc-pprof);
+line ships as [`mimalloc-pprof` 0.11.x](https://crates.io/crates/mimalloc-pprof);
 the v2 line (0.8.x) is maintained on the
 [`v2`](https://github.com/zackees/mimalloc-pprof/tree/v2) branch.
 

--- a/docs/allocator-features.json
+++ b/docs/allocator-features.json
@@ -5,7 +5,7 @@
     {
       "key": "mimalloc-pprof",
       "label": "mimalloc-pprof",
-      "version": "this fork, 0.9.x"
+      "version": "this fork, 0.11.x"
     },
     {
       "key": "upstream",

--- a/docs/rust-integration.md
+++ b/docs/rust-integration.md
@@ -4,7 +4,7 @@
 
 ```toml
 [dependencies]
-mimalloc-pprof = "0.9"          # v3 engine (current)
+mimalloc-pprof = "0.11"         # v3 engine (current)
 # mimalloc-pprof = "0.8"        # v2 engine
 
 [profile.release]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mimalloc-pprof"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "cc",
  "regex",

--- a/rust/mimalloc-pprof/CHANGELOG.md
+++ b/rust/mimalloc-pprof/CHANGELOG.md
@@ -1,7 +1,27 @@
 # Changelog
 
-## Unreleased
+## 0.11.0
 
+Multithreaded allocation is fast again, process-wide eager purge, Bun's heap-snapshot
+format, zero-tracking back on, and a macOS malloc zone the platform's own tools can walk.
+
+- **Fast path: 4.5× single-thread and 35× at eight threads**
+  ([#371](https://github.com/zackees/mimalloc-pprof/issues/371),
+  [#372](https://github.com/zackees/mimalloc-pprof/pull/372),
+  [#387](https://github.com/zackees/mimalloc-pprof/pull/387)). memory-events and DHAT are
+  both opt-in and both off in a default process, yet every allocation and every free
+  entered them out of line, and DHAT's prologue took **two global atomic read-modify-writes
+  per alloc and per free** — which serialised the allocator so thoroughly that the fork got
+  *slower* with more threads. Both observers now publish one cache-line-aligned armed word
+  that the call site reads inline: with nothing observing, an allocation pays **one relaxed
+  load and a not-taken branch**, and the whole prologue moves, unchanged, behind it. The
+  lazy-activation contract is preserved exactly — each observer keeps an `unresolved` bit,
+  so the first hook call still resolves its environment there and never at startup.
+  Tiny-hot loop (16–64 B, 256 live), 16 cores, Release, Mops/s at 1 / 4 / 8 threads:
+  **83 / 53 / 56 → 373 / 1196 / 1985**. A new `MI_DHAT` compile option (default on, so
+  `dhat::` keeps working) can also leave the collector out of the build entirely. Guarded
+  from here by three gates: a fast-path instruction-identity check, a ratio-based scaling
+  test in `ctest`, and a published-chart parity audit against upstream and Bun's mimalloc.
 - **Process-wide eager purge** ([#366](https://github.com/zackees/mimalloc-pprof/issues/366)):
   `purge_all(force) -> PurgeAllReport` and `purge_all_ex(PurgeFlags, wait_ms) ->
   (PurgeStatus, PurgeAllReport)` wrap `mi_purge_all_ex`; `sys::mi_purge_all_report_t`,
@@ -26,9 +46,20 @@
   `enumerator` was upstream's empty stub; it is now a real in- and out-of-process walk
   through the caller's `memory_reader_t` (ported from Bun), and `statistics` reports
   live numbers. No crate API change; the zone file rides in the vendored amalgamation.
+- **Thread exit no longer allocates through the allocator**
+  ([#350](https://github.com/zackees/mimalloc-pprof/issues/350),
+  [#357](https://github.com/zackees/mimalloc-pprof/pull/357)): the per-heap abandoned-page
+  bitmaps introduced with the lazy-bitmap work were allocated on the meta path at thread
+  exit, which made the churn benchmark's resident set bimodal (58 or 66 MB from run to run).
+  They come from the OS layer now, and the memory gate is deterministic again.
 - **CI**: a selective macOS lane runs the `macos`-labelled tests in the Recovery guest on
   PRs that touch a Darwin path or carry `needs-macos`
-  ([#348](https://github.com/zackees/mimalloc-pprof/pull/348)).
+  ([#348](https://github.com/zackees/mimalloc-pprof/pull/348)); the allocator lockfile
+  controls the effective debug level ([#314](https://github.com/zackees/mimalloc-pprof/issues/314)),
+  test binaries are relocatable so bundles run anywhere
+  ([#294](https://github.com/zackees/mimalloc-pprof/issues/294)), and the benchmark
+  publication pipeline — stalled since 2026-08-14 — renders, validates and publishes again
+  ([#376](https://github.com/zackees/mimalloc-pprof/issues/376)).
 
 ## 0.10.0
 

--- a/rust/mimalloc-pprof/Cargo.toml
+++ b/rust/mimalloc-pprof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimalloc-pprof"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 description = "mimalloc global allocator with pprof-compatible sampled heap profiling"

--- a/rust/mimalloc-pprof/README.md
+++ b/rust/mimalloc-pprof/README.md
@@ -18,7 +18,7 @@ graphs, call graphs, top reports, and profile diffs.
 
 ```toml
 [dependencies]
-mimalloc-pprof = "0.9"
+mimalloc-pprof = "0.11"
 
 [profile.release]
 debug = "line-tables-only"
@@ -80,13 +80,13 @@ MIMALLOC_PROF=1 MIMALLOC_PROF_DUMP_AT_EXIT=heap.prof ./my_app
 
 | | crate | engine |
 |---|---|---|
-| **0.10.x** — current | `mimalloc-pprof = "0.10"` | mimalloc v3 |
+| **0.11.x** — current | `mimalloc-pprof = "0.11"` | mimalloc v3 |
 | 0.8.x — previous | `mimalloc-pprof = "0.8"` | mimalloc v2 |
 
 The profiler API, environment variables, and output formats are identical in both,
 so moving between them is a version bump rather than a code change.
 
-**0.10.x is recommended.** It has strictly more test coverage, per-heap allocator
+**0.11.x is recommended.** It has strictly more test coverage, per-heap allocator
 statistics, and fixes two upstream mimalloc bugs that 0.8.x still carries —
 including an unbounded memory leak on Windows/MinGW where every exiting thread
 leaked its heap and pages (23.5 GB at 100 stress iterations, versus flat after the
@@ -94,7 +94,7 @@ fix). Note that upstream mimalloc v3 is itself still a pre-release branch.
 
 ## Exact statistics alongside sampled ones
 
-On 0.10.x, `prof::stats()` carries the allocator's **exact** counters next to the
+On 0.11.x, `prof::stats()` carries the allocator's **exact** counters next to the
 sampled ones. A sampled profile alone cannot tell you whether it under-counted;
 comparing the two measures the sampling error directly:
 


### PR DESCRIPTION
Cuts **0.11.0** on the v3 line. `0.11.0` is free on crates.io (current max is `0.10.0`), so
that is the number.

The branch was rebuilt on current `main` — the original cut was 48 commits stale and its
changelog predated the fix that unblocked it.

### What is in it

`## Unreleased` promoted to `## 0.11.0`, plus the two entries that landed after that section
was first drafted:

- **Observer fast path** ([#371](https://github.com/zackees/mimalloc-pprof/issues/371),
  [#372](https://github.com/zackees/mimalloc-pprof/pull/372),
  [#387](https://github.com/zackees/mimalloc-pprof/pull/387)) — the headline of this release.
  A disabled DHAT was taking two global atomic RMWs per alloc **and** per free, so the fork
  got slower with more threads. Tiny-hot, 16 cores, Mops/s at 1 / 4 / 8 threads:
  `83 / 53 / 56` → `373 / 1196 / 1985`. Now guarded by three gates (fast-path instruction
  identity, a ratio-based `ctest` scaling test, and a published-chart parity audit).
- **Thread exit no longer allocates through the allocator**
  ([#350](https://github.com/zackees/mimalloc-pprof/issues/350),
  [#357](https://github.com/zackees/mimalloc-pprof/pull/357)) — the churn benchmark's RSS
  was bimodal (58 / 66 MB) because the abandoned-page bitmaps came off the meta path at
  thread exit.
- CI/benchmark work from the same window (#314, #294, #376).

Everything already drafted for this release — process-wide eager purge (#366), the Bun heap
snapshot (#338), zero-tracking (#337), macOS zone introspection (#339/#349), the selective
macOS lane (#348) — is unchanged.

### Version references

`docs: the v3 line ships as 0.11.x` is a separate commit (rule 2): README "ships as" lines
and Cargo snippet, `docs/rust-integration.md`, and the feature matrix's own column label —
`docs/allocator-features.json` still said *"this fork, 0.9.x"*, two releases stale — with
both SVGs re-rendered. `CLAUDE.md`'s repo-facts line said 0.9.x too.

### Release gates run locally

- `cargo run -p xtask -- check` — vendored amalgamation matches `src/`+`include/`
- `cargo publish --dry-run -p mimalloc-pprof --locked` — packages clean as 0.11.0
- `cargo test --locked`

### ⚠️ Known red gate, tracked separately

`main`'s win-gnu bundle is red on `test-purge-all` ([#394](https://github.com/zackees/mimalloc-pprof/issues/394)) —
a C test failure, present on `main` before this PR and unrelated to the crate. The owner has
called the release ready; recording it here rather than leaving it implicit.

After merge: `git tag v0.11.0 <main sha> && git push origin v0.11.0` → `auto-release.yml`
publishes to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA