### PR TITLE
docs: lead the README with the feature matrix and the scaling charts

### DIFF
--- a/.github/assets/allocator-features-dark.svg
+++ b/.github/assets/allocator-features-dark.svg
@@ -6,571 +6,571 @@
 <text x="24" y="26" font-size="17" font-weight="600" fill="#e6edf3">Allocator feature comparison</text>
 <text x="24" y="46" font-size="11" fill="#8b949e">Sourced cell by cell in docs/allocator-features.json. Upstream and Bun are the exact commits this fork pins to and ports from; jemalloc is the build in the benchmark lockfile. The measured row is the committed churn benchmark,</text>
 <text x="24" y="61" font-size="11" fill="#8b949e">whose upstream arm is v3.4.3 (bcee5a88).</text>
-<text x="525.0" y="93" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">mimalloc-pprof</text>
-<text x="525.0" y="108" font-size="10" text-anchor="middle" fill="#8b949e">this fork, 0.9.x</text>
-<text x="735.0" y="93" font-size="12.5" font-weight="600" text-anchor="middle" fill="#8b949e">Microsoft MiMalloc-V3</text>
-<text x="735.0" y="108" font-size="10" text-anchor="middle" fill="#8b949e">v3 dev3 @ 6def7be9</text>
-<text x="945.0" y="93" font-size="12.5" font-weight="600" text-anchor="middle" fill="#8b949e">Bun mimalloc</text>
-<text x="945.0" y="108" font-size="10" text-anchor="middle" fill="#8b949e">oven-sh @ b20b60d9</text>
-<text x="1155.0" y="93" font-size="12.5" font-weight="600" text-anchor="middle" fill="#8b949e">jemalloc</text>
-<text x="1155.0" y="108" font-size="10" text-anchor="middle" fill="#8b949e">5.3.1 @ 81034ce1</text>
+<text x="432.0" y="93" font-size="12.5" font-weight="700" fill="#e6edf3">mimalloc-pprof</text>
+<text x="432.0" y="108" font-size="10" fill="#8b949e">this fork, 0.9.x</text>
+<text x="642.0" y="93" font-size="12.5" font-weight="600" fill="#8b949e">Microsoft MiMalloc-V3</text>
+<text x="642.0" y="108" font-size="10" fill="#8b949e">v3 dev3 @ 6def7be9</text>
+<text x="852.0" y="93" font-size="12.5" font-weight="600" fill="#8b949e">Bun mimalloc</text>
+<text x="852.0" y="108" font-size="10" fill="#8b949e">oven-sh @ b20b60d9</text>
+<text x="1062.0" y="93" font-size="12.5" font-weight="600" fill="#8b949e">jemalloc</text>
+<text x="1062.0" y="108" font-size="10" fill="#8b949e">5.3.1 @ 81034ce1</text>
 <line x1="24" y1="133" x2="1260" y2="133" stroke="#30363d" stroke-width="1"/>
 <text x="24" y="154.0" font-size="12" font-weight="700" fill="#e6edf3" letter-spacing="0.4">MEMORY RETURN</text>
 <text x="24" y="179.0" font-size="12" fill="#e6edf3">Process-wide eager purge, from any thread</text>
-<circle cx="452.8" cy="175.0" r="7.0" fill="#3fb950"/>
-<path d="M 449.4 175.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="463.8" y="179.0" font-size="11" fill="#8b949e">gated 72 %, default parked</text>
-<circle cx="665.5" cy="175.0" r="7.0" fill="#f85149"/>
-<path d="M 662.5 172.0 l 6.0 6.0 M 668.5 172.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="676.5" y="179.0" font-size="11" fill="#8b949e">mi_collect is caller-only</text>
-<circle cx="875.5" cy="175.0" r="7.0" fill="#f85149"/>
-<path d="M 872.5 172.0 l 6.0 6.0 M 878.5 172.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="886.5" y="179.0" font-size="11" fill="#8b949e">mi_collect is caller-only</text>
-<circle cx="1088.2" cy="175.0" r="7.0" fill="#3fb950"/>
-<path d="M 1084.8 175.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1099.2" y="179.0" font-size="11" fill="#8b949e">MALLCTL_ARENAS_ALL, 74 %</text>
+<circle cx="439.0" cy="175.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 175.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="179.0" font-size="11" fill="#8b949e">gated 72 %, default parked</text>
+<circle cx="649.0" cy="175.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 172.0 l 6.0 6.0 M 652.0 172.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="179.0" font-size="11" fill="#8b949e">mi_collect is caller-only</text>
+<circle cx="859.0" cy="175.0" r="7.0" fill="#f85149"/>
+<path d="M 856.0 172.0 l 6.0 6.0 M 862.0 172.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="179.0" font-size="11" fill="#8b949e">mi_collect is caller-only</text>
+<circle cx="1069.0" cy="175.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 175.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="179.0" font-size="11" fill="#8b949e">MALLCTL_ARENAS_ALL, 74 %</text>
 <rect x="16" y="187.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="203.0" font-size="12" fill="#e6edf3">Purge the calling thread's own memory</text>
-<circle cx="466.3" cy="199.0" r="7.0" fill="#3fb950"/>
-<path d="M 462.9 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="203.0" font-size="11" fill="#8b949e">mi_collect, idle hook</text>
-<circle cx="706.0" cy="199.0" r="7.0" fill="#3fb950"/>
-<path d="M 702.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="717.0" y="203.0" font-size="11" fill="#8b949e">mi_collect</text>
-<circle cx="886.3" cy="199.0" r="7.0" fill="#3fb950"/>
-<path d="M 882.9 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="897.3" y="203.0" font-size="11" fill="#8b949e">mi_collect, idle hook</text>
-<circle cx="1077.4" cy="199.0" r="7.0" fill="#3fb950"/>
-<path d="M 1074.0 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1088.4" y="203.0" font-size="11" fill="#8b949e">tcache.flush + arena.i.purge</text>
+<circle cx="439.0" cy="199.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="203.0" font-size="11" fill="#8b949e">mi_collect, idle hook</text>
+<circle cx="649.0" cy="199.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="203.0" font-size="11" fill="#8b949e">mi_collect</text>
+<circle cx="859.0" cy="199.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="203.0" font-size="11" fill="#8b949e">mi_collect, idle hook</text>
+<circle cx="1069.0" cy="199.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="203.0" font-size="11" fill="#8b949e">tcache.flush + arena.i.purge</text>
 <text x="24" y="227.0" font-size="12" fill="#e6edf3">Sweep another thread's heap for it</text>
-<circle cx="455.5" cy="223.0" r="7.0" fill="#3fb950"/>
-<path d="M 452.1 223.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="466.5" y="227.0" font-size="11" fill="#8b949e">all gated; parked default</text>
-<circle cx="681.7" cy="223.0" r="7.0" fill="#f85149"/>
-<path d="M 678.7 220.0 l 6.0 6.0 M 684.7 220.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="692.7" y="227.0" font-size="11" fill="#8b949e">no scavenger at all</text>
-<circle cx="891.7" cy="223.0" r="7.0" fill="#d29922"/>
-<path d="M 891.7 219.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="891.7" cy="226.4" r="1.1" fill="#ffffff"/>
-<text x="902.7" y="227.0" font-size="11" fill="#8b949e">parked threads only</text>
-<circle cx="1074.7" cy="223.0" r="7.0" fill="#d29922"/>
-<path d="M 1074.7 219.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1074.7" cy="226.4" r="1.1" fill="#ffffff"/>
-<text x="1085.7" y="227.0" font-size="11" fill="#8b949e">arena purge, not their tcache</text>
+<circle cx="439.0" cy="223.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 223.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="227.0" font-size="11" fill="#8b949e">all gated; parked default</text>
+<circle cx="649.0" cy="223.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 220.0 l 6.0 6.0 M 652.0 220.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="227.0" font-size="11" fill="#8b949e">no scavenger at all</text>
+<circle cx="859.0" cy="223.0" r="7.0" fill="#d29922"/>
+<path d="M 859.0 219.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="859.0" cy="226.4" r="1.1" fill="#ffffff"/>
+<text x="870.0" y="227.0" font-size="11" fill="#8b949e">parked threads only</text>
+<circle cx="1069.0" cy="223.0" r="7.0" fill="#d29922"/>
+<path d="M 1069.0 219.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="226.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="227.0" font-size="11" fill="#8b949e">arena purge, not their tcache</text>
 <rect x="16" y="235.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="251.0" font-size="12" fill="#e6edf3">Sub-page return inside a still-used page</text>
-<circle cx="450.1" cy="247.0" r="7.0" fill="#3fb950"/>
-<path d="M 446.7 247.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="461.1" y="251.0" font-size="11" fill="#8b949e">hole purging, on by default</text>
-<circle cx="689.8" cy="247.0" r="7.0" fill="#f85149"/>
-<path d="M 686.8 244.0 l 6.0 6.0 M 692.8 244.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="700.8" y="251.0" font-size="11" fill="#8b949e">whole pages only</text>
-<circle cx="870.1" cy="247.0" r="7.0" fill="#3fb950"/>
-<path d="M 866.7 247.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="881.1" y="251.0" font-size="11" fill="#8b949e">hole purging, on by default</text>
-<circle cx="1096.3" cy="247.0" r="7.0" fill="#f85149"/>
-<path d="M 1093.3 244.0 l 6.0 6.0 M 1099.3 244.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1107.3" y="251.0" font-size="11" fill="#8b949e">extent-granular purge</text>
+<circle cx="439.0" cy="247.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 247.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="251.0" font-size="11" fill="#8b949e">hole purging, on by default</text>
+<circle cx="649.0" cy="247.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 244.0 l 6.0 6.0 M 652.0 244.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="251.0" font-size="11" fill="#8b949e">whole pages only</text>
+<circle cx="859.0" cy="247.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 247.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="251.0" font-size="11" fill="#8b949e">hole purging, on by default</text>
+<circle cx="1069.0" cy="247.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 244.0 l 6.0 6.0 M 1072.0 244.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="251.0" font-size="11" fill="#8b949e">extent-granular purge</text>
 <text x="24" y="275.0" font-size="12" fill="#e6edf3">Background purge thread</text>
-<circle cx="487.9" cy="271.0" r="7.0" fill="#3fb950"/>
-<path d="M 484.5 271.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="498.9" y="275.0" font-size="11" fill="#8b949e">on by default</text>
-<circle cx="668.2" cy="271.0" r="7.0" fill="#f85149"/>
-<path d="M 665.2 268.0 l 6.0 6.0 M 671.2 268.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="679.2" y="275.0" font-size="11" fill="#8b949e">purge waits for a malloc</text>
-<circle cx="907.9" cy="271.0" r="7.0" fill="#3fb950"/>
-<path d="M 904.5 271.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="918.9" y="275.0" font-size="11" fill="#8b949e">on by default</text>
-<circle cx="1115.2" cy="271.0" r="7.0" fill="#d29922"/>
-<path d="M 1115.2 267.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1115.2" cy="274.4" r="1.1" fill="#ffffff"/>
-<text x="1126.2" y="275.0" font-size="11" fill="#8b949e">off by default</text>
+<circle cx="439.0" cy="271.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 271.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="275.0" font-size="11" fill="#8b949e">on by default</text>
+<circle cx="649.0" cy="271.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 268.0 l 6.0 6.0 M 652.0 268.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="275.0" font-size="11" fill="#8b949e">purge waits for a malloc</text>
+<circle cx="859.0" cy="271.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 271.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="275.0" font-size="11" fill="#8b949e">on by default</text>
+<circle cx="1069.0" cy="271.0" r="7.0" fill="#d29922"/>
+<path d="M 1069.0 267.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="274.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="275.0" font-size="11" fill="#8b949e">off by default</text>
 <rect x="16" y="283.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="299.0" font-size="12" fill="#e6edf3">Time-delayed / decaying purge</text>
-<circle cx="474.4" cy="295.0" r="7.0" fill="#3fb950"/>
-<path d="M 471.0 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="485.4" y="299.0" font-size="11" fill="#8b949e">purge_delay 100 ms</text>
-<circle cx="681.7" cy="295.0" r="7.0" fill="#3fb950"/>
-<path d="M 678.3 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="692.7" y="299.0" font-size="11" fill="#8b949e">purge_delay 1000 ms</text>
-<circle cx="894.4" cy="295.0" r="7.0" fill="#3fb950"/>
-<path d="M 891.0 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="905.4" y="299.0" font-size="11" fill="#8b949e">purge_delay 100 ms</text>
-<circle cx="1101.7" cy="295.0" r="7.0" fill="#3fb950"/>
-<path d="M 1098.3 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1112.7" y="299.0" font-size="11" fill="#8b949e">dirty_decay_ms 10 s</text>
+<circle cx="439.0" cy="295.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="299.0" font-size="11" fill="#8b949e">purge_delay 100 ms</text>
+<circle cx="649.0" cy="295.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="299.0" font-size="11" fill="#8b949e">purge_delay 1000 ms</text>
+<circle cx="859.0" cy="295.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="299.0" font-size="11" fill="#8b949e">purge_delay 100 ms</text>
+<circle cx="1069.0" cy="295.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="299.0" font-size="11" fill="#8b949e">dirty_decay_ms 10 s</text>
 <text x="24" y="323.0" font-size="12" fill="#e6edf3">RSS returned after 10 s idle (churn)</text>
-<text x="525.0" y="323.0" font-size="11" text-anchor="middle" fill="#e6edf3">74 %</text>
-<text x="735.0" y="323.0" font-size="11" text-anchor="middle" fill="#e6edf3">0 % (18 % w/ mi_collect)</text>
-<text x="945.0" y="323.0" font-size="11" text-anchor="middle" fill="#e6edf3">74 %</text>
-<text x="1155.0" y="323.0" font-size="11" text-anchor="middle" fill="#e6edf3">0 % (74 % if asked)</text>
+<text x="450.0" y="323.0" font-size="11" fill="#e6edf3">74 %</text>
+<text x="660.0" y="323.0" font-size="11" fill="#e6edf3">0 % (18 % w/ mi_collect)</text>
+<text x="870.0" y="323.0" font-size="11" fill="#e6edf3">74 %</text>
+<text x="1080.0" y="323.0" font-size="11" fill="#e6edf3">0 % (74 % if asked)</text>
 <text x="24" y="352.0" font-size="12" font-weight="700" fill="#e6edf3" letter-spacing="0.4">PROFILING AND OBSERVABILITY</text>
 <text x="24" y="377.0" font-size="12" fill="#e6edf3">pprof-compatible sampled heap profiler</text>
-<circle cx="485.2" cy="373.0" r="7.0" fill="#3fb950"/>
-<path d="M 481.8 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="496.2" y="377.0" font-size="11" fill="#8b949e">runtime opt-in</text>
-<circle cx="703.3" cy="373.0" r="7.0" fill="#f85149"/>
-<path d="M 700.3 370.0 l 6.0 6.0 M 706.3 370.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="714.3" y="377.0" font-size="11" fill="#8b949e">none at all</text>
-<circle cx="905.2" cy="373.0" r="7.0" fill="#3fb950"/>
-<path d="M 901.8 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="916.2" y="377.0" font-size="11" fill="#8b949e">runtime opt-in</text>
-<circle cx="1088.2" cy="373.0" r="7.0" fill="#3fb950"/>
-<path d="M 1084.8 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1099.2" y="377.0" font-size="11" fill="#8b949e">build-time --enable-prof</text>
+<circle cx="439.0" cy="373.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="377.0" font-size="11" fill="#8b949e">runtime opt-in</text>
+<circle cx="649.0" cy="373.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 370.0 l 6.0 6.0 M 652.0 370.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="377.0" font-size="11" fill="#8b949e">none at all</text>
+<circle cx="859.0" cy="373.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="377.0" font-size="11" fill="#8b949e">runtime opt-in</text>
+<circle cx="1069.0" cy="373.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="377.0" font-size="11" fill="#8b949e">build-time --enable-prof</text>
 <rect x="16" y="385.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="401.0" font-size="12" fill="#e6edf3">Heap profiler on Windows</text>
-<circle cx="485.2" cy="397.0" r="7.0" fill="#3fb950"/>
-<path d="M 481.8 397.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="496.2" y="401.0" font-size="11" fill="#8b949e">MSVC and MinGW</text>
-<circle cx="703.3" cy="397.0" r="7.0" fill="#f85149"/>
-<path d="M 700.3 394.0 l 6.0 6.0 M 706.3 394.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="714.3" y="401.0" font-size="11" fill="#8b949e">no profiler</text>
-<circle cx="886.3" cy="397.0" r="7.0" fill="#d29922"/>
-<path d="M 886.3 393.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="886.3" cy="400.4" r="1.1" fill="#ffffff"/>
-<text x="897.3" y="401.0" font-size="11" fill="#8b949e">frames, no module map</text>
-<circle cx="1088.2" cy="397.0" r="7.0" fill="#d29922"/>
-<path d="M 1088.2 393.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1088.2" cy="400.4" r="1.1" fill="#ffffff"/>
-<text x="1099.2" y="401.0" font-size="11" fill="#8b949e">not MSVC; MinGW untested</text>
+<circle cx="439.0" cy="397.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 397.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="401.0" font-size="11" fill="#8b949e">MSVC and MinGW</text>
+<circle cx="649.0" cy="397.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 394.0 l 6.0 6.0 M 652.0 394.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="401.0" font-size="11" fill="#8b949e">no profiler</text>
+<circle cx="859.0" cy="397.0" r="7.0" fill="#d29922"/>
+<path d="M 859.0 393.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="859.0" cy="400.4" r="1.1" fill="#ffffff"/>
+<text x="870.0" y="401.0" font-size="11" fill="#8b949e">frames, no module map</text>
+<circle cx="1069.0" cy="397.0" r="7.0" fill="#d29922"/>
+<path d="M 1069.0 393.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="400.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="401.0" font-size="11" fill="#8b949e">not MSVC; MinGW untested</text>
 <text x="24" y="425.0" font-size="12" fill="#e6edf3">profile.proto (protobuf) output</text>
-<circle cx="471.7" cy="421.0" r="7.0" fill="#3fb950"/>
-<path d="M 468.3 421.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="482.7" y="425.0" font-size="11" fill="#8b949e">and gperftools text</text>
-<circle cx="703.3" cy="421.0" r="7.0" fill="#f85149"/>
-<path d="M 700.3 418.0 l 6.0 6.0 M 706.3 418.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="714.3" y="425.0" font-size="11" fill="#8b949e">no profiler</text>
-<circle cx="945.0" cy="421.0" r="7.0" fill="#3fb950"/>
-<path d="M 941.6 421.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="1085.5" cy="421.0" r="7.0" fill="#f85149"/>
-<path d="M 1082.5 418.0 l 6.0 6.0 M 1088.5 418.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1096.5" y="425.0" font-size="11" fill="#8b949e">text format; jeprof reads</text>
+<circle cx="439.0" cy="421.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 421.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="425.0" font-size="11" fill="#8b949e">and gperftools text</text>
+<circle cx="649.0" cy="421.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 418.0 l 6.0 6.0 M 652.0 418.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="425.0" font-size="11" fill="#8b949e">no profiler</text>
+<circle cx="859.0" cy="421.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 421.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="1069.0" cy="421.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 418.0 l 6.0 6.0 M 1072.0 418.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="425.0" font-size="11" fill="#8b949e">text format; jeprof reads</text>
 <rect x="16" y="433.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="449.0" font-size="12" fill="#e6edf3">Exact allocator statistics</text>
-<circle cx="490.6" cy="445.0" r="7.0" fill="#3fb950"/>
-<path d="M 487.2 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="501.6" y="449.0" font-size="11" fill="#8b949e">mi_stats_get</text>
-<circle cx="700.6" cy="445.0" r="7.0" fill="#3fb950"/>
-<path d="M 697.2 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="711.6" y="449.0" font-size="11" fill="#8b949e">mi_stats_get</text>
-<circle cx="910.6" cy="445.0" r="7.0" fill="#3fb950"/>
-<path d="M 907.2 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="921.6" y="449.0" font-size="11" fill="#8b949e">mi_stats_get</text>
-<circle cx="1077.4" cy="445.0" r="7.0" fill="#3fb950"/>
-<path d="M 1074.0 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1088.4" y="449.0" font-size="11" fill="#8b949e">mallctl / malloc_stats_print</text>
+<circle cx="439.0" cy="445.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="449.0" font-size="11" fill="#8b949e">mi_stats_get</text>
+<circle cx="649.0" cy="445.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="449.0" font-size="11" fill="#8b949e">mi_stats_get</text>
+<circle cx="859.0" cy="445.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="449.0" font-size="11" fill="#8b949e">mi_stats_get</text>
+<circle cx="1069.0" cy="445.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="449.0" font-size="11" fill="#8b949e">mallctl / malloc_stats_print</text>
 <text x="24" y="473.0" font-size="12" fill="#e6edf3">Statistics as JSON</text>
-<circle cx="477.1" cy="469.0" r="7.0" fill="#3fb950"/>
-<path d="M 473.7 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="488.1" y="473.0" font-size="11" fill="#8b949e">mi_stats_get_json</text>
-<circle cx="687.1" cy="469.0" r="7.0" fill="#3fb950"/>
-<path d="M 683.7 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="698.1" y="473.0" font-size="11" fill="#8b949e">mi_stats_get_json</text>
-<circle cx="897.1" cy="469.0" r="7.0" fill="#3fb950"/>
-<path d="M 893.7 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="908.1" y="473.0" font-size="11" fill="#8b949e">mi_stats_get_json</text>
-<circle cx="1107.1" cy="469.0" r="7.0" fill="#3fb950"/>
-<path d="M 1103.7 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1118.1" y="473.0" font-size="11" fill="#8b949e">the &quot;J&quot; opts flag</text>
+<circle cx="439.0" cy="469.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="473.0" font-size="11" fill="#8b949e">mi_stats_get_json</text>
+<circle cx="649.0" cy="469.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="473.0" font-size="11" fill="#8b949e">mi_stats_get_json</text>
+<circle cx="859.0" cy="469.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="473.0" font-size="11" fill="#8b949e">mi_stats_get_json</text>
+<circle cx="1069.0" cy="469.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="473.0" font-size="11" fill="#8b949e">the &quot;J&quot; opts flag</text>
 <rect x="16" y="481.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="497.0" font-size="12" fill="#e6edf3">Per-heap JSON dump</text>
-<circle cx="477.1" cy="493.0" r="7.0" fill="#3fb950"/>
-<path d="M 473.7 493.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="488.1" y="497.0" font-size="11" fill="#8b949e">mi_heap_dump_json</text>
-<circle cx="670.9" cy="493.0" r="7.0" fill="#f85149"/>
-<path d="M 667.9 490.0 l 6.0 6.0 M 673.9 490.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="681.9" y="497.0" font-size="11" fill="#8b949e">process-wide stats only</text>
-<circle cx="897.1" cy="493.0" r="7.0" fill="#3fb950"/>
-<path d="M 893.7 493.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="908.1" y="497.0" font-size="11" fill="#8b949e">mi_heap_dump_json</text>
-<circle cx="1090.9" cy="493.0" r="7.0" fill="#f85149"/>
-<path d="M 1087.9 490.0 l 6.0 6.0 M 1093.9 490.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1101.9" y="497.0" font-size="11" fill="#8b949e">per-arena, not per-heap</text>
+<circle cx="439.0" cy="493.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 493.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="497.0" font-size="11" fill="#8b949e">mi_heap_dump_json</text>
+<circle cx="649.0" cy="493.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 490.0 l 6.0 6.0 M 652.0 490.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="497.0" font-size="11" fill="#8b949e">process-wide stats only</text>
+<circle cx="859.0" cy="493.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 493.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="497.0" font-size="11" fill="#8b949e">mi_heap_dump_json</text>
+<circle cx="1069.0" cy="493.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 490.0 l 6.0 6.0 M 1072.0 490.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="497.0" font-size="11" fill="#8b949e">per-arena, not per-heap</text>
 <text x="24" y="521.0" font-size="12" fill="#e6edf3">DHAT exact profiling (Valgrind format)</text>
-<circle cx="487.9" cy="517.0" r="7.0" fill="#3fb950"/>
-<path d="M 484.5 517.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="498.9" y="521.0" font-size="11" fill="#8b949e">mi_dhat_start</text>
-<circle cx="735.0" cy="517.0" r="7.0" fill="#f85149"/>
-<path d="M 732.0 514.0 l 6.0 6.0 M 738.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="945.0" cy="517.0" r="7.0" fill="#f85149"/>
-<path d="M 942.0 514.0 l 6.0 6.0 M 948.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="1155.0" cy="517.0" r="7.0" fill="#f85149"/>
-<path d="M 1152.0 514.0 l 6.0 6.0 M 1158.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="439.0" cy="517.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 517.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="521.0" font-size="11" fill="#8b949e">mi_dhat_start</text>
+<circle cx="649.0" cy="517.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 514.0 l 6.0 6.0 M 652.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="517.0" r="7.0" fill="#f85149"/>
+<path d="M 856.0 514.0 l 6.0 6.0 M 862.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="1069.0" cy="517.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 514.0 l 6.0 6.0 M 1072.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
 <rect x="16" y="529.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="545.0" font-size="12" fill="#e6edf3">Allocation-event callbacks</text>
-<circle cx="460.9" cy="541.0" r="7.0" fill="#3fb950"/>
-<path d="M 457.5 541.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="471.9" y="545.0" font-size="11" fill="#8b949e">mi_memory_set_callbacks</text>
-<circle cx="735.0" cy="541.0" r="7.0" fill="#f85149"/>
-<path d="M 732.0 538.0 l 6.0 6.0 M 738.0 538.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="945.0" cy="541.0" r="7.0" fill="#f85149"/>
-<path d="M 942.0 538.0 l 6.0 6.0 M 948.0 538.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="1082.8" cy="541.0" r="7.0" fill="#d29922"/>
-<path d="M 1082.8 537.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1082.8" cy="544.4" r="1.1" fill="#ffffff"/>
-<text x="1093.8" y="545.0" font-size="11" fill="#8b949e">experimental.hooks.install</text>
+<circle cx="439.0" cy="541.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 541.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="545.0" font-size="11" fill="#8b949e">mi_memory_set_callbacks</text>
+<circle cx="649.0" cy="541.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 538.0 l 6.0 6.0 M 652.0 538.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="541.0" r="7.0" fill="#f85149"/>
+<path d="M 856.0 538.0 l 6.0 6.0 M 862.0 538.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="1069.0" cy="541.0" r="7.0" fill="#d29922"/>
+<path d="M 1069.0 537.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="544.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="545.0" font-size="11" fill="#8b949e">experimental.hooks.install</text>
 <text x="24" y="569.0" font-size="12" fill="#e6edf3">Walk every live block in a heap</text>
-<circle cx="469.0" cy="565.0" r="7.0" fill="#3fb950"/>
-<path d="M 465.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="480.0" y="569.0" font-size="11" fill="#8b949e">mi_heap_visit_blocks</text>
-<circle cx="679.0" cy="565.0" r="7.0" fill="#3fb950"/>
-<path d="M 675.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="690.0" y="569.0" font-size="11" fill="#8b949e">mi_heap_visit_blocks</text>
-<circle cx="889.0" cy="565.0" r="7.0" fill="#3fb950"/>
-<path d="M 885.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="900.0" y="569.0" font-size="11" fill="#8b949e">mi_heap_visit_blocks</text>
-<circle cx="1099.0" cy="565.0" r="7.0" fill="#f85149"/>
-<path d="M 1096.0 562.0 l 6.0 6.0 M 1102.0 562.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1110.0" y="569.0" font-size="11" fill="#8b949e">no iteration mallctl</text>
+<circle cx="439.0" cy="565.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="569.0" font-size="11" fill="#8b949e">mi_heap_visit_blocks</text>
+<circle cx="649.0" cy="565.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="569.0" font-size="11" fill="#8b949e">mi_heap_visit_blocks</text>
+<circle cx="859.0" cy="565.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="569.0" font-size="11" fill="#8b949e">mi_heap_visit_blocks</text>
+<circle cx="1069.0" cy="565.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 562.0 l 6.0 6.0 M 1072.0 562.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="569.0" font-size="11" fill="#8b949e">no iteration mallctl</text>
 <rect x="16" y="577.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="593.0" font-size="12" fill="#e6edf3">Live heap snapshot with a viewer</text>
-<circle cx="460.9" cy="589.0" r="7.0" fill="#3fb950"/>
-<path d="M 457.5 589.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="471.9" y="593.0" font-size="11" fill="#8b949e">mi_heap_snapshot — #338</text>
-<circle cx="735.0" cy="589.0" r="7.0" fill="#f85149"/>
-<path d="M 732.0 586.0 l 6.0 6.0 M 738.0 586.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="891.7" cy="589.0" r="7.0" fill="#3fb950"/>
-<path d="M 888.3 589.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="902.7" y="593.0" font-size="11" fill="#8b949e">+ tools/mi-heapview</text>
-<circle cx="1155.0" cy="589.0" r="7.0" fill="#f85149"/>
-<path d="M 1152.0 586.0 l 6.0 6.0 M 1158.0 586.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="439.0" cy="589.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 589.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="593.0" font-size="11" fill="#8b949e">mi_heap_snapshot — #338</text>
+<circle cx="649.0" cy="589.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 586.0 l 6.0 6.0 M 652.0 586.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="589.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 589.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="593.0" font-size="11" fill="#8b949e">+ tools/mi-heapview</text>
+<circle cx="1069.0" cy="589.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 586.0 l 6.0 6.0 M 1072.0 586.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
 <text x="24" y="617.0" font-size="12" fill="#e6edf3">No fast-path cost while profiling is off</text>
-<circle cx="452.8" cy="613.0" r="7.0" fill="#3fb950"/>
-<path d="M 449.4 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="463.8" y="617.0" font-size="11" fill="#8b949e">malloc path byte-identical</text>
-<circle cx="692.5" cy="613.0" r="7.0" fill="#3fb950"/>
-<path d="M 689.1 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="703.5" y="617.0" font-size="11" fill="#8b949e">nothing to cost</text>
-<circle cx="878.2" cy="613.0" r="7.0" fill="#3fb950"/>
-<path d="M 874.8 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="889.2" y="617.0" font-size="11" fill="#8b949e">sample rate 0 by default</text>
-<circle cx="1107.1" cy="613.0" r="7.0" fill="#d29922"/>
-<path d="M 1107.1 609.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1107.1" cy="616.4" r="1.1" fill="#ffffff"/>
-<text x="1118.1" y="617.0" font-size="11" fill="#8b949e">build-time opt-in</text>
+<circle cx="439.0" cy="613.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="617.0" font-size="11" fill="#8b949e">malloc path byte-identical</text>
+<circle cx="649.0" cy="613.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="617.0" font-size="11" fill="#8b949e">nothing to cost</text>
+<circle cx="859.0" cy="613.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="617.0" font-size="11" fill="#8b949e">sample rate 0 by default</text>
+<circle cx="1069.0" cy="613.0" r="7.0" fill="#d29922"/>
+<path d="M 1069.0 609.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="616.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="617.0" font-size="11" fill="#8b949e">build-time opt-in</text>
 <text x="24" y="646.0" font-size="12" font-weight="700" fill="#e6edf3" letter-spacing="0.4">ROBUSTNESS</text>
 <text x="24" y="671.0" font-size="12" fill="#e6edf3">fork() handlers (pthread_atfork)</text>
-<circle cx="466.3" cy="667.0" r="7.0" fill="#3fb950"/>
-<path d="M 462.9 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="671.0" font-size="11" fill="#8b949e">documented lock order</text>
-<circle cx="692.5" cy="667.0" r="7.0" fill="#f85149"/>
-<path d="M 689.5 664.0 l 6.0 6.0 M 695.5 664.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="703.5" y="671.0" font-size="11" fill="#8b949e">none registered</text>
-<circle cx="945.0" cy="667.0" r="7.0" fill="#3fb950"/>
-<path d="M 941.6 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="1109.8" cy="667.0" r="7.0" fill="#3fb950"/>
-<path d="M 1106.4 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1120.8" y="671.0" font-size="11" fill="#8b949e">jemalloc_prefork</text>
+<circle cx="439.0" cy="667.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="671.0" font-size="11" fill="#8b949e">documented lock order</text>
+<circle cx="649.0" cy="667.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 664.0 l 6.0 6.0 M 652.0 664.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="671.0" font-size="11" fill="#8b949e">none registered</text>
+<circle cx="859.0" cy="667.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="1069.0" cy="667.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="671.0" font-size="11" fill="#8b949e">jemalloc_prefork</text>
 <rect x="16" y="679.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="695.0" font-size="12" fill="#e6edf3">Runtime lock-order checker</text>
-<circle cx="496.0" cy="691.0" r="7.0" fill="#3fb950"/>
-<path d="M 492.6 691.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="507.0" y="695.0" font-size="11" fill="#8b949e">MI_DEBUG&gt;2</text>
-<circle cx="670.9" cy="691.0" r="7.0" fill="#f85149"/>
-<path d="M 667.9 688.0 l 6.0 6.0 M 673.9 688.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="681.9" y="695.0" font-size="11" fill="#8b949e">no fork handlers either</text>
-<circle cx="894.4" cy="691.0" r="7.0" fill="#f85149"/>
-<path d="M 891.4 688.0 l 6.0 6.0 M 897.4 688.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="905.4" y="695.0" font-size="11" fill="#8b949e">order kept by hand</text>
-<circle cx="1074.7" cy="691.0" r="7.0" fill="#3fb950"/>
-<path d="M 1071.3 691.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1085.7" y="695.0" font-size="11" fill="#8b949e">witness ranks, --enable-debug</text>
+<circle cx="439.0" cy="691.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 691.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="695.0" font-size="11" fill="#8b949e">MI_DEBUG&gt;2</text>
+<circle cx="649.0" cy="691.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 688.0 l 6.0 6.0 M 652.0 688.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="695.0" font-size="11" fill="#8b949e">no fork handlers either</text>
+<circle cx="859.0" cy="691.0" r="7.0" fill="#f85149"/>
+<path d="M 856.0 688.0 l 6.0 6.0 M 862.0 688.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="695.0" font-size="11" fill="#8b949e">order kept by hand</text>
+<circle cx="1069.0" cy="691.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 691.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="695.0" font-size="11" fill="#8b949e">witness ranks, --enable-debug</text>
 <text x="24" y="719.0" font-size="12" fill="#e6edf3">Heap-teardown ABA claim protocol</text>
-<circle cx="460.9" cy="715.0" r="7.0" fill="#3fb950"/>
-<path d="M 457.5 715.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="471.9" y="719.0" font-size="11" fill="#8b949e">+ fault-injection tests</text>
-<circle cx="735.0" cy="715.0" r="7.0" fill="#f85149"/>
-<path d="M 732.0 712.0 l 6.0 6.0 M 738.0 712.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="945.0" cy="715.0" r="7.0" fill="#3fb950"/>
-<path d="M 941.6 715.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="1090.9" cy="715.0" r="7.0" fill="#f85149"/>
-<path d="M 1087.9 712.0 l 6.0 6.0 M 1093.9 712.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1101.9" y="719.0" font-size="11" fill="#8b949e">caller must flush first</text>
+<circle cx="439.0" cy="715.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 715.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="719.0" font-size="11" fill="#8b949e">+ fault-injection tests</text>
+<circle cx="649.0" cy="715.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 712.0 l 6.0 6.0 M 652.0 712.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="715.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 715.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="1069.0" cy="715.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 712.0 l 6.0 6.0 M 1072.0 712.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="719.0" font-size="11" fill="#8b949e">caller must flush first</text>
 <rect x="16" y="727.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="743.0" font-size="12" fill="#e6edf3">Guard-page (guarded) allocations</text>
-<circle cx="496.0" cy="739.0" r="7.0" fill="#3fb950"/>
-<path d="M 492.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="507.0" y="743.0" font-size="11" fill="#8b949e">MI_GUARDED</text>
-<circle cx="706.0" cy="739.0" r="7.0" fill="#3fb950"/>
-<path d="M 702.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="717.0" y="743.0" font-size="11" fill="#8b949e">MI_GUARDED</text>
-<circle cx="916.0" cy="739.0" r="7.0" fill="#3fb950"/>
-<path d="M 912.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="927.0" y="743.0" font-size="11" fill="#8b949e">MI_GUARDED</text>
-<circle cx="1085.5" cy="739.0" r="7.0" fill="#d29922"/>
-<path d="M 1085.5 735.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1085.5" cy="742.4" r="1.1" fill="#ffffff"/>
-<text x="1096.5" y="743.0" font-size="11" fill="#8b949e">opt.san_guard_small/large</text>
+<circle cx="439.0" cy="739.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="743.0" font-size="11" fill="#8b949e">MI_GUARDED</text>
+<circle cx="649.0" cy="739.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="743.0" font-size="11" fill="#8b949e">MI_GUARDED</text>
+<circle cx="859.0" cy="739.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="743.0" font-size="11" fill="#8b949e">MI_GUARDED</text>
+<circle cx="1069.0" cy="739.0" r="7.0" fill="#d29922"/>
+<path d="M 1069.0 735.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="742.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="743.0" font-size="11" fill="#8b949e">opt.san_guard_small/large</text>
 <text x="24" y="767.0" font-size="12" fill="#e6edf3">Hardened / secure build mode</text>
-<circle cx="487.9" cy="763.0" r="7.0" fill="#3fb950"/>
-<path d="M 484.5 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="498.9" y="767.0" font-size="11" fill="#8b949e">MI_SECURE 1-4</text>
-<circle cx="697.9" cy="763.0" r="7.0" fill="#3fb950"/>
-<path d="M 694.5 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="708.9" y="767.0" font-size="11" fill="#8b949e">MI_SECURE 1-4</text>
-<circle cx="907.9" cy="763.0" r="7.0" fill="#3fb950"/>
-<path d="M 904.5 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="918.9" y="767.0" font-size="11" fill="#8b949e">MI_SECURE 1-4</text>
-<circle cx="1104.4" cy="763.0" r="7.0" fill="#f85149"/>
-<path d="M 1101.4 760.0 l 6.0 6.0 M 1107.4 760.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1115.4" y="767.0" font-size="11" fill="#8b949e">no equivalent mode</text>
+<circle cx="439.0" cy="763.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="767.0" font-size="11" fill="#8b949e">MI_SECURE 1-4</text>
+<circle cx="649.0" cy="763.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="767.0" font-size="11" fill="#8b949e">MI_SECURE 1-4</text>
+<circle cx="859.0" cy="763.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="767.0" font-size="11" fill="#8b949e">MI_SECURE 1-4</text>
+<circle cx="1069.0" cy="763.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 760.0 l 6.0 6.0 M 1072.0 760.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="767.0" font-size="11" fill="#8b949e">no equivalent mode</text>
 <rect x="16" y="775.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="791.0" font-size="12" fill="#e6edf3">ASan / Valgrind / ETW tracking</text>
-<circle cx="498.7" cy="787.0" r="7.0" fill="#3fb950"/>
-<path d="M 495.3 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="509.7" y="791.0" font-size="11" fill="#8b949e">all three</text>
-<circle cx="708.7" cy="787.0" r="7.0" fill="#3fb950"/>
-<path d="M 705.3 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="719.7" y="791.0" font-size="11" fill="#8b949e">all three</text>
-<circle cx="918.7" cy="787.0" r="7.0" fill="#3fb950"/>
-<path d="M 915.3 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="929.7" y="791.0" font-size="11" fill="#8b949e">all three</text>
-<circle cx="1072.0" cy="787.0" r="7.0" fill="#f85149"/>
-<path d="M 1069.0 784.0 l 6.0 6.0 M 1075.0 784.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1083.0" y="791.0" font-size="11" fill="#8b949e">no ASan, no ETW; Valgrind gone</text>
+<circle cx="439.0" cy="787.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="791.0" font-size="11" fill="#8b949e">all three</text>
+<circle cx="649.0" cy="787.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="791.0" font-size="11" fill="#8b949e">all three</text>
+<circle cx="859.0" cy="787.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="791.0" font-size="11" fill="#8b949e">all three</text>
+<circle cx="1069.0" cy="787.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 784.0 l 6.0 6.0 M 1072.0 784.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="791.0" font-size="11" fill="#8b949e">no ASan, no ETW; Valgrind gone</text>
 <text x="24" y="820.0" font-size="12" font-weight="700" fill="#e6edf3" letter-spacing="0.4">PLATFORM AND INTEGRATION</text>
 <text x="24" y="845.0" font-size="12" fill="#e6edf3">Windows MSVC as a first-class target</text>
-<circle cx="466.3" cy="841.0" r="7.0" fill="#3fb950"/>
-<path d="M 462.9 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="845.0" font-size="11" fill="#8b949e">native cl gate per PR</text>
-<circle cx="684.4" cy="841.0" r="7.0" fill="#3fb950"/>
-<path d="M 681.0 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="695.4" y="845.0" font-size="11" fill="#8b949e">in the test matrix</text>
-<circle cx="894.4" cy="841.0" r="7.0" fill="#3fb950"/>
-<path d="M 891.0 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="905.4" y="845.0" font-size="11" fill="#8b949e">in the test matrix</text>
-<circle cx="1096.3" cy="841.0" r="7.0" fill="#d29922"/>
-<path d="M 1096.3 837.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1096.3" cy="844.4" r="1.1" fill="#ffffff"/>
-<text x="1107.3" y="845.0" font-size="11" fill="#8b949e">no prof, no bg thread</text>
+<circle cx="439.0" cy="841.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="845.0" font-size="11" fill="#8b949e">native cl gate per PR</text>
+<circle cx="649.0" cy="841.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="845.0" font-size="11" fill="#8b949e">in the test matrix</text>
+<circle cx="859.0" cy="841.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="845.0" font-size="11" fill="#8b949e">in the test matrix</text>
+<circle cx="1069.0" cy="841.0" r="7.0" fill="#d29922"/>
+<path d="M 1069.0 837.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="844.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="845.0" font-size="11" fill="#8b949e">no prof, no bg thread</text>
 <rect x="16" y="853.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="869.0" font-size="12" fill="#e6edf3">Windows malloc override via a redirect DLL</text>
-<circle cx="466.3" cy="865.0" r="7.0" fill="#3fb950"/>
-<path d="M 462.9 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="869.0" font-size="11" fill="#8b949e">mimalloc-redirect.dll</text>
-<circle cx="676.3" cy="865.0" r="7.0" fill="#3fb950"/>
-<path d="M 672.9 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="687.3" y="869.0" font-size="11" fill="#8b949e">mimalloc-redirect.dll</text>
-<circle cx="886.3" cy="865.0" r="7.0" fill="#3fb950"/>
-<path d="M 882.9 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="897.3" y="869.0" font-size="11" fill="#8b949e">mimalloc-redirect.dll</text>
-<circle cx="1082.8" cy="865.0" r="7.0" fill="#f85149"/>
-<path d="M 1079.8 862.0 l 6.0 6.0 M 1085.8 862.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1093.8" y="869.0" font-size="11" fill="#8b949e">link-time replacement only</text>
+<circle cx="439.0" cy="865.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="869.0" font-size="11" fill="#8b949e">mimalloc-redirect.dll</text>
+<circle cx="649.0" cy="865.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="869.0" font-size="11" fill="#8b949e">mimalloc-redirect.dll</text>
+<circle cx="859.0" cy="865.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="869.0" font-size="11" fill="#8b949e">mimalloc-redirect.dll</text>
+<circle cx="1069.0" cy="865.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 862.0 l 6.0 6.0 M 1072.0 862.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="869.0" font-size="11" fill="#8b949e">link-time replacement only</text>
 <text x="24" y="893.0" font-size="12" fill="#e6edf3">MinGW / win-gnu covered in CI</text>
-<circle cx="466.3" cy="889.0" r="7.0" fill="#3fb950"/>
-<path d="M 462.9 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="893.0" font-size="11" fill="#8b949e">cross-built, then run</text>
-<circle cx="700.6" cy="889.0" r="7.0" fill="#3fb950"/>
-<path d="M 697.2 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="711.6" y="893.0" font-size="11" fill="#8b949e">mingw-ucrt64</text>
-<circle cx="910.6" cy="889.0" r="7.0" fill="#3fb950"/>
-<path d="M 907.2 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="921.6" y="893.0" font-size="11" fill="#8b949e">mingw-ucrt64</text>
-<circle cx="1104.4" cy="889.0" r="7.0" fill="#3fb950"/>
-<path d="M 1101.0 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1115.4" y="893.0" font-size="11" fill="#8b949e">MSYS2 mingw32-make</text>
+<circle cx="439.0" cy="889.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="893.0" font-size="11" fill="#8b949e">cross-built, then run</text>
+<circle cx="649.0" cy="889.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="893.0" font-size="11" fill="#8b949e">mingw-ucrt64</text>
+<circle cx="859.0" cy="889.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="893.0" font-size="11" fill="#8b949e">mingw-ucrt64</text>
+<circle cx="1069.0" cy="889.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="893.0" font-size="11" fill="#8b949e">MSYS2 mingw32-make</text>
 <rect x="16" y="901.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="917.0" font-size="12" fill="#e6edf3">macOS malloc-zone interpose</text>
-<circle cx="525.0" cy="913.0" r="7.0" fill="#3fb950"/>
-<path d="M 521.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="735.0" cy="913.0" r="7.0" fill="#3fb950"/>
-<path d="M 731.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="945.0" cy="913.0" r="7.0" fill="#3fb950"/>
-<path d="M 941.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="1155.0" cy="913.0" r="7.0" fill="#3fb950"/>
-<path d="M 1151.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="439.0" cy="913.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="649.0" cy="913.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="859.0" cy="913.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="1069.0" cy="913.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
 <text x="24" y="941.0" font-size="12" fill="#e6edf3">macOS zone introspection (leaks, vmmap)</text>
-<circle cx="444.7" cy="937.0" r="7.0" fill="#3fb950"/>
-<path d="M 441.3 937.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="455.7" y="941.0" font-size="11" fill="#8b949e">in- and out-of-process — #349</text>
-<circle cx="692.5" cy="937.0" r="7.0" fill="#f85149"/>
-<path d="M 689.5 934.0 l 6.0 6.0 M 695.5 934.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="703.5" y="941.0" font-size="11" fill="#8b949e">stub enumerator</text>
-<circle cx="883.6" cy="937.0" r="7.0" fill="#3fb950"/>
-<path d="M 880.2 937.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="894.6" y="941.0" font-size="11" fill="#8b949e">in- and out-of-process</text>
-<circle cx="1112.5" cy="937.0" r="7.0" fill="#f85149"/>
-<path d="M 1109.5 934.0 l 6.0 6.0 M 1115.5 934.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1123.5" y="941.0" font-size="11" fill="#8b949e">stub enumerator</text>
+<circle cx="439.0" cy="937.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 937.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="941.0" font-size="11" fill="#8b949e">in- and out-of-process — #349</text>
+<circle cx="649.0" cy="937.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 934.0 l 6.0 6.0 M 652.0 934.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="941.0" font-size="11" fill="#8b949e">stub enumerator</text>
+<circle cx="859.0" cy="937.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 937.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="941.0" font-size="11" fill="#8b949e">in- and out-of-process</text>
+<circle cx="1069.0" cy="937.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 934.0 l 6.0 6.0 M 1072.0 934.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="941.0" font-size="11" fill="#8b949e">stub enumerator</text>
 <rect x="16" y="949.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="965.0" font-size="12" fill="#e6edf3">First-party Rust crate, full C API</text>
-<circle cx="450.1" cy="961.0" r="7.0" fill="#3fb950"/>
-<path d="M 446.7 961.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="461.1" y="965.0" font-size="11" fill="#8b949e">mimalloc-pprof on crates.io</text>
-<circle cx="670.9" cy="961.0" r="7.0" fill="#f85149"/>
-<path d="M 667.9 958.0 l 6.0 6.0 M 673.9 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="681.9" y="965.0" font-size="11" fill="#8b949e">third-party crates only</text>
-<circle cx="921.4" cy="961.0" r="7.0" fill="#f85149"/>
-<path d="M 918.4 958.0 l 6.0 6.0 M 924.4 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="932.4" y="965.0" font-size="11" fill="#8b949e">no crate</text>
-<circle cx="1090.9" cy="961.0" r="7.0" fill="#f85149"/>
-<path d="M 1087.9 958.0 l 6.0 6.0 M 1093.9 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1101.9" y="965.0" font-size="11" fill="#8b949e">third-party crates only</text>
+<circle cx="439.0" cy="961.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 961.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="965.0" font-size="11" fill="#8b949e">mimalloc-pprof on crates.io</text>
+<circle cx="649.0" cy="961.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 958.0 l 6.0 6.0 M 652.0 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="965.0" font-size="11" fill="#8b949e">third-party crates only</text>
+<circle cx="859.0" cy="961.0" r="7.0" fill="#f85149"/>
+<path d="M 856.0 958.0 l 6.0 6.0 M 862.0 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="965.0" font-size="11" fill="#8b949e">no crate</text>
+<circle cx="1069.0" cy="961.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 958.0 l 6.0 6.0 M 1072.0 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="965.0" font-size="11" fill="#8b949e">third-party crates only</text>
 <text x="24" y="989.0" font-size="12" fill="#e6edf3">Release targets cross-built on Linux</text>
-<circle cx="460.9" cy="985.0" r="7.0" fill="#3fb950"/>
-<path d="M 457.5 985.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="471.9" y="989.0" font-size="11" fill="#8b949e">5 targets through soldr</text>
-<circle cx="679.0" cy="985.0" r="7.0" fill="#f85149"/>
-<path d="M 676.0 982.0 l 6.0 6.0 M 682.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="690.0" y="989.0" font-size="11" fill="#8b949e">native runner per OS</text>
-<circle cx="889.0" cy="985.0" r="7.0" fill="#f85149"/>
-<path d="M 886.0 982.0 l 6.0 6.0 M 892.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="900.0" y="989.0" font-size="11" fill="#8b949e">native runner per OS</text>
-<circle cx="1099.0" cy="985.0" r="7.0" fill="#f85149"/>
-<path d="M 1096.0 982.0 l 6.0 6.0 M 1102.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1110.0" y="989.0" font-size="11" fill="#8b949e">native runner per OS</text>
+<circle cx="439.0" cy="985.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 985.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="989.0" font-size="11" fill="#8b949e">5 targets through soldr</text>
+<circle cx="649.0" cy="985.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 982.0 l 6.0 6.0 M 652.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="989.0" font-size="11" fill="#8b949e">native runner per OS</text>
+<circle cx="859.0" cy="985.0" r="7.0" fill="#f85149"/>
+<path d="M 856.0 982.0 l 6.0 6.0 M 862.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="989.0" font-size="11" fill="#8b949e">native runner per OS</text>
+<circle cx="1069.0" cy="985.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 982.0 l 6.0 6.0 M 1072.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="989.0" font-size="11" fill="#8b949e">native runner per OS</text>
 <rect x="16" y="997.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="1013.0" font-size="12" fill="#e6edf3">macOS covered with no Apple hardware</text>
-<circle cx="444.7" cy="1009.0" r="7.0" fill="#3fb950"/>
-<path d="M 441.3 1009.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="455.7" y="1013.0" font-size="11" fill="#8b949e">cross-built; guest run manual</text>
-<circle cx="679.0" cy="1009.0" r="7.0" fill="#f85149"/>
-<path d="M 676.0 1006.0 l 6.0 6.0 M 682.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="690.0" y="1013.0" font-size="11" fill="#8b949e">hosted macOS runners</text>
-<circle cx="889.0" cy="1009.0" r="7.0" fill="#f85149"/>
-<path d="M 886.0 1006.0 l 6.0 6.0 M 892.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="900.0" y="1013.0" font-size="11" fill="#8b949e">hosted macOS runners</text>
-<circle cx="1099.0" cy="1009.0" r="7.0" fill="#f85149"/>
-<path d="M 1096.0 1006.0 l 6.0 6.0 M 1102.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1110.0" y="1013.0" font-size="11" fill="#8b949e">hosted macOS runners</text>
+<circle cx="439.0" cy="1009.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1009.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1013.0" font-size="11" fill="#8b949e">cross-built; guest run manual</text>
+<circle cx="649.0" cy="1009.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 1006.0 l 6.0 6.0 M 652.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="1013.0" font-size="11" fill="#8b949e">hosted macOS runners</text>
+<circle cx="859.0" cy="1009.0" r="7.0" fill="#f85149"/>
+<path d="M 856.0 1006.0 l 6.0 6.0 M 862.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="1013.0" font-size="11" fill="#8b949e">hosted macOS runners</text>
+<circle cx="1069.0" cy="1009.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 1006.0 l 6.0 6.0 M 1072.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="1013.0" font-size="11" fill="#8b949e">hosted macOS runners</text>
 <text x="24" y="1042.0" font-size="12" font-weight="700" fill="#e6edf3" letter-spacing="0.4">ALLOCATOR DESIGN</text>
 <text x="24" y="1067.0" font-size="12" fill="#e6edf3">Per-thread heaps and caches</text>
-<circle cx="466.3" cy="1063.0" r="7.0" fill="#3fb950"/>
-<path d="M 462.9 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="1067.0" font-size="11" fill="#8b949e">mi_theap_t per thread</text>
-<circle cx="676.3" cy="1063.0" r="7.0" fill="#3fb950"/>
-<path d="M 672.9 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="687.3" y="1067.0" font-size="11" fill="#8b949e">mi_theap_t per thread</text>
-<circle cx="886.3" cy="1063.0" r="7.0" fill="#3fb950"/>
-<path d="M 882.9 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="897.3" y="1067.0" font-size="11" fill="#8b949e">mi_theap_t per thread</text>
-<circle cx="1085.5" cy="1063.0" r="7.0" fill="#3fb950"/>
-<path d="M 1082.1 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1096.5" y="1067.0" font-size="11" fill="#8b949e">tcache + per-thread arena</text>
+<circle cx="439.0" cy="1063.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1067.0" font-size="11" fill="#8b949e">mi_theap_t per thread</text>
+<circle cx="649.0" cy="1063.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1067.0" font-size="11" fill="#8b949e">mi_theap_t per thread</text>
+<circle cx="859.0" cy="1063.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1067.0" font-size="11" fill="#8b949e">mi_theap_t per thread</text>
+<circle cx="1069.0" cy="1063.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1067.0" font-size="11" fill="#8b949e">tcache + per-thread arena</text>
 <rect x="16" y="1075.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="1091.0" font-size="12" fill="#e6edf3">Create and destroy your own heaps</text>
-<circle cx="493.3" cy="1087.0" r="7.0" fill="#3fb950"/>
-<path d="M 489.9 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="504.3" y="1091.0" font-size="11" fill="#8b949e">mi_heap_new</text>
-<circle cx="703.3" cy="1087.0" r="7.0" fill="#3fb950"/>
-<path d="M 699.9 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="714.3" y="1091.0" font-size="11" fill="#8b949e">mi_heap_new</text>
-<circle cx="913.3" cy="1087.0" r="7.0" fill="#3fb950"/>
-<path d="M 909.9 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="924.3" y="1091.0" font-size="11" fill="#8b949e">mi_heap_new</text>
-<circle cx="1117.9" cy="1087.0" r="7.0" fill="#3fb950"/>
-<path d="M 1114.5 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1128.9" y="1091.0" font-size="11" fill="#8b949e">arenas.create</text>
+<circle cx="439.0" cy="1087.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1091.0" font-size="11" fill="#8b949e">mi_heap_new</text>
+<circle cx="649.0" cy="1087.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1091.0" font-size="11" fill="#8b949e">mi_heap_new</text>
+<circle cx="859.0" cy="1087.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1091.0" font-size="11" fill="#8b949e">mi_heap_new</text>
+<circle cx="1069.0" cy="1087.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1091.0" font-size="11" fill="#8b949e">arenas.create</text>
 <text x="24" y="1115.0" font-size="12" fill="#e6edf3">Shared arenas under the per-thread layer</text>
-<circle cx="469.0" cy="1111.0" r="7.0" fill="#3fb950"/>
-<path d="M 465.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="480.0" y="1115.0" font-size="11" fill="#8b949e">arena-of-slices (v3)</text>
-<circle cx="679.0" cy="1111.0" r="7.0" fill="#3fb950"/>
-<path d="M 675.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="690.0" y="1115.0" font-size="11" fill="#8b949e">arena-of-slices (v3)</text>
-<circle cx="889.0" cy="1111.0" r="7.0" fill="#3fb950"/>
-<path d="M 885.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="900.0" y="1115.0" font-size="11" fill="#8b949e">arena-of-slices (v3)</text>
-<circle cx="1093.6" cy="1111.0" r="7.0" fill="#3fb950"/>
-<path d="M 1090.2 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1104.6" y="1115.0" font-size="11" fill="#8b949e">per-CPU mode available</text>
+<circle cx="439.0" cy="1111.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1115.0" font-size="11" fill="#8b949e">arena-of-slices (v3)</text>
+<circle cx="649.0" cy="1111.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1115.0" font-size="11" fill="#8b949e">arena-of-slices (v3)</text>
+<circle cx="859.0" cy="1111.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1115.0" font-size="11" fill="#8b949e">arena-of-slices (v3)</text>
+<circle cx="1069.0" cy="1111.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1115.0" font-size="11" fill="#8b949e">per-CPU mode available</text>
 <rect x="16" y="1123.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="1139.0" font-size="12" fill="#e6edf3">Large / huge OS pages</text>
-<circle cx="469.0" cy="1135.0" r="7.0" fill="#3fb950"/>
-<path d="M 465.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="480.0" y="1139.0" font-size="11" fill="#8b949e">allow_large_os_pages</text>
-<circle cx="679.0" cy="1135.0" r="7.0" fill="#3fb950"/>
-<path d="M 675.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="690.0" y="1139.0" font-size="11" fill="#8b949e">allow_large_os_pages</text>
-<circle cx="889.0" cy="1135.0" r="7.0" fill="#3fb950"/>
-<path d="M 885.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="900.0" y="1139.0" font-size="11" fill="#8b949e">allow_large_os_pages</text>
-<circle cx="1085.5" cy="1135.0" r="7.0" fill="#3fb950"/>
-<path d="M 1082.1 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1096.5" y="1139.0" font-size="11" fill="#8b949e">opt.thp, opt.metadata_thp</text>
+<circle cx="439.0" cy="1135.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1139.0" font-size="11" fill="#8b949e">allow_large_os_pages</text>
+<circle cx="649.0" cy="1135.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1139.0" font-size="11" fill="#8b949e">allow_large_os_pages</text>
+<circle cx="859.0" cy="1135.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1139.0" font-size="11" fill="#8b949e">allow_large_os_pages</text>
+<circle cx="1069.0" cy="1135.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1139.0" font-size="11" fill="#8b949e">opt.thp, opt.metadata_thp</text>
 <text x="24" y="1163.0" font-size="12" fill="#e6edf3">NUMA-aware reservation</text>
-<circle cx="485.2" cy="1159.0" r="7.0" fill="#3fb950"/>
-<path d="M 481.8 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="496.2" y="1163.0" font-size="11" fill="#8b949e">use_numa_nodes</text>
-<circle cx="695.2" cy="1159.0" r="7.0" fill="#3fb950"/>
-<path d="M 691.8 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="706.2" y="1163.0" font-size="11" fill="#8b949e">use_numa_nodes</text>
-<circle cx="905.2" cy="1159.0" r="7.0" fill="#3fb950"/>
-<path d="M 901.8 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="916.2" y="1163.0" font-size="11" fill="#8b949e">use_numa_nodes</text>
-<circle cx="1115.2" cy="1159.0" r="7.0" fill="#f85149"/>
-<path d="M 1112.2 1156.0 l 6.0 6.0 M 1118.2 1156.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1126.2" y="1163.0" font-size="11" fill="#8b949e">no NUMA option</text>
+<circle cx="439.0" cy="1159.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1163.0" font-size="11" fill="#8b949e">use_numa_nodes</text>
+<circle cx="649.0" cy="1159.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1163.0" font-size="11" fill="#8b949e">use_numa_nodes</text>
+<circle cx="859.0" cy="1159.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1163.0" font-size="11" fill="#8b949e">use_numa_nodes</text>
+<circle cx="1069.0" cy="1159.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 1156.0 l 6.0 6.0 M 1072.0 1156.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="1163.0" font-size="11" fill="#8b949e">no NUMA option</text>
 <rect x="16" y="1171.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="1187.0" font-size="12" fill="#e6edf3">Bring your own memory region</text>
-<circle cx="471.7" cy="1183.0" r="7.0" fill="#3fb950"/>
-<path d="M 468.3 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="482.7" y="1187.0" font-size="11" fill="#8b949e">mi_manage_os_memory</text>
-<circle cx="681.7" cy="1183.0" r="7.0" fill="#3fb950"/>
-<path d="M 678.3 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="692.7" y="1187.0" font-size="11" fill="#8b949e">mi_manage_os_memory</text>
-<circle cx="891.7" cy="1183.0" r="7.0" fill="#3fb950"/>
-<path d="M 888.3 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="902.7" y="1187.0" font-size="11" fill="#8b949e">mi_manage_os_memory</text>
-<circle cx="1120.6" cy="1183.0" r="7.0" fill="#3fb950"/>
-<path d="M 1117.2 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1131.6" y="1187.0" font-size="11" fill="#8b949e">extent hooks</text>
+<circle cx="439.0" cy="1183.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1187.0" font-size="11" fill="#8b949e">mi_manage_os_memory</text>
+<circle cx="649.0" cy="1183.0" r="7.0" fill="#3fb950"/>
+<path d="M 645.6 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1187.0" font-size="11" fill="#8b949e">mi_manage_os_memory</text>
+<circle cx="859.0" cy="1183.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1187.0" font-size="11" fill="#8b949e">mi_manage_os_memory</text>
+<circle cx="1069.0" cy="1183.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1187.0" font-size="11" fill="#8b949e">extent hooks</text>
 <text x="24" y="1211.0" font-size="12" fill="#e6edf3">Lazy abandoned-page bitmaps</text>
-<circle cx="463.6" cy="1207.0" r="7.0" fill="#3fb950"/>
-<path d="M 460.2 1207.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="474.6" y="1211.0" font-size="11" fill="#8b949e">~110 KB saved per heap</text>
-<circle cx="687.1" cy="1207.0" r="7.0" fill="#f85149"/>
-<path d="M 684.1 1204.0 l 6.0 6.0 M 690.1 1204.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="698.1" y="1211.0" font-size="11" fill="#8b949e">allocated eagerly</text>
-<circle cx="883.6" cy="1207.0" r="7.0" fill="#3fb950"/>
-<path d="M 880.2 1207.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="894.6" y="1211.0" font-size="11" fill="#8b949e">~110 KB saved per heap</text>
-<circle cx="1107.1" cy="1207.0" r="7.0" fill="#f85149"/>
-<path d="M 1104.1 1204.0 l 6.0 6.0 M 1110.1 1204.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1118.1" y="1211.0" font-size="11" fill="#8b949e">no such structure</text>
+<circle cx="439.0" cy="1207.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1207.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1211.0" font-size="11" fill="#8b949e">~110 KB saved per heap</text>
+<circle cx="649.0" cy="1207.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 1204.0 l 6.0 6.0 M 652.0 1204.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="1211.0" font-size="11" fill="#8b949e">allocated eagerly</text>
+<circle cx="859.0" cy="1207.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1207.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1211.0" font-size="11" fill="#8b949e">~110 KB saved per heap</text>
+<circle cx="1069.0" cy="1207.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 1204.0 l 6.0 6.0 M 1072.0 1204.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="1211.0" font-size="11" fill="#8b949e">no such structure</text>
 <rect x="16" y="1219.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="1235.0" font-size="12" fill="#e6edf3">Fixed TLS slots on macOS</text>
-<circle cx="493.3" cy="1231.0" r="7.0" fill="#3fb950"/>
-<path d="M 489.9 1231.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="504.3" y="1235.0" font-size="11" fill="#8b949e">slots 96/97</text>
-<circle cx="670.9" cy="1231.0" r="7.0" fill="#d29922"/>
-<path d="M 670.9 1227.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="670.9" cy="1234.4" r="1.1" fill="#ffffff"/>
-<text x="681.9" y="1235.0" font-size="11" fill="#8b949e">slots 108/109 — collide</text>
-<circle cx="913.3" cy="1231.0" r="7.0" fill="#3fb950"/>
-<path d="M 909.9 1231.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="924.3" y="1235.0" font-size="11" fill="#8b949e">slots 96/97</text>
-<circle cx="1101.7" cy="1231.0" r="7.0" fill="#f85149"/>
-<path d="M 1098.7 1228.0 l 6.0 6.0 M 1104.7 1228.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1112.7" y="1235.0" font-size="11" fill="#8b949e">pthread_getspecific</text>
+<circle cx="439.0" cy="1231.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1231.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1235.0" font-size="11" fill="#8b949e">slots 96/97</text>
+<circle cx="649.0" cy="1231.0" r="7.0" fill="#d29922"/>
+<path d="M 649.0 1227.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="649.0" cy="1234.4" r="1.1" fill="#ffffff"/>
+<text x="660.0" y="1235.0" font-size="11" fill="#8b949e">slots 108/109 — collide</text>
+<circle cx="859.0" cy="1231.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1231.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1235.0" font-size="11" fill="#8b949e">slots 96/97</text>
+<circle cx="1069.0" cy="1231.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 1228.0 l 6.0 6.0 M 1072.0 1228.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="1235.0" font-size="11" fill="#8b949e">pthread_getspecific</text>
 <text x="24" y="1259.0" font-size="12" fill="#e6edf3">Purged memory tracked as still-zero</text>
-<circle cx="436.6" cy="1255.0" r="7.0" fill="#3fb950"/>
-<path d="M 433.2 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="447.6" y="1259.0" font-size="11" fill="#8b949e">_mi_os_purge_zero, opt-in — #337</text>
-<circle cx="660.1" cy="1255.0" r="7.0" fill="#f85149"/>
-<path d="M 657.1 1252.0 l 6.0 6.0 M 663.1 1252.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="671.1" y="1259.0" font-size="11" fill="#8b949e">_mi_os_purge has no is_zero</text>
-<circle cx="897.1" cy="1255.0" r="7.0" fill="#3fb950"/>
-<path d="M 893.7 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="908.1" y="1259.0" font-size="11" fill="#8b949e">_mi_os_purge_zero</text>
-<circle cx="1069.3" cy="1255.0" r="7.0" fill="#3fb950"/>
-<path d="M 1065.9 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1080.3" y="1259.0" font-size="11" fill="#8b949e">edata_zeroed after forced purge</text>
+<circle cx="439.0" cy="1255.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1259.0" font-size="11" fill="#8b949e">_mi_os_purge_zero, opt-in — #337</text>
+<circle cx="649.0" cy="1255.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 1252.0 l 6.0 6.0 M 652.0 1252.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="1259.0" font-size="11" fill="#8b949e">_mi_os_purge has no is_zero</text>
+<circle cx="859.0" cy="1255.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1259.0" font-size="11" fill="#8b949e">_mi_os_purge_zero</text>
+<circle cx="1069.0" cy="1255.0" r="7.0" fill="#3fb950"/>
+<path d="M 1065.6 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1259.0" font-size="11" fill="#8b949e">edata_zeroed after forced purge</text>
 <rect x="16" y="1267.0" width="1252" height="24" fill="#30363d" opacity="0.22"/>
 <text x="24" y="1283.0" font-size="12" fill="#e6edf3">Opt out of the exit-time destructor</text>
-<circle cx="469.0" cy="1279.0" r="7.0" fill="#3fb950"/>
-<path d="M 465.6 1279.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="480.0" y="1283.0" font-size="11" fill="#8b949e">MI_NO_PROCESS_DETACH</text>
-<circle cx="735.0" cy="1279.0" r="7.0" fill="#f85149"/>
-<path d="M 732.0 1276.0 l 6.0 6.0 M 738.0 1276.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="889.0" cy="1279.0" r="7.0" fill="#3fb950"/>
-<path d="M 885.6 1279.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="900.0" y="1283.0" font-size="11" fill="#8b949e">MI_NO_PROCESS_DETACH</text>
-<circle cx="1155.0" cy="1279.0" r="7.0" fill="#f85149"/>
-<path d="M 1152.0 1276.0 l 6.0 6.0 M 1158.0 1276.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="439.0" cy="1279.0" r="7.0" fill="#3fb950"/>
+<path d="M 435.6 1279.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1283.0" font-size="11" fill="#8b949e">MI_NO_PROCESS_DETACH</text>
+<circle cx="649.0" cy="1279.0" r="7.0" fill="#f85149"/>
+<path d="M 646.0 1276.0 l 6.0 6.0 M 652.0 1276.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="1279.0" r="7.0" fill="#3fb950"/>
+<path d="M 855.6 1279.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1283.0" font-size="11" fill="#8b949e">MI_NO_PROCESS_DETACH</text>
+<circle cx="1069.0" cy="1279.0" r="7.0" fill="#f85149"/>
+<path d="M 1066.0 1276.0 l 6.0 6.0 M 1072.0 1276.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
 <circle cx="31.0" cy="1311.0" r="7.0" fill="#3fb950"/>
 <path d="M 27.6 1311.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
 <text x="43.0" y="1315.0" font-size="11" fill="#8b949e">has it</text>

--- a/.github/assets/allocator-features-light.svg
+++ b/.github/assets/allocator-features-light.svg
@@ -6,571 +6,571 @@
 <text x="24" y="26" font-size="17" font-weight="600" fill="#1f2328">Allocator feature comparison</text>
 <text x="24" y="46" font-size="11" fill="#59636e">Sourced cell by cell in docs/allocator-features.json. Upstream and Bun are the exact commits this fork pins to and ports from; jemalloc is the build in the benchmark lockfile. The measured row is the committed churn benchmark,</text>
 <text x="24" y="61" font-size="11" fill="#59636e">whose upstream arm is v3.4.3 (bcee5a88).</text>
-<text x="525.0" y="93" font-size="12.5" font-weight="700" text-anchor="middle" fill="#1f2328">mimalloc-pprof</text>
-<text x="525.0" y="108" font-size="10" text-anchor="middle" fill="#59636e">this fork, 0.9.x</text>
-<text x="735.0" y="93" font-size="12.5" font-weight="600" text-anchor="middle" fill="#59636e">Microsoft MiMalloc-V3</text>
-<text x="735.0" y="108" font-size="10" text-anchor="middle" fill="#59636e">v3 dev3 @ 6def7be9</text>
-<text x="945.0" y="93" font-size="12.5" font-weight="600" text-anchor="middle" fill="#59636e">Bun mimalloc</text>
-<text x="945.0" y="108" font-size="10" text-anchor="middle" fill="#59636e">oven-sh @ b20b60d9</text>
-<text x="1155.0" y="93" font-size="12.5" font-weight="600" text-anchor="middle" fill="#59636e">jemalloc</text>
-<text x="1155.0" y="108" font-size="10" text-anchor="middle" fill="#59636e">5.3.1 @ 81034ce1</text>
+<text x="432.0" y="93" font-size="12.5" font-weight="700" fill="#1f2328">mimalloc-pprof</text>
+<text x="432.0" y="108" font-size="10" fill="#59636e">this fork, 0.9.x</text>
+<text x="642.0" y="93" font-size="12.5" font-weight="600" fill="#59636e">Microsoft MiMalloc-V3</text>
+<text x="642.0" y="108" font-size="10" fill="#59636e">v3 dev3 @ 6def7be9</text>
+<text x="852.0" y="93" font-size="12.5" font-weight="600" fill="#59636e">Bun mimalloc</text>
+<text x="852.0" y="108" font-size="10" fill="#59636e">oven-sh @ b20b60d9</text>
+<text x="1062.0" y="93" font-size="12.5" font-weight="600" fill="#59636e">jemalloc</text>
+<text x="1062.0" y="108" font-size="10" fill="#59636e">5.3.1 @ 81034ce1</text>
 <line x1="24" y1="133" x2="1260" y2="133" stroke="#d8dee4" stroke-width="1"/>
 <text x="24" y="154.0" font-size="12" font-weight="700" fill="#1f2328" letter-spacing="0.4">MEMORY RETURN</text>
 <text x="24" y="179.0" font-size="12" fill="#1f2328">Process-wide eager purge, from any thread</text>
-<circle cx="452.8" cy="175.0" r="7.0" fill="#1a7f47"/>
-<path d="M 449.4 175.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="463.8" y="179.0" font-size="11" fill="#59636e">gated 72 %, default parked</text>
-<circle cx="665.5" cy="175.0" r="7.0" fill="#cf222e"/>
-<path d="M 662.5 172.0 l 6.0 6.0 M 668.5 172.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="676.5" y="179.0" font-size="11" fill="#59636e">mi_collect is caller-only</text>
-<circle cx="875.5" cy="175.0" r="7.0" fill="#cf222e"/>
-<path d="M 872.5 172.0 l 6.0 6.0 M 878.5 172.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="886.5" y="179.0" font-size="11" fill="#59636e">mi_collect is caller-only</text>
-<circle cx="1088.2" cy="175.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1084.8 175.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1099.2" y="179.0" font-size="11" fill="#59636e">MALLCTL_ARENAS_ALL, 74 %</text>
+<circle cx="439.0" cy="175.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 175.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="179.0" font-size="11" fill="#59636e">gated 72 %, default parked</text>
+<circle cx="649.0" cy="175.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 172.0 l 6.0 6.0 M 652.0 172.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="179.0" font-size="11" fill="#59636e">mi_collect is caller-only</text>
+<circle cx="859.0" cy="175.0" r="7.0" fill="#cf222e"/>
+<path d="M 856.0 172.0 l 6.0 6.0 M 862.0 172.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="179.0" font-size="11" fill="#59636e">mi_collect is caller-only</text>
+<circle cx="1069.0" cy="175.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 175.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="179.0" font-size="11" fill="#59636e">MALLCTL_ARENAS_ALL, 74 %</text>
 <rect x="16" y="187.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="203.0" font-size="12" fill="#1f2328">Purge the calling thread's own memory</text>
-<circle cx="466.3" cy="199.0" r="7.0" fill="#1a7f47"/>
-<path d="M 462.9 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="203.0" font-size="11" fill="#59636e">mi_collect, idle hook</text>
-<circle cx="706.0" cy="199.0" r="7.0" fill="#1a7f47"/>
-<path d="M 702.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="717.0" y="203.0" font-size="11" fill="#59636e">mi_collect</text>
-<circle cx="886.3" cy="199.0" r="7.0" fill="#1a7f47"/>
-<path d="M 882.9 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="897.3" y="203.0" font-size="11" fill="#59636e">mi_collect, idle hook</text>
-<circle cx="1077.4" cy="199.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1074.0 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1088.4" y="203.0" font-size="11" fill="#59636e">tcache.flush + arena.i.purge</text>
+<circle cx="439.0" cy="199.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="203.0" font-size="11" fill="#59636e">mi_collect, idle hook</text>
+<circle cx="649.0" cy="199.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="203.0" font-size="11" fill="#59636e">mi_collect</text>
+<circle cx="859.0" cy="199.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="203.0" font-size="11" fill="#59636e">mi_collect, idle hook</text>
+<circle cx="1069.0" cy="199.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 199.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="203.0" font-size="11" fill="#59636e">tcache.flush + arena.i.purge</text>
 <text x="24" y="227.0" font-size="12" fill="#1f2328">Sweep another thread's heap for it</text>
-<circle cx="455.5" cy="223.0" r="7.0" fill="#1a7f47"/>
-<path d="M 452.1 223.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="466.5" y="227.0" font-size="11" fill="#59636e">all gated; parked default</text>
-<circle cx="681.7" cy="223.0" r="7.0" fill="#cf222e"/>
-<path d="M 678.7 220.0 l 6.0 6.0 M 684.7 220.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="692.7" y="227.0" font-size="11" fill="#59636e">no scavenger at all</text>
-<circle cx="891.7" cy="223.0" r="7.0" fill="#bf8700"/>
-<path d="M 891.7 219.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="891.7" cy="226.4" r="1.1" fill="#ffffff"/>
-<text x="902.7" y="227.0" font-size="11" fill="#59636e">parked threads only</text>
-<circle cx="1074.7" cy="223.0" r="7.0" fill="#bf8700"/>
-<path d="M 1074.7 219.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1074.7" cy="226.4" r="1.1" fill="#ffffff"/>
-<text x="1085.7" y="227.0" font-size="11" fill="#59636e">arena purge, not their tcache</text>
+<circle cx="439.0" cy="223.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 223.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="227.0" font-size="11" fill="#59636e">all gated; parked default</text>
+<circle cx="649.0" cy="223.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 220.0 l 6.0 6.0 M 652.0 220.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="227.0" font-size="11" fill="#59636e">no scavenger at all</text>
+<circle cx="859.0" cy="223.0" r="7.0" fill="#bf8700"/>
+<path d="M 859.0 219.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="859.0" cy="226.4" r="1.1" fill="#ffffff"/>
+<text x="870.0" y="227.0" font-size="11" fill="#59636e">parked threads only</text>
+<circle cx="1069.0" cy="223.0" r="7.0" fill="#bf8700"/>
+<path d="M 1069.0 219.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="226.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="227.0" font-size="11" fill="#59636e">arena purge, not their tcache</text>
 <rect x="16" y="235.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="251.0" font-size="12" fill="#1f2328">Sub-page return inside a still-used page</text>
-<circle cx="450.1" cy="247.0" r="7.0" fill="#1a7f47"/>
-<path d="M 446.7 247.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="461.1" y="251.0" font-size="11" fill="#59636e">hole purging, on by default</text>
-<circle cx="689.8" cy="247.0" r="7.0" fill="#cf222e"/>
-<path d="M 686.8 244.0 l 6.0 6.0 M 692.8 244.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="700.8" y="251.0" font-size="11" fill="#59636e">whole pages only</text>
-<circle cx="870.1" cy="247.0" r="7.0" fill="#1a7f47"/>
-<path d="M 866.7 247.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="881.1" y="251.0" font-size="11" fill="#59636e">hole purging, on by default</text>
-<circle cx="1096.3" cy="247.0" r="7.0" fill="#cf222e"/>
-<path d="M 1093.3 244.0 l 6.0 6.0 M 1099.3 244.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1107.3" y="251.0" font-size="11" fill="#59636e">extent-granular purge</text>
+<circle cx="439.0" cy="247.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 247.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="251.0" font-size="11" fill="#59636e">hole purging, on by default</text>
+<circle cx="649.0" cy="247.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 244.0 l 6.0 6.0 M 652.0 244.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="251.0" font-size="11" fill="#59636e">whole pages only</text>
+<circle cx="859.0" cy="247.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 247.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="251.0" font-size="11" fill="#59636e">hole purging, on by default</text>
+<circle cx="1069.0" cy="247.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 244.0 l 6.0 6.0 M 1072.0 244.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="251.0" font-size="11" fill="#59636e">extent-granular purge</text>
 <text x="24" y="275.0" font-size="12" fill="#1f2328">Background purge thread</text>
-<circle cx="487.9" cy="271.0" r="7.0" fill="#1a7f47"/>
-<path d="M 484.5 271.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="498.9" y="275.0" font-size="11" fill="#59636e">on by default</text>
-<circle cx="668.2" cy="271.0" r="7.0" fill="#cf222e"/>
-<path d="M 665.2 268.0 l 6.0 6.0 M 671.2 268.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="679.2" y="275.0" font-size="11" fill="#59636e">purge waits for a malloc</text>
-<circle cx="907.9" cy="271.0" r="7.0" fill="#1a7f47"/>
-<path d="M 904.5 271.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="918.9" y="275.0" font-size="11" fill="#59636e">on by default</text>
-<circle cx="1115.2" cy="271.0" r="7.0" fill="#bf8700"/>
-<path d="M 1115.2 267.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1115.2" cy="274.4" r="1.1" fill="#ffffff"/>
-<text x="1126.2" y="275.0" font-size="11" fill="#59636e">off by default</text>
+<circle cx="439.0" cy="271.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 271.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="275.0" font-size="11" fill="#59636e">on by default</text>
+<circle cx="649.0" cy="271.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 268.0 l 6.0 6.0 M 652.0 268.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="275.0" font-size="11" fill="#59636e">purge waits for a malloc</text>
+<circle cx="859.0" cy="271.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 271.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="275.0" font-size="11" fill="#59636e">on by default</text>
+<circle cx="1069.0" cy="271.0" r="7.0" fill="#bf8700"/>
+<path d="M 1069.0 267.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="274.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="275.0" font-size="11" fill="#59636e">off by default</text>
 <rect x="16" y="283.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="299.0" font-size="12" fill="#1f2328">Time-delayed / decaying purge</text>
-<circle cx="474.4" cy="295.0" r="7.0" fill="#1a7f47"/>
-<path d="M 471.0 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="485.4" y="299.0" font-size="11" fill="#59636e">purge_delay 100 ms</text>
-<circle cx="681.7" cy="295.0" r="7.0" fill="#1a7f47"/>
-<path d="M 678.3 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="692.7" y="299.0" font-size="11" fill="#59636e">purge_delay 1000 ms</text>
-<circle cx="894.4" cy="295.0" r="7.0" fill="#1a7f47"/>
-<path d="M 891.0 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="905.4" y="299.0" font-size="11" fill="#59636e">purge_delay 100 ms</text>
-<circle cx="1101.7" cy="295.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1098.3 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1112.7" y="299.0" font-size="11" fill="#59636e">dirty_decay_ms 10 s</text>
+<circle cx="439.0" cy="295.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="299.0" font-size="11" fill="#59636e">purge_delay 100 ms</text>
+<circle cx="649.0" cy="295.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="299.0" font-size="11" fill="#59636e">purge_delay 1000 ms</text>
+<circle cx="859.0" cy="295.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="299.0" font-size="11" fill="#59636e">purge_delay 100 ms</text>
+<circle cx="1069.0" cy="295.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 295.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="299.0" font-size="11" fill="#59636e">dirty_decay_ms 10 s</text>
 <text x="24" y="323.0" font-size="12" fill="#1f2328">RSS returned after 10 s idle (churn)</text>
-<text x="525.0" y="323.0" font-size="11" text-anchor="middle" fill="#1f2328">74 %</text>
-<text x="735.0" y="323.0" font-size="11" text-anchor="middle" fill="#1f2328">0 % (18 % w/ mi_collect)</text>
-<text x="945.0" y="323.0" font-size="11" text-anchor="middle" fill="#1f2328">74 %</text>
-<text x="1155.0" y="323.0" font-size="11" text-anchor="middle" fill="#1f2328">0 % (74 % if asked)</text>
+<text x="450.0" y="323.0" font-size="11" fill="#1f2328">74 %</text>
+<text x="660.0" y="323.0" font-size="11" fill="#1f2328">0 % (18 % w/ mi_collect)</text>
+<text x="870.0" y="323.0" font-size="11" fill="#1f2328">74 %</text>
+<text x="1080.0" y="323.0" font-size="11" fill="#1f2328">0 % (74 % if asked)</text>
 <text x="24" y="352.0" font-size="12" font-weight="700" fill="#1f2328" letter-spacing="0.4">PROFILING AND OBSERVABILITY</text>
 <text x="24" y="377.0" font-size="12" fill="#1f2328">pprof-compatible sampled heap profiler</text>
-<circle cx="485.2" cy="373.0" r="7.0" fill="#1a7f47"/>
-<path d="M 481.8 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="496.2" y="377.0" font-size="11" fill="#59636e">runtime opt-in</text>
-<circle cx="703.3" cy="373.0" r="7.0" fill="#cf222e"/>
-<path d="M 700.3 370.0 l 6.0 6.0 M 706.3 370.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="714.3" y="377.0" font-size="11" fill="#59636e">none at all</text>
-<circle cx="905.2" cy="373.0" r="7.0" fill="#1a7f47"/>
-<path d="M 901.8 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="916.2" y="377.0" font-size="11" fill="#59636e">runtime opt-in</text>
-<circle cx="1088.2" cy="373.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1084.8 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1099.2" y="377.0" font-size="11" fill="#59636e">build-time --enable-prof</text>
+<circle cx="439.0" cy="373.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="377.0" font-size="11" fill="#59636e">runtime opt-in</text>
+<circle cx="649.0" cy="373.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 370.0 l 6.0 6.0 M 652.0 370.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="377.0" font-size="11" fill="#59636e">none at all</text>
+<circle cx="859.0" cy="373.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="377.0" font-size="11" fill="#59636e">runtime opt-in</text>
+<circle cx="1069.0" cy="373.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 373.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="377.0" font-size="11" fill="#59636e">build-time --enable-prof</text>
 <rect x="16" y="385.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="401.0" font-size="12" fill="#1f2328">Heap profiler on Windows</text>
-<circle cx="485.2" cy="397.0" r="7.0" fill="#1a7f47"/>
-<path d="M 481.8 397.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="496.2" y="401.0" font-size="11" fill="#59636e">MSVC and MinGW</text>
-<circle cx="703.3" cy="397.0" r="7.0" fill="#cf222e"/>
-<path d="M 700.3 394.0 l 6.0 6.0 M 706.3 394.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="714.3" y="401.0" font-size="11" fill="#59636e">no profiler</text>
-<circle cx="886.3" cy="397.0" r="7.0" fill="#bf8700"/>
-<path d="M 886.3 393.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="886.3" cy="400.4" r="1.1" fill="#ffffff"/>
-<text x="897.3" y="401.0" font-size="11" fill="#59636e">frames, no module map</text>
-<circle cx="1088.2" cy="397.0" r="7.0" fill="#bf8700"/>
-<path d="M 1088.2 393.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1088.2" cy="400.4" r="1.1" fill="#ffffff"/>
-<text x="1099.2" y="401.0" font-size="11" fill="#59636e">not MSVC; MinGW untested</text>
+<circle cx="439.0" cy="397.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 397.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="401.0" font-size="11" fill="#59636e">MSVC and MinGW</text>
+<circle cx="649.0" cy="397.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 394.0 l 6.0 6.0 M 652.0 394.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="401.0" font-size="11" fill="#59636e">no profiler</text>
+<circle cx="859.0" cy="397.0" r="7.0" fill="#bf8700"/>
+<path d="M 859.0 393.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="859.0" cy="400.4" r="1.1" fill="#ffffff"/>
+<text x="870.0" y="401.0" font-size="11" fill="#59636e">frames, no module map</text>
+<circle cx="1069.0" cy="397.0" r="7.0" fill="#bf8700"/>
+<path d="M 1069.0 393.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="400.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="401.0" font-size="11" fill="#59636e">not MSVC; MinGW untested</text>
 <text x="24" y="425.0" font-size="12" fill="#1f2328">profile.proto (protobuf) output</text>
-<circle cx="471.7" cy="421.0" r="7.0" fill="#1a7f47"/>
-<path d="M 468.3 421.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="482.7" y="425.0" font-size="11" fill="#59636e">and gperftools text</text>
-<circle cx="703.3" cy="421.0" r="7.0" fill="#cf222e"/>
-<path d="M 700.3 418.0 l 6.0 6.0 M 706.3 418.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="714.3" y="425.0" font-size="11" fill="#59636e">no profiler</text>
-<circle cx="945.0" cy="421.0" r="7.0" fill="#1a7f47"/>
-<path d="M 941.6 421.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="1085.5" cy="421.0" r="7.0" fill="#cf222e"/>
-<path d="M 1082.5 418.0 l 6.0 6.0 M 1088.5 418.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1096.5" y="425.0" font-size="11" fill="#59636e">text format; jeprof reads</text>
+<circle cx="439.0" cy="421.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 421.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="425.0" font-size="11" fill="#59636e">and gperftools text</text>
+<circle cx="649.0" cy="421.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 418.0 l 6.0 6.0 M 652.0 418.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="425.0" font-size="11" fill="#59636e">no profiler</text>
+<circle cx="859.0" cy="421.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 421.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="1069.0" cy="421.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 418.0 l 6.0 6.0 M 1072.0 418.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="425.0" font-size="11" fill="#59636e">text format; jeprof reads</text>
 <rect x="16" y="433.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="449.0" font-size="12" fill="#1f2328">Exact allocator statistics</text>
-<circle cx="490.6" cy="445.0" r="7.0" fill="#1a7f47"/>
-<path d="M 487.2 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="501.6" y="449.0" font-size="11" fill="#59636e">mi_stats_get</text>
-<circle cx="700.6" cy="445.0" r="7.0" fill="#1a7f47"/>
-<path d="M 697.2 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="711.6" y="449.0" font-size="11" fill="#59636e">mi_stats_get</text>
-<circle cx="910.6" cy="445.0" r="7.0" fill="#1a7f47"/>
-<path d="M 907.2 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="921.6" y="449.0" font-size="11" fill="#59636e">mi_stats_get</text>
-<circle cx="1077.4" cy="445.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1074.0 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1088.4" y="449.0" font-size="11" fill="#59636e">mallctl / malloc_stats_print</text>
+<circle cx="439.0" cy="445.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="449.0" font-size="11" fill="#59636e">mi_stats_get</text>
+<circle cx="649.0" cy="445.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="449.0" font-size="11" fill="#59636e">mi_stats_get</text>
+<circle cx="859.0" cy="445.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="449.0" font-size="11" fill="#59636e">mi_stats_get</text>
+<circle cx="1069.0" cy="445.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 445.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="449.0" font-size="11" fill="#59636e">mallctl / malloc_stats_print</text>
 <text x="24" y="473.0" font-size="12" fill="#1f2328">Statistics as JSON</text>
-<circle cx="477.1" cy="469.0" r="7.0" fill="#1a7f47"/>
-<path d="M 473.7 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="488.1" y="473.0" font-size="11" fill="#59636e">mi_stats_get_json</text>
-<circle cx="687.1" cy="469.0" r="7.0" fill="#1a7f47"/>
-<path d="M 683.7 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="698.1" y="473.0" font-size="11" fill="#59636e">mi_stats_get_json</text>
-<circle cx="897.1" cy="469.0" r="7.0" fill="#1a7f47"/>
-<path d="M 893.7 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="908.1" y="473.0" font-size="11" fill="#59636e">mi_stats_get_json</text>
-<circle cx="1107.1" cy="469.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1103.7 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1118.1" y="473.0" font-size="11" fill="#59636e">the &quot;J&quot; opts flag</text>
+<circle cx="439.0" cy="469.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="473.0" font-size="11" fill="#59636e">mi_stats_get_json</text>
+<circle cx="649.0" cy="469.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="473.0" font-size="11" fill="#59636e">mi_stats_get_json</text>
+<circle cx="859.0" cy="469.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="473.0" font-size="11" fill="#59636e">mi_stats_get_json</text>
+<circle cx="1069.0" cy="469.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 469.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="473.0" font-size="11" fill="#59636e">the &quot;J&quot; opts flag</text>
 <rect x="16" y="481.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="497.0" font-size="12" fill="#1f2328">Per-heap JSON dump</text>
-<circle cx="477.1" cy="493.0" r="7.0" fill="#1a7f47"/>
-<path d="M 473.7 493.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="488.1" y="497.0" font-size="11" fill="#59636e">mi_heap_dump_json</text>
-<circle cx="670.9" cy="493.0" r="7.0" fill="#cf222e"/>
-<path d="M 667.9 490.0 l 6.0 6.0 M 673.9 490.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="681.9" y="497.0" font-size="11" fill="#59636e">process-wide stats only</text>
-<circle cx="897.1" cy="493.0" r="7.0" fill="#1a7f47"/>
-<path d="M 893.7 493.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="908.1" y="497.0" font-size="11" fill="#59636e">mi_heap_dump_json</text>
-<circle cx="1090.9" cy="493.0" r="7.0" fill="#cf222e"/>
-<path d="M 1087.9 490.0 l 6.0 6.0 M 1093.9 490.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1101.9" y="497.0" font-size="11" fill="#59636e">per-arena, not per-heap</text>
+<circle cx="439.0" cy="493.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 493.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="497.0" font-size="11" fill="#59636e">mi_heap_dump_json</text>
+<circle cx="649.0" cy="493.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 490.0 l 6.0 6.0 M 652.0 490.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="497.0" font-size="11" fill="#59636e">process-wide stats only</text>
+<circle cx="859.0" cy="493.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 493.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="497.0" font-size="11" fill="#59636e">mi_heap_dump_json</text>
+<circle cx="1069.0" cy="493.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 490.0 l 6.0 6.0 M 1072.0 490.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="497.0" font-size="11" fill="#59636e">per-arena, not per-heap</text>
 <text x="24" y="521.0" font-size="12" fill="#1f2328">DHAT exact profiling (Valgrind format)</text>
-<circle cx="487.9" cy="517.0" r="7.0" fill="#1a7f47"/>
-<path d="M 484.5 517.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="498.9" y="521.0" font-size="11" fill="#59636e">mi_dhat_start</text>
-<circle cx="735.0" cy="517.0" r="7.0" fill="#cf222e"/>
-<path d="M 732.0 514.0 l 6.0 6.0 M 738.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="945.0" cy="517.0" r="7.0" fill="#cf222e"/>
-<path d="M 942.0 514.0 l 6.0 6.0 M 948.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="1155.0" cy="517.0" r="7.0" fill="#cf222e"/>
-<path d="M 1152.0 514.0 l 6.0 6.0 M 1158.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="439.0" cy="517.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 517.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="521.0" font-size="11" fill="#59636e">mi_dhat_start</text>
+<circle cx="649.0" cy="517.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 514.0 l 6.0 6.0 M 652.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="517.0" r="7.0" fill="#cf222e"/>
+<path d="M 856.0 514.0 l 6.0 6.0 M 862.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="1069.0" cy="517.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 514.0 l 6.0 6.0 M 1072.0 514.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
 <rect x="16" y="529.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="545.0" font-size="12" fill="#1f2328">Allocation-event callbacks</text>
-<circle cx="460.9" cy="541.0" r="7.0" fill="#1a7f47"/>
-<path d="M 457.5 541.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="471.9" y="545.0" font-size="11" fill="#59636e">mi_memory_set_callbacks</text>
-<circle cx="735.0" cy="541.0" r="7.0" fill="#cf222e"/>
-<path d="M 732.0 538.0 l 6.0 6.0 M 738.0 538.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="945.0" cy="541.0" r="7.0" fill="#cf222e"/>
-<path d="M 942.0 538.0 l 6.0 6.0 M 948.0 538.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="1082.8" cy="541.0" r="7.0" fill="#bf8700"/>
-<path d="M 1082.8 537.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1082.8" cy="544.4" r="1.1" fill="#ffffff"/>
-<text x="1093.8" y="545.0" font-size="11" fill="#59636e">experimental.hooks.install</text>
+<circle cx="439.0" cy="541.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 541.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="545.0" font-size="11" fill="#59636e">mi_memory_set_callbacks</text>
+<circle cx="649.0" cy="541.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 538.0 l 6.0 6.0 M 652.0 538.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="541.0" r="7.0" fill="#cf222e"/>
+<path d="M 856.0 538.0 l 6.0 6.0 M 862.0 538.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="1069.0" cy="541.0" r="7.0" fill="#bf8700"/>
+<path d="M 1069.0 537.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="544.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="545.0" font-size="11" fill="#59636e">experimental.hooks.install</text>
 <text x="24" y="569.0" font-size="12" fill="#1f2328">Walk every live block in a heap</text>
-<circle cx="469.0" cy="565.0" r="7.0" fill="#1a7f47"/>
-<path d="M 465.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="480.0" y="569.0" font-size="11" fill="#59636e">mi_heap_visit_blocks</text>
-<circle cx="679.0" cy="565.0" r="7.0" fill="#1a7f47"/>
-<path d="M 675.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="690.0" y="569.0" font-size="11" fill="#59636e">mi_heap_visit_blocks</text>
-<circle cx="889.0" cy="565.0" r="7.0" fill="#1a7f47"/>
-<path d="M 885.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="900.0" y="569.0" font-size="11" fill="#59636e">mi_heap_visit_blocks</text>
-<circle cx="1099.0" cy="565.0" r="7.0" fill="#cf222e"/>
-<path d="M 1096.0 562.0 l 6.0 6.0 M 1102.0 562.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1110.0" y="569.0" font-size="11" fill="#59636e">no iteration mallctl</text>
+<circle cx="439.0" cy="565.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="569.0" font-size="11" fill="#59636e">mi_heap_visit_blocks</text>
+<circle cx="649.0" cy="565.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="569.0" font-size="11" fill="#59636e">mi_heap_visit_blocks</text>
+<circle cx="859.0" cy="565.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 565.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="569.0" font-size="11" fill="#59636e">mi_heap_visit_blocks</text>
+<circle cx="1069.0" cy="565.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 562.0 l 6.0 6.0 M 1072.0 562.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="569.0" font-size="11" fill="#59636e">no iteration mallctl</text>
 <rect x="16" y="577.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="593.0" font-size="12" fill="#1f2328">Live heap snapshot with a viewer</text>
-<circle cx="460.9" cy="589.0" r="7.0" fill="#1a7f47"/>
-<path d="M 457.5 589.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="471.9" y="593.0" font-size="11" fill="#59636e">mi_heap_snapshot — #338</text>
-<circle cx="735.0" cy="589.0" r="7.0" fill="#cf222e"/>
-<path d="M 732.0 586.0 l 6.0 6.0 M 738.0 586.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="891.7" cy="589.0" r="7.0" fill="#1a7f47"/>
-<path d="M 888.3 589.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="902.7" y="593.0" font-size="11" fill="#59636e">+ tools/mi-heapview</text>
-<circle cx="1155.0" cy="589.0" r="7.0" fill="#cf222e"/>
-<path d="M 1152.0 586.0 l 6.0 6.0 M 1158.0 586.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="439.0" cy="589.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 589.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="593.0" font-size="11" fill="#59636e">mi_heap_snapshot — #338</text>
+<circle cx="649.0" cy="589.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 586.0 l 6.0 6.0 M 652.0 586.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="589.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 589.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="593.0" font-size="11" fill="#59636e">+ tools/mi-heapview</text>
+<circle cx="1069.0" cy="589.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 586.0 l 6.0 6.0 M 1072.0 586.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
 <text x="24" y="617.0" font-size="12" fill="#1f2328">No fast-path cost while profiling is off</text>
-<circle cx="452.8" cy="613.0" r="7.0" fill="#1a7f47"/>
-<path d="M 449.4 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="463.8" y="617.0" font-size="11" fill="#59636e">malloc path byte-identical</text>
-<circle cx="692.5" cy="613.0" r="7.0" fill="#1a7f47"/>
-<path d="M 689.1 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="703.5" y="617.0" font-size="11" fill="#59636e">nothing to cost</text>
-<circle cx="878.2" cy="613.0" r="7.0" fill="#1a7f47"/>
-<path d="M 874.8 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="889.2" y="617.0" font-size="11" fill="#59636e">sample rate 0 by default</text>
-<circle cx="1107.1" cy="613.0" r="7.0" fill="#bf8700"/>
-<path d="M 1107.1 609.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1107.1" cy="616.4" r="1.1" fill="#ffffff"/>
-<text x="1118.1" y="617.0" font-size="11" fill="#59636e">build-time opt-in</text>
+<circle cx="439.0" cy="613.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="617.0" font-size="11" fill="#59636e">malloc path byte-identical</text>
+<circle cx="649.0" cy="613.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="617.0" font-size="11" fill="#59636e">nothing to cost</text>
+<circle cx="859.0" cy="613.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 613.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="617.0" font-size="11" fill="#59636e">sample rate 0 by default</text>
+<circle cx="1069.0" cy="613.0" r="7.0" fill="#bf8700"/>
+<path d="M 1069.0 609.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="616.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="617.0" font-size="11" fill="#59636e">build-time opt-in</text>
 <text x="24" y="646.0" font-size="12" font-weight="700" fill="#1f2328" letter-spacing="0.4">ROBUSTNESS</text>
 <text x="24" y="671.0" font-size="12" fill="#1f2328">fork() handlers (pthread_atfork)</text>
-<circle cx="466.3" cy="667.0" r="7.0" fill="#1a7f47"/>
-<path d="M 462.9 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="671.0" font-size="11" fill="#59636e">documented lock order</text>
-<circle cx="692.5" cy="667.0" r="7.0" fill="#cf222e"/>
-<path d="M 689.5 664.0 l 6.0 6.0 M 695.5 664.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="703.5" y="671.0" font-size="11" fill="#59636e">none registered</text>
-<circle cx="945.0" cy="667.0" r="7.0" fill="#1a7f47"/>
-<path d="M 941.6 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="1109.8" cy="667.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1106.4 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1120.8" y="671.0" font-size="11" fill="#59636e">jemalloc_prefork</text>
+<circle cx="439.0" cy="667.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="671.0" font-size="11" fill="#59636e">documented lock order</text>
+<circle cx="649.0" cy="667.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 664.0 l 6.0 6.0 M 652.0 664.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="671.0" font-size="11" fill="#59636e">none registered</text>
+<circle cx="859.0" cy="667.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="1069.0" cy="667.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 667.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="671.0" font-size="11" fill="#59636e">jemalloc_prefork</text>
 <rect x="16" y="679.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="695.0" font-size="12" fill="#1f2328">Runtime lock-order checker</text>
-<circle cx="496.0" cy="691.0" r="7.0" fill="#1a7f47"/>
-<path d="M 492.6 691.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="507.0" y="695.0" font-size="11" fill="#59636e">MI_DEBUG&gt;2</text>
-<circle cx="670.9" cy="691.0" r="7.0" fill="#cf222e"/>
-<path d="M 667.9 688.0 l 6.0 6.0 M 673.9 688.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="681.9" y="695.0" font-size="11" fill="#59636e">no fork handlers either</text>
-<circle cx="894.4" cy="691.0" r="7.0" fill="#cf222e"/>
-<path d="M 891.4 688.0 l 6.0 6.0 M 897.4 688.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="905.4" y="695.0" font-size="11" fill="#59636e">order kept by hand</text>
-<circle cx="1074.7" cy="691.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1071.3 691.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1085.7" y="695.0" font-size="11" fill="#59636e">witness ranks, --enable-debug</text>
+<circle cx="439.0" cy="691.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 691.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="695.0" font-size="11" fill="#59636e">MI_DEBUG&gt;2</text>
+<circle cx="649.0" cy="691.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 688.0 l 6.0 6.0 M 652.0 688.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="695.0" font-size="11" fill="#59636e">no fork handlers either</text>
+<circle cx="859.0" cy="691.0" r="7.0" fill="#cf222e"/>
+<path d="M 856.0 688.0 l 6.0 6.0 M 862.0 688.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="695.0" font-size="11" fill="#59636e">order kept by hand</text>
+<circle cx="1069.0" cy="691.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 691.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="695.0" font-size="11" fill="#59636e">witness ranks, --enable-debug</text>
 <text x="24" y="719.0" font-size="12" fill="#1f2328">Heap-teardown ABA claim protocol</text>
-<circle cx="460.9" cy="715.0" r="7.0" fill="#1a7f47"/>
-<path d="M 457.5 715.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="471.9" y="719.0" font-size="11" fill="#59636e">+ fault-injection tests</text>
-<circle cx="735.0" cy="715.0" r="7.0" fill="#cf222e"/>
-<path d="M 732.0 712.0 l 6.0 6.0 M 738.0 712.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="945.0" cy="715.0" r="7.0" fill="#1a7f47"/>
-<path d="M 941.6 715.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="1090.9" cy="715.0" r="7.0" fill="#cf222e"/>
-<path d="M 1087.9 712.0 l 6.0 6.0 M 1093.9 712.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1101.9" y="719.0" font-size="11" fill="#59636e">caller must flush first</text>
+<circle cx="439.0" cy="715.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 715.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="719.0" font-size="11" fill="#59636e">+ fault-injection tests</text>
+<circle cx="649.0" cy="715.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 712.0 l 6.0 6.0 M 652.0 712.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="715.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 715.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="1069.0" cy="715.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 712.0 l 6.0 6.0 M 1072.0 712.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="719.0" font-size="11" fill="#59636e">caller must flush first</text>
 <rect x="16" y="727.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="743.0" font-size="12" fill="#1f2328">Guard-page (guarded) allocations</text>
-<circle cx="496.0" cy="739.0" r="7.0" fill="#1a7f47"/>
-<path d="M 492.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="507.0" y="743.0" font-size="11" fill="#59636e">MI_GUARDED</text>
-<circle cx="706.0" cy="739.0" r="7.0" fill="#1a7f47"/>
-<path d="M 702.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="717.0" y="743.0" font-size="11" fill="#59636e">MI_GUARDED</text>
-<circle cx="916.0" cy="739.0" r="7.0" fill="#1a7f47"/>
-<path d="M 912.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="927.0" y="743.0" font-size="11" fill="#59636e">MI_GUARDED</text>
-<circle cx="1085.5" cy="739.0" r="7.0" fill="#bf8700"/>
-<path d="M 1085.5 735.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1085.5" cy="742.4" r="1.1" fill="#ffffff"/>
-<text x="1096.5" y="743.0" font-size="11" fill="#59636e">opt.san_guard_small/large</text>
+<circle cx="439.0" cy="739.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="743.0" font-size="11" fill="#59636e">MI_GUARDED</text>
+<circle cx="649.0" cy="739.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="743.0" font-size="11" fill="#59636e">MI_GUARDED</text>
+<circle cx="859.0" cy="739.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 739.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="743.0" font-size="11" fill="#59636e">MI_GUARDED</text>
+<circle cx="1069.0" cy="739.0" r="7.0" fill="#bf8700"/>
+<path d="M 1069.0 735.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="742.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="743.0" font-size="11" fill="#59636e">opt.san_guard_small/large</text>
 <text x="24" y="767.0" font-size="12" fill="#1f2328">Hardened / secure build mode</text>
-<circle cx="487.9" cy="763.0" r="7.0" fill="#1a7f47"/>
-<path d="M 484.5 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="498.9" y="767.0" font-size="11" fill="#59636e">MI_SECURE 1-4</text>
-<circle cx="697.9" cy="763.0" r="7.0" fill="#1a7f47"/>
-<path d="M 694.5 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="708.9" y="767.0" font-size="11" fill="#59636e">MI_SECURE 1-4</text>
-<circle cx="907.9" cy="763.0" r="7.0" fill="#1a7f47"/>
-<path d="M 904.5 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="918.9" y="767.0" font-size="11" fill="#59636e">MI_SECURE 1-4</text>
-<circle cx="1104.4" cy="763.0" r="7.0" fill="#cf222e"/>
-<path d="M 1101.4 760.0 l 6.0 6.0 M 1107.4 760.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1115.4" y="767.0" font-size="11" fill="#59636e">no equivalent mode</text>
+<circle cx="439.0" cy="763.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="767.0" font-size="11" fill="#59636e">MI_SECURE 1-4</text>
+<circle cx="649.0" cy="763.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="767.0" font-size="11" fill="#59636e">MI_SECURE 1-4</text>
+<circle cx="859.0" cy="763.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 763.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="767.0" font-size="11" fill="#59636e">MI_SECURE 1-4</text>
+<circle cx="1069.0" cy="763.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 760.0 l 6.0 6.0 M 1072.0 760.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="767.0" font-size="11" fill="#59636e">no equivalent mode</text>
 <rect x="16" y="775.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="791.0" font-size="12" fill="#1f2328">ASan / Valgrind / ETW tracking</text>
-<circle cx="498.7" cy="787.0" r="7.0" fill="#1a7f47"/>
-<path d="M 495.3 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="509.7" y="791.0" font-size="11" fill="#59636e">all three</text>
-<circle cx="708.7" cy="787.0" r="7.0" fill="#1a7f47"/>
-<path d="M 705.3 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="719.7" y="791.0" font-size="11" fill="#59636e">all three</text>
-<circle cx="918.7" cy="787.0" r="7.0" fill="#1a7f47"/>
-<path d="M 915.3 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="929.7" y="791.0" font-size="11" fill="#59636e">all three</text>
-<circle cx="1072.0" cy="787.0" r="7.0" fill="#cf222e"/>
-<path d="M 1069.0 784.0 l 6.0 6.0 M 1075.0 784.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1083.0" y="791.0" font-size="11" fill="#59636e">no ASan, no ETW; Valgrind gone</text>
+<circle cx="439.0" cy="787.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="791.0" font-size="11" fill="#59636e">all three</text>
+<circle cx="649.0" cy="787.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="791.0" font-size="11" fill="#59636e">all three</text>
+<circle cx="859.0" cy="787.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 787.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="791.0" font-size="11" fill="#59636e">all three</text>
+<circle cx="1069.0" cy="787.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 784.0 l 6.0 6.0 M 1072.0 784.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="791.0" font-size="11" fill="#59636e">no ASan, no ETW; Valgrind gone</text>
 <text x="24" y="820.0" font-size="12" font-weight="700" fill="#1f2328" letter-spacing="0.4">PLATFORM AND INTEGRATION</text>
 <text x="24" y="845.0" font-size="12" fill="#1f2328">Windows MSVC as a first-class target</text>
-<circle cx="466.3" cy="841.0" r="7.0" fill="#1a7f47"/>
-<path d="M 462.9 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="845.0" font-size="11" fill="#59636e">native cl gate per PR</text>
-<circle cx="684.4" cy="841.0" r="7.0" fill="#1a7f47"/>
-<path d="M 681.0 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="695.4" y="845.0" font-size="11" fill="#59636e">in the test matrix</text>
-<circle cx="894.4" cy="841.0" r="7.0" fill="#1a7f47"/>
-<path d="M 891.0 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="905.4" y="845.0" font-size="11" fill="#59636e">in the test matrix</text>
-<circle cx="1096.3" cy="841.0" r="7.0" fill="#bf8700"/>
-<path d="M 1096.3 837.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="1096.3" cy="844.4" r="1.1" fill="#ffffff"/>
-<text x="1107.3" y="845.0" font-size="11" fill="#59636e">no prof, no bg thread</text>
+<circle cx="439.0" cy="841.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="845.0" font-size="11" fill="#59636e">native cl gate per PR</text>
+<circle cx="649.0" cy="841.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="845.0" font-size="11" fill="#59636e">in the test matrix</text>
+<circle cx="859.0" cy="841.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 841.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="845.0" font-size="11" fill="#59636e">in the test matrix</text>
+<circle cx="1069.0" cy="841.0" r="7.0" fill="#bf8700"/>
+<path d="M 1069.0 837.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="1069.0" cy="844.4" r="1.1" fill="#ffffff"/>
+<text x="1080.0" y="845.0" font-size="11" fill="#59636e">no prof, no bg thread</text>
 <rect x="16" y="853.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="869.0" font-size="12" fill="#1f2328">Windows malloc override via a redirect DLL</text>
-<circle cx="466.3" cy="865.0" r="7.0" fill="#1a7f47"/>
-<path d="M 462.9 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="869.0" font-size="11" fill="#59636e">mimalloc-redirect.dll</text>
-<circle cx="676.3" cy="865.0" r="7.0" fill="#1a7f47"/>
-<path d="M 672.9 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="687.3" y="869.0" font-size="11" fill="#59636e">mimalloc-redirect.dll</text>
-<circle cx="886.3" cy="865.0" r="7.0" fill="#1a7f47"/>
-<path d="M 882.9 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="897.3" y="869.0" font-size="11" fill="#59636e">mimalloc-redirect.dll</text>
-<circle cx="1082.8" cy="865.0" r="7.0" fill="#cf222e"/>
-<path d="M 1079.8 862.0 l 6.0 6.0 M 1085.8 862.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1093.8" y="869.0" font-size="11" fill="#59636e">link-time replacement only</text>
+<circle cx="439.0" cy="865.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="869.0" font-size="11" fill="#59636e">mimalloc-redirect.dll</text>
+<circle cx="649.0" cy="865.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="869.0" font-size="11" fill="#59636e">mimalloc-redirect.dll</text>
+<circle cx="859.0" cy="865.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 865.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="869.0" font-size="11" fill="#59636e">mimalloc-redirect.dll</text>
+<circle cx="1069.0" cy="865.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 862.0 l 6.0 6.0 M 1072.0 862.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="869.0" font-size="11" fill="#59636e">link-time replacement only</text>
 <text x="24" y="893.0" font-size="12" fill="#1f2328">MinGW / win-gnu covered in CI</text>
-<circle cx="466.3" cy="889.0" r="7.0" fill="#1a7f47"/>
-<path d="M 462.9 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="893.0" font-size="11" fill="#59636e">cross-built, then run</text>
-<circle cx="700.6" cy="889.0" r="7.0" fill="#1a7f47"/>
-<path d="M 697.2 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="711.6" y="893.0" font-size="11" fill="#59636e">mingw-ucrt64</text>
-<circle cx="910.6" cy="889.0" r="7.0" fill="#1a7f47"/>
-<path d="M 907.2 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="921.6" y="893.0" font-size="11" fill="#59636e">mingw-ucrt64</text>
-<circle cx="1104.4" cy="889.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1101.0 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1115.4" y="893.0" font-size="11" fill="#59636e">MSYS2 mingw32-make</text>
+<circle cx="439.0" cy="889.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="893.0" font-size="11" fill="#59636e">cross-built, then run</text>
+<circle cx="649.0" cy="889.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="893.0" font-size="11" fill="#59636e">mingw-ucrt64</text>
+<circle cx="859.0" cy="889.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="893.0" font-size="11" fill="#59636e">mingw-ucrt64</text>
+<circle cx="1069.0" cy="889.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 889.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="893.0" font-size="11" fill="#59636e">MSYS2 mingw32-make</text>
 <rect x="16" y="901.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="917.0" font-size="12" fill="#1f2328">macOS malloc-zone interpose</text>
-<circle cx="525.0" cy="913.0" r="7.0" fill="#1a7f47"/>
-<path d="M 521.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="735.0" cy="913.0" r="7.0" fill="#1a7f47"/>
-<path d="M 731.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="945.0" cy="913.0" r="7.0" fill="#1a7f47"/>
-<path d="M 941.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<circle cx="1155.0" cy="913.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1151.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="439.0" cy="913.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="649.0" cy="913.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="859.0" cy="913.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="1069.0" cy="913.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 913.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
 <text x="24" y="941.0" font-size="12" fill="#1f2328">macOS zone introspection (leaks, vmmap)</text>
-<circle cx="444.7" cy="937.0" r="7.0" fill="#1a7f47"/>
-<path d="M 441.3 937.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="455.7" y="941.0" font-size="11" fill="#59636e">in- and out-of-process — #349</text>
-<circle cx="692.5" cy="937.0" r="7.0" fill="#cf222e"/>
-<path d="M 689.5 934.0 l 6.0 6.0 M 695.5 934.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="703.5" y="941.0" font-size="11" fill="#59636e">stub enumerator</text>
-<circle cx="883.6" cy="937.0" r="7.0" fill="#1a7f47"/>
-<path d="M 880.2 937.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="894.6" y="941.0" font-size="11" fill="#59636e">in- and out-of-process</text>
-<circle cx="1112.5" cy="937.0" r="7.0" fill="#cf222e"/>
-<path d="M 1109.5 934.0 l 6.0 6.0 M 1115.5 934.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1123.5" y="941.0" font-size="11" fill="#59636e">stub enumerator</text>
+<circle cx="439.0" cy="937.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 937.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="941.0" font-size="11" fill="#59636e">in- and out-of-process — #349</text>
+<circle cx="649.0" cy="937.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 934.0 l 6.0 6.0 M 652.0 934.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="941.0" font-size="11" fill="#59636e">stub enumerator</text>
+<circle cx="859.0" cy="937.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 937.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="941.0" font-size="11" fill="#59636e">in- and out-of-process</text>
+<circle cx="1069.0" cy="937.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 934.0 l 6.0 6.0 M 1072.0 934.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="941.0" font-size="11" fill="#59636e">stub enumerator</text>
 <rect x="16" y="949.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="965.0" font-size="12" fill="#1f2328">First-party Rust crate, full C API</text>
-<circle cx="450.1" cy="961.0" r="7.0" fill="#1a7f47"/>
-<path d="M 446.7 961.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="461.1" y="965.0" font-size="11" fill="#59636e">mimalloc-pprof on crates.io</text>
-<circle cx="670.9" cy="961.0" r="7.0" fill="#cf222e"/>
-<path d="M 667.9 958.0 l 6.0 6.0 M 673.9 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="681.9" y="965.0" font-size="11" fill="#59636e">third-party crates only</text>
-<circle cx="921.4" cy="961.0" r="7.0" fill="#cf222e"/>
-<path d="M 918.4 958.0 l 6.0 6.0 M 924.4 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="932.4" y="965.0" font-size="11" fill="#59636e">no crate</text>
-<circle cx="1090.9" cy="961.0" r="7.0" fill="#cf222e"/>
-<path d="M 1087.9 958.0 l 6.0 6.0 M 1093.9 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1101.9" y="965.0" font-size="11" fill="#59636e">third-party crates only</text>
+<circle cx="439.0" cy="961.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 961.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="965.0" font-size="11" fill="#59636e">mimalloc-pprof on crates.io</text>
+<circle cx="649.0" cy="961.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 958.0 l 6.0 6.0 M 652.0 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="965.0" font-size="11" fill="#59636e">third-party crates only</text>
+<circle cx="859.0" cy="961.0" r="7.0" fill="#cf222e"/>
+<path d="M 856.0 958.0 l 6.0 6.0 M 862.0 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="965.0" font-size="11" fill="#59636e">no crate</text>
+<circle cx="1069.0" cy="961.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 958.0 l 6.0 6.0 M 1072.0 958.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="965.0" font-size="11" fill="#59636e">third-party crates only</text>
 <text x="24" y="989.0" font-size="12" fill="#1f2328">Release targets cross-built on Linux</text>
-<circle cx="460.9" cy="985.0" r="7.0" fill="#1a7f47"/>
-<path d="M 457.5 985.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="471.9" y="989.0" font-size="11" fill="#59636e">5 targets through soldr</text>
-<circle cx="679.0" cy="985.0" r="7.0" fill="#cf222e"/>
-<path d="M 676.0 982.0 l 6.0 6.0 M 682.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="690.0" y="989.0" font-size="11" fill="#59636e">native runner per OS</text>
-<circle cx="889.0" cy="985.0" r="7.0" fill="#cf222e"/>
-<path d="M 886.0 982.0 l 6.0 6.0 M 892.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="900.0" y="989.0" font-size="11" fill="#59636e">native runner per OS</text>
-<circle cx="1099.0" cy="985.0" r="7.0" fill="#cf222e"/>
-<path d="M 1096.0 982.0 l 6.0 6.0 M 1102.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1110.0" y="989.0" font-size="11" fill="#59636e">native runner per OS</text>
+<circle cx="439.0" cy="985.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 985.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="989.0" font-size="11" fill="#59636e">5 targets through soldr</text>
+<circle cx="649.0" cy="985.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 982.0 l 6.0 6.0 M 652.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="989.0" font-size="11" fill="#59636e">native runner per OS</text>
+<circle cx="859.0" cy="985.0" r="7.0" fill="#cf222e"/>
+<path d="M 856.0 982.0 l 6.0 6.0 M 862.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="989.0" font-size="11" fill="#59636e">native runner per OS</text>
+<circle cx="1069.0" cy="985.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 982.0 l 6.0 6.0 M 1072.0 982.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="989.0" font-size="11" fill="#59636e">native runner per OS</text>
 <rect x="16" y="997.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="1013.0" font-size="12" fill="#1f2328">macOS covered with no Apple hardware</text>
-<circle cx="444.7" cy="1009.0" r="7.0" fill="#1a7f47"/>
-<path d="M 441.3 1009.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="455.7" y="1013.0" font-size="11" fill="#59636e">cross-built; guest run manual</text>
-<circle cx="679.0" cy="1009.0" r="7.0" fill="#cf222e"/>
-<path d="M 676.0 1006.0 l 6.0 6.0 M 682.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="690.0" y="1013.0" font-size="11" fill="#59636e">hosted macOS runners</text>
-<circle cx="889.0" cy="1009.0" r="7.0" fill="#cf222e"/>
-<path d="M 886.0 1006.0 l 6.0 6.0 M 892.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="900.0" y="1013.0" font-size="11" fill="#59636e">hosted macOS runners</text>
-<circle cx="1099.0" cy="1009.0" r="7.0" fill="#cf222e"/>
-<path d="M 1096.0 1006.0 l 6.0 6.0 M 1102.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1110.0" y="1013.0" font-size="11" fill="#59636e">hosted macOS runners</text>
+<circle cx="439.0" cy="1009.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1009.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1013.0" font-size="11" fill="#59636e">cross-built; guest run manual</text>
+<circle cx="649.0" cy="1009.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 1006.0 l 6.0 6.0 M 652.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="1013.0" font-size="11" fill="#59636e">hosted macOS runners</text>
+<circle cx="859.0" cy="1009.0" r="7.0" fill="#cf222e"/>
+<path d="M 856.0 1006.0 l 6.0 6.0 M 862.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="870.0" y="1013.0" font-size="11" fill="#59636e">hosted macOS runners</text>
+<circle cx="1069.0" cy="1009.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 1006.0 l 6.0 6.0 M 1072.0 1006.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="1013.0" font-size="11" fill="#59636e">hosted macOS runners</text>
 <text x="24" y="1042.0" font-size="12" font-weight="700" fill="#1f2328" letter-spacing="0.4">ALLOCATOR DESIGN</text>
 <text x="24" y="1067.0" font-size="12" fill="#1f2328">Per-thread heaps and caches</text>
-<circle cx="466.3" cy="1063.0" r="7.0" fill="#1a7f47"/>
-<path d="M 462.9 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="477.3" y="1067.0" font-size="11" fill="#59636e">mi_theap_t per thread</text>
-<circle cx="676.3" cy="1063.0" r="7.0" fill="#1a7f47"/>
-<path d="M 672.9 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="687.3" y="1067.0" font-size="11" fill="#59636e">mi_theap_t per thread</text>
-<circle cx="886.3" cy="1063.0" r="7.0" fill="#1a7f47"/>
-<path d="M 882.9 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="897.3" y="1067.0" font-size="11" fill="#59636e">mi_theap_t per thread</text>
-<circle cx="1085.5" cy="1063.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1082.1 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1096.5" y="1067.0" font-size="11" fill="#59636e">tcache + per-thread arena</text>
+<circle cx="439.0" cy="1063.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1067.0" font-size="11" fill="#59636e">mi_theap_t per thread</text>
+<circle cx="649.0" cy="1063.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1067.0" font-size="11" fill="#59636e">mi_theap_t per thread</text>
+<circle cx="859.0" cy="1063.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1067.0" font-size="11" fill="#59636e">mi_theap_t per thread</text>
+<circle cx="1069.0" cy="1063.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 1063.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1067.0" font-size="11" fill="#59636e">tcache + per-thread arena</text>
 <rect x="16" y="1075.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="1091.0" font-size="12" fill="#1f2328">Create and destroy your own heaps</text>
-<circle cx="493.3" cy="1087.0" r="7.0" fill="#1a7f47"/>
-<path d="M 489.9 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="504.3" y="1091.0" font-size="11" fill="#59636e">mi_heap_new</text>
-<circle cx="703.3" cy="1087.0" r="7.0" fill="#1a7f47"/>
-<path d="M 699.9 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="714.3" y="1091.0" font-size="11" fill="#59636e">mi_heap_new</text>
-<circle cx="913.3" cy="1087.0" r="7.0" fill="#1a7f47"/>
-<path d="M 909.9 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="924.3" y="1091.0" font-size="11" fill="#59636e">mi_heap_new</text>
-<circle cx="1117.9" cy="1087.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1114.5 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1128.9" y="1091.0" font-size="11" fill="#59636e">arenas.create</text>
+<circle cx="439.0" cy="1087.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1091.0" font-size="11" fill="#59636e">mi_heap_new</text>
+<circle cx="649.0" cy="1087.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1091.0" font-size="11" fill="#59636e">mi_heap_new</text>
+<circle cx="859.0" cy="1087.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1091.0" font-size="11" fill="#59636e">mi_heap_new</text>
+<circle cx="1069.0" cy="1087.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 1087.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1091.0" font-size="11" fill="#59636e">arenas.create</text>
 <text x="24" y="1115.0" font-size="12" fill="#1f2328">Shared arenas under the per-thread layer</text>
-<circle cx="469.0" cy="1111.0" r="7.0" fill="#1a7f47"/>
-<path d="M 465.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="480.0" y="1115.0" font-size="11" fill="#59636e">arena-of-slices (v3)</text>
-<circle cx="679.0" cy="1111.0" r="7.0" fill="#1a7f47"/>
-<path d="M 675.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="690.0" y="1115.0" font-size="11" fill="#59636e">arena-of-slices (v3)</text>
-<circle cx="889.0" cy="1111.0" r="7.0" fill="#1a7f47"/>
-<path d="M 885.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="900.0" y="1115.0" font-size="11" fill="#59636e">arena-of-slices (v3)</text>
-<circle cx="1093.6" cy="1111.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1090.2 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1104.6" y="1115.0" font-size="11" fill="#59636e">per-CPU mode available</text>
+<circle cx="439.0" cy="1111.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1115.0" font-size="11" fill="#59636e">arena-of-slices (v3)</text>
+<circle cx="649.0" cy="1111.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1115.0" font-size="11" fill="#59636e">arena-of-slices (v3)</text>
+<circle cx="859.0" cy="1111.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1115.0" font-size="11" fill="#59636e">arena-of-slices (v3)</text>
+<circle cx="1069.0" cy="1111.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 1111.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1115.0" font-size="11" fill="#59636e">per-CPU mode available</text>
 <rect x="16" y="1123.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="1139.0" font-size="12" fill="#1f2328">Large / huge OS pages</text>
-<circle cx="469.0" cy="1135.0" r="7.0" fill="#1a7f47"/>
-<path d="M 465.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="480.0" y="1139.0" font-size="11" fill="#59636e">allow_large_os_pages</text>
-<circle cx="679.0" cy="1135.0" r="7.0" fill="#1a7f47"/>
-<path d="M 675.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="690.0" y="1139.0" font-size="11" fill="#59636e">allow_large_os_pages</text>
-<circle cx="889.0" cy="1135.0" r="7.0" fill="#1a7f47"/>
-<path d="M 885.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="900.0" y="1139.0" font-size="11" fill="#59636e">allow_large_os_pages</text>
-<circle cx="1085.5" cy="1135.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1082.1 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1096.5" y="1139.0" font-size="11" fill="#59636e">opt.thp, opt.metadata_thp</text>
+<circle cx="439.0" cy="1135.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1139.0" font-size="11" fill="#59636e">allow_large_os_pages</text>
+<circle cx="649.0" cy="1135.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1139.0" font-size="11" fill="#59636e">allow_large_os_pages</text>
+<circle cx="859.0" cy="1135.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1139.0" font-size="11" fill="#59636e">allow_large_os_pages</text>
+<circle cx="1069.0" cy="1135.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 1135.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1139.0" font-size="11" fill="#59636e">opt.thp, opt.metadata_thp</text>
 <text x="24" y="1163.0" font-size="12" fill="#1f2328">NUMA-aware reservation</text>
-<circle cx="485.2" cy="1159.0" r="7.0" fill="#1a7f47"/>
-<path d="M 481.8 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="496.2" y="1163.0" font-size="11" fill="#59636e">use_numa_nodes</text>
-<circle cx="695.2" cy="1159.0" r="7.0" fill="#1a7f47"/>
-<path d="M 691.8 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="706.2" y="1163.0" font-size="11" fill="#59636e">use_numa_nodes</text>
-<circle cx="905.2" cy="1159.0" r="7.0" fill="#1a7f47"/>
-<path d="M 901.8 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="916.2" y="1163.0" font-size="11" fill="#59636e">use_numa_nodes</text>
-<circle cx="1115.2" cy="1159.0" r="7.0" fill="#cf222e"/>
-<path d="M 1112.2 1156.0 l 6.0 6.0 M 1118.2 1156.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1126.2" y="1163.0" font-size="11" fill="#59636e">no NUMA option</text>
+<circle cx="439.0" cy="1159.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1163.0" font-size="11" fill="#59636e">use_numa_nodes</text>
+<circle cx="649.0" cy="1159.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1163.0" font-size="11" fill="#59636e">use_numa_nodes</text>
+<circle cx="859.0" cy="1159.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1159.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1163.0" font-size="11" fill="#59636e">use_numa_nodes</text>
+<circle cx="1069.0" cy="1159.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 1156.0 l 6.0 6.0 M 1072.0 1156.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="1163.0" font-size="11" fill="#59636e">no NUMA option</text>
 <rect x="16" y="1171.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="1187.0" font-size="12" fill="#1f2328">Bring your own memory region</text>
-<circle cx="471.7" cy="1183.0" r="7.0" fill="#1a7f47"/>
-<path d="M 468.3 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="482.7" y="1187.0" font-size="11" fill="#59636e">mi_manage_os_memory</text>
-<circle cx="681.7" cy="1183.0" r="7.0" fill="#1a7f47"/>
-<path d="M 678.3 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="692.7" y="1187.0" font-size="11" fill="#59636e">mi_manage_os_memory</text>
-<circle cx="891.7" cy="1183.0" r="7.0" fill="#1a7f47"/>
-<path d="M 888.3 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="902.7" y="1187.0" font-size="11" fill="#59636e">mi_manage_os_memory</text>
-<circle cx="1120.6" cy="1183.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1117.2 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1131.6" y="1187.0" font-size="11" fill="#59636e">extent hooks</text>
+<circle cx="439.0" cy="1183.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1187.0" font-size="11" fill="#59636e">mi_manage_os_memory</text>
+<circle cx="649.0" cy="1183.0" r="7.0" fill="#1a7f47"/>
+<path d="M 645.6 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="660.0" y="1187.0" font-size="11" fill="#59636e">mi_manage_os_memory</text>
+<circle cx="859.0" cy="1183.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1187.0" font-size="11" fill="#59636e">mi_manage_os_memory</text>
+<circle cx="1069.0" cy="1183.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 1183.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1187.0" font-size="11" fill="#59636e">extent hooks</text>
 <text x="24" y="1211.0" font-size="12" fill="#1f2328">Lazy abandoned-page bitmaps</text>
-<circle cx="463.6" cy="1207.0" r="7.0" fill="#1a7f47"/>
-<path d="M 460.2 1207.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="474.6" y="1211.0" font-size="11" fill="#59636e">~110 KB saved per heap</text>
-<circle cx="687.1" cy="1207.0" r="7.0" fill="#cf222e"/>
-<path d="M 684.1 1204.0 l 6.0 6.0 M 690.1 1204.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="698.1" y="1211.0" font-size="11" fill="#59636e">allocated eagerly</text>
-<circle cx="883.6" cy="1207.0" r="7.0" fill="#1a7f47"/>
-<path d="M 880.2 1207.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="894.6" y="1211.0" font-size="11" fill="#59636e">~110 KB saved per heap</text>
-<circle cx="1107.1" cy="1207.0" r="7.0" fill="#cf222e"/>
-<path d="M 1104.1 1204.0 l 6.0 6.0 M 1110.1 1204.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1118.1" y="1211.0" font-size="11" fill="#59636e">no such structure</text>
+<circle cx="439.0" cy="1207.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1207.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1211.0" font-size="11" fill="#59636e">~110 KB saved per heap</text>
+<circle cx="649.0" cy="1207.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 1204.0 l 6.0 6.0 M 652.0 1204.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="1211.0" font-size="11" fill="#59636e">allocated eagerly</text>
+<circle cx="859.0" cy="1207.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1207.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1211.0" font-size="11" fill="#59636e">~110 KB saved per heap</text>
+<circle cx="1069.0" cy="1207.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 1204.0 l 6.0 6.0 M 1072.0 1204.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="1211.0" font-size="11" fill="#59636e">no such structure</text>
 <rect x="16" y="1219.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="1235.0" font-size="12" fill="#1f2328">Fixed TLS slots on macOS</text>
-<circle cx="493.3" cy="1231.0" r="7.0" fill="#1a7f47"/>
-<path d="M 489.9 1231.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="504.3" y="1235.0" font-size="11" fill="#59636e">slots 96/97</text>
-<circle cx="670.9" cy="1231.0" r="7.0" fill="#bf8700"/>
-<path d="M 670.9 1227.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
-<circle cx="670.9" cy="1234.4" r="1.1" fill="#ffffff"/>
-<text x="681.9" y="1235.0" font-size="11" fill="#59636e">slots 108/109 — collide</text>
-<circle cx="913.3" cy="1231.0" r="7.0" fill="#1a7f47"/>
-<path d="M 909.9 1231.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="924.3" y="1235.0" font-size="11" fill="#59636e">slots 96/97</text>
-<circle cx="1101.7" cy="1231.0" r="7.0" fill="#cf222e"/>
-<path d="M 1098.7 1228.0 l 6.0 6.0 M 1104.7 1228.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="1112.7" y="1235.0" font-size="11" fill="#59636e">pthread_getspecific</text>
+<circle cx="439.0" cy="1231.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1231.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1235.0" font-size="11" fill="#59636e">slots 96/97</text>
+<circle cx="649.0" cy="1231.0" r="7.0" fill="#bf8700"/>
+<path d="M 649.0 1227.4 l 0 4.4" fill="none" stroke="#ffffff" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="649.0" cy="1234.4" r="1.1" fill="#ffffff"/>
+<text x="660.0" y="1235.0" font-size="11" fill="#59636e">slots 108/109 — collide</text>
+<circle cx="859.0" cy="1231.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1231.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1235.0" font-size="11" fill="#59636e">slots 96/97</text>
+<circle cx="1069.0" cy="1231.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 1228.0 l 6.0 6.0 M 1072.0 1228.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="1080.0" y="1235.0" font-size="11" fill="#59636e">pthread_getspecific</text>
 <text x="24" y="1259.0" font-size="12" fill="#1f2328">Purged memory tracked as still-zero</text>
-<circle cx="436.6" cy="1255.0" r="7.0" fill="#1a7f47"/>
-<path d="M 433.2 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="447.6" y="1259.0" font-size="11" fill="#59636e">_mi_os_purge_zero, opt-in — #337</text>
-<circle cx="660.1" cy="1255.0" r="7.0" fill="#cf222e"/>
-<path d="M 657.1 1252.0 l 6.0 6.0 M 663.1 1252.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<text x="671.1" y="1259.0" font-size="11" fill="#59636e">_mi_os_purge has no is_zero</text>
-<circle cx="897.1" cy="1255.0" r="7.0" fill="#1a7f47"/>
-<path d="M 893.7 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="908.1" y="1259.0" font-size="11" fill="#59636e">_mi_os_purge_zero</text>
-<circle cx="1069.3" cy="1255.0" r="7.0" fill="#1a7f47"/>
-<path d="M 1065.9 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="1080.3" y="1259.0" font-size="11" fill="#59636e">edata_zeroed after forced purge</text>
+<circle cx="439.0" cy="1255.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1259.0" font-size="11" fill="#59636e">_mi_os_purge_zero, opt-in — #337</text>
+<circle cx="649.0" cy="1255.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 1252.0 l 6.0 6.0 M 652.0 1252.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<text x="660.0" y="1259.0" font-size="11" fill="#59636e">_mi_os_purge has no is_zero</text>
+<circle cx="859.0" cy="1255.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1259.0" font-size="11" fill="#59636e">_mi_os_purge_zero</text>
+<circle cx="1069.0" cy="1255.0" r="7.0" fill="#1a7f47"/>
+<path d="M 1065.6 1255.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="1080.0" y="1259.0" font-size="11" fill="#59636e">edata_zeroed after forced purge</text>
 <rect x="16" y="1267.0" width="1252" height="24" fill="#d8dee4" opacity="0.22"/>
 <text x="24" y="1283.0" font-size="12" fill="#1f2328">Opt out of the exit-time destructor</text>
-<circle cx="469.0" cy="1279.0" r="7.0" fill="#1a7f47"/>
-<path d="M 465.6 1279.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="480.0" y="1283.0" font-size="11" fill="#59636e">MI_NO_PROCESS_DETACH</text>
-<circle cx="735.0" cy="1279.0" r="7.0" fill="#cf222e"/>
-<path d="M 732.0 1276.0 l 6.0 6.0 M 738.0 1276.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
-<circle cx="889.0" cy="1279.0" r="7.0" fill="#1a7f47"/>
-<path d="M 885.6 1279.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="900.0" y="1283.0" font-size="11" fill="#59636e">MI_NO_PROCESS_DETACH</text>
-<circle cx="1155.0" cy="1279.0" r="7.0" fill="#cf222e"/>
-<path d="M 1152.0 1276.0 l 6.0 6.0 M 1158.0 1276.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="439.0" cy="1279.0" r="7.0" fill="#1a7f47"/>
+<path d="M 435.6 1279.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="450.0" y="1283.0" font-size="11" fill="#59636e">MI_NO_PROCESS_DETACH</text>
+<circle cx="649.0" cy="1279.0" r="7.0" fill="#cf222e"/>
+<path d="M 646.0 1276.0 l 6.0 6.0 M 652.0 1276.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
+<circle cx="859.0" cy="1279.0" r="7.0" fill="#1a7f47"/>
+<path d="M 855.6 1279.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="870.0" y="1283.0" font-size="11" fill="#59636e">MI_NO_PROCESS_DETACH</text>
+<circle cx="1069.0" cy="1279.0" r="7.0" fill="#cf222e"/>
+<path d="M 1066.0 1276.0 l 6.0 6.0 M 1072.0 1276.0 l -6.0 6.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round"/>
 <circle cx="31.0" cy="1311.0" r="7.0" fill="#1a7f47"/>
 <path d="M 27.6 1311.2 l 2.2 2.4 l 4.2 -5.0" fill="none" stroke="#ffffff" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
 <text x="43.0" y="1315.0" font-size="11" fill="#59636e">has it</text>

--- a/README.md
+++ b/README.md
@@ -71,10 +71,116 @@ what that risk means and what was measured.
   <img alt="Star history for zackees/mimalloc-pprof" src=".github/assets/star-history-light.svg" width="100%" />
 </picture>
 
+## Feature comparison
+
+Everything the four allocators in the
+[memory-return chart](#memory-returned-after-idle) do, side by side: this fork, Microsoft MiMalloc-V3 (upstream `dev3`), [Bun's fork](https://github.com/oven-sh/mimalloc),
+and [jemalloc](https://jemalloc.net/). Every cell is sourced — a `path:line` in this
+tree, a path in the pinned upstream commit, or an official doc anchor — in
+[`docs/allocator-features.json`](docs/allocator-features.json), which is what both the
+image and the table below are rendered from.
+
+<!-- feature-table:start -->
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset=".github/assets/allocator-features-dark.svg" />
+  <source media="(prefers-color-scheme: light)" srcset=".github/assets/allocator-features-light.svg" />
+  <img alt="Feature comparison of mimalloc-pprof, Microsoft MiMalloc-V3, Bun's mimalloc and jemalloc across memory return, profiling, robustness, platform support and allocator design" src=".github/assets/allocator-features-light.svg" width="100%" />
+</picture>
+
+<details>
+<summary><b>The same matrix as text</b> — searchable, screen-readable, and what an LLM reading this file will use</summary>
+
+| Feature | **mimalloc-pprof** | Microsoft MiMalloc-V3 | Bun mimalloc | jemalloc |
+|---|:--|:--|:--|:--|
+|  | this fork, 0.9.x | v3 dev3 @ 6def7be9 | oven-sh @ b20b60d9 | 5.3.1 @ 81034ce1 |
+| **Memory return** | | | | |
+| Process-wide eager purge, from any thread | ✅ gated 72 %, default parked | ❌ mi_collect is caller-only | ❌ mi_collect is caller-only | ✅ MALLCTL_ARENAS_ALL, 74 % |
+| Purge the calling thread's own memory | ✅ mi_collect, idle hook | ✅ mi_collect | ✅ mi_collect, idle hook | ✅ tcache.flush + arena.i.purge |
+| Sweep another thread's heap for it | ✅ all gated; parked default | ❌ no scavenger at all | ⚠️ parked threads only | ⚠️ arena purge, not their tcache |
+| Sub-page return inside a still-used page | ✅ hole purging, on by default | ❌ whole pages only | ✅ hole purging, on by default | ❌ extent-granular purge |
+| Background purge thread | ✅ on by default | ❌ purge waits for a malloc | ✅ on by default | ⚠️ off by default |
+| Time-delayed / decaying purge | ✅ purge_delay 100 ms | ✅ purge_delay 1000 ms | ✅ purge_delay 100 ms | ✅ dirty_decay_ms 10 s |
+| RSS returned after 10 s idle (churn) | 74 % | 0 % (18 % w/ mi_collect) | 74 % | 0 % (74 % if asked) |
+| **Profiling and observability** | | | | |
+| pprof-compatible sampled heap profiler | ✅ runtime opt-in | ❌ none at all | ✅ runtime opt-in | ✅ build-time --enable-prof |
+| Heap profiler on Windows | ✅ MSVC and MinGW | ❌ no profiler | ⚠️ frames, no module map | ⚠️ not MSVC; MinGW untested |
+| profile.proto (protobuf) output | ✅ and gperftools text | ❌ no profiler | ✅ | ❌ text format; jeprof reads |
+| Exact allocator statistics | ✅ mi_stats_get | ✅ mi_stats_get | ✅ mi_stats_get | ✅ mallctl / malloc_stats_print |
+| Statistics as JSON | ✅ mi_stats_get_json | ✅ mi_stats_get_json | ✅ mi_stats_get_json | ✅ the "J" opts flag |
+| Per-heap JSON dump | ✅ mi_heap_dump_json | ❌ process-wide stats only | ✅ mi_heap_dump_json | ❌ per-arena, not per-heap |
+| DHAT exact profiling (Valgrind format) | ✅ mi_dhat_start | ❌ | ❌ | ❌ |
+| Allocation-event callbacks | ✅ mi_memory_set_callbacks | ❌ | ❌ | ⚠️ experimental.hooks.install |
+| Walk every live block in a heap | ✅ mi_heap_visit_blocks | ✅ mi_heap_visit_blocks | ✅ mi_heap_visit_blocks | ❌ no iteration mallctl |
+| Live heap snapshot with a viewer | ✅ mi_heap_snapshot — [#338](https://github.com/zackees/mimalloc-pprof/issues/338) | ❌ | ✅ + tools/mi-heapview | ❌ |
+| No fast-path cost while profiling is off | ✅ malloc path byte-identical | ✅ nothing to cost | ✅ sample rate 0 by default | ⚠️ build-time opt-in |
+| **Robustness** | | | | |
+| fork() handlers (pthread_atfork) | ✅ documented lock order | ❌ none registered | ✅ | ✅ jemalloc_prefork |
+| Runtime lock-order checker | ✅ MI_DEBUG>2 | ❌ no fork handlers either | ❌ order kept by hand | ✅ witness ranks, --enable-debug |
+| Heap-teardown ABA claim protocol | ✅ + fault-injection tests | ❌ | ✅ | ❌ caller must flush first |
+| Guard-page (guarded) allocations | ✅ MI_GUARDED | ✅ MI_GUARDED | ✅ MI_GUARDED | ⚠️ opt.san_guard_small/large |
+| Hardened / secure build mode | ✅ MI_SECURE 1-4 | ✅ MI_SECURE 1-4 | ✅ MI_SECURE 1-4 | ❌ no equivalent mode |
+| ASan / Valgrind / ETW tracking | ✅ all three | ✅ all three | ✅ all three | ❌ no ASan, no ETW; Valgrind gone |
+| **Platform and integration** | | | | |
+| Windows MSVC as a first-class target | ✅ native cl gate per PR | ✅ in the test matrix | ✅ in the test matrix | ⚠️ no prof, no bg thread |
+| Windows malloc override via a redirect DLL | ✅ mimalloc-redirect.dll | ✅ mimalloc-redirect.dll | ✅ mimalloc-redirect.dll | ❌ link-time replacement only |
+| MinGW / win-gnu covered in CI | ✅ cross-built, then run | ✅ mingw-ucrt64 | ✅ mingw-ucrt64 | ✅ MSYS2 mingw32-make |
+| macOS malloc-zone interpose | ✅ | ✅ | ✅ | ✅ |
+| macOS zone introspection (leaks, vmmap) | ✅ in- and out-of-process — #349 | ❌ stub enumerator | ✅ in- and out-of-process | ❌ stub enumerator |
+| First-party Rust crate, full C API | ✅ mimalloc-pprof on crates.io | ❌ third-party crates only | ❌ no crate | ❌ third-party crates only |
+| Release targets cross-built on Linux | ✅ 5 targets through soldr | ❌ native runner per OS | ❌ native runner per OS | ❌ native runner per OS |
+| macOS covered with no Apple hardware | ✅ cross-built; guest run manual | ❌ hosted macOS runners | ❌ hosted macOS runners | ❌ hosted macOS runners |
+| **Allocator design** | | | | |
+| Per-thread heaps and caches | ✅ mi_theap_t per thread | ✅ mi_theap_t per thread | ✅ mi_theap_t per thread | ✅ tcache + per-thread arena |
+| Create and destroy your own heaps | ✅ mi_heap_new | ✅ mi_heap_new | ✅ mi_heap_new | ✅ arenas.create |
+| Shared arenas under the per-thread layer | ✅ arena-of-slices (v3) | ✅ arena-of-slices (v3) | ✅ arena-of-slices (v3) | ✅ per-CPU mode available |
+| Large / huge OS pages | ✅ allow_large_os_pages | ✅ allow_large_os_pages | ✅ allow_large_os_pages | ✅ opt.thp, opt.metadata_thp |
+| NUMA-aware reservation | ✅ use_numa_nodes | ✅ use_numa_nodes | ✅ use_numa_nodes | ❌ no NUMA option |
+| Bring your own memory region | ✅ mi_manage_os_memory | ✅ mi_manage_os_memory | ✅ mi_manage_os_memory | ✅ extent hooks |
+| Lazy abandoned-page bitmaps | ✅ ~110 KB saved per heap | ❌ allocated eagerly | ✅ ~110 KB saved per heap | ❌ no such structure |
+| Fixed TLS slots on macOS | ✅ slots 96/97 | ⚠️ slots 108/109 — collide | ✅ slots 96/97 | ❌ pthread_getspecific |
+| Purged memory tracked as still-zero | ✅ _mi_os_purge_zero, opt-in — [#337](https://github.com/zackees/mimalloc-pprof/issues/337) | ❌ _mi_os_purge has no is_zero | ✅ _mi_os_purge_zero | ✅ edata_zeroed after forced purge |
+| Opt out of the exit-time destructor | ✅ MI_NO_PROCESS_DETACH | ❌ | ✅ MI_NO_PROCESS_DETACH | ❌ |
+
+✅ has it &nbsp;·&nbsp; ⚠️ partly — see the note &nbsp;·&nbsp; ❌ does not. `mimalloc-pprof` is [this fork](https://github.com/zackees/mimalloc-pprof); *upstream* is [microsoft/mimalloc](https://github.com/microsoft/mimalloc) at the pinned `dev3` commit `6def7be9`; *Bun* is [oven-sh/mimalloc](https://github.com/oven-sh/mimalloc) at `b20b60d9`; *jemalloc* is 5.3.1 (`81034ce1`), the build in [`allocator-lock.json`](rust/benchmark-suite/allocators/allocator-lock.json). Every ❌ and ⚠️ in the `mimalloc-pprof` column links the issue tracking it. The per-cell sources — a `path:line` in this tree, a path in the pinned upstream or Bun commit, or a jemalloc doc anchor — are in [`docs/allocator-features.json`](docs/allocator-features.json), which this table and the image above are both rendered from by [`ci/render_feature_table.py`](ci/render_feature_table.py).
+
+</details>
+
+<!-- feature-table:end -->
+
+---
+
+## Thread scaling by allocation pattern
+
+Aggregate throughput as worker threads go from 1 to 4 to 16, for four allocation
+patterns. Each pattern is a seeded random operation stream, so all five
+allocators replay one identical stream inside each paired block.
+
+> **Coverage mode: reduced statistical rigor (3 blocks per cell).** These panels
+> trade statistical rigor for thread coverage — no confidence intervals, no noise
+> gating; read them for shape. The runner allows 4 logical CPUs, so the 16-thread
+> point is 4× oversubscribed and describes contention, not core scaling — it is
+> shaded on every chart.
+
+[![Tiny hot path: aggregate throughput by worker count for all five allocators](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-scaling-tiny-hot.svg)](https://zackees.github.io/mimalloc-pprof/#scaling)
+
+[![General mix including realloc: aggregate throughput by worker count for all five allocators](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-scaling-mixed-general.svg)](https://zackees.github.io/mimalloc-pprof/#scaling)
+
+[![Large page-touched buffers: aggregate throughput by worker count for all five allocators](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-scaling-large-buffers.svg)](https://zackees.github.io/mimalloc-pprof/#scaling)
+
+[![Cross-thread producer/consumer handoff: aggregate throughput by worker count for all five allocators](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-scaling-cross-thread.svg)](https://zackees.github.io/mimalloc-pprof/#scaling)
+
+Full methodology, per-cell tables and the other benchmark families are in
+[Performance](#performance) below and on the
+[dashboard](https://zackees.github.io/mimalloc-pprof/#scaling).
+
+---
+
 **Contents**
 
+- [Feature comparison](#feature-comparison) — every feature of this fork, Microsoft mimalloc, Bun's mimalloc and jemalloc, side by side *(above)*
+- [Thread scaling](#thread-scaling-by-allocation-pattern) — how the five allocators scale from 1 to 16 threads *(above)*
 - [At a glance](#at-a-glance--why-use-this-version) — what you get over upstream mimalloc, in one screen
-- [Feature comparison](#feature-comparison) — every feature of this fork, upstream mimalloc, Bun's mimalloc and jemalloc, side by side
 - [Integration](#integration) — pprof, exact stats and DHAT in Rust and C, plus the full API table
 - [Performance](#performance) — continuous benchmarks vs. upstream mimalloc, Bun's fork, TCMalloc, and jemalloc, plus a measured memory-returned-after-idle chart
 - [Why use this fork](#why-use-this-fork) — the most tested mimalloc fork in existence
@@ -158,80 +264,6 @@ re-verified under this tree's stress suite. → [Bun features](#bun-features)
 - **A Rust crate with full parity.** `mimalloc-pprof` on crates.io binds every fork C
   export and every `mi_option_t` enumerator, with layout and enum-value checks against
   the C compiler on every build. → [API surface](#api-surface)
-
-### Feature comparison
-
-Everything the four allocators in the
-[memory-return chart](#memory-returned-after-idle) do, side by side: this fork, Microsoft MiMalloc-V3 (upstream `dev3`), [Bun's fork](https://github.com/oven-sh/mimalloc),
-and [jemalloc](https://jemalloc.net/). Every cell is sourced — a `path:line` in this
-tree, a path in the pinned upstream commit, or an official doc anchor — in
-[`docs/allocator-features.json`](docs/allocator-features.json), which is what both the
-image and the table below are rendered from.
-
-<!-- feature-table:start -->
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset=".github/assets/allocator-features-dark.svg" />
-  <source media="(prefers-color-scheme: light)" srcset=".github/assets/allocator-features-light.svg" />
-  <img alt="Feature comparison of mimalloc-pprof, Microsoft MiMalloc-V3, Bun's mimalloc and jemalloc across memory return, profiling, robustness, platform support and allocator design" src=".github/assets/allocator-features-light.svg" width="100%" />
-</picture>
-
-| Feature | **mimalloc-pprof** | Microsoft MiMalloc-V3 | Bun mimalloc | jemalloc |
-|---|:--|:--|:--|:--|
-|  | this fork, 0.9.x | v3 dev3 @ 6def7be9 | oven-sh @ b20b60d9 | 5.3.1 @ 81034ce1 |
-| **Memory return** | | | | |
-| Process-wide eager purge, from any thread | ✅ gated 72 %, default parked | ❌ mi_collect is caller-only | ❌ mi_collect is caller-only | ✅ MALLCTL_ARENAS_ALL, 74 % |
-| Purge the calling thread's own memory | ✅ mi_collect, idle hook | ✅ mi_collect | ✅ mi_collect, idle hook | ✅ tcache.flush + arena.i.purge |
-| Sweep another thread's heap for it | ✅ all gated; parked default | ❌ no scavenger at all | ⚠️ parked threads only | ⚠️ arena purge, not their tcache |
-| Sub-page return inside a still-used page | ✅ hole purging, on by default | ❌ whole pages only | ✅ hole purging, on by default | ❌ extent-granular purge |
-| Background purge thread | ✅ on by default | ❌ purge waits for a malloc | ✅ on by default | ⚠️ off by default |
-| Time-delayed / decaying purge | ✅ purge_delay 100 ms | ✅ purge_delay 1000 ms | ✅ purge_delay 100 ms | ✅ dirty_decay_ms 10 s |
-| RSS returned after 10 s idle (churn) | 74 % | 0 % (18 % w/ mi_collect) | 74 % | 0 % (74 % if asked) |
-| **Profiling and observability** | | | | |
-| pprof-compatible sampled heap profiler | ✅ runtime opt-in | ❌ none at all | ✅ runtime opt-in | ✅ build-time --enable-prof |
-| Heap profiler on Windows | ✅ MSVC and MinGW | ❌ no profiler | ⚠️ frames, no module map | ⚠️ not MSVC; MinGW untested |
-| profile.proto (protobuf) output | ✅ and gperftools text | ❌ no profiler | ✅ | ❌ text format; jeprof reads |
-| Exact allocator statistics | ✅ mi_stats_get | ✅ mi_stats_get | ✅ mi_stats_get | ✅ mallctl / malloc_stats_print |
-| Statistics as JSON | ✅ mi_stats_get_json | ✅ mi_stats_get_json | ✅ mi_stats_get_json | ✅ the "J" opts flag |
-| Per-heap JSON dump | ✅ mi_heap_dump_json | ❌ process-wide stats only | ✅ mi_heap_dump_json | ❌ per-arena, not per-heap |
-| DHAT exact profiling (Valgrind format) | ✅ mi_dhat_start | ❌ | ❌ | ❌ |
-| Allocation-event callbacks | ✅ mi_memory_set_callbacks | ❌ | ❌ | ⚠️ experimental.hooks.install |
-| Walk every live block in a heap | ✅ mi_heap_visit_blocks | ✅ mi_heap_visit_blocks | ✅ mi_heap_visit_blocks | ❌ no iteration mallctl |
-| Live heap snapshot with a viewer | ✅ mi_heap_snapshot — [#338](https://github.com/zackees/mimalloc-pprof/issues/338) | ❌ | ✅ + tools/mi-heapview | ❌ |
-| No fast-path cost while profiling is off | ✅ malloc path byte-identical | ✅ nothing to cost | ✅ sample rate 0 by default | ⚠️ build-time opt-in |
-| **Robustness** | | | | |
-| fork() handlers (pthread_atfork) | ✅ documented lock order | ❌ none registered | ✅ | ✅ jemalloc_prefork |
-| Runtime lock-order checker | ✅ MI_DEBUG>2 | ❌ no fork handlers either | ❌ order kept by hand | ✅ witness ranks, --enable-debug |
-| Heap-teardown ABA claim protocol | ✅ + fault-injection tests | ❌ | ✅ | ❌ caller must flush first |
-| Guard-page (guarded) allocations | ✅ MI_GUARDED | ✅ MI_GUARDED | ✅ MI_GUARDED | ⚠️ opt.san_guard_small/large |
-| Hardened / secure build mode | ✅ MI_SECURE 1-4 | ✅ MI_SECURE 1-4 | ✅ MI_SECURE 1-4 | ❌ no equivalent mode |
-| ASan / Valgrind / ETW tracking | ✅ all three | ✅ all three | ✅ all three | ❌ no ASan, no ETW; Valgrind gone |
-| **Platform and integration** | | | | |
-| Windows MSVC as a first-class target | ✅ native cl gate per PR | ✅ in the test matrix | ✅ in the test matrix | ⚠️ no prof, no bg thread |
-| Windows malloc override via a redirect DLL | ✅ mimalloc-redirect.dll | ✅ mimalloc-redirect.dll | ✅ mimalloc-redirect.dll | ❌ link-time replacement only |
-| MinGW / win-gnu covered in CI | ✅ cross-built, then run | ✅ mingw-ucrt64 | ✅ mingw-ucrt64 | ✅ MSYS2 mingw32-make |
-| macOS malloc-zone interpose | ✅ | ✅ | ✅ | ✅ |
-| macOS zone introspection (leaks, vmmap) | ✅ in- and out-of-process — #349 | ❌ stub enumerator | ✅ in- and out-of-process | ❌ stub enumerator |
-| First-party Rust crate, full C API | ✅ mimalloc-pprof on crates.io | ❌ third-party crates only | ❌ no crate | ❌ third-party crates only |
-| Release targets cross-built on Linux | ✅ 5 targets through soldr | ❌ native runner per OS | ❌ native runner per OS | ❌ native runner per OS |
-| macOS covered with no Apple hardware | ✅ cross-built; guest run manual | ❌ hosted macOS runners | ❌ hosted macOS runners | ❌ hosted macOS runners |
-| **Allocator design** | | | | |
-| Per-thread heaps and caches | ✅ mi_theap_t per thread | ✅ mi_theap_t per thread | ✅ mi_theap_t per thread | ✅ tcache + per-thread arena |
-| Create and destroy your own heaps | ✅ mi_heap_new | ✅ mi_heap_new | ✅ mi_heap_new | ✅ arenas.create |
-| Shared arenas under the per-thread layer | ✅ arena-of-slices (v3) | ✅ arena-of-slices (v3) | ✅ arena-of-slices (v3) | ✅ per-CPU mode available |
-| Large / huge OS pages | ✅ allow_large_os_pages | ✅ allow_large_os_pages | ✅ allow_large_os_pages | ✅ opt.thp, opt.metadata_thp |
-| NUMA-aware reservation | ✅ use_numa_nodes | ✅ use_numa_nodes | ✅ use_numa_nodes | ❌ no NUMA option |
-| Bring your own memory region | ✅ mi_manage_os_memory | ✅ mi_manage_os_memory | ✅ mi_manage_os_memory | ✅ extent hooks |
-| Lazy abandoned-page bitmaps | ✅ ~110 KB saved per heap | ❌ allocated eagerly | ✅ ~110 KB saved per heap | ❌ no such structure |
-| Fixed TLS slots on macOS | ✅ slots 96/97 | ⚠️ slots 108/109 — collide | ✅ slots 96/97 | ❌ pthread_getspecific |
-| Purged memory tracked as still-zero | ✅ _mi_os_purge_zero, opt-in — [#337](https://github.com/zackees/mimalloc-pprof/issues/337) | ❌ _mi_os_purge has no is_zero | ✅ _mi_os_purge_zero | ✅ edata_zeroed after forced purge |
-| Opt out of the exit-time destructor | ✅ MI_NO_PROCESS_DETACH | ❌ | ✅ MI_NO_PROCESS_DETACH | ❌ |
-
-✅ has it &nbsp;·&nbsp; ⚠️ partly — see the note &nbsp;·&nbsp; ❌ does not. `mimalloc-pprof` is [this fork](https://github.com/zackees/mimalloc-pprof); *upstream* is [microsoft/mimalloc](https://github.com/microsoft/mimalloc) at the pinned `dev3` commit `6def7be9`; *Bun* is [oven-sh/mimalloc](https://github.com/oven-sh/mimalloc) at `b20b60d9`; *jemalloc* is 5.3.1 (`81034ce1`), the build in [`allocator-lock.json`](rust/benchmark-suite/allocators/allocator-lock.json). Every ❌ and ⚠️ in the `mimalloc-pprof` column links the issue tracking it. The per-cell sources — a `path:line` in this tree, a path in the pinned upstream or Bun commit, or a jemalloc doc anchor — are in [`docs/allocator-features.json`](docs/allocator-features.json), which this table and the image above are both rendered from by [`ci/render_feature_table.py`](ci/render_feature_table.py).
-
-<!-- feature-table:end -->
-
----
 
 ## Integration
 
@@ -673,29 +705,16 @@ recipe over one base: since [#332](https://github.com/zackees/mimalloc-pprof/iss
 commit this fork's overlay is based on, so all three rows are v3.5.0 and
 upstream-vs-fork is fork-versus-its-own-base
 ([methodology](docs/benchmarks.md)). The Bun pin moves in the same PR as each
-future Bun-parity ingest. The throughput charts below are regenerated by the
-scheduled dashboard run, and a freshly added row appears there first; the memory
-charts that close this section are regenerated by hand, by the script they name.
+future Bun-parity ingest. The [throughput charts at the top of this
+file](#thread-scaling-by-allocation-pattern) are regenerated by the scheduled
+dashboard run, and a freshly added row appears there first; the memory charts
+that close this section are regenerated by hand, by the script they name.
 
-### Thread scaling by allocation pattern
+### What the four scaling patterns stress
 
-Aggregate throughput as worker threads go from 1 to 4 to 16, for four allocation
-patterns. Each pattern is a seeded random operation stream, so all five
+The charts themselves are [at the top of this file](#thread-scaling-by-allocation-pattern);
+this is what each pattern is made of. Each is a seeded random operation stream, so all five
 allocators replay one identical stream inside each paired block.
-
-> **Coverage mode: reduced statistical rigor (3 blocks per cell).** These panels
-> trade statistical rigor for thread coverage — no confidence intervals, no noise
-> gating; read them for shape. The runner allows 4 logical CPUs, so the 16-thread
-> point is 4× oversubscribed and describes contention, not core scaling — it is
-> shaded on every chart.
-
-[![Tiny hot path: aggregate throughput by worker count for all five allocators](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-scaling-tiny-hot.svg)](https://zackees.github.io/mimalloc-pprof/#scaling)
-
-[![General mix including realloc: aggregate throughput by worker count for all five allocators](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-scaling-mixed-general.svg)](https://zackees.github.io/mimalloc-pprof/#scaling)
-
-[![Large page-touched buffers: aggregate throughput by worker count for all five allocators](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-scaling-large-buffers.svg)](https://zackees.github.io/mimalloc-pprof/#scaling)
-
-[![Cross-thread producer/consumer handoff: aggregate throughput by worker count for all five allocators](https://raw.githubusercontent.com/zackees/mimalloc-pprof/benchmark-stats/benchmark-scaling-cross-thread.svg)](https://zackees.github.io/mimalloc-pprof/#scaling)
 
 | Pattern | Sizes | What it stresses |
 |---|---|---|

--- a/ci/render_feature_table.py
+++ b/ci/render_feature_table.py
@@ -275,8 +275,16 @@ def render_markdown(doc: FeatureDoc) -> str:
 
 
 def render_readme_region(doc: FeatureDoc) -> str:
-    """Everything between the markers: the highlighted image, then the Markdown table
-    (searchable, screen-readable, diffable), then the legend."""
+    """Everything between the markers: the image, then the same matrix as Markdown inside
+    a collapsed `<details>`, then the legend.
+
+    The table is not dropped even though the image says the same thing. It is what makes
+    the comparison searchable, screen-readable, diffable in review, and legible to a model
+    reading the raw file -- none of which an SVG offers. But repeating it open, directly
+    under the image, made a reader scroll past the same matrix twice before reaching
+    anything new, so it is collapsed: present for whoever wants it, out of the way of
+    whoever does not.
+    """
     alt = (
         "Feature comparison of mimalloc-pprof, Microsoft MiMalloc-V3, Bun's mimalloc and "
         "jemalloc across memory return, profiling, robustness, platform support and "
@@ -294,9 +302,15 @@ def render_readme_region(doc: FeatureDoc) -> str:
             f'  <img alt="{alt}" src=".github/assets/allocator-features-light.svg" width="100%" />',
             "</picture>",
             "",
+            "<details>",
+            "<summary><b>The same matrix as text</b> — searchable, screen-readable, and "
+            "what an LLM reading this file will use</summary>",
+            "",
             render_markdown(doc),
             "",
             doc.legend,
+            "",
+            "</details>",
             "",
             END_MARKER,
         ]
@@ -395,6 +409,17 @@ def column_center(index: int) -> float:
     return COL_START + COL_W * index + COL_W / 2
 
 
+#: Left inset of a column's content. Every glyph in a column starts here, so ticks,
+#: crosses and warnings line up in a vertical rule down the page instead of drifting with
+#: the length of the note beside them -- which is what centring the glyph-plus-note pair
+#: used to do, and it made the columns unreadable at a glance.
+COL_PAD = 12
+
+
+def column_left(index: int) -> float:
+    return COL_START + COL_W * index + COL_PAD
+
+
 def note_width(text: str) -> float:
     return len(text) * NOTE_CHAR_PX
 
@@ -427,24 +452,31 @@ def glyph_svg(cx: float, cy: float, status: str, theme: Theme) -> list[str]:
 
 
 def cell_svg(index: int, baseline: float, cell: Cell, theme: Theme) -> list[str]:
-    """Glyph, then the note to its right, the pair centred in the column."""
-    cx = column_center(index)
+    """Glyph at the column's left inset, then the note to its right.
+
+    Left-justified, not centred. A reader scanning one allocator's column wants to see
+    where the crosses are without reading a word; centring the glyph-plus-note pair moved
+    every glyph by half the length of its own note, so the marks wandered across the column
+    and the column could only be read cell by cell.
+    """
+    left = column_left(index)
     cy = baseline - 4
+    # Every note in the table starts here, past the glyph. A glyphless "value" cell uses
+    # the same x, so its text lines up with the notes above and below it instead of
+    # jutting out into the gutter where the glyphs are.
+    note_x = left + 2 * GLYPH_R + 4
     if cell.status == "value":
         return [
-            f'<text x="{cx:.1f}" y="{baseline:.1f}" font-size="11" text-anchor="middle" '
+            f'<text x="{note_x:.1f}" y="{baseline:.1f}" font-size="11" '
             f'fill="{theme.text}">{escape(cell.note or "—")}</text>'
         ]
-    note = cell.note
-    if not note:
-        return glyph_svg(cx, cy, cell.status, theme)
-    total = 2 * GLYPH_R + 4 + note_width(note)
-    left = cx - total / 2
     parts = glyph_svg(left + GLYPH_R, cy, cell.status, theme)
-    parts.append(
-        f'<text x="{left + 2 * GLYPH_R + 4:.1f}" y="{baseline:.1f}" font-size="11" '
-        f'fill="{theme.muted}">{escape(note)}</text>'
-    )
+    note = cell.note
+    if note:
+        parts.append(
+            f'<text x="{note_x:.1f}" y="{baseline:.1f}" font-size="11" '
+            f'fill="{theme.muted}">{escape(note)}</text>'
+        )
     return parts
 
 
@@ -513,15 +545,16 @@ def render_svg(doc: FeatureDoc, theme: Theme) -> str:
         )
 
     for index, allocator in enumerate(doc.allocators):
-        cx = column_center(index)
+        # Headers share the cells' left inset so each column reads as one flush edge.
+        left = column_left(index)
         weight = "700" if allocator.key == SUBJECT else "600"
         ink = theme.text if allocator.key == SUBJECT else theme.muted
         parts.append(
-            f'<text x="{cx:.1f}" y="{top_h + 6}" font-size="12.5" font-weight="{weight}" '
-            f'text-anchor="middle" fill="{ink}">{escape(allocator.label)}</text>'
+            f'<text x="{left:.1f}" y="{top_h + 6}" font-size="12.5" font-weight="{weight}" '
+            f'fill="{ink}">{escape(allocator.label)}</text>'
         )
         parts.append(
-            f'<text x="{cx:.1f}" y="{top_h + 21}" font-size="10" text-anchor="middle" '
+            f'<text x="{left:.1f}" y="{top_h + 21}" font-size="10" '
             f'fill="{theme.muted}">{escape(allocator.version)}</text>'
         )
     parts.append(


### PR DESCRIPTION
Owner request, four parts.

### 1. Feature comparison first

`## Feature comparison` now sits directly under the intro, before **Contents**. It is
the one element that answers "what does this fork give me that the others don't"
without reading prose.

### 2. Then the thread-scaling charts

`## Thread scaling by allocation pattern` follows it, so anyone landing here sees the
performance characteristics in the same screen as the feature claims. Both keep their
contents-list entries, marked *(above)*.

The pattern table that describes the four workloads stayed behind in **Performance**
when its heading moved up; it gets its own heading (`### What the four scaling patterns
stress`) and links back to the charts. The Performance prose that said "the throughput
charts below" now points up.

### 3. Left-justified cells in the image

`cell_svg` centred the glyph-plus-note pair inside its column, so each glyph was
displaced by half the length of its own note. Measured before the fix: the marks in one
column landed on **17–20 distinct x-positions, spanning up to 88px**. A reader scanning
a column for crosses had to read every cell to find them.

Cells now start at a fixed inset (`column_left(index) = COL_START + COL_W*index + 12`),
so every glyph in a column sits on **exactly one x**. Column headers moved with them. A
glyphless *value* cell (the RSS row) uses the note x rather than the glyph x, so its
text lines up with the notes above and below instead of jutting into the gutter.

### 4. Markdown matrix into a `<details>`

Directly under the image the text matrix is redundant for a human, but it is what a
screen reader, ctrl-F and an LLM reading this file actually consume — so it stays in the
file, one fold away, under *"The same matrix as text"*.

### Verification

- `ci/tests/test_render_feature_table.py` — 33 passed
- `uv run python ci/render_feature_table.py --check` — `up to date: README.md region,
  allocator-features-light.svg, allocator-features-dark.svg`
- ruff check / ruff format / pyright — clean
- Both SVGs rasterized and inspected; alignment confirmed in light and dark

Docs and `ci/` only — no C-core and no `rust/` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfNcj3bdhvjVF9xPPXKPAA