### PR TITLE
ci(windows-bundles): Phase D review follow-ups (#296)

### DIFF
--- a/.github/workflows/windows-bundles.yml
+++ b/.github/workflows/windows-bundles.yml
@@ -445,8 +445,19 @@ jobs:
           # `cl`. The toolchain file deliberately does NOT pass it, so this is the check
           # that the detection still fires -- if it stopped, the whole library would
           # quietly switch from C++ atomics to C11 ones with no other symptom.
+          # #296 (2): assert the option itself, from the line CMakeLists.txt prints when it
+          # turns it on (`message(STATUS "Use the C++ compiler to compile (MI_USE_CXX=ON)")`,
+          # CMakeLists.txt:229). `/Zc:__cplusplus` is only a side effect of that decision and
+          # could in principle arrive from somewhere else; the flag check stays as the second
+          # half, because the option being ON and the flag reaching the compiler are two
+          # different claims and this lane depends on both.
+          if ! grep -qF 'Use the C++ compiler to compile (MI_USE_CXX=ON)' configure.log; then
+            echo "::error::MI_USE_CXX is not ON for clang-cl; the library would switch from C++ atomics to C11 ones"
+            grep -E 'Compiler flags|Use the C\+\+' configure.log || true
+            exit 1
+          fi
           if ! grep -qE '^-- Compiler flags .*(/|-)Zc:__cplusplus' configure.log; then
-            echo "::error::clang-cl was not detected as MSVC-like (MI_USE_CXX/Zc:__cplusplus missing)"
+            echo "::error::MI_USE_CXX is ON but /Zc:__cplusplus did not reach the compiler"
             grep -E 'Compiler flags|Use the C\+\+' configure.log || true
             exit 1
           fi
@@ -787,9 +798,6 @@ jobs:
           case " $excluded_crates " in *" mimalloc-pprof "*)
             echo "::error::a mimalloc-pprof test binary embeds the builder's absolute path; the MSVC lane would silently stop testing the profiler"
             exit 1;; esac
-          # cross.yml's `test (x86_64-pc-windows-msvc)` has `pprof: true`, so run-windows
-          # needs these two specifically. Assert it here, next to the compiler output,
-          # instead of letting the consumer fail without saying why.
           # cross.yml's `test (x86_64-pc-windows-msvc)` has `pprof: true`, and it is a
           # RELEASE row, so the dump checks must find these in the release set. Assert it
           # here, next to the compiler output, instead of letting the consumer fail
@@ -1161,7 +1169,27 @@ jobs:
         run: |
           set -uo pipefail
           missing=0
-          for dll in VCRUNTIME140.dll MSVCP140.dll; do
+          # #296 (1): the list comes from the bundle, not from this file. `--allow-msvc-runtime`
+          # waives eight names; hardcoding two here meant a bundle importing one of the other
+          # six (`vcruntime140_1.dll`, say) passed the closure check and then failed on the
+          # runner as a dialog-free 0xC0000135. bundle_tests.py now records the intersection
+          # of "what this bundle imports" and "what was waived" in msvc-runtime.txt.
+          # Union over every MSVC bundle this job runs: they are separate builds and need
+          # not import the same set.
+          dlls=""
+          for bundle in bundle/windows-msvc-x64-release bundle/windows-msvc-x64-debug-full \
+                        bundle/windows-msvc-x64-shared bundle/windows-msvc-x64-gated; do
+            if [ ! -f "$bundle/msvc-runtime.txt" ]; then
+              echo "::error::$bundle/msvc-runtime.txt is missing; the producer did not record which redistributable DLLs it left behind"
+              exit 1
+            fi
+            dlls="$dlls $(tr -d '\r' < "$bundle/msvc-runtime.txt")"
+          done
+          dlls=$(printf '%s\n' $dlls | sort -fu)
+          if [ -z "$dlls" ]; then
+            echo "  the MSVC bundles import no Visual C++ redistributable DLL; nothing to check"
+          fi
+          for dll in $dlls; do
             # `where` is the native lookup and searches the real PATH the loader will use.
             # The System32 fallback is not redundant: this step runs in Git Bash, and if
             # `where.exe` itself were unavailable the loop would otherwise report every
@@ -1650,15 +1678,29 @@ jobs:
           echo "::group::native cl: mimalloc.dll import order"
           cat native-msvc-imports-dll.txt
           echo "::endgroup::"
+          # #296 (3): GATE this, do not merely observe it. The cross MSVC bundles have
+          # asserted REDIRECT_BEHAVIOURAL=1 since phase D (see the gate step above); the
+          # retained native `cl` tree ran the same probe with `|| true` and only printed
+          # the answer, so a native build that stopped overriding would have been visible
+          # in the log and green in the checks. The probe itself always exits 0 by design
+          # (test/test-redirect-probe.c says so): whether a configuration is REQUIRED to
+          # redirect is a property of the configuration, so the requirement is asserted
+          # here, where it is known -- and this configuration is a full MSVC override
+          # build, the same claim the cross bundles already gate.
           native_probe=$(find native-msvc-release/Release -maxdepth 1 -name 'mimalloc-test-redirect-probe.exe' 2>/dev/null | head -1 || true)
-          if [ -n "$native_probe" ]; then
-            probe_dir=$(dirname "$native_probe")
-            PATH="$PWD/$probe_dir:$PATH" "$native_probe" > native-msvc-probe.txt 2>&1 || true
-            echo "native cl redirect probe:"
-            sed 's/^/  /' native-msvc-probe.txt
-          else
+          if [ -z "$native_probe" ]; then
             echo "REDIRECT_BEHAVIOURAL=?" > native-msvc-probe.txt
-            echo "::warning::the native cl tree built no redirect probe"
+            echo "::error::the native cl tree built no redirect probe, so the override claim for the cl build is unverified"
+            exit 1
+          fi
+          probe_dir=$(dirname "$native_probe")
+          probe_rc=0
+          PATH="$PWD/$probe_dir:$PATH" "$native_probe" > native-msvc-probe.txt 2>&1 || probe_rc=$?
+          echo "native cl redirect probe:"
+          sed 's/^/  /' native-msvc-probe.txt
+          if [ "$probe_rc" -ne 0 ] || ! grep -q '^REDIRECT_BEHAVIOURAL=1$' native-msvc-probe.txt; then
+            echo "::error::the native cl build did not prove the override (rc=$probe_rc); its own allocations did not come from mimalloc"
+            exit 1
           fi
       - name: Coverage -- the bundles must run every test the native runner would
         if: ${{ !cancelled() }}

--- a/ci/bundle_tests.py
+++ b/ci/bundle_tests.py
@@ -671,6 +671,10 @@ SYSTEM_DLLS = frozenset(
 #: (CMakeLists.txt turns that on by itself for `cl` and clang-cl alike). soldr's xwin splat
 #: carries import libraries only and no redistributable DLLs, so a cross build could not
 #: ship them even if it wanted to; the `windows-latest` image has them in System32.
+#: #296 (1): where a bundle records the redistributable DLLs it imports and was allowed
+#: not to carry. The consumer verifies these are present before running anything.
+MSVC_RUNTIME_MANIFEST = "msvc-runtime.txt"
+
 MSVC_RUNTIME_DLLS = frozenset(
     name.lower()
     for name in (
@@ -725,6 +729,7 @@ def resolve_runtime_dlls(
     search_dirs: Sequence[Path],
     objdump: str,
     allow_msvc_runtime: bool = False,
+    waived_out: set[str] | None = None,
 ) -> list[Path]:
     """Every non-system DLL the staged files import, transitively, found in `search_dirs`.
 
@@ -742,6 +747,7 @@ def resolve_runtime_dlls(
     """
     # Case-insensitive, because PE import names are (`KERNEL32.dll` vs `kernel32.dll`) and
     # the search directories live on a case-sensitive filesystem during a cross build.
+    waived_msvc_runtime: set[str] = set() if waived_out is None else waived_out
     available: dict[str, Path] = {}
     for directory in search_dirs:
         if not directory.is_dir():
@@ -757,6 +763,13 @@ def resolve_runtime_dlls(
         current = pending.pop(0)
         for imported in read_pe_imports(current, objdump):
             key = imported.lower()
+            # #296 (1): remember the redistributable DLLs this bundle actually leans on.
+            # `--allow-msvc-runtime` waives eight names; a bundle importing one of the six
+            # the runner did not happen to check (`vcruntime140_1.dll`, say) used to pass
+            # here and then fail on the runner as a dialog-free 0xC0000135. Recording the
+            # intersection lets the consumer verify exactly what was waived for it.
+            if allow_msvc_runtime and key in MSVC_RUNTIME_DLLS:
+                waived_msvc_runtime.add(imported)
             if key in carried or is_system_dll(imported, allow_msvc_runtime):
                 continue
             resolved = available.get(key)
@@ -908,15 +921,29 @@ def main(argv: Sequence[str] | None = None) -> int:
                 seen[source.name] = source
                 unique.append(source)
         runtime_dlls: list[Path] = []
+        waived_msvc_runtime: set[str] = set()
         if search_dirs or bool(args.check_dll_closure):
             runtime_dlls = resolve_runtime_dlls(
-                unique, search_dirs, objdump, bool(args.allow_msvc_runtime)
+                unique,
+                search_dirs,
+                objdump,
+                bool(args.allow_msvc_runtime),
+                waived_msvc_runtime,
             )
             for dll in runtime_dlls:
                 if dll.name not in seen:
                     seen[dll.name] = dll
                     unique.append(dll)
         copied = copy_into(out_dir, unique)
+        # #296 (1): the bundle says which redistributable DLLs it was allowed to leave
+        # behind, so the runner checks exactly those instead of a hardcoded pair. Written
+        # whenever the waiver is in force -- an empty file is a real answer ("this bundle
+        # needs none of them") and is not the same as the file being absent.
+        if bool(args.allow_msvc_runtime):
+            (out_dir / MSVC_RUNTIME_MANIFEST).write_text(
+                "".join(f"{name}\n" for name in sorted(waived_msvc_runtime)),
+                encoding="utf-8",
+            )
         manifest_path = write_manifest(out_dir, tests, build_dir, config)
     except BundleError as exc:
         print(f"bundle_tests: {exc}", file=sys.stderr)

--- a/ci/tests/test_test_bundles.py
+++ b/ci/tests/test_test_bundles.py
@@ -1237,11 +1237,36 @@ class RuntimeDllScanTest(unittest.TestCase):
             self._run_no_dirs({"t.exe": ["libgcc_s_seh-1.dll"]}, ["t.exe"], allow_msvc_runtime=True)
         self.assertIn("t.exe imports libgcc_s_seh-1.dll", str(caught.exception))
 
+    def test_waived_msvc_runtime_dlls_are_reported_to_the_consumer(self) -> None:
+        """#296 (1): the bundle has to say WHICH redistributable DLLs it leans on.
+
+        `--allow-msvc-runtime` waives eight names while the runner used to check two by
+        hand, so a bundle importing `vcruntime140_1.dll` passed here and then failed on
+        the runner as a dialog-free 0xC0000135. The waived set is the intersection of what
+        this bundle imports and what the waiver covers -- not the whole allowlist, and not
+        ordinary system DLLs.
+        """
+        waived: set[str] = set()
+        self._run_no_dirs(
+            {"t.exe": ["VCRUNTIME140_1.dll", "MSVCP140.dll", "KERNEL32.dll"]},
+            ["t.exe"],
+            allow_msvc_runtime=True,
+            waived_out=waived,
+        )
+        self.assertEqual(waived, {"VCRUNTIME140_1.dll", "MSVCP140.dll"})
+
+    def test_nothing_is_waived_when_the_lane_did_not_ask(self) -> None:
+        waived: set[str] = set()
+        with self.assertRaises(bundle_tests.BundleError):
+            self._run_no_dirs({"t.exe": ["VCRUNTIME140.dll"]}, ["t.exe"], waived_out=waived)
+        self.assertEqual(waived, set())
+
     def _run_no_dirs(
         self,
         imports: dict[str, list[str]],
         staged: list[str],
         allow_msvc_runtime: bool = False,
+        waived_out: set[str] | None = None,
     ) -> list[Path]:
         build = self.root / "build"
         build.mkdir(exist_ok=True)
@@ -1252,4 +1277,5 @@ class RuntimeDllScanTest(unittest.TestCase):
             [],
             self._launcher(imports),
             allow_msvc_runtime,
+            waived_out,
         )


### PR DESCRIPTION
Closes #296 — four of the five items; the fifth needed no change.

### (1) The redistributable-DLL check is derived, not hardcoded

`--allow-msvc-runtime` waives **eight** names from the closure check while the runner verified **two** by hand. A bundle importing one of the other six — `vcruntime140_1.dll` is the realistic one — passed the closure check and would then have failed on the runner as a dialog-free `0xC0000135`, which is the exact failure that check exists to prevent.

`bundle_tests.py` now records the intersection of *what this bundle imports* and *what the waiver covers* into `msvc-runtime.txt`, and the runner unions those across the four MSVC bundles. An empty file is a real answer ("needs none"); a **missing** file is an error, because the producer has to say.

Two tests: the waived set is exactly the imported-and-waived names (a system DLL in the same import table is not one, and `vcruntime140_1.dll` — the name the old pair missed — is), and nothing is recorded when the lane did not ask for the waiver.

### (2) MI_USE_CXX asserted directly

From the line CMake prints when it turns the option on (`Use the C++ compiler to compile (MI_USE_CXX=ON)`, `CMakeLists.txt:229`) rather than only via the `/Zc:__cplusplus` side effect. The flag check stays as the second half — "the option is ON" and "the flag reached the compiler" are different claims, and this lane depends on both.

### (3) The native `cl` redirect probe is now a gate

The cross MSVC bundles have asserted `REDIRECT_BEHAVIOURAL=1` since phase D. The retained native `cl` tree ran the same probe under `|| true` and only printed the answer — so **a native build that stopped overriding would have been visible in the log and green in the checks.** Now asserted, and a missing probe is an error rather than a warning.

The probe itself still always exits 0, by its own design: whether a configuration is *required* to redirect is a property of the configuration, so the requirement is asserted where that is known.

> If this turns the lane red, that is a genuine finding about the native `cl` build, not something to loosen.

### (5) Duplicated comment block

One block again; the surviving copy is the one that names the release set the loop actually checks.

### (4) needed no change

#307 already corrected that count to "7 → 2". I also verified the neighbouring claim: "branch protection requires `decide` plus 13 other checks" matches the API, which reports **14** required contexts.

## Verification

`ci/tests` 384 → 386 passed (two added), ruff + format + pyright clean. Every `run:` block in the workflow syntax-checked with `bash -n` — 53 blocks, the only non-parsing one being a `pwsh` step. **That check caught a real bug in this change:** an unescaped backtick pair inside a double-quoted `echo` would have executed `cl` as a command.

Items (1) and (3) change bundle contents and a Windows-only gate, so this PR wants the full `windows-bundles` run rather than a local proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA