### PR TITLE
fix(benchmarks): a round-tripped legacy memory section renders again (#376)

### DIFF
--- a/ci/benchmark_report.py
+++ b/ci/benchmark_report.py
@@ -920,7 +920,19 @@ def fragmentation_reason(scenario_id: str, delta_bytes: int, peak_live_bytes: in
 def validate_memory_sample(value: object, label: str, *, legacy: bool = False) -> dict[str, object]:
     sample = object_value(value, label)
     if legacy:
-        exact_fields(sample, MEMORY_SAMPLE_FIELDS, label)
+        # #376: a legacy section that has been round-tripped through the Rust
+        # `LatestReport` structs comes back carrying `fragmentation_proxy_reason: null`.
+        # `benchmark-scaling-validate` does exactly that on every scaling run -- it reads
+        # the published latest.json, injects the fresh scaling section and writes the whole
+        # file back -- and serde writes the `Option<String>` field
+        # (rust/benchmark-suite/src/memory.rs:274) whether or not the artifact it read had
+        # the key. A null there is precisely the absence the legacy shape means, so it is
+        # accepted; a legacy sample carrying a real reason is still a contradiction between
+        # the methodology it declares and the data it holds, and still fails.
+        allowed = MEMORY_SAMPLE_FIELDS
+        if sample.get("fragmentation_proxy_reason", "absent") is None:
+            allowed = MEMORY_SAMPLE_FIELDS | {"fragmentation_proxy_reason"}
+        exact_fields(sample, allowed, label)
     else:
         exact_fields(sample, MEMORY_SAMPLE_FIELDS | {"fragmentation_proxy_reason"}, label)
     if sample.get("metric_schema_version") != MEMORY_SCHEMA:

--- a/ci/tests/test_benchmark_report.py
+++ b/ci/tests/test_benchmark_report.py
@@ -445,6 +445,41 @@ class BenchmarkReportTests(unittest.TestCase):
         )
         return site, digest
 
+    def test_a_round_tripped_legacy_sample_keeps_rendering(self) -> None:
+        """#376: what stopped the pipeline publishing for three weeks.
+
+        `benchmark-scaling-validate` reads the published latest.json into the Rust
+        `LatestReport` structs, injects the fresh scaling section and writes the whole file
+        back. Serde writes `fragmentation_proxy_reason` (an `Option<String>`,
+        rust/benchmark-suite/src/memory.rs:274) whether or not the artifact it read had the
+        key, so every scaling run handed the renderer a legacy section carrying
+        `fragmentation_proxy_reason: null` -- and the renderer rejected it as an unexpected
+        field. A null there is exactly the absence the legacy shape means.
+        """
+        latest = self.with_complete_memory(self.load_latest(), legacy=True)
+        memory = latest["memory"]
+        assert isinstance(memory, dict)
+        samples = memory["raw_samples"]
+        assert isinstance(samples, list)
+        for sample in samples:
+            assert isinstance(sample, dict)
+            sample["fragmentation_proxy_reason"] = None
+        report.validate_latest(latest, "round-tripped legacy")
+
+    def test_a_legacy_sample_claiming_a_real_reason_is_still_rejected(self) -> None:
+        """The tolerance is for the null serde adds, not for a section whose methodology
+        says the proxy is unconditional while its samples explain why it is missing."""
+        latest = self.with_complete_memory(self.load_latest(), legacy=True)
+        memory = latest["memory"]
+        assert isinstance(memory, dict)
+        samples = memory["raw_samples"]
+        assert isinstance(samples, list)
+        first = samples[0]
+        assert isinstance(first, dict)
+        first["fragmentation_proxy_reason"] = "baseline-not-positive"
+        with self.assertRaisesRegex(report.ReportError, "fragmentation_proxy_reason"):
+            report.validate_latest(latest, "legacy with a reason")
+
     def test_fixture_renders_exact_allowlist_and_validates(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             site, digest = self.render_fixture(Path(temporary))
@@ -2050,9 +2085,16 @@ class LegacyAllocatorLineageTests(unittest.TestCase):
             report.render(source, FIXTURE / "history.jsonl", site, root / "digest", False)
             self.assertTrue((site / "benchmark-fragmentation.png").is_file())
 
-        # The tolerance is for the old shape exactly, not for a mixture: the old
-        # producer could not emit a non-positive delta, and the new one always
-        # writes the reason field.
+        # The tolerance is for the old shape, not for a genuine mixture: the old producer
+        # could not emit a non-positive delta, and a legacy section that *explains* a
+        # missing proxy contradicts the methodology it declares.
+        #
+        # #376 narrowed this. A legacy section carrying `fragmentation_proxy_reason: null`
+        # is NOT a mixture -- it is what serde writes when `benchmark-scaling-validate`
+        # round-trips the published latest.json through the Rust structs to inject a fresh
+        # scaling section, and rejecting it stopped the pipeline publishing for three
+        # weeks. A null is the absence the legacy shape means; only a real reason string is
+        # a contradiction, and that is what is asserted below now.
         degenerate = helper.with_complete_memory(helper.load_latest(), legacy=True)
         target = helper.plant_non_positive_delta(degenerate)
         del target["fragmentation_proxy_reason"]
@@ -2065,7 +2107,7 @@ class LegacyAllocatorLineageTests(unittest.TestCase):
         assert isinstance(memory, dict)
         samples = memory["raw_samples"]
         assert isinstance(samples, list) and isinstance(samples[0], dict)
-        samples[0]["fragmentation_proxy_reason"] = None
+        samples[0]["fragmentation_proxy_reason"] = "baseline-not-positive"
         with self.assertRaisesRegex(report.ReportError, "fields mismatch"):
             report.validate_latest(mixed, "mixed memory shape")
 


### PR DESCRIPTION
The head-of-line blocker in #376 — why `benchmark-scaling.yml` has not published since 2026-08-14, and the second of the three things #377 needs before the chart can show the tier-2 fix.

## Reproduced from the published artifact

Take `benchmark-stats`'s own `latest.json` — its memory section is **legacy** (2026-08-16, methodology *"both operands must be positive"*, no reason key anywhere) — add `fragmentation_proxy_reason: null` to its samples, and the renderer fails with the CI message byte for byte:

```
latest.json.memory.raw_samples[0]: fields mismatch; missing=[] unexpected=['fragmentation_proxy_reason']
```

Without the null it renders fine. So the question was only: where does the null come from?

## Where it comes from

`benchmark-scaling-validate` reads the published `latest.json` into the Rust `LatestReport` structs, injects the fresh scaling section, and writes the **whole file** back. `fragmentation_proxy_reason` is an `Option<String>` with no `skip_serializing_if` (`rust/benchmark-suite/src/memory.rs:274`), so serde writes it as `null` whether or not the artifact it read had the key.

Every scaling run therefore handed the renderer a legacy section carrying a key the legacy shape forbids. **The writer is not a new producer** — it is a faithful copy that cannot help adding the field.

## The fix

The renderer accepts `fragmentation_proxy_reason: null` under the legacy methodology — precisely the absence that shape means. A legacy sample carrying a **real** reason is still a contradiction between the methodology it declares and the data it holds, and is still rejected.

Fixing it on the producer side instead (`skip_serializing_if`) would be wrong: a *modern* sample with a valid proxy also has `reason = None`, and the modern schema lists the key as **required**, so skipping it would break modern artifacts.

## This narrows a deliberate assertion

`test_a_memory_section_from_before_the_optional_proxy_still_validates` asserted that legacy + the reason key is a "mixed shape", reasoning *"the new producer always writes the reason field"* — which missed that the round-trip writer is not a producer. That case now uses a real reason string, and the comment records why. Two tests added (round-tripped section renders; real-reason contradiction still fails), both RED against the unfixed renderer.

## Verified on real data

With the fix, the published `latest.json` still renders to a **byte-identical manifest** (`sha256 a5ef648c…`), so nothing about a modern section changed. `ci/tests` 388 passed; ruff, format, pyright clean.

## Remaining in #376

This unblocks the render step. Of the other three failure modes: the attempt-suffixed artifact name is already fixed (#341, merged), and the `history append` duplicate-run rule and the Pages deployment collision are still open — both of which only bite *after* a run gets this far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA