### PR TITLE
fix(rust): relocatable test binaries + a guard that can actually fire (#294)

### DIFF
--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -653,7 +653,18 @@ jobs:
             rc=0
             cargo test --no-run --target x86_64-pc-windows-msvc "$@" \
               --message-format=json > "cargo-$label.json" || rc=$?
-            jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | .executable' \
+            # #294: the CRATE NAME travels with each path. The guard below has to know
+            # which crate an unstageable binary belongs to, and a basename cannot say --
+            # the profiler crate's integration tests are named after their source files
+            # (t3_stats, t12_proto, ...), so a `*mimalloc_pprof*` basename match would
+            # never fire for the very crate it exists to protect. The raw package id is
+            # no good either: it embeds the checkout path, and this repository is itself
+            # called mimalloc-pprof, so every id on a GitHub runner contains that string.
+            # Cargo writes `path+file:///...#name@version`, collapsing to
+            # `path+file:///...#version` when the crate name equals its directory, so take
+            # the name from between `#` and `@` when it is there and from the last path
+            # segment when it is not.
+            jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | [((.package_id | if test("#[^@/]+@") then (split("#")[1] | split("@")[0]) else (split("#")[0] | split("/") | last) end)), .executable] | @tsv' \
               "cargo-$label.json" > "bins-$label.txt"
             if [ "$rc" -ne 0 ]; then
               jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' "cargo-$label.json" >&2
@@ -671,20 +682,22 @@ jobs:
           # picking a profile by hash ordering.
           mkdir -p dist/msvc-tests/debug dist/msvc-tests/release
           excluded=""
+          excluded_crates=""
           stage() {
           local label="$1" profile="$2"
           # NOT every workspace test binary can be moved to another machine, and the ones
           # that cannot say so in their own bytes.
           #
           # `env!("CARGO_BIN_EXE_<name>")` is expanded by cargo AT COMPILE TIME into the
-          # absolute path of the companion binary in the builder's target directory. Four
-          # tests here spawn `stress-child` that way (bench-harness's planted_control,
-          # rejections and throughput; dashboard's stress_child), so their binaries carry
-          # a literal `/home/runner/work/.../target/.../<profile>/stress-child.exe`. There
-          # is no env override -- the string is frozen into the image -- and a Linux path
-          # cannot be reconstructed on a Windows runner, so shipping `stress-child.exe`
-          # alongside them would not help either. Cross-built, they can only run on the
-          # machine that built them.
+          # absolute path of the companion binary in the builder's target directory, so a
+          # test using it carries a literal
+          # `/home/runner/work/.../target/.../<profile>/stress-child.exe` and can only run
+          # on the machine that built it. Four tests did that (bench-harness's
+          # planted_control, rejections and throughput; dashboard's stress_child) and were
+          # dropped here; #294 moved them to `stress_harness::sibling_bin`, which resolves
+          # the companion at run time relative to the test executable, so they stage and
+          # run like everything else. The scan stays: it is what makes a future
+          # reintroduction visible instead of silent.
           #
           # So detect them by the thing that makes them unrelocatable -- the builder's own
           # target path appearing inside the executable -- rather than by a hardcoded list
@@ -707,9 +720,10 @@ jobs:
             exit 1
           fi
           rm -f scanner-control.bin
-          while read -r bin; do
+          while IFS="$(printf '\t')" read -r crate bin; do
             if grep -aqF "$target_root/" "$bin" 2>/dev/null; then
               excluded="$excluded $(basename "$bin")"
+              excluded_crates="$excluded_crates $crate"
             else
               cp "$bin" "dist/msvc-tests/$profile/"
             fi
@@ -732,7 +746,10 @@ jobs:
           # The profiler's own crate must NEVER land in that set -- it is the reason this
           # lane exists, and losing it silently is exactly the failure this whole phase is
           # supposed to make impossible.
-          case "$excluded" in *mimalloc_pprof*)
+          # #294: matched on the cargo CRATE NAME, which every artifact line now carries,
+          # rather than on a basename the crate's tests never have. Whole-token match:
+          # a substring test would also fire on a crate merely named after this one.
+          case " $excluded_crates " in *" mimalloc-pprof "*)
             echo "::error::a mimalloc-pprof test binary embeds the builder's absolute path; the MSVC lane would silently stop testing the profiler"
             exit 1;; esac
           # cross.yml's `test (x86_64-pc-windows-msvc)` has `pprof: true`, so run-windows

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -666,6 +666,20 @@ jobs:
             # segment when it is not.
             jq -r 'select(.reason == "compiler-artifact" and .profile.test and .executable != null) | [((.package_id | if test("#[^@/]+@") then (split("#")[1] | split("@")[0]) else (split("#")[0] | split("/") | last) end)), .executable] | @tsv' \
               "cargo-$label.json" > "bins-$label.txt"
+            # #294: the companion BINARIES the relocatable tests spawn.
+            # `stress_harness::sibling_bin` looks for them right next to the test
+            # executable, which is what a flat bundle directory gives it -- but only if
+            # they are staged too. They are not test artifacts, so the filter above does
+            # not see them, and before #294 nothing needed them here because the tests
+            # that spawn them were dropped from the bundle entirely.
+            #
+            # Named, not "every bin in the workspace": the workspace's debug binaries come
+            # to 339 MB, almost all of it benchmark-suite runners no test spawns. A test
+            # that starts spawning something else fails loudly on the runner with a bare
+            # "cannot find the file specified", so the assertion below names them here
+            # instead, next to the compiler output.
+            jq -r 'select(.reason == "compiler-artifact" and .executable != null and (.profile.test | not) and (.target.kind | index("bin")) and (.target.name as $n | ["stress-child", "dashboard"] | index($n) != null)) | .executable' \
+              "cargo-$label.json" | sort -u > "companions-$label.txt"
             if [ "$rc" -ne 0 ]; then
               jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' "cargo-$label.json" >&2
               exit "$rc"
@@ -728,9 +742,25 @@ jobs:
               cp "$bin" "dist/msvc-tests/$profile/"
             fi
           done < "bins-$label.txt"
+          # #294: companions are staged unconditionally -- a test that needs one and does
+          # not find it fails with a bare "cannot find the file specified", far from here.
+          while read -r bin; do
+            [ -n "$bin" ] && cp "$bin" "dist/msvc-tests/$profile/"
+          done < "companions-$label.txt"
           }
           stage workspace-debug debug
           stage pprof-release release
+          # #294: a missing companion surfaces on the runner as a bare "cannot find the
+          # file specified" from inside a test, with nothing naming the cause. Say it here
+          # instead, next to the compiler output, the same way the required-test check
+          # below does.
+          for companion in stress-child dashboard; do
+            if [ ! -f "dist/msvc-tests/debug/$companion.exe" ]; then
+              echo "::error::$companion.exe was not staged; the relocatable bench-harness/dashboard tests spawn it as a sibling and would fail on the runner with no explanation"
+              ls dist/msvc-tests/debug
+              exit 1
+            fi
+          done
           if [ -n "$excluded" ]; then
             echo "::warning::not staged (they embed the builder's absolute path via CARGO_BIN_EXE_*, so they cannot run on another machine):$excluded"
             {

--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -740,6 +740,11 @@ jobs:
               excluded_crates="$excluded_crates $crate"
             else
               cp "$bin" "dist/msvc-tests/$profile/"
+              # #294: the runner used to glob *.exe. It cannot any more -- the companions
+              # staged below are executables too, and running `stress-child.exe` directly
+              # makes it read a request from stdin, hit EOF and exit 1. So say which files
+              # are tests, here, where it is known, instead of guessing there.
+              basename "$bin" >> "dist/msvc-tests/$profile/tests.list"
             fi
           done < "bins-$label.txt"
           # #294: companions are staged unconditionally -- a test that needs one and does
@@ -797,8 +802,8 @@ jobs:
             fi
           done
           built=$(cat bins-workspace-debug.txt bins-pprof-release.txt | wc -l)
-          staged=$(( $(ls -1 dist/msvc-tests/debug | wc -l) + $(ls -1 dist/msvc-tests/release | wc -l) ))
-          echo "staged $staged of $built test binaries ($(ls -1 dist/msvc-tests/debug | wc -l) debug + $(ls -1 dist/msvc-tests/release | wc -l) release)"
+          staged=$(( $(wc -l < dist/msvc-tests/debug/tests.list) + $(wc -l < dist/msvc-tests/release/tests.list) ))
+          echo "staged $staged of $built test binaries ($(wc -l < dist/msvc-tests/debug/tests.list) debug + $(wc -l < dist/msvc-tests/release/tests.list) release)"
       - name: Build the PR benchmark sentinel
         # NOT gated on the `benchmark` label even though running it is (see run-windows):
         # this is a cross-build on the Linux builder that already builds the whole Rust
@@ -1269,13 +1274,24 @@ jobs:
           count=0
           for profile in debug release; do
             echo "== $profile =="
-            for test_binary in "rust-bins-msvc/$profile"/*.exe; do
-              [ -e "$test_binary" ] || continue
-              echo "::group::$profile/$(basename "$test_binary")"
+            # #294: the staged set now also contains the companion binaries the
+            # relocatable tests spawn, which are executables but not tests. The build job
+            # wrote tests.list saying which is which; globbing *.exe here would run
+            # `stress-child.exe` as if it were a test suite.
+            manifest="rust-bins-msvc/$profile/tests.list"
+            if [ ! -s "$manifest" ]; then
+              echo "::error::$manifest is missing or empty; the staging job did not say which binaries are tests"
+              ls -1 "rust-bins-msvc/$profile" || true
+              exit 1
+            fi
+            while read -r test_name; do
+              [ -n "$test_name" ] || continue
+              test_binary="rust-bins-msvc/$profile/$test_name"
+              echo "::group::$profile/$test_name"
               "$test_binary" --test-threads=4
               echo "::endgroup::"
               count=$((count + 1))
-            done
+            done < "$manifest"
           done
           echo "ran $count MSVC test binaries"
           # A silently-empty artifact would make this step pass having run nothing.

--- a/rust/bench-harness/tests/planted_control.rs
+++ b/rust/bench-harness/tests/planted_control.rs
@@ -11,7 +11,7 @@ static ALLOCATOR: MiMalloc = MiMalloc;
 
 fn stress_child() -> ChildProgram {
     ChildProgram {
-        program: env!("CARGO_BIN_EXE_stress-child").into(),
+        program: stress_harness::sibling_bin("stress-child"),
         arguments: Vec::new(),
         environment: Vec::new(),
     }

--- a/rust/bench-harness/tests/rejections.rs
+++ b/rust/bench-harness/tests/rejections.rs
@@ -26,7 +26,7 @@ fn child(response: Option<&str>) -> ChildProgram {
         ));
     }
     ChildProgram {
-        program: env!("CARGO_BIN_EXE_stress-child").into(),
+        program: stress_harness::sibling_bin("stress-child"),
         arguments: Vec::new(),
         environment,
     }

--- a/rust/bench-harness/tests/throughput.rs
+++ b/rust/bench-harness/tests/throughput.rs
@@ -9,7 +9,7 @@ static ALLOCATOR: MiMalloc = MiMalloc;
 
 fn stress_child() -> ChildProgram {
     ChildProgram {
-        program: env!("CARGO_BIN_EXE_stress-child").into(),
+        program: stress_harness::sibling_bin("stress-child"),
         arguments: Vec::new(),
         environment: Vec::new(),
     }

--- a/rust/dashboard/tests/stress_child.rs
+++ b/rust/dashboard/tests/stress_child.rs
@@ -19,7 +19,7 @@ fn dashboard_stress_child_accepts_one_request_and_emits_one_response() {
         scenario: ScenarioType::AllocFree,
         execution_mode: ExecutionMode::Normal,
     };
-    let mut child = Command::new(env!("CARGO_BIN_EXE_dashboard"))
+    let mut child = Command::new(stress_harness::sibling_bin("dashboard"))
         .arg("--stress-child")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/rust/stress-harness/src/lib.rs
+++ b/rust/stress-harness/src/lib.rs
@@ -194,6 +194,42 @@ impl SeededRng {
 
 /// Run in-process without a hard timeout. Use a child process when a workload
 /// must be forcibly bounded.
+/// Locate a cargo-built binary that sits next to the running test executable.
+///
+/// #294: `env!("CARGO_BIN_EXE_<name>")` is expanded by cargo AT COMPILE TIME into the
+/// *builder's* absolute path, so a test using it carries a literal
+/// `/home/runner/work/.../target/<profile>/stress-child` in its image and cannot run on
+/// any other machine -- which is why windows-bundles.yml had to detect and drop those
+/// binaries instead of shipping them. Resolving the path at run time keeps the test
+/// relocatable: cargo puts integration-test executables in `<target>/<profile>/deps/`
+/// and binaries one level up in `<target>/<profile>/`, and a test staged into a flat
+/// bundle directory finds its companion right beside it.
+///
+/// `MIMALLOC_PPROF_BIN_DIR` overrides the search entirely, for a bundle that stages
+/// binaries somewhere else again.
+pub fn sibling_bin(name: &str) -> std::path::PathBuf {
+    let file_name = format!("{name}{}", std::env::consts::EXE_SUFFIX);
+    if let Some(dir) = std::env::var_os("MIMALLOC_PPROF_BIN_DIR") {
+        return std::path::PathBuf::from(dir).join(file_name);
+    }
+    let exe = std::env::current_exe().expect("the running test executable has a path");
+    let dir = exe
+        .parent()
+        .expect("the running test executable has a parent directory")
+        .to_path_buf();
+    // Prefer `<profile>/<name>` when we are in `<profile>/deps/`; fall back to a sibling,
+    // which is where a flat test bundle puts both.
+    if dir.file_name().is_some_and(|component| component == "deps") {
+        if let Some(parent) = dir.parent() {
+            let candidate = parent.join(&file_name);
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+    dir.join(file_name)
+}
+
 pub fn run_scenario(
     config: StressConfig,
     scenario: ScenarioType,


### PR DESCRIPTION
Closes #294.

## Part 1 — the binaries

`env!("CARGO_BIN_EXE_<name>")` is expanded by cargo at **compile** time into the builder's absolute path, so four workspace test binaries carried a literal `/home/runner/work/.../target/<profile>/stress-child` and could only run on the machine that built them — bench-harness's `planted_control`, `rejections`, `throughput`, and dashboard's `stress_child`. `windows-bundles.yml` detects exactly that and drops them, so they have had no Windows coverage, and would lose it entirely once the native `rust-native` Windows rows go away.

`stress_harness::sibling_bin` resolves the companion at run time: cargo puts integration tests in `<target>/<profile>/deps/` and binaries one level up, and a test staged into a flat bundle directory finds its companion right beside it — exactly what the Windows bundle provides. `MIMALLOC_PPROF_BIN_DIR` overrides the search for a bundle that stages binaries elsewhere.

**Verified two ways, locally:**

1. The workflow's own rule — `grep -aF "$target_root/"` over each binary: all four now **clean**, where before every one matched.
2. For real: copied the four test binaries plus `stress-child` and `dashboard` into a flat directory with no cargo target tree and ran them there — `rc=0` for all four (1, 1, 7 and 2 tests).

`cargo test --workspace`: 66/66 binaries ok. Clippy clean on the new helper.

## Part 2 — the guard

The guard that must fail if a mimalloc-pprof test binary is ever dropped from the MSVC lane matched the basename `*mimalloc_pprof*`. The crate's 18 integration tests are named after their source files (`t3_stats`, `t12_proto`, `t19_layout`), so **it could never have fired for the crate it exists to protect.**

Each artifact line now carries its cargo **crate name** and the guard is a whole-token match on it. The raw package id would not do: it embeds the checkout path, and this repository is itself called `mimalloc-pprof`, so on a GitHub runner every id contains that string and the guard would fire for any excluded binary at all. Cargo writes `path+file:///...#name@version`, collapsing to `#version` when the crate name equals its directory, so the name is taken from between `#` and `@` when present and from the last path segment when not — validated against this workspace's real `--message-format=json` stream (`bench-harness`, `benchmark-suite`, `dashboard`, `mimalloc-pprof`, `stress-harness`, `xtask`).

Guard behaviour, simulated on a GitHub-shaped checkout path:

| excluded set | result |
|---|---|
| nothing | passes |
| `xtask` (checkout dir is `.../mimalloc-pprof/rust/xtask`) | passes |
| `bench-harness mimalloc-pprof` | **fires** |
| `mimalloc-pprof-extra` | passes |

The scan itself stays — it is what makes a reintroduction visible instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA