### PR TITLE
ci(benchmarks): the sparse sweep becomes the daily signal, benchmark-stats goes weekly (#208)

### DIFF
--- a/.github/workflows/benchmark-scaling.yml
+++ b/.github/workflows/benchmark-scaling.yml
@@ -28,7 +28,11 @@ on:
         default: 3
         required: false
   schedule:
-    - cron: "23 7 * * 0"
+    # #208: daily. This landed weekly-first so one live run could prove its budget before
+    # the daily signal depended on it; run 31759621920 did (3m01s measuring, 10m00s job,
+    # 20-minute timeout, `fits_limit: true`), so it takes over from benchmark-stats, which
+    # moves to weekly.
+    - cron: "23 7 * * *"
 
 concurrency:
   group: benchmark-stats-production

--- a/.github/workflows/benchmark-scaling.yml
+++ b/.github/workflows/benchmark-scaling.yml
@@ -1,6 +1,6 @@
 name: benchmark-scaling
 
-# Linux-only thread-scaling sweep. It serializes with the daily producer and
+# Linux-only thread-scaling sweep. It serializes with the other benchmark workflows and
 # publishes through the same sealed branch/Pages pipeline. Coverage mode:
 # 4 patterns x 6 thread points x 5 allocators x 3 blocks. The sweep doubled
 # with the dense thread points (issue #211 WP4) and grew another 25% with the

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -1,6 +1,6 @@
 name: benchmark-stats
 
-# Phase 5 publication: manual + daily schedule, publication eligibility,
+# Phase 5 publication: manual + weekly schedule, publication eligibility,
 # lease-protected benchmark-stats branch push, GitHub Pages deployment,
 # and independent publication audit.
 # First-party actions (checkout, upload-/download-artifact, pages) use

--- a/.github/workflows/benchmark-stats.yml
+++ b/.github/workflows/benchmark-stats.yml
@@ -25,7 +25,12 @@ on:
         default: 15
         required: false
   schedule:
-    - cron: "17 9 * * *"
+    # #208: weekly. The sparse scaling sweep (#204) is the daily freshness signal now;
+    # this is the rigorous suite and it costs ~40 minutes a run. Wednesday, deliberately
+    # away from the Sunday cluster (scaling was 07:23 Sun, memory and latency are 08:41
+    # Sun): all four share the `benchmark-stats-production` concurrency group, so
+    # same-day runs serialize into one long queue.
+    - cron: "17 9 * * 3"
 
 concurrency:
   group: benchmark-stats-production

--- a/ci/check_benchmark_scaling_workflow.py
+++ b/ci/check_benchmark_scaling_workflow.py
@@ -90,6 +90,8 @@ def validate(workflow: Mapping[str, object]) -> None:
     schedule = triggers.get("schedule")
     if not isinstance(schedule, list) or len(cast(list[object], schedule)) != 1:
         fail("workflow.on.schedule: expected exactly one schedule entry")
+    if schedule != [{"cron": "23 7 * * *"}]:
+        fail("workflow.on.schedule: expected daily cron '23 7 * * *' (#208)")
     dispatch = mapping(triggers.get("workflow_dispatch"), "workflow.on.workflow_dispatch")
     inputs = mapping(dispatch.get("inputs"), "workflow.on.workflow_dispatch.inputs")
     if set(inputs) != {"mode", "run_seed", "blocks"}:
@@ -262,6 +264,9 @@ def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
 
 
 MUTATIONS: dict[str, Callable[[dict[str, Any]], None]] = {
+    "weekly scaling schedule": lambda wf: _triggers(wf).__setitem__(
+        "schedule", [{"cron": "23 7 * * 0"}]
+    ),
     "push trigger added": lambda wf: _triggers(wf).__setitem__("push", {"branches": ["main"]}),
     "shared concurrency group dropped": lambda wf: wf.__setitem__(
         "concurrency", {"group": "scaling-only", "cancel-in-progress": False}

--- a/ci/check_benchmark_workflow.py
+++ b/ci/check_benchmark_workflow.py
@@ -139,6 +139,8 @@ def check_triggers(workflow: Mapping[str, object]) -> None:
                 fail(f"workflow.on.{key}: trigger not allowed in Phase 5")
         if "workflow_dispatch" not in on:
             fail("workflow.on: workflow_dispatch is required")
+        if on.get("schedule") != [{"cron": "17 9 * * 3"}]:
+            fail("workflow.on.schedule: expected weekly Wednesday cron '17 9 * * 3' (#208)")
         dispatch = object_value(on["workflow_dispatch"], "workflow.on.workflow_dispatch")
         inputs = object_value(dispatch.get("inputs", {}), "workflow.on.workflow_dispatch.inputs")
         if "publish" in inputs:
@@ -450,7 +452,7 @@ def selftest() -> int:
                     "blocks": {"type": "number", "default": 15, "required": False},
                 }
             },
-            "schedule": [{"cron": "17 9 * * *"}],
+            "schedule": [{"cron": "17 9 * * 3"}],
         },
         "concurrency": {"group": "benchmark-stats-production", "cancel-in-progress": False},
         "permissions": {"contents": "read"},
@@ -546,6 +548,10 @@ def selftest() -> int:
     }
     # valid Phase 5 fixture
     check(base)
+    # negative: the expensive suite must not silently become daily again (#208)
+    bad = cast(dict[str, object], _deep_copy(base))
+    bad["on"]["schedule"] = [{"cron": "17 9 * * *"}]  # type: ignore[index]
+    _expect_policy_error(lambda: check(bad), "daily stats schedule")
     # negative: write permission at workflow level
     bad = cast(dict[str, object], _deep_copy(base))
     bad["permissions"]["contents"] = "write"  # type: ignore[index]

--- a/ci/tests/test_benchmark_scaling_workflow.py
+++ b/ci/tests/test_benchmark_scaling_workflow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import copy
 import unittest
+from typing import cast
 
 import benchmark_report as report
 import check_benchmark_scaling_workflow as policy
@@ -16,6 +17,17 @@ class BenchmarkScalingWorkflowTests(unittest.TestCase):
 
     def test_production_workflow_passes(self) -> None:
         policy.validate(self.workflow())
+
+    def test_daily_cadence_is_required(self) -> None:
+        for schedule in ([], [{"cron": "23 7 * * 0"}], [{}]):
+            with self.subTest(schedule=schedule):
+                value = self.workflow()
+                raw = cast(dict[object, object], value)  # PyYAML 1.1 may use True for `on`.
+                triggers = raw.get("on", raw.get(True))
+                assert isinstance(triggers, dict)
+                triggers["schedule"] = schedule
+                with self.assertRaisesRegex(policy.ScalingWorkflowError, "schedule"):
+                    policy.validate(value)
 
     def test_selftest_negative_controls_all_fail_closed(self) -> None:
         # The selftest is the real guard against a checker that checks nothing.

--- a/ci/tests/test_benchmark_workflow.py
+++ b/ci/tests/test_benchmark_workflow.py
@@ -21,7 +21,7 @@ def _phase5_workflow() -> dict[str, object]:
                     "blocks": {"type": "number", "default": 15, "required": False},
                 }
             },
-            "schedule": [{"cron": "17 9 * * *"}],
+            "schedule": [{"cron": "17 9 * * 3"}],
         },
         "concurrency": {"group": "benchmark-stats-production", "cancel-in-progress": False},
         "permissions": {"contents": "read"},
@@ -118,6 +118,14 @@ def _phase5_workflow() -> dict[str, object]:
 
 
 class TestPhase5Policy(unittest.TestCase):
+    def test_weekly_cadence_is_required(self) -> None:
+        for schedule in (None, [], [{"cron": "17 9 * * *"}], [{"cron": "17 9 * * 0"}]):
+            with self.subTest(schedule=schedule):
+                bad = _phase5_workflow()
+                bad["on"]["schedule"] = schedule
+                with self.assertRaisesRegex(PolicyError, "schedule"):
+                    check(bad)
+
     def test_valid_phase5_fixture_passes(self) -> None:
         check(_phase5_workflow())
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -115,7 +115,8 @@ allocators replay one identical stream inside each paired block.
 | Large buffers | 64 KiB–4 MiB | large allocations with one-byte-per-page touching |
 | Cross-thread handoff | 16–512 B | remote-free pressure; blocks are freed by another worker |
 
-*Protocol `throughput-scaling-sparse-v1`, published weekly.  Full per-cell
+*Protocol `throughput-scaling-sparse-v1`, published daily (#208; it is the daily
+freshness signal, and `benchmark-stats` -- the rigorous suite -- is the weekly one).  Full per-cell
 tables, min/max spreads, and the metric comparison key are on the
 [dashboard](https://zackees.github.io/mimalloc-pprof/#scaling).*
 


### PR DESCRIPTION
Closes #208.

Make the sparse scaling sweep the daily freshness signal (`23 7 * * *`) and move the rigorous benchmark-stats suite to Wednesday (`17 9 * * 3`), away from the Sunday memory/latency cluster. All benchmark workflows retain their shared publication concurrency group. Documentation and workflow comments describe the new cadence.

Both policy checkers now enforce the actual schedule, including exactly one cron entry. Regression tests reject the previous cadence, absent/malformed schedules, and a Sunday stats schedule; selftest controls also reject reverting the swap. Previously, the checker selftests passed even when the real workflow used the wrong cadence.

Validation: the new cadence tests reproduced six failing subcases before the checker fix; afterward 31 focused tests and seven subcases passed. Both policy selftests and checks against the real workflows pass; Ruff and Pyright pass. Pre-push review found only stale cadence comments, now corrected. The branch includes current main and the validated Windows teardown repair from #397. CI is running on the updated head.

**Merge blocker: #376 remains open.** Its scaling publication failures need to be repaired and validated before promoting that workflow to the daily signal. This PR prepares the cadence swap and its checks; it does not claim to resolve those publishing failures.
