### PR TITLE
ci: assert the fork scales like the mimallocs beside it (#371 layer 3)

### DIFF
--- a/.github/workflows/benchmark-scaling.yml
+++ b/.github/workflows/benchmark-scaling.yml
@@ -311,3 +311,19 @@ jobs:
             --site-dir audit/site/ \
             --page-url "${{ needs.deploy-pages.outputs.page_url }}"
           echo "Scaling publication branch and Pages bytes match." >> "$GITHUB_STEP_SUMMARY"
+      - name: The fork must scale like the mimallocs beside it
+        # #371 layer 3. The data to catch that regression was always being published --
+        # `speedup_vs_single_worker`, per allocator, per pattern, per thread point -- and
+        # nothing looked at it, so the fork sat at 1.30x against upstream's 2.60x for
+        # eleven days, through a release and a daily benchmark job.
+        #
+        # Deliberately AFTER publication: a parity failure means the fork got slower, not
+        # that the measurement is untrustworthy, and suppressing the chart would hide the
+        # very evidence someone needs. The site publishes; then this fails loudly.
+        #
+        # Compared against the other two mimallocs IN THE SAME RUN, which is what makes it
+        # gate-able on a hosted runner: absolute rates move with whatever else the machine
+        # is doing, but every row in one run met the same conditions.
+        run: |
+          set -euo pipefail
+          python ci/check_scaling_parity.py --latest audit/site/latest.json

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -57,6 +57,7 @@ jobs:
           python3 ci/check_benchmark_memory_workflow.py --selftest
           python3 ci/check_benchmark_latency_workflow.py --selftest
           python3 ci/check_benchmark_scaling_workflow.py --selftest
+          python3 ci/check_scaling_parity.py --selftest
       # Issue #277 phase B2. Both Apple architectures are cross-built on Linux and the
       # x86_64 bundle runs under dockurr/macos, so a macOS runner label anywhere in
       # .github/workflows is a regression. This is the check that says so out loud --

--- a/ci/check_benchmark_scaling_workflow.py
+++ b/ci/check_benchmark_scaling_workflow.py
@@ -242,8 +242,14 @@ def _build_job(workflow: dict[str, Any]) -> dict[str, Any]:
     return cast(dict[str, Any], cast(dict[str, Any], workflow["jobs"])["build-and-measure"])
 
 
-def _step(workflow: dict[str, Any], name: str) -> dict[str, Any]:
-    for step in cast(list[dict[str, Any]], _build_job(workflow)["steps"]):
+def _step(workflow: dict[str, Any], name: str, job: str | None = None) -> dict[str, Any]:
+    """A step by name, from `build-and-measure` unless another job is named."""
+    steps = (
+        cast(list[dict[str, Any]], cast(dict[str, Any], workflow["jobs"])[job]["steps"])
+        if job is not None
+        else cast(list[dict[str, Any]], _build_job(workflow)["steps"])
+    )
+    for step in steps:
         if step.get("name") == name:
             return step
     raise KeyError(name)
@@ -299,9 +305,12 @@ MUTATIONS: dict[str, Callable[[dict[str, Any]], None]] = {
     "lease dropped": lambda wf: cast(
         list[dict[str, Any]], cast(dict[str, Any], wf["jobs"])["publish-branch"]["steps"]
     )[-1].__setitem__("run", "git push origin HEAD:$PUBLISH_REF"),
-    "publication audit weakened": lambda wf: cast(
-        list[dict[str, Any]], cast(dict[str, Any], wf["jobs"])["publication-audit"]["steps"]
-    )[-1].__setitem__("run", "echo ok"),
+    # #371: by NAME, not by position. This used to mutate `steps[-1]`, which silently
+    # stopped testing the audit step the moment another step was appended after it -- the
+    # parity assertion did exactly that, and the control failed to fail.
+    "publication audit weakened": lambda wf: _step(
+        wf, "audit scaling publication", "publication-audit"
+    ).__setitem__("run", "echo ok"),
 }
 
 

--- a/ci/check_scaling_parity.py
+++ b/ci/check_scaling_parity.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Assert the fork scales like the allocators it is measured against (#371 layer 3).
+
+#371's regression published a chart in which `mimalloc-pprof` gained 1.30x from eight
+threads on the tiny hot path while upstream mimalloc, Bun's fork and jemalloc all gained
+~2.60x -- and it stayed that way for eleven days, through a release and a daily benchmark
+job, because nothing ever looked at the numbers. The data to catch it was already being
+published: `speedup_vs_single_worker` is recorded per allocator, per pattern, per thread
+point, in every run.
+
+This compares the fork against the OTHER MIMALLOCS IN THE SAME RUN, which is what makes it
+usable as a gate on a hosted runner: absolute throughput varies with whatever else the
+machine is doing, but every row in one run met the same conditions, so a ratio between them
+is not noise in the way a rate is.
+
+It runs AFTER publication on purpose. A parity failure means the fork got slower, not that
+the measurement is untrustworthy -- suppressing the chart would hide exactly the evidence
+someone needs. So the site publishes and this then fails loudly.
+
+Usage:
+    check_scaling_parity.py --latest <latest.json> [--min-ratio 0.75] [--pattern ...]
+    check_scaling_parity.py --selftest
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+#: The fork, and the rows it must keep up with. tcmalloc and jemalloc are deliberately not
+#: references here: they are different allocators with their own scaling characteristics,
+#: whereas the other two mimallocs share this one's design and are the honest comparison.
+FORK = "mimalloc-pprof"
+REFERENCES = ("upstream-mimalloc", "bun-mimalloc")
+
+#: Patterns where scaling is the point of the measurement.
+DEFAULT_PATTERNS = ("sparse-tiny-hot", "sparse-mixed-general")
+
+#: The fork must reach this fraction of the best reference's speedup. Wide on purpose: the
+#: regression produced 1.30x against 2.60x (a ratio of 0.50), and a healthy build measures
+#: within a few percent, so 0.75 fails the regression by a distance while tolerating an
+#: unlucky run.
+DEFAULT_MIN_RATIO = 0.75
+
+
+def cells(scaling: Mapping[str, object]) -> list[dict[str, object]]:
+    summaries = scaling.get("cell_summaries")
+    if not isinstance(summaries, list):
+        return []
+    return [
+        cast("dict[str, object]", c) for c in cast("list[object]", summaries) if isinstance(c, dict)
+    ]
+
+
+def top_thread_speedups(
+    scaling: Mapping[str, object], pattern: str
+) -> tuple[int, dict[str, float]]:
+    """(highest thread point, {allocator: speedup}) for one pattern."""
+    rows = [c for c in cells(scaling) if c.get("pattern") == pattern]
+    if not rows:
+        return 0, {}
+    top = max(int(cast("int", c["thread_count"])) for c in rows)
+    out: dict[str, float] = {}
+    for c in rows:
+        if int(cast("int", c["thread_count"])) != top:
+            continue
+        allocator = c.get("allocator_id")
+        speedup = c.get("speedup_vs_single_worker")
+        if isinstance(allocator, str) and isinstance(speedup, (int, float)):
+            out[allocator] = float(speedup)
+    return top, out
+
+
+def check(latest: Mapping[str, object], patterns: tuple[str, ...], min_ratio: float) -> int:
+    scaling = latest.get("scaling")
+    if not isinstance(scaling, dict):
+        print("check_scaling_parity: no scaling section in this report; nothing to compare")
+        return 0
+    problems: list[str] = []
+    checked = 0
+    for pattern in patterns:
+        top, speedups = top_thread_speedups(cast("Mapping[str, object]", scaling), pattern)
+        if not speedups:
+            continue
+        fork = speedups.get(FORK)
+        refs = {name: speedups[name] for name in REFERENCES if name in speedups}
+        if fork is None or not refs:
+            continue
+        best_name, best = max(refs.items(), key=lambda item: item[1])
+        ratio = fork / best if best > 0 else 0.0
+        checked += 1
+        verdict = "ok" if ratio >= min_ratio else "FAIL"
+        print(
+            f"  {pattern} @{top} threads: {FORK} {fork:.2f}x vs {best_name} {best:.2f}x "
+            f"-> {ratio:.2f} of it  [{verdict}]"
+        )
+        if ratio < min_ratio:
+            problems.append(
+                f"{pattern}: {FORK} gains only {fork:.2f}x from {top} threads while "
+                f"{best_name} gains {best:.2f}x ({ratio:.2f} of it, floor {min_ratio:.2f})"
+            )
+    if not checked:
+        print("check_scaling_parity: no comparable cells found; nothing asserted")
+        return 0
+    if problems:
+        print("\ncheck_scaling_parity: the fork is not scaling like the mimallocs beside it\n")
+        for problem in problems:
+            print(f"  - {problem}")
+        print(
+            "\n  This is the #371 shape: work done on every allocation that touches memory "
+            "shared\n  between threads. See MI_OBSERVERS_INITIAL in "
+            "include/mimalloc/internal.h, and\n  test-observer-scaling for the same "
+            "assertion at ctest scale.",
+        )
+        return 1
+    print(f"check_scaling_parity: PASS ({checked} pattern(s) at parity)")
+    return 0
+
+
+def selftest() -> int:
+    """The regression, and a healthy run, on synthetic sections."""
+    ok = True
+
+    def section(fork_speedup: float) -> dict[str, object]:
+        rows: list[dict[str, object]] = []
+        for allocator, speedup in (
+            (FORK, fork_speedup),
+            ("upstream-mimalloc", 2.60),
+            ("bun-mimalloc", 2.58),
+        ):
+            for threads in (1, 8):
+                rows.append(
+                    {
+                        "pattern": "sparse-tiny-hot",
+                        "allocator_id": allocator,
+                        "thread_count": threads,
+                        "speedup_vs_single_worker": (1.0 if threads == 1 else speedup),
+                        "median_throughput": 1.0,
+                    }
+                )
+        return {"cell_summaries": rows}
+
+    regressed = {"scaling": section(1.30)}
+    if check(regressed, ("sparse-tiny-hot",), DEFAULT_MIN_RATIO) != 1:
+        print("FAIL: the published regression (1.30x vs 2.60x) was not caught")
+        ok = False
+    healthy = {"scaling": section(2.55)}
+    if check(healthy, ("sparse-tiny-hot",), DEFAULT_MIN_RATIO) != 0:
+        print("FAIL: a healthy run was flagged")
+        ok = False
+    # A run with no scaling section must not fail: sections are carried forward and a
+    # metric that has not been measured at these pins is legitimately absent (#376).
+    if check({}, ("sparse-tiny-hot",), DEFAULT_MIN_RATIO) != 0:
+        print("FAIL: a report with no scaling section was treated as a regression")
+        ok = False
+    print("check_scaling_parity --selftest:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--latest", type=Path)
+    parser.add_argument("--min-ratio", type=float, default=DEFAULT_MIN_RATIO)
+    parser.add_argument("--pattern", action="append", dest="patterns")
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args(argv)
+    if args.selftest:
+        return selftest()
+    if args.latest is None:
+        parser.error("--latest is required unless --selftest")
+    latest = json.loads(Path(cast("Path", args.latest)).read_text(encoding="utf-8"))
+    patterns = tuple(cast("list[str]", args.patterns) or DEFAULT_PATTERNS)
+    return check(latest, patterns, float(cast("float", args.min_ratio)))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/verify_local.py
+++ b/ci/verify_local.py
@@ -790,6 +790,8 @@ def run_lint(ctx: RunCtx) -> bool:
         "ci/check_benchmark_memory_workflow.py",
         "ci/check_benchmark_latency_workflow.py",
         "ci/check_benchmark_scaling_workflow.py",
+        # #371 layer 3: the published-parity assertion's own parsers.
+        "ci/check_scaling_parity.py",
     ):
         rc, _ = run_logged(
             ["uv", "run", "--with", "pyyaml==6.0.2", script, "--selftest"],


### PR DESCRIPTION
The third and last layer of #371's regression gate.

## The data was always there

`speedup_vs_single_worker` is published per allocator, per pattern, per thread point, in every run. Nothing looked at it — so the fork sat at **1.30× against upstream's 2.60×** for eleven days, through a release and a daily benchmark job, with every chart cheerfully drawing it.

## What it does

Compares the fork against the **other two mimallocs in the same run**. That is what makes it gate-able on a hosted runner: absolute rates move with whatever else the machine is doing, but every row in one run met the same conditions, so a ratio between them is not noise the way a rate is.

tcmalloc and jemalloc are deliberately *not* references — different allocators with their own scaling characteristics. The two mimallocs share this one's design and are the honest comparison.

**It runs after publication, on purpose.** A parity failure means the fork got slower, not that the measurement is untrustworthy, and suppressing the chart would hide exactly the evidence someone needs. The site publishes; then this fails loudly.

Floor is **0.75** of the best reference: the regression measured 0.50 of it, a healthy build lands within a few percent. A report with no scaling section **passes** rather than fails, since a metric not yet measured at the current pins is legitimately absent (#376).

## Verified against the live published artifact

Run against the regression that is published *right now*:

```
sparse-tiny-hot      @8: mimalloc-pprof 1.30x vs bun-mimalloc 2.60x -> 0.50 of it  [FAIL]
sparse-mixed-general @8: mimalloc-pprof 1.61x vs bun-mimalloc 2.64x -> 0.61 of it  [FAIL]
```

exit 1. Its selftest covers the regression, a healthy run, and an absent section.

## Two of this repo's drift guards caught me, and both were right

1. `verify_local.py` must mirror every `python-lint` command — the new selftest is registered there too.
2. The scaling workflow's **"publication audit weakened"** negative control mutated `steps[-1]`, which silently stopped testing the audit step the moment a step was appended after it — exactly what this change does. That control now finds its step **by name**, in its own job. It was a latent hole, not just an inconvenience.

`ci/tests` 390 passed; ruff, format, pyright clean; both scaling-workflow checkers pass selftest and live.

## Sequencing

Held unmerged with #391 until the published chart is verified — neither should risk perturbing the pipeline that is mid-flight producing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA