### PR TITLE
build: register the #167 lock controls on the effective MI_DEBUG, not the option (#314)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1695,11 +1695,16 @@ if (MI_BUILD_TESTS)
   add_test(NAME test-threadlocal-growth COMMAND mimalloc-test-threadlocal-growth)
   set_tests_properties(test-threadlocal-growth PROPERTIES TIMEOUT 60)
 
-  # MI_DEBUG_FULL-only positive control for the internal lock diagnostics (#167).
-  # The program deliberately reacquires a non-recursive lock. The CMake wrapper
-  # requires an immediate diagnostic failure with the expected message; a deadlock
-  # times out and fails the test instead of wedging the suite.
-  if(MI_DEBUG_FULL)
+  # Positive control for the internal lock diagnostics (#167). The program deliberately
+  # reacquires a non-recursive lock. The CMake wrapper requires an immediate diagnostic
+  # failure with the expected message; a deadlock times out and fails the test instead of
+  # wedging the suite.
+  # #314: gated on `mi_need_diagnostic_c`, NOT on the MI_DEBUG_FULL *option*. The
+  # diagnostics these controls exercise are compiled whenever the EFFECTIVE MI_DEBUG > 2
+  # (#312/#313 -- option, MI_EXTRA_CPPDEFS, or CMAKE_C_FLAGS), so registering them on the
+  # option alone left the `-DMI_EXTRA_CPPDEFS=MI_DEBUG=3` route compiling src/diagnostic.c
+  # with nothing ever running its controls. Same variable, same reason, one layer up.
+  if(mi_need_diagnostic_c)
     add_executable(mimalloc-test-lock-reentrancy test/test-lock-reentrancy.c)
     target_compile_definitions(mimalloc-test-lock-reentrancy PRIVATE ${mi_defines})
     target_compile_options(mimalloc-test-lock-reentrancy PRIVATE ${mi_cflags})
@@ -1741,7 +1746,9 @@ if (MI_BUILD_TESTS)
       test-lock-reentrancy test-lock-uncleared-owner
       test-lock-nonowner-release test-lock-destroy-owned
       PROPERTIES TIMEOUT 15)
+  endif()
 
+  if(MI_DEBUG_FULL)
     # Compile a private amalgamation with deterministic fault/poison controls.
     # MI_TEST_TLS_CONTROL is absent from all library targets and releases.
     add_executable(mimalloc-test-tls-controls src/static.c test/test-tls-controls.c)

--- a/ci/verify_local.py
+++ b/ci/verify_local.py
@@ -313,12 +313,13 @@ def run_debug3_extra(ctx: RunCtx) -> bool:
     this local config additionally runs a small ctest subset.
 
     Only `test-fork-locks*` and `test-api*` run here (ctest -R 'lock|api'), not the full
-    suite `debug-full` covers -- and notably not #167's `test-lock-reentrancy` /
+    suite `debug-full` covers -- plus, since #314, #167's `test-lock-reentrancy` /
     `-uncleared-owner` / `-nonowner-release` / `-destroy-owned` positive controls, which
-    are separately registered under `if(MI_DEBUG_FULL)` in CMakeLists.txt (the same
-    option-vs-effective-value gap this issue is about, but for *test* registration rather
-    than the *source* compiled -- there's no CMake-side way to see a MI_DEBUG=N smuggled
-    into CMAKE_C_FLAGS at the point those tests get registered, so left out of #312's fix).
+    the `lock` half of that filter already matched by name but which CMakeLists.txt used
+    to register under the MI_DEBUG_FULL *option* rather than `mi_need_diagnostic_c` (the
+    effective MI_DEBUG > 2 that #313 computes), so this route compiled src/diagnostic.c
+    and then ran none of its controls. Their registration is asserted below: a filter that
+    silently matches nothing is how that gap stayed invisible in the first place.
     """
     build = ctx.dir / "build"
     rc, configure_out = cmake_configure(
@@ -334,6 +335,30 @@ def run_debug3_extra(ctx: RunCtx) -> bool:
         log_write(ctx.log, "\n[verify_local] FAIL: MI_DEBUG=3 did not reach mi_defines\n")
         return False
     if cmake_build(ctx, build, config="Debug"):
+        return False
+    # #314: the four #167 controls must be REGISTERED on this route, not just matched by a
+    # regex that would happily match nothing.
+    rc, listed = run_logged(
+        ["ctest", "--test-dir", str(build), "-C", "Debug", "-N"], cwd=ROOT, log=ctx.log
+    )
+    if rc:
+        return False
+    missing = [
+        name
+        for name in (
+            "test-lock-reentrancy",
+            "test-lock-uncleared-owner",
+            "test-lock-nonowner-release",
+            "test-lock-destroy-owned",
+        )
+        if name not in listed
+    ]
+    if missing:
+        log_write(
+            ctx.log,
+            f"\n[verify_local] FAIL: #167 lock controls not registered under "
+            f"MI_EXTRA_CPPDEFS=MI_DEBUG=3: {', '.join(missing)}\n",
+        )
         return False
     return ctest_run(ctx, build, config="Debug", filter_regex="lock|api") == 0
 


### PR DESCRIPTION
Closes #314.

## The gap

#313 made `src/diagnostic.c` compile whenever the **effective** `MI_DEBUG > 2` (the option, `MI_EXTRA_CPPDEFS`, or `CMAKE_C_FLAGS`). The four #167 positive controls — `test-lock-reentrancy`, `-uncleared-owner`, `-nonowner-release`, `-destroy-owned` — stayed registered under `if(MI_DEBUG_FULL)`, so the `-DMI_EXTRA_CPPDEFS=MI_DEBUG=3` route compiled the diagnostics and then ran **none** of their controls. Same option-vs-effective-value gap as #312, one layer up: test registration instead of source selection.

## The fix

They register on the same `mi_need_diagnostic_c` #313 introduced (computed at `CMakeLists.txt:418`, so it is available where the tests are declared). The `MI_TEST_TLS_CONTROL` fault-injection tests that happened to share the block are a different feature and keep their `if(MI_DEBUG_FULL)` gate — the block is split rather than widened.

`ci/verify_local.py --only debug3-extra` now **asserts** the four controls are registered. Its filter is `lock|api`, which already matched them by name; they were simply never registered on this route, and a filter that silently matches nothing is exactly how the gap stayed invisible. The docstring claiming CMake cannot see a `MI_DEBUG=N` at registration time is stale as of #313 and is corrected.

## Verified locally

Lock controls / TLS controls registered:

| configure | lock | tls |
|---|---|---|
| `-DMI_EXTRA_CPPDEFS=MI_DEBUG=3` | **4** (was 0) | 0 |
| `-DMI_DEBUG_FULL=ON` | 4 | 32 |
| Release | 0 | 0 |

All four pass on the `MI_EXTRA_CPPDEFS` route, `ci/verify_local.py --only debug3-extra` PASS (10.4s, and the log shows the controls executing), `ci/tests` 381/381, ruff + ruff format + pyright clean.

Two commits per rule 2: `CMakeLists.txt`, then `ci/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA