### PR TITLE
ci(benchmarks): drop the run-attempt suffix from artifact names (#341)

### DIFF
--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -151,7 +151,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-latency-raw-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-latency-raw-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: "${{ runner.temp }}/latency-output-${{ github.run_id }}/"
           include-hidden-files: true
           retention-days: 30
@@ -160,7 +161,8 @@ jobs:
         if: (inputs.mode || 'full') == 'full' && always()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-latency-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-latency-validation-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: |
             ${{ runner.temp }}/latency-report.json
             ${{ runner.temp }}/manifest.sha256
@@ -170,7 +172,8 @@ jobs:
         if: (inputs.mode || 'full') == 'full' && success()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-latency-site-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: ${{ runner.temp }}/site/
           include-hidden-files: true
           retention-days: 30
@@ -189,11 +192,11 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-latency-site-${{ github.run_id }}
           path: audit/site/
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-latency-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-latency-validation-${{ github.run_id }}
           path: audit/validation/
       - name: audit sealed latency site
         run: |
@@ -214,7 +217,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-latency-site-${{ github.run_id }}
           path: site-temp/
       - name: publish exact latency site revision
         run: |
@@ -249,7 +252,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-latency-site-${{ github.run_id }}
           path: _site/
       - uses: actions/upload-pages-artifact@v4.0.0
         with:
@@ -286,7 +289,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-latency-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-latency-site-${{ github.run_id }}
           path: audit/site/
       - name: audit latency publication
         run: |

--- a/.github/workflows/benchmark-memory.yml
+++ b/.github/workflows/benchmark-memory.yml
@@ -154,7 +154,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-memory-raw-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-memory-raw-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: "${{ runner.temp }}/memory-output-${{ github.run_id }}/"
           include-hidden-files: true
           retention-days: 30
@@ -163,7 +164,8 @@ jobs:
         if: (inputs.mode || 'full') == 'full' && always()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-memory-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-memory-validation-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: |
             ${{ runner.temp }}/memory-report.json
             ${{ runner.temp }}/manifest.sha256
@@ -173,7 +175,8 @@ jobs:
         if: (inputs.mode || 'full') == 'full' && success()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-memory-site-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: ${{ runner.temp }}/site/
           include-hidden-files: true
           retention-days: 30
@@ -192,11 +195,11 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-memory-site-${{ github.run_id }}
           path: audit/site/
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-memory-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-memory-validation-${{ github.run_id }}
           path: audit/validation/
       - name: audit sealed memory site
         run: |
@@ -217,7 +220,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-memory-site-${{ github.run_id }}
           path: site-temp/
       - name: publish exact memory site revision
         run: |
@@ -252,7 +255,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-memory-site-${{ github.run_id }}
           path: _site/
       - uses: actions/upload-pages-artifact@v4.0.0
         with:
@@ -289,7 +292,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-memory-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-memory-site-${{ github.run_id }}
           path: audit/site/
       - name: audit memory publication
         run: |

--- a/.github/workflows/benchmark-scaling.yml
+++ b/.github/workflows/benchmark-scaling.yml
@@ -159,7 +159,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-scaling-raw-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-scaling-raw-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: "${{ runner.temp }}/scaling-output-${{ github.run_id }}/"
           include-hidden-files: true
           retention-days: 30
@@ -168,7 +169,8 @@ jobs:
         if: (inputs.mode || 'full') == 'full' && always()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-scaling-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-scaling-validation-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: |
             ${{ runner.temp }}/scaling-report.json
             ${{ runner.temp }}/manifest.sha256
@@ -178,7 +180,8 @@ jobs:
         if: (inputs.mode || 'full') == 'full' && success()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-scaling-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-scaling-site-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: ${{ runner.temp }}/site/
           include-hidden-files: true
           retention-days: 30
@@ -197,11 +200,11 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-scaling-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-scaling-site-${{ github.run_id }}
           path: audit/site/
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-scaling-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-scaling-validation-${{ github.run_id }}
           path: audit/validation/
       - name: audit sealed scaling site
         run: |
@@ -222,7 +225,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-scaling-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-scaling-site-${{ github.run_id }}
           path: site-temp/
       - name: publish exact scaling site revision
         run: |
@@ -257,7 +260,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-scaling-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-scaling-site-${{ github.run_id }}
           path: _site/
       - uses: actions/upload-pages-artifact@v4.0.0
         with:
@@ -294,7 +297,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-scaling-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-scaling-site-${{ github.run_id }}
           path: audit/site/
       - name: audit scaling publication
         run: |

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -183,7 +183,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-raw-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-raw-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: "${{ runner.temp }}/benchmark-output-${{ github.run_id }}/raw-run.json"
           retention-days: 30
           if-no-files-found: ignore
@@ -191,7 +192,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-provenance-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-provenance-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: |
             ${{ runner.temp }}/validation-report.json
             rust/benchmark-suite/allocators/allocator-lock.json
@@ -201,7 +203,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-validation-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: |
             ${{ runner.temp }}/validation-report.json
             ${{ runner.temp }}/manifest.sha256
@@ -211,7 +214,8 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-site-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: ${{ runner.temp }}/site/
           include-hidden-files: true
           retention-days: 30
@@ -220,7 +224,8 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: benchmark-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-diagnostics-${{ github.run_id }}
+          overwrite: true   # a re-run of this job replaces attempt 1's upload (#341)
           path: |
             ${{ runner.temp }}/*.json
             ${{ runner.temp }}/*.sha256
@@ -240,12 +245,12 @@ jobs:
       - name: download site artifact
         uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-site-${{ github.run_id }}
           path: audit/site/
       - name: download validation artifact
         uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-validation-${{ github.run_id }}
           path: audit/validation/
       - name: audit site artifact
         run: |
@@ -271,7 +276,7 @@ jobs:
       - name: download site artifact
         uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-site-${{ github.run_id }}
           path: site-temp/
       - name: validate site before push
         run: |
@@ -323,7 +328,7 @@ jobs:
       - name: download site artifact
         uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-site-${{ github.run_id }}
           path: _site/
       - name: upload pages artifact
         uses: actions/upload-pages-artifact@v4.0.0
@@ -362,7 +367,7 @@ jobs:
       - name: download sealed site artifact
         uses: actions/download-artifact@v4.3.0
         with:
-          name: benchmark-site-${{ github.run_id }}-${{ github.run_attempt }}
+          name: benchmark-site-${{ github.run_id }}
           path: audit/site/
       - name: audit publication
         run: |


### PR DESCRIPTION
Closes #341. One of the four failure modes tracked in #376 / the meta issue #377.

## The bug

Re-running only the failed jobs of a benchmark run leaves attempt 1's artifacts named `<name>-<run_id>-1`, while every consumer in attempt 2 asks for `-2`. Run 33820645718 failed exactly this way: attempt 2's `deploy-pages` succeeded, then `publication-audit` died with

```
Unable to download artifact(s): Artifact not found for name: benchmark-scaling-site-33820645718-2
```

The run id is already unique per run, so the suffix bought nothing but this mismatch.

## The fix

- Artifact names become `<name>-${{ github.run_id }}` across all four production benchmark workflows — 34 names in `benchmark-scaling.yml`, `benchmark-memory.yml`, `benchmark-latency.yml`, `benchmark-stats.yml`.
- Every upload that carries such a name gains `overwrite: true` (14 of them), so a re-run of a job that *did* upload replaces its own artifact rather than colliding with it — the case the attempt suffix presumably existed for.
- `run_attempt` stays in commit messages and step summaries, where it is information rather than a key.

## Verified locally

- `ci/check_benchmark_workflow.py`, `check_benchmark_memory_workflow.py`, `check_benchmark_latency_workflow.py`, `check_benchmark_scaling_workflow.py` — all pass `--selftest` *and* against the real files (25 controls on the scaling one).
- `ci/tests` — 381/381.
- Every benchmark workflow still parses as YAML.

This does not fix the *current* head-of-line blocker in #376 (the `benchmark_report.py render` field mismatch), which still stops `build-and-measure` before any artifact is produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA