### PR TITLE
fix(benchmarks): a pin move leaves stale sections pending instead of killing the render (#376)

### DIFF
--- a/ci/benchmark_report.py
+++ b/ci/benchmark_report.py
@@ -4091,11 +4091,74 @@ def pending_scaling_svg(pattern: str, reason: str) -> bytes:
     return ("\n".join(parts) + "\n").encode("utf-8")
 
 
+#: Where each optional section records the allocator each of its samples was measured
+#: against. The shapes differ because the sections were written at different times.
+OPTIONAL_SECTION_SAMPLE_PINS = {
+    "memory": ("raw_samples", "allocator_id", "allocator_source_sha"),
+    "latency": ("raw_samples", "allocator_id", "allocator_source_sha"),
+    "scaling": ("raw_samples", "allocator_id", "allocator_source_sha"),
+}
+
+
+def _pinned_pairs(rows: object, id_key: str, sha_key: str) -> set[tuple[str, str]]:
+    """(allocator, source sha) pairs from a list of records, lock-pinned competitors only.
+
+    The fork's own commit legitimately differs between a carried section and the core run
+    (see `validate_carried_pins`), so it is never part of the comparison.
+    """
+    pairs: set[tuple[str, str]] = set()
+    if not isinstance(rows, list):
+        return pairs
+    for row in cast("list[object]", rows):
+        if not isinstance(row, dict):
+            continue
+        record = cast("dict[str, object]", row)
+        allocator = record.get(id_key)
+        sha = record.get(sha_key)
+        if (
+            isinstance(allocator, str)
+            and isinstance(sha, str)
+            and allocator in LOCK_PINNED_ALLOCATORS
+        ):
+            pairs.add((allocator, sha))
+    return pairs
+
+
+def section_pinned_pairs(section: object) -> set[tuple[str, str]]:
+    """The pins a carried optional section was measured at."""
+    if not isinstance(section, dict):
+        return set()
+    return _pinned_pairs(
+        cast("dict[str, object]", section).get("raw_samples"),
+        "allocator_id",
+        "allocator_source_sha",
+    )
+
+
+def core_pinned_pairs(latest: Mapping[str, object]) -> set[tuple[str, str]]:
+    """The same pins for the core run itself."""
+    return _pinned_pairs(latest.get("allocators"), "allocator_id", "source_sha")
+
+
 def carry_forward_optional_metrics(latest: dict[str, object], prior: dict[str, object]) -> bool:
     validate_latest(prior, "prior latest")
     carried = False
+    core = core_pinned_pairs(latest)
     for metric in ("memory", "latency", "scaling"):
         if metric not in latest and metric in prior:
+            # #376: a section measured against different allocator pins may not ride on this
+            # core envelope. `validate_carried_pins` rejects exactly that a few lines later,
+            # so carrying it anyway does not publish stale data -- it fails the whole render
+            # and publishes NOTHING, which is what a pin move used to do to this pipeline
+            # (the #332 bump to 6def7be9 took benchmark-stats red immediately).
+            #
+            # A section left behind is not lost data: it simply stays `pending`, which the
+            # report already knows how to render, and the next memory/latency/scaling run
+            # refills it at the new pin. Re-baselining one metric at a time is the normal
+            # consequence of moving a pin; a dead pipeline is not.
+            stale = section_pinned_pairs(prior[metric]) - core
+            if stale and core:
+                continue
             latest[metric] = copy.deepcopy(prior[metric])
             pending = list_value(latest["pending_metrics"], "latest.pending_metrics")
             latest["pending_metrics"] = [

--- a/ci/tests/test_benchmark_report.py
+++ b/ci/tests/test_benchmark_report.py
@@ -445,6 +445,68 @@ class BenchmarkReportTests(unittest.TestCase):
         )
         return site, digest
 
+    def test_a_section_measured_at_another_pin_is_left_pending(self) -> None:
+        """#376/#332: moving an allocator pin must not kill the pipeline.
+
+        `validate_carried_pins` refuses a carried section whose lock-pinned competitors
+        differ from the core run's -- correctly, since the two halves would then describe
+        different builds. But the carry-forward copied it anyway, so the whole render died
+        and NOTHING was published: the #332 bump of upstream-mimalloc to 6def7be9 took
+        `benchmark-stats` red on its first run. A section left behind is not lost data; it
+        stays `pending`, which the report already renders, and the next run of that metric
+        refills it at the new pin.
+        """
+        prior = self.with_complete_memory(self.load_latest())
+        fresh = copy.deepcopy(prior)
+        for metric in ("memory", "latency", "scaling"):
+            fresh.pop(metric, None)
+        allocators = fresh["allocators"]
+        assert isinstance(allocators, list)
+        for value in allocators:
+            assert isinstance(value, dict)
+            if value["allocator_id"] == "upstream-mimalloc":
+                value["source_sha"] = "6" * 40
+        fresh["pending_metrics"] = [
+            {
+                "metric_id": metric,
+                "status": "pending",
+                "reason": "not measured at this pin",
+                "phase_issue_url": "https://github.com/zackees/mimalloc-pprof/issues/332",
+            }
+            for metric in ("memory", "latency", "scaling", "pprof-tax")
+        ]
+        self.assertFalse(report.carry_forward_optional_metrics(fresh, prior))
+        self.assertNotIn("memory", fresh)
+        pending = fresh["pending_metrics"]
+        assert isinstance(pending, list)
+        self.assertIn("memory", [cast("dict[str, object]", p)["metric_id"] for p in pending])
+
+    def test_a_section_still_carries_when_only_the_fork_moved(self) -> None:
+        """The everyday case the carry-forward exists for: memory and latency are weekly,
+        the core run is not, so the fork's own commit is routinely newer in the core run
+        than in the section riding on it. That must keep working."""
+        prior = self.with_complete_memory(self.load_latest())
+        fresh = copy.deepcopy(prior)
+        for metric in ("memory", "latency", "scaling"):
+            fresh.pop(metric, None)
+        allocators = fresh["allocators"]
+        assert isinstance(allocators, list)
+        for value in allocators:
+            assert isinstance(value, dict)
+            if value["allocator_id"] == "mimalloc-pprof":
+                value["source_sha"] = "1" * 40
+        fresh["pending_metrics"] = [
+            {
+                "metric_id": metric,
+                "status": "pending",
+                "reason": "x",
+                "phase_issue_url": "https://github.com/zackees/mimalloc-pprof/issues/183",
+            }
+            for metric in ("memory", "latency", "scaling", "pprof-tax")
+        ]
+        self.assertTrue(report.carry_forward_optional_metrics(fresh, prior))
+        self.assertIn("memory", fresh)
+
     def test_a_round_tripped_legacy_sample_keeps_rendering(self) -> None:
         """#376: what stopped the pipeline publishing for three weeks.
 


### PR DESCRIPTION
Third blocker on the way to a published chart (#377), found by actually running the pipeline.

## What happened

The core suite ran clean at the new pin — measurement succeeded — and then died in `render site`:

```
latest.json.memory: allocator source pins differ from the core run
```

`carry_forward_optional_metrics` copies memory/latency/scaling from the published `latest.json` onto the new core envelope **unconditionally**. `validate_carried_pins` then rejects a section whose lock-pinned competitors differ from the core run's — *correctly*, since the two halves would otherwise describe different builds. So the render failed and **nothing was published**.

That is exactly what #332's bump of `upstream-mimalloc` to `6def7be9` did on its first core run ([34078023876](https://github.com/zackees/mimalloc-pprof/actions/runs/34078023876)).

## The fix

The carry-forward now asks the same question the validator does, and skips a section measured at other pins. **Nothing is lost:** the metric stays `pending`, which the report already renders, and the next memory/latency/scaling run refills it at the new pin. Re-baselining one metric at a time is the normal consequence of moving a pin; a dead pipeline is not.

## The everyday case is deliberately untouched

Memory and latency are weekly while the core run is not, so **the fork's own commit is routinely newer** in the core run than in the section riding on it. Only the lock-pinned competitors are compared — precisely the asymmetry `validate_carried_pins` documents after it held `benchmark-stats` red for eight days from 2026-08-27. That path has its own test.

## Verified against the real published artifact

- the 2026-08-16 memory section (old pin) is **left behind** when the core run carries `6def7be9`, and the metric goes back to `pending`;
- it is **still carried** when only the fork's own sha moves.

`ci/tests` 390 passed (two added); ruff, format, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA