### PR TITLE
fix(stress-harness): timing-contract tests run where their hook exists (#295)

### DIFF
--- a/rust/stress-harness/tests/timing_contract.rs
+++ b/rust/stress-harness/tests/timing_contract.rs
@@ -1,3 +1,4 @@
+#[cfg(debug_assertions)]
 use std::time::Instant;
 use stress_harness::{run_scenario, ScenarioType, StressConfig};
 
@@ -12,6 +13,12 @@ fn tiny_config() -> StressConfig {
     }
 }
 
+// #295: `STRESS_HARNESS_TEST_SETUP_DELAY_MS` is a `#[cfg(debug_assertions)]` hook in
+// src/lib.rs -- "never present in release builds", by design, so a release build has
+// nothing to delay and the first assertion below ("test hook must delay setup") fails.
+// The failure was never about the 50 ms tolerance: it is this test asserting a hook that
+// its own build profile compiled out. It runs where the hook exists.
+#[cfg(debug_assertions)]
 #[test]
 fn timed_interval_excludes_setup_delay() {
     std::env::set_var("STRESS_HARNESS_TEST_SETUP_DELAY_MS", "100");
@@ -30,6 +37,8 @@ fn timed_interval_excludes_setup_delay() {
     );
 }
 
+// #295: same -- `STRESS_HARNESS_TEST_PRE_PARK_DELAY_MS` is debug-only (src/lib.rs:282).
+#[cfg(debug_assertions)]
 #[test]
 fn timed_interval_excludes_delay_between_ready_and_start_gate() {
     let mut config = tiny_config();
@@ -51,6 +60,8 @@ fn timed_interval_excludes_delay_between_ready_and_start_gate() {
     );
 }
 
+// #295: no hook, so this one runs in every profile -- and release is where a fixed
+// grace/poll floor would actually matter, since that is what the benchmarks measure with.
 #[test]
 fn timed_interval_has_no_fixed_grace_floor() {
     let result = run_scenario(tiny_config(), ScenarioType::AllocFree).expect("valid configuration");


### PR DESCRIPTION
Closes #295.

## What it actually was

Reproduced release-only, 3/3, as reported. But the issue's two hypotheses — "the tolerance assumes debug-build timings" and "release inlining changes the measured interval" — are both wrong. Every failure is the **first** assertion in its test:

```
timed_interval_excludes_setup_delay                    -> "test hook must delay setup"
timed_interval_excludes_delay_between_ready_and_start_gate -> "test hook must delay pre-start parking"
```

never the 50 ms interval check. `STRESS_HARNESS_TEST_SETUP_DELAY_MS` (`src/lib.rs:359`) and `STRESS_HARNESS_TEST_PRE_PARK_DELAY_MS` (`:282`) are `#[cfg(debug_assertions)]`, and the comment beside the first says so outright:

> Debug-test-only setup delay used to prove that pre-start coordination is outside the reported interval. **It is never present in release builds.**

So in release there is nothing to delay. The harness is behaving exactly as designed; the tests were asserting the effect of a hook their own build profile had compiled out.

## The fix

Both hook-dependent tests are now `#[cfg(debug_assertions)]` too — the profile where they can mean anything. The third test, `timed_interval_has_no_fixed_grace_floor`, needs no hook and **keeps running in both profiles**, deliberately: release is what the benchmarks actually measure with, so it is where a fixed grace/poll floor would bite.

| | before | after |
|---|---|---|
| `--release` | 1 passed, **2 FAILED** | 1 passed |
| debug | 3 passed | 3 passed |

Per the issue's instruction, this fixes the test rather than loosening the tolerance — the tolerance was never involved.

`cargo test --workspace --release`: 66/66 binaries green. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA