### PR TITLE
fix: make heap diagnostics ownership-safe without hot-path changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1215,6 +1215,27 @@ if (MI_BUILD_TESTS)
     set_tests_properties(test-heap-teardown PROPERTIES TIMEOUT 300)
   endif()
 
+  # #374 uses native threads on Windows and pthreads elsewhere. Keep these outside
+  # the POSIX-only tests: both MSVC and win-gnu must execute the ownership regressions.
+  # Internal page state requires the static library and its exact compilation defines.
+  if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
+    add_executable(mimalloc-test-diagnostic-walks test/test-diagnostic-walks.c)
+    target_compile_definitions(mimalloc-test-diagnostic-walks PRIVATE ${mi_defines} MI_STATIC_LIB)
+    target_compile_options(mimalloc-test-diagnostic-walks PRIVATE ${mi_cflags})
+    target_include_directories(mimalloc-test-diagnostic-walks PRIVATE include)
+    target_link_libraries(mimalloc-test-diagnostic-walks PRIVATE mimalloc-static ${mi_libraries})
+    if(NOT WIN32)
+      find_package(Threads REQUIRED)
+      target_link_libraries(mimalloc-test-diagnostic-walks PRIVATE Threads::Threads)
+    endif()
+    add_test(NAME test-diagnostic-walks COMMAND mimalloc-test-diagnostic-walks)
+    set_tests_properties(test-diagnostic-walks PROPERTIES TIMEOUT 120
+                         ENVIRONMENT "MIMALLOC_SCAVENGER=0")
+    add_test(NAME test-diagnostic-walks-os COMMAND mimalloc-test-diagnostic-walks)
+    set_tests_properties(test-diagnostic-walks-os PROPERTIES TIMEOUT 120
+                         ENVIRONMENT "MIMALLOC_SCAVENGER=0;MIMALLOC_DISALLOW_ARENA_ALLOC=1")
+  endif()
+
   # pthread_atfork fork-safety handlers (issue #270, Bun parity P5). POSIX-only --
   # both sources compile to a Windows-skip stub via #ifdef _WIN32, but there is no
   # pthread/fork() to link against on MSVC/MinGW, so only build+register them off
@@ -1335,17 +1356,6 @@ if (MI_BUILD_TESTS)
     # (`MI_BUILD_STATIC=OFF`) skips it rather than failing to link.
     if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
       add_executable(mimalloc-test-purge-holes test/test-purge-holes.c)
-      add_executable(mimalloc-test-diagnostic-walks test/test-diagnostic-walks.c)
-      target_compile_definitions(mimalloc-test-diagnostic-walks PRIVATE ${mi_defines} MI_STATIC_LIB)
-      target_compile_options(mimalloc-test-diagnostic-walks PRIVATE ${mi_cflags})
-      target_include_directories(mimalloc-test-diagnostic-walks PRIVATE include)
-      target_link_libraries(mimalloc-test-diagnostic-walks PRIVATE mimalloc-static ${mi_libraries} Threads::Threads)
-      add_test(NAME test-diagnostic-walks COMMAND mimalloc-test-diagnostic-walks)
-      set_tests_properties(test-diagnostic-walks PROPERTIES TIMEOUT 120
-                           ENVIRONMENT "MIMALLOC_SCAVENGER=0")
-      add_test(NAME test-diagnostic-walks-os COMMAND mimalloc-test-diagnostic-walks)
-      set_tests_properties(test-diagnostic-walks-os PROPERTIES TIMEOUT 120
-                           ENVIRONMENT "MIMALLOC_SCAVENGER=0;MIMALLOC_DISALLOW_ARENA_ALLOC=1")
       target_compile_definitions(mimalloc-test-purge-holes PRIVATE ${mi_defines})
       target_compile_options(mimalloc-test-purge-holes PRIVATE ${mi_cflags})
       target_include_directories(mimalloc-test-purge-holes PRIVATE include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,6 +754,7 @@ endif()
 # set language for source files now
 if(MI_USE_CXX)
   set_source_files_properties(${mi_sources} PROPERTIES LANGUAGE CXX )
+  set_source_files_properties(test/test-diagnostic-walks.c PROPERTIES LANGUAGE CXX)
   # #272 (P7b): test-purge-holes.c and test-profile-race.c reach `mimalloc/internal.h`
   # (`_mi_ptr_page`, `mi_page_block_is_purged`, `_mi_os_page_size`, ...), which is NOT wrapped
   # in `extern "C"`. With MI_USE_CXX the library's symbols are C++-mangled, so a C test cannot
@@ -1334,6 +1335,17 @@ if (MI_BUILD_TESTS)
     # (`MI_BUILD_STATIC=OFF`) skips it rather than failing to link.
     if(MI_BUILD_STATIC AND NOT MI_DEBUG_TSAN)
       add_executable(mimalloc-test-purge-holes test/test-purge-holes.c)
+      add_executable(mimalloc-test-diagnostic-walks test/test-diagnostic-walks.c)
+      target_compile_definitions(mimalloc-test-diagnostic-walks PRIVATE ${mi_defines} MI_STATIC_LIB)
+      target_compile_options(mimalloc-test-diagnostic-walks PRIVATE ${mi_cflags})
+      target_include_directories(mimalloc-test-diagnostic-walks PRIVATE include)
+      target_link_libraries(mimalloc-test-diagnostic-walks PRIVATE mimalloc-static ${mi_libraries} Threads::Threads)
+      add_test(NAME test-diagnostic-walks COMMAND mimalloc-test-diagnostic-walks)
+      set_tests_properties(test-diagnostic-walks PROPERTIES TIMEOUT 120
+                           ENVIRONMENT "MIMALLOC_SCAVENGER=0")
+      add_test(NAME test-diagnostic-walks-os COMMAND mimalloc-test-diagnostic-walks)
+      set_tests_properties(test-diagnostic-walks-os PROPERTIES TIMEOUT 120
+                           ENVIRONMENT "MIMALLOC_SCAVENGER=0;MIMALLOC_DISALLOW_ARENA_ALLOC=1")
       target_compile_definitions(mimalloc-test-purge-holes PRIVATE ${mi_defines})
       target_compile_options(mimalloc-test-purge-holes PRIVATE ${mi_cflags})
       target_include_directories(mimalloc-test-purge-holes PRIVATE include)
@@ -2054,6 +2066,8 @@ endif()
 # (MI_PPROF, non-Windows, ...), and set_tests_properties() on a test that was never
 # registered is a hard CMake error.
 set(mi_serial_tests
+  test-diagnostic-walks
+  test-diagnostic-walks-os
   test-osx-zone-introspect-remote
   test-memory-gate
   test-degenerate

--- a/ci/internal-state-inventory.json
+++ b/ci/internal-state-inventory.json
@@ -329,22 +329,42 @@
       ]
     },
     {
+      "id": "heap-dump-capture-scratch",
+      "path": "src/heap-dump.c",
+      "callee": "_mi_os_alloc",
+      "args": "ctx->subproc,sizeof(*chunk),&memid",
+      "occurrence": 1,
+      "owner": "operation-local mi_dump_ctx_t",
+      "initial_owner": "raw OS allocation; never a hooked allocator heap",
+      "owner_transitions": "initialized chunk is prepended to ctx->chunks; records and text borrow bump-allocated extents",
+      "destroyable_by": "mi_dump_dispose on every success or failure path",
+      "lifetime": "one mi_heap_dump_json call, including capture and serialization",
+      "logical_size": "sizeof(mi_dump_chunk_t), including 64 KiB of scratch data",
+      "usable_size": "only sizeof(*chunk) is used and passed with its memid to _mi_os_free",
+      "cleanup": "capture failure first releases page ownership and locks; mi_dump_dispose frees every chunk even when formatting or final result allocation fails",
+      "publication": "chunk memid, used and next initialized before private ctx->chunks update; never published to other threads",
+      "locks": [
+        "capture: subproc heaps_lock and heap theaps_lock; may also hold a page pin, owner claim, metadata lock, or OS abandoned-pages lock",
+        "serialization: no traversal lock or owner claim; raw OS allocation cannot reenter hooked allocation"
+      ]
+    },
+    {
       "id": "heap-dump-json-buffer",
       "path": "src/heap-dump.c",
-      "callee": "mi_rezalloc",
-      "args": "hbuf->buf,newsize",
+      "callee": "mi_malloc",
+      "args": "ctx.text_size+1",
       "occurrence": 1,
       "owner": "mi_heap_dump_json caller",
       "initial_owner": "calling thread's default heap",
-      "owner_transitions": "returned to the dump caller; moving growth preserves old buffer on failure, matching stats.c's mi_json_buf_expand this mirrors",
+      "owner_transitions": "allocated once after capture and serialization; copied from raw-OS scratch then returned to the dump caller",
       "destroyable_by": "caller via mi_free (Bun's BunJSCModule.h frees the same way after JSONParse)",
       "lifetime": "until caller invokes mi_free",
-      "logical_size": "initial good size near 12 KiB, then doubled",
-      "usable_size": "allocator size class; hbuf->size retains requested logical capacity",
-      "cleanup": "caller owns returned buffer and frees with mi_free; a growth failure mid-print leaves the buffer at its last successfully-written prefix (same discipline as src/stats.c's mi_json_buf_expand)",
-      "publication": "hbuf pointer and size update only after successful rezalloc",
+      "logical_size": "ctx.text_size + 1, with overflow checked while accumulating text",
+      "usable_size": "allocator size class; copy only ctx.text_size bytes and one NUL terminator",
+      "cleanup": "caller frees successful result with mi_free; any allocation failure returns NULL after freeing raw-OS scratch, never a truncated JSON prefix",
+      "publication": "returned only after every text chunk is copied and the NUL terminator is written",
       "locks": [
-        "none; buffer is operation-local"
+        "all diagnostic traversal locks and owner claims released before mi_malloc; ordinary allocation may acquire its usual allocator locks"
       ]
     },
     {

--- a/docs/internal-state-diagnostics.md
+++ b/docs/internal-state-diagnostics.md
@@ -47,6 +47,8 @@ fields.
 | `profiler-proto-modules` | raw OS -> dump-local modules | one protobuf dump | fixed module array / same cleanup expression | never global; every exit frees |
 | `profiler-proto-pc-table` | raw OS -> dump-local hash table | one protobuf dump | power-of-two table / same cleanup expression | zero before use; every exit frees |
 | `stats-json-buffer` | default heap -> stats caller | caller lifetime | requested capacity / allocator class | pointer/size update after successful growth; caller frees |
+| `heap-dump-capture-scratch` | raw OS -> private dump capture/serialization arena | one JSON dump; dispose on every exit | header + 64 KiB / exact retained size | initialize then link; capture may hold ownership/registry locks; no hooked allocation |
+| `heap-dump-json-buffer` | default heap -> dump caller | caller lifetime; `mi_free` | final text length + NUL / allocator class | allocate once after releasing all capture claims/locks; return complete JSON or NULL |
 | `thread-heap-object` | sub-process meta -> heap and TLD lists | refcounted thread/heap lifetime | theap size / meta slot | dual-list publication locks; refcount-zero frees |
 | `exclusive-arena-theap` | exclusive arena -> heap and TLD lists | refcounted thread/heap lifetime | rounded theap size / arena slice | arena + list locks; matching arena free |
 | `test-control-tls-slot-array-owner` | test default heap -> prospective TLS pointer | negative-control process only | TLS logical count / allocator class | owner check must reject before publication; test-only |

--- a/docs/purge-all-implementation.md
+++ b/docs/purge-all-implementation.md
@@ -139,6 +139,7 @@ as "mine", as `_mi_park_leave` already does).
 | `mi_theap_collect`, `mi_collect`, `mi_heap_collect` | `src/theap.c` | the **public** collect entries — not `mi_theap_collect_ex` (§6) |
 | `_mi_thread_done` | `src/init.c` | teardown; enter, abandon theaps, `mi_tld_unregister`, free the tld — **no leave** (an unregistered `RUNNING` tld can never be found or claimed; nothing dereferences the freed tld) |
 | `mi_heap_delete`, `mi_heap_destroy`, `mi_theap_set_default` | `src/heap.c`, `src/theap.c` | mutate theap ownership |
+| `_mi_purge_holes_report_collect` | `src/page-holes.c` | #374: reads owner-private free lists; `theaps_lock` alone does not exclude a foreign collect |
 
 Every gated body has exactly one leave: `r = inner(...); MI_GATE_LEAVE(tld); return r;`
 with `inner` being the existing body. No leave on an early-return path.
@@ -147,6 +148,46 @@ Not gated: `mi_free_block_mt`'s atomic push onto `xthread_free`; arena, page-map
 layers; profiler and memory-events internals (rule 4 memory, never theap state).
 
 ### 5.2 Coverage is a tested property
+
+#### Diagnostic audit (#374)
+
+The holes reporter now takes the caller's owner gate before `theaps_lock`: a
+foreign sweep's collect phase does not take that lock. Its deterministic test
+holds the reporter at entry, proves a purge cannot claim it, then proves a
+foreign purge reaches it after the reporter leaves.
+
+The JSON dump uses a separate ownership-protected capture path in
+`src/diagnostic-walk.c` (included by `arena.c`, and transitively `static.c`).
+Arena storage pins are followed by an owner claim before mutable metadata or
+free-list reads. Pins alone do **not** prevent page-map unregistration.
+Abandoned pages require page ownership; live OS pages require the owner gate or
+park claim; abandoned OS pages are claimed under their list lock and released
+after that lock is dropped. The detached metadata theap uses a try-acquire of
+its existing `theap_meta_lock`, never the park protocol.
+
+There is no 64-owner limit or unclaimed fallback. Each arena page's owner claim
+lasts only for capture. RUNNING/SWEEPING owners and contended metadata pages are
+not waited for; `complete`, `skipped_pages`, and `busy_theaps` in the JSON expose
+observed incomplete coverage. Registry locks and the capture itself can still
+take time: this is not a lock-free or bounded-latency API. Ungated threads need a
+successful cooperative idle handoff for capture; merely sleeping is insufficient.
+The coverage flag is not a claim that independently captured pages represent one
+global instant. Concurrent mutation can change coverage/counts between pages.
+
+Captured records and formatting buffers are raw-OS-backed chunks. The final
+`mi_malloc`-allocated, `mi_free`-compatible string is created only after releasing
+all claims and registry locks. Allocation failure releases scratch storage and
+claims and returns NULL; truncated JSON is never returned as success.
+
+This does not change the documented concurrency precondition of the public
+`mi_heap_visit_blocks`/`mi_theap_visit_blocks` APIs or the binary snapshot format.
+Memory-events visitation still walks only the calling thread's gated theaps.
+The separate binary snapshot is not used as a purported safe JSON substitute.
+
+No allocation/free/retirement fast path is changed. Validate that boundary with
+`python ci/check_fastpath_identity.py --base 7d8e5e86` (five named hot-path entry
+points plus the positive gated control); diagnostic runtime/memory is a separate
+measurement and must report coverage along with timing.
 
 In `MI_DEBUG` gated builds every owner-private leaf accessor asserts `_mi_gate_held(theap->tld)`:
 `_mi_theap_get_free_small_page` (`internal.h`), `mi_page_malloc_zero` and

--- a/include/mimalloc-stats.h
+++ b/include/mimalloc-stats.h
@@ -162,8 +162,12 @@ mi_decl_export char*   mi_stats_as_json(mi_stats_t* stats, size_t buf_size, char
 mi_decl_export size_t  mi_stats_get_bin_size(size_t bin) mi_attr_noexcept;
 
 // per-heap -> per-page -> (optional) per-block live snapshot (issue #269, Bun parity).
-// Backs bun:jsc heapStats({ dump: true | "blocks" }).mimallocDump. Best-effort under
-// concurrent frees, same caveat as mi_heap_visit_blocks (#78) -- see src/heap-dump.c.
+// Backs bun:jsc heapStats({ dump: true | "blocks" }).mimallocDump. Safe, best-effort
+// capture under concurrent frees (#374); unlike mi_heap_visit_blocks, it never
+// reads mutable state of an unclaimed owner. Top-level complete/skipped_pages/
+// busy_theaps describe observed coverage. Busy owners are omitted, not waited for.
+// Ungated foreign owners must cooperatively park for coverage. A true complete
+// flag is not a process-wide atomic snapshot: pages are captured independently.
 // use mi_free to free the result.
 mi_decl_export char*   mi_heap_dump_json(bool include_blocks, bool hash_addresses) mi_attr_noexcept;
 mi_decl_export size_t  mi_heap_get_seq(mi_heap_t* heap) mi_attr_noexcept;

--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -327,6 +327,8 @@ extern mi_decl_export volatile long mi_debug_fail_os_commit_after;
 // `arena.c` (`mi_heap_visit_page_claim`) sets it to 2 once it has a page pinned but not yet
 // claimed, and stalls there until the test sets it back to 0.
 extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_heap_delete_claim;
+// #374: reporter entry handshake (1 -> 2, test releases with 0).
+extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_holes_report;
 // Bun parity P10b (#317), ported from oven-sh/mimalloc @ 1515c3c9 (C linkage) /
 // 787be2a8 (the counter itself). test-abandoned-lazy.c: per-bin abandoned bitmaps
 // (`mi_arena_pages_t::pages_abandoned[]`, arena.c) published so far via the CAS in

--- a/include/mimalloc/internal.h
+++ b/include/mimalloc/internal.h
@@ -329,6 +329,9 @@ extern mi_decl_export volatile long mi_debug_fail_os_commit_after;
 extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_heap_delete_claim;
 // #374: reporter entry handshake (1 -> 2, test releases with 0).
 extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_holes_report;
+// #374: fail the Nth diagnostic scratch request (0 disables, UINTPTR_MAX fails
+// the first serialization request after all claims have been released).
+extern mi_decl_export _Atomic(uintptr_t) mi_debug_dump_fail_after;
 // Bun parity P10b (#317), ported from oven-sh/mimalloc @ 1515c3c9 (C linkage) /
 // 787be2a8 (the counter itself). test-abandoned-lazy.c: per-bin abandoned bitmaps
 // (`mi_arena_pages_t::pages_abandoned[]`, arena.c) published so far via the CAS in

--- a/include/mimalloc/owner-gate.h
+++ b/include/mimalloc/owner-gate.h
@@ -64,7 +64,7 @@ static inline bool _mi_gate_held(const mi_tld_t* tld) {
   if (tld == NULL) return false;
   if (tld->thread_id == MI_THREADID_DETACHED) return true;   // `theap_meta`: guarded by theap_meta_lock, never gated
   const mi_threadid_t me = _mi_thread_id();
-  if (tld->gate_depth > 0 && tld->thread_id == me) return true;
+  if (tld->thread_id == me && tld->gate_depth > 0) return true;
   return (mi_atomic_load_acquire((_Atomic(size_t)*)&tld->park_state) == MI_PARK_SWEEPING &&
           mi_atomic_load_acquire((_Atomic(uintptr_t)*)&tld->sweeper) == (uintptr_t)me);
 }

--- a/rust/mimalloc-pprof/src/lib.rs
+++ b/rust/mimalloc-pprof/src/lib.rs
@@ -208,10 +208,12 @@ pub unsafe fn usable_size(p: *const u8) -> usize {
 /// Set `hash_addresses` to mix every reported address through a per-process key so a
 /// dump can be shared or diffed without exposing raw ASLR-derived pointers.
 ///
-/// Best-effort under concurrent frees on the heaps being walked (mimalloc's
-/// `mi_heap_visit_blocks`/`mi_subproc_visit_heaps` contract; see the caveat on
-/// `src/heap-dump.c` and issue #78) -- never `unsafe` to call, but a heap another
-/// thread is actively freeing into may be under- or over-reported in the returned JSON.
+/// Safe, best-effort capture under concurrent frees (#374). Mutable page state is
+/// copied only under ownership; busy foreign owners are omitted. Top-level JSON
+/// fields `complete`, `skipped_pages`, and `busy_theaps` expose observed coverage.
+/// Without the `owner-gate` feature, foreign threads generally remain uninspectable
+/// unless they cooperatively park. `complete: true` is not a process-wide atomic
+/// snapshot: individual pages are captured independently.
 ///
 /// Returns `None` only on allocation failure (out of memory building the JSON buffer),
 /// not for an empty subprocess.

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2d88074e of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit b852cb91 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -4709,6 +4709,9 @@ extern mi_decl_export volatile long mi_debug_fail_os_commit_after;
 extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_heap_delete_claim;
 // #374: reporter entry handshake (1 -> 2, test releases with 0).
 extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_holes_report;
+// #374: fail the Nth diagnostic scratch request (0 disables, UINTPTR_MAX fails
+// the first serialization request after all claims have been released).
+extern mi_decl_export _Atomic(uintptr_t) mi_debug_dump_fail_after;
 // Bun parity P10b (#317), ported from oven-sh/mimalloc @ 1515c3c9 (C linkage) /
 // 787be2a8 (the counter itself). test-abandoned-lazy.c: per-bin abandoned bitmaps
 // (`mi_arena_pages_t::pages_abandoned[]`, arena.c) published so far via the CAS in
@@ -5447,7 +5450,7 @@ static inline bool _mi_gate_held(const mi_tld_t* tld) {
   if (tld == NULL) return false;
   if (tld->thread_id == MI_THREADID_DETACHED) return true;   // `theap_meta`: guarded by theap_meta_lock, never gated
   const mi_threadid_t me = _mi_thread_id();
-  if (tld->gate_depth > 0 && tld->thread_id == me) return true;
+  if (tld->thread_id == me && tld->gate_depth > 0) return true;
   return (mi_atomic_load_acquire((_Atomic(size_t)*)&tld->park_state) == MI_PARK_SWEEPING &&
           mi_atomic_load_acquire((_Atomic(uintptr_t)*)&tld->sweeper) == (uintptr_t)me);
 }
@@ -13732,11 +13735,12 @@ typedef struct mi_diag_coverage_s {
   size_t skipped_pages;
   size_t busy_theaps;
 } mi_diag_coverage_t;
+typedef void* (mi_diag_alloc_fun)(void* arg, size_t size);
 
 // Caller holds subproc->heaps_lock and its own owner gate. The callback must only
 // copy metadata to raw-OS storage: no user code, allocator reentry, or payload reads.
 bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
-                              void* arg, mi_diag_coverage_t* coverage);
+                              void* arg, mi_diag_coverage_t* coverage, mi_diag_alloc_fun* allocate);
 /* ---- end inlined: src/diagnostic-walk.h ---- */
 
 typedef struct mi_diag_walk_s {
@@ -13746,6 +13750,7 @@ typedef struct mi_diag_walk_s {
   void* arg;
   mi_diag_coverage_t* coverage;
   mi_arena_pages_t* arena_pages;
+  mi_diag_alloc_fun* allocate;
 } mi_diag_walk_t;
 
 // heap->theaps_lock pins the tld. Never wait while holding a page pin: the owner
@@ -13831,23 +13836,19 @@ static bool mi_diag_owned_os_page(mi_theap_t* theap, mi_page_queue_t* pq, mi_pag
 // the list lock: unown can free/unlink a page and would otherwise self-deadlock.
 typedef struct mi_diag_os_batch_s {
   struct mi_diag_os_batch_s* next;
-  mi_memid_t memid;
   size_t used;
   mi_page_t* pages[64];
 } mi_diag_os_batch_t;
 
 static bool mi_diag_abandoned_os(mi_diag_walk_t* walk) {
   mi_diag_os_batch_t* batches = NULL;
-  mi_subproc_t* subproc = walk->heap->subproc;
   bool ok = true;
   mi_lock(&walk->heap->os_abandoned_pages_lock) {
     for (mi_page_t* page = walk->heap->os_abandoned_pages; page != NULL; page = page->next) {
       if (batches == NULL || batches->used == 64) {
-        mi_memid_t memid;
-        mi_diag_os_batch_t* batch = (mi_diag_os_batch_t*)_mi_os_alloc(subproc, sizeof(*batch), &memid);
+        mi_diag_os_batch_t* batch = (mi_diag_os_batch_t*)walk->allocate(walk->arg, sizeof(*batch));
         if (batch == NULL) { ok = false; break; }
         batch->next = batches;
-        batch->memid = memid;
         batch->used = 0;
         batches = batch;
       }
@@ -13862,15 +13863,15 @@ static bool mi_diag_abandoned_os(mi_diag_walk_t* walk) {
       if (ok) { ok = mi_diag_visit_page(page, walk); }
       mi_abandoned_page_unown(page, NULL);
     }
-    _mi_os_free(subproc, batches, sizeof(*batches), batches->memid);
+    // Batch storage belongs to the capture arena and is released by its caller.
     batches = next;
   }
   return ok;
 }
 
 bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
-                              void* arg, mi_diag_coverage_t* coverage) {
-  mi_diag_walk_t walk = { heap, blocks, visitor, arg, coverage, NULL };
+                              void* arg, mi_diag_coverage_t* coverage, mi_diag_alloc_fun* allocate) {
+  mi_diag_walk_t walk = { heap, blocks, visitor, arg, coverage, NULL, allocate };
   bool ok = true;
   mi_lock(&heap->theaps_lock) {
     // Arena pins + individual owner claims keep claims short (one page capture)
@@ -17689,6 +17690,10 @@ bool _mi_test_heaps_lock_poison_observed(void) {
    pages are captured independently. Cooperatively park foreign owners for coverage.
    The generic mi_heap_visit_blocks API retains its existing concurrency contract. */
 
+#if MI_DEBUG > 0
+mi_decl_export _Atomic(uintptr_t) mi_debug_dump_fail_after;
+#endif
+
 // A bump arena amortizes raw OS allocation across thousands of block records.
 // It never installs profiler records or participates in memory-event accounting.
 typedef struct mi_dump_chunk_s {
@@ -17735,11 +17740,21 @@ typedef struct mi_dump_ctx_s {
   mi_subproc_t* subproc;
   mi_diag_coverage_t coverage;
   size_t text_size;
+  size_t alloc_count;
   uintptr_t key;
-  bool include_blocks, hash_addresses, failed;
+  bool include_blocks, hash_addresses, failed, formatting;
 } mi_dump_ctx_t;
 
-static void* mi_dump_alloc(mi_dump_ctx_t* ctx, size_t size) {
+static void* mi_dump_alloc(void* arg, size_t size) {
+  mi_dump_ctx_t* ctx = (mi_dump_ctx_t*)arg;
+  ctx->alloc_count++;
+  #if MI_DEBUG > 0
+  const uintptr_t fail = mi_atomic_load_relaxed(&mi_debug_dump_fail_after);
+  if (fail > 0 && (ctx->alloc_count == fail || (fail == UINTPTR_MAX && ctx->formatting))) {
+    ctx->failed = true;
+    return NULL;
+  }
+  #endif
   size = _mi_align_up(size, sizeof(void*));
   mi_assert_internal(size <= sizeof(ctx->chunks->data));
   if (ctx->failed) return NULL;
@@ -17792,7 +17807,9 @@ static bool mi_cdecl mi_dump_capture_block(const mi_heap_t* heap, const mi_heap_
     const mi_page_t* page = (const mi_page_t*)area->reserved1;
     p->id = (uintptr_t)area->blocks;
     p->block_size = area->block_size;
-    p->used = area->used;
+    // The block walker collects pending remote frees after its area callback.
+    // For block dumps count the captured records, not the pre-collect counter.
+    p->used = ctx->include_blocks ? 0 : area->used;
     p->reserved = area->reserved / (area->block_size > 0 ? area->block_size : 1);
     p->tid = mi_page_thread_id(page);
     if (out->last_page == NULL) { out->pages = p; }
@@ -17808,6 +17825,7 @@ static bool mi_cdecl mi_dump_capture_block(const mi_heap_t* heap, const mi_heap_
     if (p->last_block == NULL) { p->blocks = b; }
     else { p->last_block->next = b; }
     p->last_block = b;
+    p->used++;
   }
   return true;
 }
@@ -17820,12 +17838,15 @@ static bool mi_cdecl mi_dump_capture_heap(mi_heap_t* heap, void* arg) {
   if (ctx->last_heap == NULL) { ctx->heaps = out; }
   else { ctx->last_heap->next = out; }
   ctx->last_heap = out;
-  return _mi_heap_visit_diagnostic(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage);
+  return _mi_heap_visit_diagnostic(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage, &mi_dump_alloc);
 }
 
 static bool mi_dump_print(mi_dump_ctx_t* ctx, const char* msg) {
   if (ctx->failed) return false;
-  while (*msg != 0) {
+  size_t len = _mi_strlen(msg);
+  if (len > SIZE_MAX - 1 - ctx->text_size) { ctx->failed = true; return false; }
+  ctx->text_size += len;
+  while (len > 0) {
     if (ctx->last_text == NULL || ctx->last_text->used == sizeof(ctx->last_text->data)) {
       mi_dump_text_t* text = (mi_dump_text_t*)mi_dump_alloc(ctx, sizeof(*text));
       if (text == NULL) return false;
@@ -17833,9 +17854,12 @@ static bool mi_dump_print(mi_dump_ctx_t* ctx, const char* msg) {
       else { ctx->last_text->next = text; }
       ctx->last_text = text;
     }
-    if (ctx->text_size == SIZE_MAX - 1) { ctx->failed = true; return false; }
-    ctx->last_text->data[ctx->last_text->used++] = *msg++;
-    ctx->text_size++;
+    const size_t available = sizeof(ctx->last_text->data) - ctx->last_text->used;
+    const size_t take = len < available ? len : available;
+    _mi_memcpy(ctx->last_text->data + ctx->last_text->used, msg, take);
+    ctx->last_text->used += take;
+    msg += take;
+    len -= take;
   }
   return true;
 }
@@ -17882,7 +17906,9 @@ static bool mi_dump_serialize(mi_dump_ctx_t* ctx) {
 }
 
 char* mi_heap_dump_json(bool include_blocks, bool hash_addresses) mi_attr_noexcept {
-  mi_theap_t* self = mi_theap_get_default();
+  mi_theap_t* self = _mi_theap_default();
+  if (!mi_theap_is_initialized(self)) { self = _mi_thread_init(); }
+  if (self == NULL) return NULL; // fresh-thread initialization can fail under OOM
   MI_GATE_ENTER(self);
   mi_dump_ctx_t ctx;
   _mi_memzero(&ctx, sizeof(ctx));
@@ -17892,6 +17918,7 @@ char* mi_heap_dump_json(bool include_blocks, bool hash_addresses) mi_attr_noexce
   ctx.key = _mi_os_random_weak((uintptr_t)&ctx) | 1;
   const bool captured = mi_subproc_visit_heaps(mi_subproc_current(), &mi_dump_capture_heap, &ctx);
   MI_GATE_LEAVE(self->tld);
+  ctx.formatting = true;
   // No page/theap claims or registry locks remain. Format saved values only.
   char* result = NULL;
   if (captured && mi_dump_serialize(&ctx)) {

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit b852cb91 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit ec0d30a8 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -13739,7 +13739,7 @@ typedef void* (mi_diag_alloc_fun)(void* arg, size_t size);
 
 // Caller holds subproc->heaps_lock and its own owner gate. The callback must only
 // copy metadata to raw-OS storage: no user code, allocator reentry, or payload reads.
-bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
+bool _mi_heap_visit_capture(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
                               void* arg, mi_diag_coverage_t* coverage, mi_diag_alloc_fun* allocate);
 /* ---- end inlined: src/diagnostic-walk.h ---- */
 
@@ -13869,7 +13869,8 @@ static bool mi_diag_abandoned_os(mi_diag_walk_t* walk) {
   return ok;
 }
 
-bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
+// This is a production capture API, not an MI_DEBUG-only `_mi_*diagnostic` hook.
+bool _mi_heap_visit_capture(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
                               void* arg, mi_diag_coverage_t* coverage, mi_diag_alloc_fun* allocate) {
   mi_diag_walk_t walk = { heap, blocks, visitor, arg, coverage, NULL, allocate };
   bool ok = true;
@@ -17838,7 +17839,7 @@ static bool mi_cdecl mi_dump_capture_heap(mi_heap_t* heap, void* arg) {
   if (ctx->last_heap == NULL) { ctx->heaps = out; }
   else { ctx->last_heap->next = out; }
   ctx->last_heap = out;
-  return _mi_heap_visit_diagnostic(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage, &mi_dump_alloc);
+  return _mi_heap_visit_capture(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage, &mi_dump_alloc);
 }
 
 static bool mi_dump_print(mi_dump_ctx_t* ctx, const char* msg) {

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.c
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit e77bb668 of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2d88074e of src/static.c. Regenerate with: cargo run -p xtask -- amalgamate-c */
 
 /* ---- begin inlined: src/static.c ---- */
 /* ----------------------------------------------------------------------------
@@ -4707,6 +4707,8 @@ extern mi_decl_export volatile long mi_debug_fail_os_commit_after;
 // `arena.c` (`mi_heap_visit_page_claim`) sets it to 2 once it has a page pinned but not yet
 // claimed, and stalls there until the test sets it back to 0.
 extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_heap_delete_claim;
+// #374: reporter entry handshake (1 -> 2, test releases with 0).
+extern mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_holes_report;
 // Bun parity P10b (#317), ported from oven-sh/mimalloc @ 1515c3c9 (C linkage) /
 // 787be2a8 (the counter itself). test-abandoned-lazy.c: per-bin abandoned bitmaps
 // (`mi_arena_pages_t::pages_abandoned[]`, arena.c) published so far via the CAS in
@@ -13717,6 +13719,183 @@ bool mi_heap_visit_abandoned_blocks(mi_heap_t* heap, bool visit_blocks, mi_block
   return mi_heap_visit_blocks_gated(heap, true, visit_blocks, visitor, arg);
 }
 
+// #374: kept separate from the upstream visitor; needs this TU's private page pins
+// and ownership-release helpers. Also included transitively by src/static.c.
+/* ---- begin inlined: src/diagnostic-walk.c ---- */
+// #374: compiled inside arena.c (including the Rust single-TU build).
+// No allocator fast-path changes: ownership is acquired only by this diagnostic.
+/* ---- begin inlined: src/diagnostic-walk.h ---- */
+// #374: internal ownership-protected capture. Not a general user-callback API.
+#pragma once
+
+typedef struct mi_diag_coverage_s {
+  size_t skipped_pages;
+  size_t busy_theaps;
+} mi_diag_coverage_t;
+
+// Caller holds subproc->heaps_lock and its own owner gate. The callback must only
+// copy metadata to raw-OS storage: no user code, allocator reentry, or payload reads.
+bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
+                              void* arg, mi_diag_coverage_t* coverage);
+/* ---- end inlined: src/diagnostic-walk.h ---- */
+
+typedef struct mi_diag_walk_s {
+  mi_heap_t* heap;
+  bool blocks;
+  mi_block_visit_fun* visitor;
+  void* arg;
+  mi_diag_coverage_t* coverage;
+  mi_arena_pages_t* arena_pages;
+} mi_diag_walk_t;
+
+// heap->theaps_lock pins the tld. Never wait while holding a page pin: the owner
+// or an in-flight sweeper might be retiring that page and waiting for our bit.
+static bool mi_diag_try_tld(mi_subproc_t* subproc, mi_tld_t* tld, bool* claimed) {
+  *claimed = false;
+  if (tld == NULL) return false;
+  if (tld->thread_id == MI_THREADID_DETACHED) {
+    *claimed = mi_lock_try_acquire(&subproc->theap_meta_lock);
+    return *claimed;
+  }
+  if (tld->thread_id == _mi_thread_id()) return true; // caller already gated
+  size_t expected = MI_PARK_PARKED;
+  if (!mi_atomic_cas_strong_acq_rel(&tld->park_state, &expected, (size_t)MI_PARK_SWEEPING)) return false;
+  mi_atomic_store_release(&tld->sweeper, (uintptr_t)_mi_thread_id());
+  *claimed = true;
+  return true;
+}
+
+static void mi_diag_release_tld(mi_subproc_t* subproc, mi_tld_t* tld, bool claimed) {
+  if (!claimed) return;
+  if (tld->thread_id == MI_THREADID_DETACHED) {
+    mi_lock_release(&subproc->theap_meta_lock);
+    return;
+  }
+  mi_atomic_store_release(&tld->sweeper, (uintptr_t)0);
+  mi_atomic_store_release(&tld->park_state, (size_t)MI_PARK_PARKED);
+}
+
+static bool mi_diag_visit_page(mi_page_t* page, mi_diag_walk_t* walk) {
+  mi_heap_area_t area;
+  _mi_heap_area_init(&area, page);
+  if (!walk->visitor(walk->heap, &area, NULL, area.block_size, walk->arg)) return false;
+  return !walk->blocks || _mi_theap_area_visit_blocks(&area, page, walk->visitor, walk->arg);
+}
+
+static bool mi_diag_arena_page(size_t index, size_t count, mi_arena_t* arena, void* arg) {
+  MI_UNUSED(count);
+  mi_diag_walk_t* walk = (mi_diag_walk_t*)arg;
+  mi_bitmap_t* bitmap = walk->arena_pages->pages;
+  if (!mi_bitmap_clear(bitmap, index)) {
+    walk->coverage->skipped_pages++;
+    return true;
+  }
+  // Pin only establishes storage lifetime, NOT a registered page map or stable
+  // owner-private fields. Read just atomic ownership until exclusivity is proven.
+  mi_page_t* page = mi_arena_page_at_slice(arena, index);
+  const mi_threadid_t tid = mi_page_thread_id(page);
+  mi_tld_t* tld = NULL;
+  bool claimed = false;
+  bool owned = false;
+  bool ready = false;
+  if (tid <= MI_THREADID_ABANDONED_MAPPED) {
+    owned = mi_page_claim_ownership(page);
+    ready = owned;
+  }
+  else {
+    for (mi_theap_t* theap = walk->heap->theaps; theap != NULL; theap = theap->hnext) {
+      if (theap->tld != NULL && theap->tld->thread_id == tid) { tld = theap->tld; break; }
+    }
+    if (mi_diag_try_tld(walk->heap->subproc, tld, &claimed)) {
+      // The page could have been abandoned/reclaimed between our atomic tid read
+      // and the owner claim. Never use the earlier observation as ownership proof.
+      ready = (mi_page_thread_id(page) == tid);
+    }
+  }
+  bool ok = true;
+  if (ready) { ok = mi_diag_visit_page(page, walk); }
+  else { walk->coverage->skipped_pages++; }
+  mi_bitmap_set(bitmap, index); // before unown, which may retire the page
+  if (owned) { mi_abandoned_page_unown(page, NULL); }
+  mi_diag_release_tld(walk->heap->subproc, tld, claimed);
+  return ok;
+}
+
+static bool mi_diag_owned_os_page(mi_theap_t* theap, mi_page_queue_t* pq, mi_page_t* page, void* arg1, void* arg2) {
+  MI_UNUSED(theap); MI_UNUSED(pq); MI_UNUSED(arg2);
+  return page->memid.memkind == MI_MEM_ARENA || mi_diag_visit_page(page, (mi_diag_walk_t*)arg1);
+}
+
+// Gather page OWNERSHIP under the OS list lock, not an unlocked list of borrowed
+// next pointers. Batch storage is raw OS, and all unowns happen after releasing
+// the list lock: unown can free/unlink a page and would otherwise self-deadlock.
+typedef struct mi_diag_os_batch_s {
+  struct mi_diag_os_batch_s* next;
+  mi_memid_t memid;
+  size_t used;
+  mi_page_t* pages[64];
+} mi_diag_os_batch_t;
+
+static bool mi_diag_abandoned_os(mi_diag_walk_t* walk) {
+  mi_diag_os_batch_t* batches = NULL;
+  mi_subproc_t* subproc = walk->heap->subproc;
+  bool ok = true;
+  mi_lock(&walk->heap->os_abandoned_pages_lock) {
+    for (mi_page_t* page = walk->heap->os_abandoned_pages; page != NULL; page = page->next) {
+      if (batches == NULL || batches->used == 64) {
+        mi_memid_t memid;
+        mi_diag_os_batch_t* batch = (mi_diag_os_batch_t*)_mi_os_alloc(subproc, sizeof(*batch), &memid);
+        if (batch == NULL) { ok = false; break; }
+        batch->next = batches;
+        batch->memid = memid;
+        batch->used = 0;
+        batches = batch;
+      }
+      if (mi_page_claim_ownership(page)) { batches->pages[batches->used++] = page; }
+      else { walk->coverage->skipped_pages++; }
+    }
+  }
+  while (batches != NULL) {
+    mi_diag_os_batch_t* next = batches->next;
+    for (size_t i = 0; i < batches->used; i++) {
+      mi_page_t* page = batches->pages[i];
+      if (ok) { ok = mi_diag_visit_page(page, walk); }
+      mi_abandoned_page_unown(page, NULL);
+    }
+    _mi_os_free(subproc, batches, sizeof(*batches), batches->memid);
+    batches = next;
+  }
+  return ok;
+}
+
+bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
+                              void* arg, mi_diag_coverage_t* coverage) {
+  mi_diag_walk_t walk = { heap, blocks, visitor, arg, coverage, NULL };
+  bool ok = true;
+  mi_lock(&heap->theaps_lock) {
+    // Arena pins + individual owner claims keep claims short (one page capture)
+    // and avoid the old fixed 64-owner cap and its unsafe unclaimed fallback.
+    mi_forall_arenas(heap, ((mi_arena_t*)NULL), 0, arena) {
+      if (!ok) break;
+      walk.arena_pages = mi_heap_arena_pages(heap, arena);
+      if (walk.arena_pages != NULL) {
+        ok = _mi_bitmap_forall_set(walk.arena_pages->pages, &mi_diag_arena_page, arena, &walk);
+      }
+    }
+    mi_forall_arenas_end();
+    // Live OS pages are absent from the arena bitmap and abandoned OS list.
+    for (mi_theap_t* theap = heap->theaps; theap != NULL && ok; theap = theap->hnext) {
+      bool claimed;
+      if (!mi_diag_try_tld(heap->subproc, theap->tld, &claimed)) { coverage->busy_theaps++; continue; }
+      ok = _mi_theap_visit_pages(theap, &mi_diag_owned_os_page, true, &walk, NULL);
+      mi_diag_release_tld(heap->subproc, theap->tld, claimed);
+    }
+    if (ok) { ok = mi_diag_abandoned_os(&walk); }
+  }
+  return ok;
+}
+/* ---- end inlined: src/diagnostic-walk.c ---- */
+
 
 typedef struct mi_heap_delete_visit_info_s {
   mi_heap_t*  heap_target;
@@ -17502,265 +17681,236 @@ bool _mi_test_heaps_lock_poison_observed(void) {
 /* ---- end inlined: src/fork.c ---- */
 #endif
 /* ---- begin inlined: src/heap-dump.c ---- */
-/* Live heap dump: mi_heap_dump_json / mi_heap_get_seq (issue #269, Bun parity P4).
+/* Live heap JSON capture (#269, #374).
+   The public result is still released with mi_free. Capture and serialization use
+   raw-OS scratch storage; no hooked allocation or user callback runs while page
+   ownership is held. A busy owner is OMITTED, never read optimistically.
+   "complete" describes observed coverage, not a process-wide atomic instant:
+   pages are captured independently. Cooperatively park foreign owners for coverage.
+   The generic mi_heap_visit_blocks API retains its existing concurrency contract. */
 
-   Backs Bun's shipped `bun:jsc` `heapStats({ dump: true | "blocks" }).mimallocDump`
-   (declared in `include/mimalloc-stats.h`, called from `BunJSCModule.h`). Independent of
-   MI_PPROF: Bun builds this unconditionally (see src/static.c), so it is a plain
-   diagnostics API, not part of the sampling profiler.
+// A bump arena amortizes raw OS allocation across thousands of block records.
+// It never installs profiler records or participates in memory-event accounting.
+typedef struct mi_dump_chunk_s {
+  struct mi_dump_chunk_s* next;
+  mi_memid_t memid;
+  size_t used;
+  uint8_t data[64 * MI_KiB];
+} mi_dump_chunk_t;
 
-   Per rule 6 this is a new file so upstream files stay untouched beyond the two
-   declarations in include/mimalloc-stats.h. The JSON-buffer helpers below intentionally
-   duplicate (rather than share) stats.c's private `mi_json_buf_t` machinery, to keep this
-   feature self-contained in its own file instead of exporting stats.c internals.
+typedef struct mi_dump_block_s {
+  struct mi_dump_block_s* next;
+  uintptr_t id;
+  size_t size;
+} mi_dump_block_t;
 
-   Ported from oven-sh/mimalloc @ 942b8342 (src/stats.c:840-949), MIT license -- see the
-   "imported from" comment below for the exact scope. Adapted: renamed the buffer type to
-   avoid colliding with stats.c's private `mi_json_buf_t`, and reads the heap sequence
-   number from our own `mi_heap_t::heap_seq` field (already present at our pin; Bun added
-   the equivalent field to their `mi_heap_t` in the same commit).
+typedef struct mi_dump_page_s {
+  struct mi_dump_page_s* next;
+  mi_dump_block_t* blocks;
+  mi_dump_block_t* last_block;
+  uintptr_t id;
+  size_t block_size, used, reserved;
+  mi_threadid_t tid;
+} mi_dump_page_t;
 
-   THREAD SAFETY (#78): this walks heaps with `mi_subproc_visit_heaps` and pages/blocks
-   with `mi_heap_visit_blocks`, both of which are documented in include/mimalloc.h as NOT
-   safe against a concurrent free into the heap being visited -- the dump is best-effort
-   under concurrent mutation, matching Bun's own implementation. Separately (see the
-   walk-order comment above mi_memory_visit_live_allocations in src/memory-events.c),
-   mi_heap_visit_blocks only sees pages registered in the heap's arena-page bitmap or its
-   os_abandoned_pages list; a page a live theap owns that was allocated directly from the
-   OS (memid.memkind == MI_MEM_OS, e.g. before this process's first arena reservation) is
-   visible to neither, so it can be silently absent from a dump. This mirrors Bun's own
-   mi_heap_dump_json, which has the identical gap for the identical reason.
+typedef struct mi_dump_heap_s {
+  struct mi_dump_heap_s* next;
+  mi_dump_page_t* pages;
+  mi_dump_page_t* last_page;
+  size_t seq;
+} mi_dump_heap_t;
 
-   SELF-MUTATION: the dump's own JSON buffer growth (mi_hdump_buf_expand -> mi_rezalloc)
-   allocates from the calling thread's default heap, and mi_heap_dump_json walks that same
-   heap if it is one of the subprocess's heaps -- so the walk can observe its own buffer's
-   allocations, and because pages and blocks are two separate mi_heap_visit_blocks passes,
-   a block size seen in the blocks[] pass is not guaranteed to already appear in the
-   pages[] pass taken moments earlier. Same class of best-effort as Bun's implementation,
-   not something either side corrects for.
-*/
-
-static char* mi_heap_dump_json_gated(bool include_blocks, bool hash_addresses);
-
-// -----------------------------------------------------------
-// small growable buffer for building the JSON string.
-// mirrors (does not share) stats.c's private mi_json_buf_t.
-// -----------------------------------------------------------
-
-typedef struct mi_hdump_buf_s {
-  char*   buf;
-  size_t  size;
-  size_t  used;
-} mi_hdump_buf_t;
-
-static bool mi_hdump_buf_expand(mi_hdump_buf_t* hbuf) {
-  if (hbuf == NULL) return false;
-  if (hbuf->buf != NULL && hbuf->size > 0) {
-    hbuf->buf[hbuf->size - 1] = 0;
-  }
-  if (hbuf->size > SIZE_MAX / 2) return false;
-  const size_t newsize = (hbuf->size == 0 ? mi_good_size(12 * MI_KiB) : 2 * hbuf->size);
-  char* const  newbuf  = (char*)mi_rezalloc(hbuf->buf, newsize);
-  if (newbuf == NULL) return false;
-  hbuf->buf = newbuf;
-  hbuf->size = newsize;
-  return true;
-}
-
-static void mi_hdump_buf_print(mi_hdump_buf_t* hbuf, const char* msg) {
-  if (msg == NULL || hbuf == NULL) return;
-  for (const char* src = msg; *src != 0; src++) {
-    if (hbuf->used + 1 >= hbuf->size) {
-      if (!mi_hdump_buf_expand(hbuf)) return;
-    }
-    mi_assert_internal(hbuf->used < hbuf->size);
-    hbuf->buf[hbuf->used++] = *src;
-  }
-  mi_assert_internal(hbuf->used < hbuf->size);
-  hbuf->buf[hbuf->used] = 0;
-}
-
-/* -----------------------------------------------------------
-  imported from oven-sh/mimalloc @ 942b8342, MIT
-  (src/stats.c:857-949: mi_dump_ctx_t, mi_dump_id, mi_dump_block_visit,
-  mi_dump_heap_visit, mi_heap_dump_json, mi_heap_get_seq)
-
-  Live heap dump: per-heap -> per-page -> (optional) per-block JSON.
-  Addresses are mixed through a per-process key when `hash_addresses`
-  so snapshots can be diffed without exposing ASLR.
------------------------------------------------------------ */
+typedef struct mi_dump_text_s {
+  struct mi_dump_text_s* next;
+  size_t used;
+  char data[8 * MI_KiB];
+} mi_dump_text_t;
 
 typedef struct mi_dump_ctx_s {
-  mi_hdump_buf_t hbuf;
-  bool           include_blocks;
-  bool           hash_addresses;
-  bool           in_block_pass;
-  uintptr_t      key;
-  bool           first_heap;
-  bool           first_page;
-  bool           first_block;
+  mi_dump_chunk_t* chunks;
+  mi_dump_heap_t* heaps;
+  mi_dump_heap_t* last_heap;
+  mi_dump_text_t* text;
+  mi_dump_text_t* last_text;
+  mi_subproc_t* subproc;
+  mi_diag_coverage_t coverage;
+  size_t text_size;
+  uintptr_t key;
+  bool include_blocks, hash_addresses, failed;
 } mi_dump_ctx_t;
 
-static uintptr_t mi_dump_id(mi_dump_ctx_t* ctx, const void* p) {
-  uintptr_t x = (uintptr_t)p;
+static void* mi_dump_alloc(mi_dump_ctx_t* ctx, size_t size) {
+  size = _mi_align_up(size, sizeof(void*));
+  mi_assert_internal(size <= sizeof(ctx->chunks->data));
+  if (ctx->failed) return NULL;
+  if (ctx->chunks == NULL || size > sizeof(ctx->chunks->data) - ctx->chunks->used) {
+    mi_memid_t memid;
+    mi_dump_chunk_t* chunk = (mi_dump_chunk_t*)_mi_os_alloc(ctx->subproc, sizeof(*chunk), &memid);
+    if (chunk == NULL) { ctx->failed = true; return NULL; }
+    chunk->memid = memid;
+    chunk->used = 0;
+    chunk->next = ctx->chunks;
+    ctx->chunks = chunk;
+  }
+  void* p = ctx->chunks->data + ctx->chunks->used;
+  ctx->chunks->used += size;
+  _mi_memzero(p, size);
+  return p;
+}
+
+static void mi_dump_dispose(mi_dump_ctx_t* ctx) {
+  while (ctx->chunks != NULL) {
+    mi_dump_chunk_t* chunk = ctx->chunks;
+    ctx->chunks = chunk->next;
+    _mi_os_free(ctx->subproc, chunk, sizeof(*chunk), chunk->memid);
+  }
+}
+
+static uintptr_t mi_dump_id(const mi_dump_ctx_t* ctx, uintptr_t x) {
   if (!ctx->hash_addresses) return x;
   x ^= ctx->key;
+#if MI_INTPTR_SIZE == 8
   x ^= x >> 33; x *= 0xff51afd7ed558ccdULL;
   x ^= x >> 33; x *= 0xc4ceb9fe1a85ec53ULL;
   x ^= x >> 33;
+#else
+  x ^= x >> 16; x *= 0x7feb352dU;
+  x ^= x >> 15; x *= 0x846ca68bU;
+  x ^= x >> 16;
+#endif
   return x;
 }
 
-static bool mi_cdecl mi_dump_block_visit(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, void* arg) {
+static bool mi_cdecl mi_dump_capture_block(const mi_heap_t* heap, const mi_heap_area_t* area,
+                                           void* block, size_t block_size, void* arg) {
   MI_UNUSED(heap);
   mi_dump_ctx_t* ctx = (mi_dump_ctx_t*)arg;
-  // 192, not Bun's 128: the page-line format below has 5 %zu fields plus ~71 fixed
-  // characters, and a 64-bit size_t can print up to 20 digits, so the worst realistic
-  // line is 71 + 5*20 = 171 bytes (+ NUL). _mi_snprintf truncates rather than overflows,
-  // but a truncated line here is a *silently* malformed JSON document -- Bun's
-  // JSONParse(json) on the caller side turns that into a hard `mimallocDump: null`
-  // rather than a visible error. Deliberate deviation from Bun's own buffer size.
-  char tmp[192];
+  mi_dump_heap_t* out = ctx->last_heap;
   if (block == NULL) {
-    if (ctx->in_block_pass) return true;
-    if (!ctx->first_page) { mi_hdump_buf_print(&ctx->hbuf, ",\n"); }
-    ctx->first_page = false;
+    mi_dump_page_t* p = (mi_dump_page_t*)mi_dump_alloc(ctx, sizeof(*p));
+    if (p == NULL) return false;
     const mi_page_t* page = (const mi_page_t*)area->reserved1;
-    const uintptr_t tid = (page != NULL ? mi_page_thread_id(page) : 0);
-    _mi_snprintf(tmp, sizeof(tmp),
-      "      { \"id\": %zu, \"block_size\": %zu, \"used\": %zu, \"reserved\": %zu, \"thread_id\": %zu }",
-      mi_dump_id(ctx, area->blocks), area->block_size, area->used,
-      area->reserved / (area->block_size > 0 ? area->block_size : 1), tid);
-    mi_hdump_buf_print(&ctx->hbuf, tmp);
+    p->id = (uintptr_t)area->blocks;
+    p->block_size = area->block_size;
+    p->used = area->used;
+    p->reserved = area->reserved / (area->block_size > 0 ? area->block_size : 1);
+    p->tid = mi_page_thread_id(page);
+    if (out->last_page == NULL) { out->pages = p; }
+    else { out->last_page->next = p; }
+    out->last_page = p;
   }
-  else if (ctx->in_block_pass) {
-    if (!ctx->first_block) { mi_hdump_buf_print(&ctx->hbuf, ","); }
-    ctx->first_block = false;
-    _mi_snprintf(tmp, sizeof(tmp), "[%zu,%zu]", mi_dump_id(ctx, block), block_size);
-    mi_hdump_buf_print(&ctx->hbuf, tmp);
+  else {
+    mi_dump_block_t* b = (mi_dump_block_t*)mi_dump_alloc(ctx, sizeof(*b));
+    if (b == NULL) return false;
+    b->id = (uintptr_t)block;
+    b->size = block_size;
+    mi_dump_page_t* p = out->last_page;
+    if (p->last_block == NULL) { p->blocks = b; }
+    else { p->last_block->next = b; }
+    p->last_block = b;
   }
   return true;
 }
 
-/* #366: exclude FOREIGN SWEEPERS while a heap is walked.
-
-   `mi_heap_visit_blocks` is documented as not thread-safe (include/mimalloc.h, #78): it reads
-   pages through the arena page bitmap with no lock, and the dump accepts torn content as
-   best-effort. What it cannot accept is a page being FREED and PURGED under the walk: in v3 the
-   `mi_page_t` header lives inside the page memory, and a purge decommits on Windows
-   (`purge_decommits=1`, `VirtualFree(MEM_DECOMMIT)`), so reading `page->next` of a page that
-   left between the bitmap read and the dereference is an access violation, not a torn value.
-   Ungated, only a page's OWNER frees it (a thread parked in `mi_on_thread_idle_start` is the
-   one exception); in a gated build the scavenger and `mi_purge_all` sweep every thread that is
-   between allocator calls, so a steady thread's all-free pages leave all the time.
-
-   So for the duration of a heap's walk this thread holds the sweepers' own ownership token on
-   each of the heap's theaps: the tld's MI_PARK_SWEEPING claim (`park_state` CAS + `sweeper`),
-   exactly as `_mi_theap_sweep_parked` and `mi_purge_all` take it. A claim excludes both of
-   them; an in-flight sweep is waited out (bounded: a sweeper never waits on us); a RUNNING
-   owner -- inside an allocator call -- is left alone and raced as before (the documented,
-   pre-existing contract). A claimed owner that wants to allocate waits in `_mi_park_leave*`
-   until the walk ends. The dumper's OWN tld is not claimed but gated (`mi_heap_dump_json`):
-   it must be RUNNING, not PARKED, while it reads its own pages, or a sweeper could claim it.
-
-   Lock order: `mi_subproc_visit_heaps` holds `sp->heaps_lock` (2); `heap->theaps_lock` (3) is
-   taken under it as `_mi_subproc_prof_sync_force_slow` does; the claim is a CAS, not a lock.
-   Waiting out a sweep under those locks is safe because a sweep takes neither (page-holes.c
-   "LOCK ORDER"), and `mi_purge_all` holds no claim while it holds `heaps_lock` (phase B). */
-#define MI_DUMP_MAX_CLAIMS  (64)   // theaps beyond this are walked unclaimed (documented best-effort)
-
-typedef struct mi_dump_claims_s {
-  mi_tld_t* tlds[MI_DUMP_MAX_CLAIMS];
-  size_t    count;
-} mi_dump_claims_t;
-
-static void mi_dump_claim_theaps(mi_heap_t* heap, mi_dump_claims_t* c) {
-  c->count = 0;
-  const mi_threadid_t me = _mi_thread_id();
-  mi_lock(&heap->theaps_lock) {
-    for (mi_theap_t* theap = heap->theaps; theap != NULL && c->count < MI_DUMP_MAX_CLAIMS; theap = theap->hnext) {
-      mi_tld_t* const tld = theap->tld;
-      if (tld == NULL || tld->thread_id == me || tld->thread_id == MI_THREADID_DETACHED) continue;
-      bool seen = false;
-      for (size_t i = 0; i < c->count; i++) { if (c->tlds[i] == tld) { seen = true; break; } }
-      if (seen) continue;
-      size_t spin = 0;
-      for (;;) {
-        size_t expected = MI_PARK_PARKED;   // word-width local: the MSVC-C atomics wrapper (see scavenger.c)
-        if (mi_atomic_cas_strong_acq_rel(&tld->park_state, &expected, (size_t)MI_PARK_SWEEPING)) {
-          mi_atomic_store_release(&tld->sweeper, (uintptr_t)me);
-          c->tlds[c->count++] = tld;
-          break;
-        }
-        if (expected != MI_PARK_SWEEPING) break;   // RUNNING: the owner is inside the allocator; walk unclaimed
-        if (spin < 256) { mi_atomic_pause(); spin++; } else { _mi_prim_thread_yield(); }   // a sweep in flight: it ends on its own
-      }
-    }
-  }
-}
-
-static void mi_dump_release_claims(mi_dump_claims_t* c) {
-  for (size_t i = 0; i < c->count; i++) {
-    mi_tld_t* const tld = c->tlds[i];
-    mi_atomic_store_release(&tld->sweeper, (uintptr_t)0);
-    mi_atomic_store_release(&tld->park_state, (size_t)MI_PARK_PARKED);   // back to PARKED: the owner owns the transition out
-  }
-  c->count = 0;
-}
-
-static bool mi_cdecl mi_dump_heap_visit(mi_heap_t* heap, void* arg) {
+static bool mi_cdecl mi_dump_capture_heap(mi_heap_t* heap, void* arg) {
   mi_dump_ctx_t* ctx = (mi_dump_ctx_t*)arg;
-  char tmp[64];
-  mi_dump_claims_t claims;
-  mi_dump_claim_theaps(heap, &claims);
-  if (!ctx->first_heap) { mi_hdump_buf_print(&ctx->hbuf, ",\n"); }
-  ctx->first_heap = false;
-  _mi_snprintf(tmp, sizeof(tmp), "  { \"seq\": %zu,\n    \"pages\": [\n", heap->heap_seq);
-  mi_hdump_buf_print(&ctx->hbuf, tmp);
-  ctx->first_page = true; ctx->in_block_pass = false;
-  mi_heap_visit_blocks(heap, false, &mi_dump_block_visit, ctx);
-  mi_hdump_buf_print(&ctx->hbuf, "\n    ]");
-  if (ctx->include_blocks) {
-    mi_hdump_buf_print(&ctx->hbuf, ",\n    \"blocks\": [");
-    ctx->first_block = true; ctx->in_block_pass = true;
-    mi_heap_visit_blocks(heap, true, &mi_dump_block_visit, ctx);
-    mi_hdump_buf_print(&ctx->hbuf, "]");
+  mi_dump_heap_t* out = (mi_dump_heap_t*)mi_dump_alloc(ctx, sizeof(*out));
+  if (out == NULL) return false;
+  out->seq = heap->heap_seq;
+  if (ctx->last_heap == NULL) { ctx->heaps = out; }
+  else { ctx->last_heap->next = out; }
+  ctx->last_heap = out;
+  return _mi_heap_visit_diagnostic(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage);
+}
+
+static bool mi_dump_print(mi_dump_ctx_t* ctx, const char* msg) {
+  if (ctx->failed) return false;
+  while (*msg != 0) {
+    if (ctx->last_text == NULL || ctx->last_text->used == sizeof(ctx->last_text->data)) {
+      mi_dump_text_t* text = (mi_dump_text_t*)mi_dump_alloc(ctx, sizeof(*text));
+      if (text == NULL) return false;
+      if (ctx->last_text == NULL) { ctx->text = text; }
+      else { ctx->last_text->next = text; }
+      ctx->last_text = text;
+    }
+    if (ctx->text_size == SIZE_MAX - 1) { ctx->failed = true; return false; }
+    ctx->last_text->data[ctx->last_text->used++] = *msg++;
+    ctx->text_size++;
   }
-  mi_dump_release_claims(&claims);
-  mi_hdump_buf_print(&ctx->hbuf, " }");
   return true;
+}
+
+static bool mi_dump_serialize(mi_dump_ctx_t* ctx) {
+  char tmp[256];
+  mi_dump_print(ctx, "{ \"heaps\": [\n");
+  bool first_heap = true;
+  for (mi_dump_heap_t* h = ctx->heaps; h != NULL && !ctx->failed; h = h->next) {
+    if (!first_heap) mi_dump_print(ctx, ",\n");
+    first_heap = false;
+    _mi_snprintf(tmp, sizeof(tmp), "  { \"seq\": %zu,\n    \"pages\": [\n", h->seq);
+    mi_dump_print(ctx, tmp);
+    bool first = true;
+    for (mi_dump_page_t* p = h->pages; p != NULL && !ctx->failed; p = p->next) {
+      if (!first) mi_dump_print(ctx, ",\n");
+      first = false;
+      _mi_snprintf(tmp, sizeof(tmp),
+        "      { \"id\": %zu, \"block_size\": %zu, \"used\": %zu, \"reserved\": %zu, \"thread_id\": %zu }",
+        mi_dump_id(ctx, p->id), p->block_size, p->used, p->reserved, (size_t)p->tid);
+      mi_dump_print(ctx, tmp);
+    }
+    mi_dump_print(ctx, "\n    ]");
+    if (ctx->include_blocks) {
+      mi_dump_print(ctx, ",\n    \"blocks\": [");
+      first = true;
+      for (mi_dump_page_t* p = h->pages; p != NULL && !ctx->failed; p = p->next) {
+        for (mi_dump_block_t* b = p->blocks; b != NULL && !ctx->failed; b = b->next) {
+          if (!first) mi_dump_print(ctx, ",");
+          first = false;
+          _mi_snprintf(tmp, sizeof(tmp), "[%zu,%zu]", mi_dump_id(ctx, b->id), b->size);
+          mi_dump_print(ctx, tmp);
+        }
+      }
+      mi_dump_print(ctx, "]");
+    }
+    mi_dump_print(ctx, " }");
+  }
+  _mi_snprintf(tmp, sizeof(tmp),
+    "\n], \"complete\": %s, \"skipped_pages\": %zu, \"busy_theaps\": %zu }\n",
+    ctx->coverage.skipped_pages == 0 && ctx->coverage.busy_theaps == 0 ? "true" : "false",
+    ctx->coverage.skipped_pages, ctx->coverage.busy_theaps);
+  return mi_dump_print(ctx, tmp);
 }
 
 char* mi_heap_dump_json(bool include_blocks, bool hash_addresses) mi_attr_noexcept {
-  // #366: be RUNNING for the whole dump (see `mi_dump_claim_theaps`): our own theaps are read
-  // below too, and a PARKED dumper could have them swept from under the walk.
-  mi_theap_t* self = _mi_theap_default();
+  mi_theap_t* self = mi_theap_get_default();
   MI_GATE_ENTER(self);
-  char* const result = mi_heap_dump_json_gated(include_blocks, hash_addresses);
+  mi_dump_ctx_t ctx;
+  _mi_memzero(&ctx, sizeof(ctx));
+  ctx.subproc = self->tld->subproc;
+  ctx.include_blocks = include_blocks;
+  ctx.hash_addresses = hash_addresses;
+  ctx.key = _mi_os_random_weak((uintptr_t)&ctx) | 1;
+  const bool captured = mi_subproc_visit_heaps(mi_subproc_current(), &mi_dump_capture_heap, &ctx);
   MI_GATE_LEAVE(self->tld);
-  #if !MI_OWNER_GATE
-  MI_UNUSED(self);
-  #endif
+  // No page/theap claims or registry locks remain. Format saved values only.
+  char* result = NULL;
+  if (captured && mi_dump_serialize(&ctx)) {
+    result = (char*)mi_malloc(ctx.text_size + 1);
+    if (result != NULL) {
+      size_t offset = 0;
+      for (mi_dump_text_t* text = ctx.text; text != NULL; text = text->next) {
+        _mi_memcpy(result + offset, text->data, text->used);
+        offset += text->used;
+      }
+      result[offset] = 0;
+    }
+  }
+  mi_dump_dispose(&ctx);
   return result;
 }
 
-static char* mi_heap_dump_json_gated(bool include_blocks, bool hash_addresses) {
-  mi_dump_ctx_t ctx;
-  _mi_memzero(&ctx, sizeof(ctx));
-  ctx.include_blocks = include_blocks;
-  ctx.hash_addresses = hash_addresses;
-  ctx.key             = _mi_os_random_weak((uintptr_t)&ctx) | 1;
-  if (!mi_hdump_buf_expand(&ctx.hbuf)) return NULL;
-  mi_hdump_buf_print(&ctx.hbuf, "{ \"heaps\": [\n");
-  ctx.first_heap = true;
-  mi_subproc_visit_heaps(mi_subproc_current(), &mi_dump_heap_visit, &ctx);
-  mi_hdump_buf_print(&ctx.hbuf, "\n] }\n");
-  if (ctx.hbuf.used >= ctx.hbuf.size) { mi_free(ctx.hbuf.buf); return NULL; }
-  return ctx.hbuf.buf;
-}
-
 size_t mi_heap_get_seq(mi_heap_t* heap) mi_attr_noexcept {
-  return (heap != NULL ? heap->heap_seq : 0);
+  return heap != NULL ? heap->heap_seq : 0;
 }
 /* ---- end inlined: src/heap-dump.c ---- */
 /* ---- begin inlined: src/heap-snapshot.c ---- */
@@ -25989,8 +26139,8 @@ void _mi_purge_holes_of(mi_tld_t* tld, bool force) {
   overlapping it is free, so a single live block pins the whole OS page. This accounts for
   that, per size class, and says how many live blocks each pinned OS page is holding.
 
-  Read-only: it does not purge, un-purge, collect, or touch a free list. It walks the three
-  free lists in place instead of collecting them.
+  Read-only: it does not purge, un-purge, or collect. It reads the three free lists
+  in place and never mutates them.
 
   A block is exactly one of:
    - free-listed: on `free`, `local_free`, or `xthread_free`;
@@ -26300,20 +26450,35 @@ void _mi_page_holes_report_print(const mi_holes_report_t* rep) {
 // Report what hole punching leaves behind. Same traversal and same ownership rules as
 // `_mi_purge_holes_of` -- every theap of this thread, plus the abandoned pages of the heaps
 // behind them -- but read-only: it collects nothing, purges nothing, un-purges nothing, and
-// never touches a free list.
+// reads the three free lists in place and never mutates them.
 static bool mi_theap_page_holes_report(mi_theap_t* theap, mi_page_queue_t* pq, mi_page_t* page, void* arg1, void* arg2) {
   MI_UNUSED(theap); MI_UNUSED(pq); MI_UNUSED(arg2);
   _mi_page_holes_report_page(page, (mi_holes_report_t*)arg1);
   return true; // continue
 }
 
+#if MI_DEBUG > 0
+mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_holes_report;
+#endif
+
 void _mi_purge_holes_report_collect(mi_holes_report_t* rep) {
   if (rep == NULL) return;
   _mi_memzero(rep, sizeof(*rep));
-  mi_theap_t* const theap0 = _mi_theap_default();
+  mi_theap_t* theap0 = _mi_theap_default();
   if (theap0 == NULL || !mi_theap_is_initialized(theap0) || theap0->tld == NULL) return;
   mi_tld_t* const tld = theap0->tld;
   if (tld->thread_id != _mi_thread_id()) return;   // owner thread only, exactly as for the sweep
+
+  // #374: theaps_lock excludes the hole pass, not a claimed sweep's preceding collect.
+  // Be RUNNING before taking that lock so neither phase can race our free-list reads.
+  MI_GATE_ENTER(theap0);
+
+  #if MI_DEBUG > 0
+  if (mi_atomic_load_relaxed(&mi_debug_stall_in_holes_report) == 1) {
+    mi_atomic_store_release(&mi_debug_stall_in_holes_report, (uintptr_t)2);
+    while (mi_atomic_load_acquire(&mi_debug_stall_in_holes_report) == 2) { _mi_prim_thread_yield(); }
+  }
+  #endif
 
   mi_heap_t* heaps[MI_PURGE_HOLES_MAX_HEAPS];
   size_t heap_count = 0;
@@ -26337,6 +26502,7 @@ void _mi_purge_holes_report_collect(mi_holes_report_t* rep) {
     // once: every heap of this thread reaches the same arenas.
     if (heap_count > 0) { _mi_arenas_holes_committed(heaps[0], rep); }
   }
+  MI_GATE_LEAVE(tld);
 }
 
 void mi_purge_holes_report(void) mi_attr_noexcept {
@@ -26855,8 +27021,12 @@ mi_decl_export char*   mi_stats_as_json(mi_stats_t* stats, size_t buf_size, char
 mi_decl_export size_t  mi_stats_get_bin_size(size_t bin) mi_attr_noexcept;
 
 // per-heap -> per-page -> (optional) per-block live snapshot (issue #269, Bun parity).
-// Backs bun:jsc heapStats({ dump: true | "blocks" }).mimallocDump. Best-effort under
-// concurrent frees, same caveat as mi_heap_visit_blocks (#78) -- see src/heap-dump.c.
+// Backs bun:jsc heapStats({ dump: true | "blocks" }).mimallocDump. Safe, best-effort
+// capture under concurrent frees (#374); unlike mi_heap_visit_blocks, it never
+// reads mutable state of an unclaimed owner. Top-level complete/skipped_pages/
+// busy_theaps describe observed coverage. Busy owners are omitted, not waited for.
+// Ungated foreign owners must cooperatively park for coverage. A true complete
+// flag is not a process-wide atomic snapshot: pages are captured independently.
 // use mi_free to free the result.
 mi_decl_export char*   mi_heap_dump_json(bool include_blocks, bool hash_addresses) mi_attr_noexcept;
 mi_decl_export size_t  mi_heap_get_seq(mi_heap_t* heap) mi_attr_noexcept;

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2d88074e of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit b852cb91 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-pprof-amalgamated.h
@@ -1,4 +1,4 @@
-/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit e77bb668 of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
+/* GENERATED FILE -- DO NOT EDIT. Produced by rust/xtask from commit 2d88074e of the public headers (mimalloc.h, mimalloc/profile.h, mimalloc/memory-events.h, mimalloc/dhat.h). Regenerate with: cargo run -p xtask -- amalgamate-h */
 
 /* ---- begin inlined: include/mimalloc.h ---- */
 /* ----------------------------------------------------------------------------

--- a/rust/mimalloc-pprof/vendor/mimalloc-stats.h
+++ b/rust/mimalloc-pprof/vendor/mimalloc-stats.h
@@ -162,8 +162,12 @@ mi_decl_export char*   mi_stats_as_json(mi_stats_t* stats, size_t buf_size, char
 mi_decl_export size_t  mi_stats_get_bin_size(size_t bin) mi_attr_noexcept;
 
 // per-heap -> per-page -> (optional) per-block live snapshot (issue #269, Bun parity).
-// Backs bun:jsc heapStats({ dump: true | "blocks" }).mimallocDump. Best-effort under
-// concurrent frees, same caveat as mi_heap_visit_blocks (#78) -- see src/heap-dump.c.
+// Backs bun:jsc heapStats({ dump: true | "blocks" }).mimallocDump. Safe, best-effort
+// capture under concurrent frees (#374); unlike mi_heap_visit_blocks, it never
+// reads mutable state of an unclaimed owner. Top-level complete/skipped_pages/
+// busy_theaps describe observed coverage. Busy owners are omitted, not waited for.
+// Ungated foreign owners must cooperatively park for coverage. A true complete
+// flag is not a process-wide atomic snapshot: pages are captured independently.
 // use mi_free to free the result.
 mi_decl_export char*   mi_heap_dump_json(bool include_blocks, bool hash_addresses) mi_attr_noexcept;
 mi_decl_export size_t  mi_heap_get_seq(mi_heap_t* heap) mi_attr_noexcept;

--- a/src/arena.c
+++ b/src/arena.c
@@ -3068,6 +3068,10 @@ bool mi_heap_visit_abandoned_blocks(mi_heap_t* heap, bool visit_blocks, mi_block
   return mi_heap_visit_blocks_gated(heap, true, visit_blocks, visitor, arg);
 }
 
+// #374: kept separate from the upstream visitor; needs this TU's private page pins
+// and ownership-release helpers. Also included transitively by src/static.c.
+#include "diagnostic-walk.c"
+
 
 typedef struct mi_heap_delete_visit_info_s {
   mi_heap_t*  heap_target;

--- a/src/diagnostic-walk.c
+++ b/src/diagnostic-walk.c
@@ -1,0 +1,159 @@
+// #374: compiled inside arena.c (including the Rust single-TU build).
+// No allocator fast-path changes: ownership is acquired only by this diagnostic.
+#include "diagnostic-walk.h"
+
+typedef struct mi_diag_walk_s {
+  mi_heap_t* heap;
+  bool blocks;
+  mi_block_visit_fun* visitor;
+  void* arg;
+  mi_diag_coverage_t* coverage;
+  mi_arena_pages_t* arena_pages;
+} mi_diag_walk_t;
+
+// heap->theaps_lock pins the tld. Never wait while holding a page pin: the owner
+// or an in-flight sweeper might be retiring that page and waiting for our bit.
+static bool mi_diag_try_tld(mi_subproc_t* subproc, mi_tld_t* tld, bool* claimed) {
+  *claimed = false;
+  if (tld == NULL) return false;
+  if (tld->thread_id == MI_THREADID_DETACHED) {
+    *claimed = mi_lock_try_acquire(&subproc->theap_meta_lock);
+    return *claimed;
+  }
+  if (tld->thread_id == _mi_thread_id()) return true; // caller already gated
+  size_t expected = MI_PARK_PARKED;
+  if (!mi_atomic_cas_strong_acq_rel(&tld->park_state, &expected, (size_t)MI_PARK_SWEEPING)) return false;
+  mi_atomic_store_release(&tld->sweeper, (uintptr_t)_mi_thread_id());
+  *claimed = true;
+  return true;
+}
+
+static void mi_diag_release_tld(mi_subproc_t* subproc, mi_tld_t* tld, bool claimed) {
+  if (!claimed) return;
+  if (tld->thread_id == MI_THREADID_DETACHED) {
+    mi_lock_release(&subproc->theap_meta_lock);
+    return;
+  }
+  mi_atomic_store_release(&tld->sweeper, (uintptr_t)0);
+  mi_atomic_store_release(&tld->park_state, (size_t)MI_PARK_PARKED);
+}
+
+static bool mi_diag_visit_page(mi_page_t* page, mi_diag_walk_t* walk) {
+  mi_heap_area_t area;
+  _mi_heap_area_init(&area, page);
+  if (!walk->visitor(walk->heap, &area, NULL, area.block_size, walk->arg)) return false;
+  return !walk->blocks || _mi_theap_area_visit_blocks(&area, page, walk->visitor, walk->arg);
+}
+
+static bool mi_diag_arena_page(size_t index, size_t count, mi_arena_t* arena, void* arg) {
+  MI_UNUSED(count);
+  mi_diag_walk_t* walk = (mi_diag_walk_t*)arg;
+  mi_bitmap_t* bitmap = walk->arena_pages->pages;
+  if (!mi_bitmap_clear(bitmap, index)) {
+    walk->coverage->skipped_pages++;
+    return true;
+  }
+  // Pin only establishes storage lifetime, NOT a registered page map or stable
+  // owner-private fields. Read just atomic ownership until exclusivity is proven.
+  mi_page_t* page = mi_arena_page_at_slice(arena, index);
+  const mi_threadid_t tid = mi_page_thread_id(page);
+  mi_tld_t* tld = NULL;
+  bool claimed = false;
+  bool owned = false;
+  bool ready = false;
+  if (tid <= MI_THREADID_ABANDONED_MAPPED) {
+    owned = mi_page_claim_ownership(page);
+    ready = owned;
+  }
+  else {
+    for (mi_theap_t* theap = walk->heap->theaps; theap != NULL; theap = theap->hnext) {
+      if (theap->tld != NULL && theap->tld->thread_id == tid) { tld = theap->tld; break; }
+    }
+    if (mi_diag_try_tld(walk->heap->subproc, tld, &claimed)) {
+      // The page could have been abandoned/reclaimed between our atomic tid read
+      // and the owner claim. Never use the earlier observation as ownership proof.
+      ready = (mi_page_thread_id(page) == tid);
+    }
+  }
+  bool ok = true;
+  if (ready) { ok = mi_diag_visit_page(page, walk); }
+  else { walk->coverage->skipped_pages++; }
+  mi_bitmap_set(bitmap, index); // before unown, which may retire the page
+  if (owned) { mi_abandoned_page_unown(page, NULL); }
+  mi_diag_release_tld(walk->heap->subproc, tld, claimed);
+  return ok;
+}
+
+static bool mi_diag_owned_os_page(mi_theap_t* theap, mi_page_queue_t* pq, mi_page_t* page, void* arg1, void* arg2) {
+  MI_UNUSED(theap); MI_UNUSED(pq); MI_UNUSED(arg2);
+  return page->memid.memkind == MI_MEM_ARENA || mi_diag_visit_page(page, (mi_diag_walk_t*)arg1);
+}
+
+// Gather page OWNERSHIP under the OS list lock, not an unlocked list of borrowed
+// next pointers. Batch storage is raw OS, and all unowns happen after releasing
+// the list lock: unown can free/unlink a page and would otherwise self-deadlock.
+typedef struct mi_diag_os_batch_s {
+  struct mi_diag_os_batch_s* next;
+  mi_memid_t memid;
+  size_t used;
+  mi_page_t* pages[64];
+} mi_diag_os_batch_t;
+
+static bool mi_diag_abandoned_os(mi_diag_walk_t* walk) {
+  mi_diag_os_batch_t* batches = NULL;
+  mi_subproc_t* subproc = walk->heap->subproc;
+  bool ok = true;
+  mi_lock(&walk->heap->os_abandoned_pages_lock) {
+    for (mi_page_t* page = walk->heap->os_abandoned_pages; page != NULL; page = page->next) {
+      if (batches == NULL || batches->used == 64) {
+        mi_memid_t memid;
+        mi_diag_os_batch_t* batch = (mi_diag_os_batch_t*)_mi_os_alloc(subproc, sizeof(*batch), &memid);
+        if (batch == NULL) { ok = false; break; }
+        batch->next = batches;
+        batch->memid = memid;
+        batch->used = 0;
+        batches = batch;
+      }
+      if (mi_page_claim_ownership(page)) { batches->pages[batches->used++] = page; }
+      else { walk->coverage->skipped_pages++; }
+    }
+  }
+  while (batches != NULL) {
+    mi_diag_os_batch_t* next = batches->next;
+    for (size_t i = 0; i < batches->used; i++) {
+      mi_page_t* page = batches->pages[i];
+      if (ok) { ok = mi_diag_visit_page(page, walk); }
+      mi_abandoned_page_unown(page, NULL);
+    }
+    _mi_os_free(subproc, batches, sizeof(*batches), batches->memid);
+    batches = next;
+  }
+  return ok;
+}
+
+bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
+                              void* arg, mi_diag_coverage_t* coverage) {
+  mi_diag_walk_t walk = { heap, blocks, visitor, arg, coverage, NULL };
+  bool ok = true;
+  mi_lock(&heap->theaps_lock) {
+    // Arena pins + individual owner claims keep claims short (one page capture)
+    // and avoid the old fixed 64-owner cap and its unsafe unclaimed fallback.
+    mi_forall_arenas(heap, ((mi_arena_t*)NULL), 0, arena) {
+      if (!ok) break;
+      walk.arena_pages = mi_heap_arena_pages(heap, arena);
+      if (walk.arena_pages != NULL) {
+        ok = _mi_bitmap_forall_set(walk.arena_pages->pages, &mi_diag_arena_page, arena, &walk);
+      }
+    }
+    mi_forall_arenas_end();
+    // Live OS pages are absent from the arena bitmap and abandoned OS list.
+    for (mi_theap_t* theap = heap->theaps; theap != NULL && ok; theap = theap->hnext) {
+      bool claimed;
+      if (!mi_diag_try_tld(heap->subproc, theap->tld, &claimed)) { coverage->busy_theaps++; continue; }
+      ok = _mi_theap_visit_pages(theap, &mi_diag_owned_os_page, true, &walk, NULL);
+      mi_diag_release_tld(heap->subproc, theap->tld, claimed);
+    }
+    if (ok) { ok = mi_diag_abandoned_os(&walk); }
+  }
+  return ok;
+}

--- a/src/diagnostic-walk.c
+++ b/src/diagnostic-walk.c
@@ -128,7 +128,8 @@ static bool mi_diag_abandoned_os(mi_diag_walk_t* walk) {
   return ok;
 }
 
-bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
+// This is a production capture API, not an MI_DEBUG-only `_mi_*diagnostic` hook.
+bool _mi_heap_visit_capture(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
                               void* arg, mi_diag_coverage_t* coverage, mi_diag_alloc_fun* allocate) {
   mi_diag_walk_t walk = { heap, blocks, visitor, arg, coverage, NULL, allocate };
   bool ok = true;

--- a/src/diagnostic-walk.c
+++ b/src/diagnostic-walk.c
@@ -9,6 +9,7 @@ typedef struct mi_diag_walk_s {
   void* arg;
   mi_diag_coverage_t* coverage;
   mi_arena_pages_t* arena_pages;
+  mi_diag_alloc_fun* allocate;
 } mi_diag_walk_t;
 
 // heap->theaps_lock pins the tld. Never wait while holding a page pin: the owner
@@ -94,23 +95,19 @@ static bool mi_diag_owned_os_page(mi_theap_t* theap, mi_page_queue_t* pq, mi_pag
 // the list lock: unown can free/unlink a page and would otherwise self-deadlock.
 typedef struct mi_diag_os_batch_s {
   struct mi_diag_os_batch_s* next;
-  mi_memid_t memid;
   size_t used;
   mi_page_t* pages[64];
 } mi_diag_os_batch_t;
 
 static bool mi_diag_abandoned_os(mi_diag_walk_t* walk) {
   mi_diag_os_batch_t* batches = NULL;
-  mi_subproc_t* subproc = walk->heap->subproc;
   bool ok = true;
   mi_lock(&walk->heap->os_abandoned_pages_lock) {
     for (mi_page_t* page = walk->heap->os_abandoned_pages; page != NULL; page = page->next) {
       if (batches == NULL || batches->used == 64) {
-        mi_memid_t memid;
-        mi_diag_os_batch_t* batch = (mi_diag_os_batch_t*)_mi_os_alloc(subproc, sizeof(*batch), &memid);
+        mi_diag_os_batch_t* batch = (mi_diag_os_batch_t*)walk->allocate(walk->arg, sizeof(*batch));
         if (batch == NULL) { ok = false; break; }
         batch->next = batches;
-        batch->memid = memid;
         batch->used = 0;
         batches = batch;
       }
@@ -125,15 +122,15 @@ static bool mi_diag_abandoned_os(mi_diag_walk_t* walk) {
       if (ok) { ok = mi_diag_visit_page(page, walk); }
       mi_abandoned_page_unown(page, NULL);
     }
-    _mi_os_free(subproc, batches, sizeof(*batches), batches->memid);
+    // Batch storage belongs to the capture arena and is released by its caller.
     batches = next;
   }
   return ok;
 }
 
 bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
-                              void* arg, mi_diag_coverage_t* coverage) {
-  mi_diag_walk_t walk = { heap, blocks, visitor, arg, coverage, NULL };
+                              void* arg, mi_diag_coverage_t* coverage, mi_diag_alloc_fun* allocate) {
+  mi_diag_walk_t walk = { heap, blocks, visitor, arg, coverage, NULL, allocate };
   bool ok = true;
   mi_lock(&heap->theaps_lock) {
     // Arena pins + individual owner claims keep claims short (one page capture)

--- a/src/diagnostic-walk.h
+++ b/src/diagnostic-walk.h
@@ -1,0 +1,13 @@
+// #374: internal ownership-protected capture. Not a general user-callback API.
+#pragma once
+#include "mimalloc/internal.h"
+
+typedef struct mi_diag_coverage_s {
+  size_t skipped_pages;
+  size_t busy_theaps;
+} mi_diag_coverage_t;
+
+// Caller holds subproc->heaps_lock and its own owner gate. The callback must only
+// copy metadata to raw-OS storage: no user code, allocator reentry, or payload reads.
+bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
+                              void* arg, mi_diag_coverage_t* coverage);

--- a/src/diagnostic-walk.h
+++ b/src/diagnostic-walk.h
@@ -10,5 +10,5 @@ typedef void* (mi_diag_alloc_fun)(void* arg, size_t size);
 
 // Caller holds subproc->heaps_lock and its own owner gate. The callback must only
 // copy metadata to raw-OS storage: no user code, allocator reentry, or payload reads.
-bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
+bool _mi_heap_visit_capture(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
                               void* arg, mi_diag_coverage_t* coverage, mi_diag_alloc_fun* allocate);

--- a/src/diagnostic-walk.h
+++ b/src/diagnostic-walk.h
@@ -6,8 +6,9 @@ typedef struct mi_diag_coverage_s {
   size_t skipped_pages;
   size_t busy_theaps;
 } mi_diag_coverage_t;
+typedef void* (mi_diag_alloc_fun)(void* arg, size_t size);
 
 // Caller holds subproc->heaps_lock and its own owner gate. The callback must only
 // copy metadata to raw-OS storage: no user code, allocator reentry, or payload reads.
 bool _mi_heap_visit_diagnostic(mi_heap_t* heap, bool blocks, mi_block_visit_fun* visitor,
-                              void* arg, mi_diag_coverage_t* coverage);
+                              void* arg, mi_diag_coverage_t* coverage, mi_diag_alloc_fun* allocate);

--- a/src/heap-dump.c
+++ b/src/heap-dump.c
@@ -10,6 +10,10 @@
 #include "mimalloc/prim-tls.h"
 #include "diagnostic-walk.h"
 
+#if MI_DEBUG > 0
+mi_decl_export _Atomic(uintptr_t) mi_debug_dump_fail_after;
+#endif
+
 // A bump arena amortizes raw OS allocation across thousands of block records.
 // It never installs profiler records or participates in memory-event accounting.
 typedef struct mi_dump_chunk_s {
@@ -56,11 +60,21 @@ typedef struct mi_dump_ctx_s {
   mi_subproc_t* subproc;
   mi_diag_coverage_t coverage;
   size_t text_size;
+  size_t alloc_count;
   uintptr_t key;
-  bool include_blocks, hash_addresses, failed;
+  bool include_blocks, hash_addresses, failed, formatting;
 } mi_dump_ctx_t;
 
-static void* mi_dump_alloc(mi_dump_ctx_t* ctx, size_t size) {
+static void* mi_dump_alloc(void* arg, size_t size) {
+  mi_dump_ctx_t* ctx = (mi_dump_ctx_t*)arg;
+  ctx->alloc_count++;
+  #if MI_DEBUG > 0
+  const uintptr_t fail = mi_atomic_load_relaxed(&mi_debug_dump_fail_after);
+  if (fail > 0 && (ctx->alloc_count == fail || (fail == UINTPTR_MAX && ctx->formatting))) {
+    ctx->failed = true;
+    return NULL;
+  }
+  #endif
   size = _mi_align_up(size, sizeof(void*));
   mi_assert_internal(size <= sizeof(ctx->chunks->data));
   if (ctx->failed) return NULL;
@@ -113,7 +127,9 @@ static bool mi_cdecl mi_dump_capture_block(const mi_heap_t* heap, const mi_heap_
     const mi_page_t* page = (const mi_page_t*)area->reserved1;
     p->id = (uintptr_t)area->blocks;
     p->block_size = area->block_size;
-    p->used = area->used;
+    // The block walker collects pending remote frees after its area callback.
+    // For block dumps count the captured records, not the pre-collect counter.
+    p->used = ctx->include_blocks ? 0 : area->used;
     p->reserved = area->reserved / (area->block_size > 0 ? area->block_size : 1);
     p->tid = mi_page_thread_id(page);
     if (out->last_page == NULL) { out->pages = p; }
@@ -129,6 +145,7 @@ static bool mi_cdecl mi_dump_capture_block(const mi_heap_t* heap, const mi_heap_
     if (p->last_block == NULL) { p->blocks = b; }
     else { p->last_block->next = b; }
     p->last_block = b;
+    p->used++;
   }
   return true;
 }
@@ -141,12 +158,15 @@ static bool mi_cdecl mi_dump_capture_heap(mi_heap_t* heap, void* arg) {
   if (ctx->last_heap == NULL) { ctx->heaps = out; }
   else { ctx->last_heap->next = out; }
   ctx->last_heap = out;
-  return _mi_heap_visit_diagnostic(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage);
+  return _mi_heap_visit_diagnostic(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage, &mi_dump_alloc);
 }
 
 static bool mi_dump_print(mi_dump_ctx_t* ctx, const char* msg) {
   if (ctx->failed) return false;
-  while (*msg != 0) {
+  size_t len = _mi_strlen(msg);
+  if (len > SIZE_MAX - 1 - ctx->text_size) { ctx->failed = true; return false; }
+  ctx->text_size += len;
+  while (len > 0) {
     if (ctx->last_text == NULL || ctx->last_text->used == sizeof(ctx->last_text->data)) {
       mi_dump_text_t* text = (mi_dump_text_t*)mi_dump_alloc(ctx, sizeof(*text));
       if (text == NULL) return false;
@@ -154,9 +174,12 @@ static bool mi_dump_print(mi_dump_ctx_t* ctx, const char* msg) {
       else { ctx->last_text->next = text; }
       ctx->last_text = text;
     }
-    if (ctx->text_size == SIZE_MAX - 1) { ctx->failed = true; return false; }
-    ctx->last_text->data[ctx->last_text->used++] = *msg++;
-    ctx->text_size++;
+    const size_t available = sizeof(ctx->last_text->data) - ctx->last_text->used;
+    const size_t take = len < available ? len : available;
+    _mi_memcpy(ctx->last_text->data + ctx->last_text->used, msg, take);
+    ctx->last_text->used += take;
+    msg += take;
+    len -= take;
   }
   return true;
 }
@@ -203,7 +226,9 @@ static bool mi_dump_serialize(mi_dump_ctx_t* ctx) {
 }
 
 char* mi_heap_dump_json(bool include_blocks, bool hash_addresses) mi_attr_noexcept {
-  mi_theap_t* self = mi_theap_get_default();
+  mi_theap_t* self = _mi_theap_default();
+  if (!mi_theap_is_initialized(self)) { self = _mi_thread_init(); }
+  if (self == NULL) return NULL; // fresh-thread initialization can fail under OOM
   MI_GATE_ENTER(self);
   mi_dump_ctx_t ctx;
   _mi_memzero(&ctx, sizeof(ctx));
@@ -213,6 +238,7 @@ char* mi_heap_dump_json(bool include_blocks, bool hash_addresses) mi_attr_noexce
   ctx.key = _mi_os_random_weak((uintptr_t)&ctx) | 1;
   const bool captured = mi_subproc_visit_heaps(mi_subproc_current(), &mi_dump_capture_heap, &ctx);
   MI_GATE_LEAVE(self->tld);
+  ctx.formatting = true;
   // No page/theap claims or registry locks remain. Format saved values only.
   char* result = NULL;
   if (captured && mi_dump_serialize(&ctx)) {

--- a/src/heap-dump.c
+++ b/src/heap-dump.c
@@ -158,7 +158,7 @@ static bool mi_cdecl mi_dump_capture_heap(mi_heap_t* heap, void* arg) {
   if (ctx->last_heap == NULL) { ctx->heaps = out; }
   else { ctx->last_heap->next = out; }
   ctx->last_heap = out;
-  return _mi_heap_visit_diagnostic(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage, &mi_dump_alloc);
+  return _mi_heap_visit_capture(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage, &mi_dump_alloc);
 }
 
 static bool mi_dump_print(mi_dump_ctx_t* ctx, const char* msg) {

--- a/src/heap-dump.c
+++ b/src/heap-dump.c
@@ -1,264 +1,235 @@
-/* Live heap dump: mi_heap_dump_json / mi_heap_get_seq (issue #269, Bun parity P4).
-
-   Backs Bun's shipped `bun:jsc` `heapStats({ dump: true | "blocks" }).mimallocDump`
-   (declared in `include/mimalloc-stats.h`, called from `BunJSCModule.h`). Independent of
-   MI_PPROF: Bun builds this unconditionally (see src/static.c), so it is a plain
-   diagnostics API, not part of the sampling profiler.
-
-   Per rule 6 this is a new file so upstream files stay untouched beyond the two
-   declarations in include/mimalloc-stats.h. The JSON-buffer helpers below intentionally
-   duplicate (rather than share) stats.c's private `mi_json_buf_t` machinery, to keep this
-   feature self-contained in its own file instead of exporting stats.c internals.
-
-   Ported from oven-sh/mimalloc @ 942b8342 (src/stats.c:840-949), MIT license -- see the
-   "imported from" comment below for the exact scope. Adapted: renamed the buffer type to
-   avoid colliding with stats.c's private `mi_json_buf_t`, and reads the heap sequence
-   number from our own `mi_heap_t::heap_seq` field (already present at our pin; Bun added
-   the equivalent field to their `mi_heap_t` in the same commit).
-
-   THREAD SAFETY (#78): this walks heaps with `mi_subproc_visit_heaps` and pages/blocks
-   with `mi_heap_visit_blocks`, both of which are documented in include/mimalloc.h as NOT
-   safe against a concurrent free into the heap being visited -- the dump is best-effort
-   under concurrent mutation, matching Bun's own implementation. Separately (see the
-   walk-order comment above mi_memory_visit_live_allocations in src/memory-events.c),
-   mi_heap_visit_blocks only sees pages registered in the heap's arena-page bitmap or its
-   os_abandoned_pages list; a page a live theap owns that was allocated directly from the
-   OS (memid.memkind == MI_MEM_OS, e.g. before this process's first arena reservation) is
-   visible to neither, so it can be silently absent from a dump. This mirrors Bun's own
-   mi_heap_dump_json, which has the identical gap for the identical reason.
-
-   SELF-MUTATION: the dump's own JSON buffer growth (mi_hdump_buf_expand -> mi_rezalloc)
-   allocates from the calling thread's default heap, and mi_heap_dump_json walks that same
-   heap if it is one of the subprocess's heaps -- so the walk can observe its own buffer's
-   allocations, and because pages and blocks are two separate mi_heap_visit_blocks passes,
-   a block size seen in the blocks[] pass is not guaranteed to already appear in the
-   pages[] pass taken moments earlier. Same class of best-effort as Bun's implementation,
-   not something either side corrects for.
-*/
+/* Live heap JSON capture (#269, #374).
+   The public result is still released with mi_free. Capture and serialization use
+   raw-OS scratch storage; no hooked allocation or user callback runs while page
+   ownership is held. A busy owner is OMITTED, never read optimistically.
+   "complete" describes observed coverage, not a process-wide atomic instant:
+   pages are captured independently. Cooperatively park foreign owners for coverage.
+   The generic mi_heap_visit_blocks API retains its existing concurrency contract. */
 #include "mimalloc.h"
 #include "mimalloc/internal.h"
-#include "mimalloc/prim.h"      // _mi_prim_thread_yield (#366)
-#include "mimalloc/prim-tls.h"  // _mi_theap_default (#366)
+#include "mimalloc/prim-tls.h"
+#include "diagnostic-walk.h"
 
-static char* mi_heap_dump_json_gated(bool include_blocks, bool hash_addresses);
+// A bump arena amortizes raw OS allocation across thousands of block records.
+// It never installs profiler records or participates in memory-event accounting.
+typedef struct mi_dump_chunk_s {
+  struct mi_dump_chunk_s* next;
+  mi_memid_t memid;
+  size_t used;
+  uint8_t data[64 * MI_KiB];
+} mi_dump_chunk_t;
 
-// -----------------------------------------------------------
-// small growable buffer for building the JSON string.
-// mirrors (does not share) stats.c's private mi_json_buf_t.
-// -----------------------------------------------------------
+typedef struct mi_dump_block_s {
+  struct mi_dump_block_s* next;
+  uintptr_t id;
+  size_t size;
+} mi_dump_block_t;
 
-typedef struct mi_hdump_buf_s {
-  char*   buf;
-  size_t  size;
-  size_t  used;
-} mi_hdump_buf_t;
+typedef struct mi_dump_page_s {
+  struct mi_dump_page_s* next;
+  mi_dump_block_t* blocks;
+  mi_dump_block_t* last_block;
+  uintptr_t id;
+  size_t block_size, used, reserved;
+  mi_threadid_t tid;
+} mi_dump_page_t;
 
-static bool mi_hdump_buf_expand(mi_hdump_buf_t* hbuf) {
-  if (hbuf == NULL) return false;
-  if (hbuf->buf != NULL && hbuf->size > 0) {
-    hbuf->buf[hbuf->size - 1] = 0;
-  }
-  if (hbuf->size > SIZE_MAX / 2) return false;
-  const size_t newsize = (hbuf->size == 0 ? mi_good_size(12 * MI_KiB) : 2 * hbuf->size);
-  char* const  newbuf  = (char*)mi_rezalloc(hbuf->buf, newsize);
-  if (newbuf == NULL) return false;
-  hbuf->buf = newbuf;
-  hbuf->size = newsize;
-  return true;
-}
+typedef struct mi_dump_heap_s {
+  struct mi_dump_heap_s* next;
+  mi_dump_page_t* pages;
+  mi_dump_page_t* last_page;
+  size_t seq;
+} mi_dump_heap_t;
 
-static void mi_hdump_buf_print(mi_hdump_buf_t* hbuf, const char* msg) {
-  if (msg == NULL || hbuf == NULL) return;
-  for (const char* src = msg; *src != 0; src++) {
-    if (hbuf->used + 1 >= hbuf->size) {
-      if (!mi_hdump_buf_expand(hbuf)) return;
-    }
-    mi_assert_internal(hbuf->used < hbuf->size);
-    hbuf->buf[hbuf->used++] = *src;
-  }
-  mi_assert_internal(hbuf->used < hbuf->size);
-  hbuf->buf[hbuf->used] = 0;
-}
-
-/* -----------------------------------------------------------
-  imported from oven-sh/mimalloc @ 942b8342, MIT
-  (src/stats.c:857-949: mi_dump_ctx_t, mi_dump_id, mi_dump_block_visit,
-  mi_dump_heap_visit, mi_heap_dump_json, mi_heap_get_seq)
-
-  Live heap dump: per-heap -> per-page -> (optional) per-block JSON.
-  Addresses are mixed through a per-process key when `hash_addresses`
-  so snapshots can be diffed without exposing ASLR.
------------------------------------------------------------ */
+typedef struct mi_dump_text_s {
+  struct mi_dump_text_s* next;
+  size_t used;
+  char data[8 * MI_KiB];
+} mi_dump_text_t;
 
 typedef struct mi_dump_ctx_s {
-  mi_hdump_buf_t hbuf;
-  bool           include_blocks;
-  bool           hash_addresses;
-  bool           in_block_pass;
-  uintptr_t      key;
-  bool           first_heap;
-  bool           first_page;
-  bool           first_block;
+  mi_dump_chunk_t* chunks;
+  mi_dump_heap_t* heaps;
+  mi_dump_heap_t* last_heap;
+  mi_dump_text_t* text;
+  mi_dump_text_t* last_text;
+  mi_subproc_t* subproc;
+  mi_diag_coverage_t coverage;
+  size_t text_size;
+  uintptr_t key;
+  bool include_blocks, hash_addresses, failed;
 } mi_dump_ctx_t;
 
-static uintptr_t mi_dump_id(mi_dump_ctx_t* ctx, const void* p) {
-  uintptr_t x = (uintptr_t)p;
+static void* mi_dump_alloc(mi_dump_ctx_t* ctx, size_t size) {
+  size = _mi_align_up(size, sizeof(void*));
+  mi_assert_internal(size <= sizeof(ctx->chunks->data));
+  if (ctx->failed) return NULL;
+  if (ctx->chunks == NULL || size > sizeof(ctx->chunks->data) - ctx->chunks->used) {
+    mi_memid_t memid;
+    mi_dump_chunk_t* chunk = (mi_dump_chunk_t*)_mi_os_alloc(ctx->subproc, sizeof(*chunk), &memid);
+    if (chunk == NULL) { ctx->failed = true; return NULL; }
+    chunk->memid = memid;
+    chunk->used = 0;
+    chunk->next = ctx->chunks;
+    ctx->chunks = chunk;
+  }
+  void* p = ctx->chunks->data + ctx->chunks->used;
+  ctx->chunks->used += size;
+  _mi_memzero(p, size);
+  return p;
+}
+
+static void mi_dump_dispose(mi_dump_ctx_t* ctx) {
+  while (ctx->chunks != NULL) {
+    mi_dump_chunk_t* chunk = ctx->chunks;
+    ctx->chunks = chunk->next;
+    _mi_os_free(ctx->subproc, chunk, sizeof(*chunk), chunk->memid);
+  }
+}
+
+static uintptr_t mi_dump_id(const mi_dump_ctx_t* ctx, uintptr_t x) {
   if (!ctx->hash_addresses) return x;
   x ^= ctx->key;
+#if MI_INTPTR_SIZE == 8
   x ^= x >> 33; x *= 0xff51afd7ed558ccdULL;
   x ^= x >> 33; x *= 0xc4ceb9fe1a85ec53ULL;
   x ^= x >> 33;
+#else
+  x ^= x >> 16; x *= 0x7feb352dU;
+  x ^= x >> 15; x *= 0x846ca68bU;
+  x ^= x >> 16;
+#endif
   return x;
 }
 
-static bool mi_cdecl mi_dump_block_visit(const mi_heap_t* heap, const mi_heap_area_t* area, void* block, size_t block_size, void* arg) {
+static bool mi_cdecl mi_dump_capture_block(const mi_heap_t* heap, const mi_heap_area_t* area,
+                                           void* block, size_t block_size, void* arg) {
   MI_UNUSED(heap);
   mi_dump_ctx_t* ctx = (mi_dump_ctx_t*)arg;
-  // 192, not Bun's 128: the page-line format below has 5 %zu fields plus ~71 fixed
-  // characters, and a 64-bit size_t can print up to 20 digits, so the worst realistic
-  // line is 71 + 5*20 = 171 bytes (+ NUL). _mi_snprintf truncates rather than overflows,
-  // but a truncated line here is a *silently* malformed JSON document -- Bun's
-  // JSONParse(json) on the caller side turns that into a hard `mimallocDump: null`
-  // rather than a visible error. Deliberate deviation from Bun's own buffer size.
-  char tmp[192];
+  mi_dump_heap_t* out = ctx->last_heap;
   if (block == NULL) {
-    if (ctx->in_block_pass) return true;
-    if (!ctx->first_page) { mi_hdump_buf_print(&ctx->hbuf, ",\n"); }
-    ctx->first_page = false;
+    mi_dump_page_t* p = (mi_dump_page_t*)mi_dump_alloc(ctx, sizeof(*p));
+    if (p == NULL) return false;
     const mi_page_t* page = (const mi_page_t*)area->reserved1;
-    const uintptr_t tid = (page != NULL ? mi_page_thread_id(page) : 0);
-    _mi_snprintf(tmp, sizeof(tmp),
-      "      { \"id\": %zu, \"block_size\": %zu, \"used\": %zu, \"reserved\": %zu, \"thread_id\": %zu }",
-      mi_dump_id(ctx, area->blocks), area->block_size, area->used,
-      area->reserved / (area->block_size > 0 ? area->block_size : 1), tid);
-    mi_hdump_buf_print(&ctx->hbuf, tmp);
+    p->id = (uintptr_t)area->blocks;
+    p->block_size = area->block_size;
+    p->used = area->used;
+    p->reserved = area->reserved / (area->block_size > 0 ? area->block_size : 1);
+    p->tid = mi_page_thread_id(page);
+    if (out->last_page == NULL) { out->pages = p; }
+    else { out->last_page->next = p; }
+    out->last_page = p;
   }
-  else if (ctx->in_block_pass) {
-    if (!ctx->first_block) { mi_hdump_buf_print(&ctx->hbuf, ","); }
-    ctx->first_block = false;
-    _mi_snprintf(tmp, sizeof(tmp), "[%zu,%zu]", mi_dump_id(ctx, block), block_size);
-    mi_hdump_buf_print(&ctx->hbuf, tmp);
+  else {
+    mi_dump_block_t* b = (mi_dump_block_t*)mi_dump_alloc(ctx, sizeof(*b));
+    if (b == NULL) return false;
+    b->id = (uintptr_t)block;
+    b->size = block_size;
+    mi_dump_page_t* p = out->last_page;
+    if (p->last_block == NULL) { p->blocks = b; }
+    else { p->last_block->next = b; }
+    p->last_block = b;
   }
   return true;
 }
 
-/* #366: exclude FOREIGN SWEEPERS while a heap is walked.
-
-   `mi_heap_visit_blocks` is documented as not thread-safe (include/mimalloc.h, #78): it reads
-   pages through the arena page bitmap with no lock, and the dump accepts torn content as
-   best-effort. What it cannot accept is a page being FREED and PURGED under the walk: in v3 the
-   `mi_page_t` header lives inside the page memory, and a purge decommits on Windows
-   (`purge_decommits=1`, `VirtualFree(MEM_DECOMMIT)`), so reading `page->next` of a page that
-   left between the bitmap read and the dereference is an access violation, not a torn value.
-   Ungated, only a page's OWNER frees it (a thread parked in `mi_on_thread_idle_start` is the
-   one exception); in a gated build the scavenger and `mi_purge_all` sweep every thread that is
-   between allocator calls, so a steady thread's all-free pages leave all the time.
-
-   So for the duration of a heap's walk this thread holds the sweepers' own ownership token on
-   each of the heap's theaps: the tld's MI_PARK_SWEEPING claim (`park_state` CAS + `sweeper`),
-   exactly as `_mi_theap_sweep_parked` and `mi_purge_all` take it. A claim excludes both of
-   them; an in-flight sweep is waited out (bounded: a sweeper never waits on us); a RUNNING
-   owner -- inside an allocator call -- is left alone and raced as before (the documented,
-   pre-existing contract). A claimed owner that wants to allocate waits in `_mi_park_leave*`
-   until the walk ends. The dumper's OWN tld is not claimed but gated (`mi_heap_dump_json`):
-   it must be RUNNING, not PARKED, while it reads its own pages, or a sweeper could claim it.
-
-   Lock order: `mi_subproc_visit_heaps` holds `sp->heaps_lock` (2); `heap->theaps_lock` (3) is
-   taken under it as `_mi_subproc_prof_sync_force_slow` does; the claim is a CAS, not a lock.
-   Waiting out a sweep under those locks is safe because a sweep takes neither (page-holes.c
-   "LOCK ORDER"), and `mi_purge_all` holds no claim while it holds `heaps_lock` (phase B). */
-#define MI_DUMP_MAX_CLAIMS  (64)   // theaps beyond this are walked unclaimed (documented best-effort)
-
-typedef struct mi_dump_claims_s {
-  mi_tld_t* tlds[MI_DUMP_MAX_CLAIMS];
-  size_t    count;
-} mi_dump_claims_t;
-
-static void mi_dump_claim_theaps(mi_heap_t* heap, mi_dump_claims_t* c) {
-  c->count = 0;
-  const mi_threadid_t me = _mi_thread_id();
-  mi_lock(&heap->theaps_lock) {
-    for (mi_theap_t* theap = heap->theaps; theap != NULL && c->count < MI_DUMP_MAX_CLAIMS; theap = theap->hnext) {
-      mi_tld_t* const tld = theap->tld;
-      if (tld == NULL || tld->thread_id == me || tld->thread_id == MI_THREADID_DETACHED) continue;
-      bool seen = false;
-      for (size_t i = 0; i < c->count; i++) { if (c->tlds[i] == tld) { seen = true; break; } }
-      if (seen) continue;
-      size_t spin = 0;
-      for (;;) {
-        size_t expected = MI_PARK_PARKED;   // word-width local: the MSVC-C atomics wrapper (see scavenger.c)
-        if (mi_atomic_cas_strong_acq_rel(&tld->park_state, &expected, (size_t)MI_PARK_SWEEPING)) {
-          mi_atomic_store_release(&tld->sweeper, (uintptr_t)me);
-          c->tlds[c->count++] = tld;
-          break;
-        }
-        if (expected != MI_PARK_SWEEPING) break;   // RUNNING: the owner is inside the allocator; walk unclaimed
-        if (spin < 256) { mi_atomic_pause(); spin++; } else { _mi_prim_thread_yield(); }   // a sweep in flight: it ends on its own
-      }
-    }
-  }
-}
-
-static void mi_dump_release_claims(mi_dump_claims_t* c) {
-  for (size_t i = 0; i < c->count; i++) {
-    mi_tld_t* const tld = c->tlds[i];
-    mi_atomic_store_release(&tld->sweeper, (uintptr_t)0);
-    mi_atomic_store_release(&tld->park_state, (size_t)MI_PARK_PARKED);   // back to PARKED: the owner owns the transition out
-  }
-  c->count = 0;
-}
-
-static bool mi_cdecl mi_dump_heap_visit(mi_heap_t* heap, void* arg) {
+static bool mi_cdecl mi_dump_capture_heap(mi_heap_t* heap, void* arg) {
   mi_dump_ctx_t* ctx = (mi_dump_ctx_t*)arg;
-  char tmp[64];
-  mi_dump_claims_t claims;
-  mi_dump_claim_theaps(heap, &claims);
-  if (!ctx->first_heap) { mi_hdump_buf_print(&ctx->hbuf, ",\n"); }
-  ctx->first_heap = false;
-  _mi_snprintf(tmp, sizeof(tmp), "  { \"seq\": %zu,\n    \"pages\": [\n", heap->heap_seq);
-  mi_hdump_buf_print(&ctx->hbuf, tmp);
-  ctx->first_page = true; ctx->in_block_pass = false;
-  mi_heap_visit_blocks(heap, false, &mi_dump_block_visit, ctx);
-  mi_hdump_buf_print(&ctx->hbuf, "\n    ]");
-  if (ctx->include_blocks) {
-    mi_hdump_buf_print(&ctx->hbuf, ",\n    \"blocks\": [");
-    ctx->first_block = true; ctx->in_block_pass = true;
-    mi_heap_visit_blocks(heap, true, &mi_dump_block_visit, ctx);
-    mi_hdump_buf_print(&ctx->hbuf, "]");
+  mi_dump_heap_t* out = (mi_dump_heap_t*)mi_dump_alloc(ctx, sizeof(*out));
+  if (out == NULL) return false;
+  out->seq = heap->heap_seq;
+  if (ctx->last_heap == NULL) { ctx->heaps = out; }
+  else { ctx->last_heap->next = out; }
+  ctx->last_heap = out;
+  return _mi_heap_visit_diagnostic(heap, ctx->include_blocks, &mi_dump_capture_block, ctx, &ctx->coverage);
+}
+
+static bool mi_dump_print(mi_dump_ctx_t* ctx, const char* msg) {
+  if (ctx->failed) return false;
+  while (*msg != 0) {
+    if (ctx->last_text == NULL || ctx->last_text->used == sizeof(ctx->last_text->data)) {
+      mi_dump_text_t* text = (mi_dump_text_t*)mi_dump_alloc(ctx, sizeof(*text));
+      if (text == NULL) return false;
+      if (ctx->last_text == NULL) { ctx->text = text; }
+      else { ctx->last_text->next = text; }
+      ctx->last_text = text;
+    }
+    if (ctx->text_size == SIZE_MAX - 1) { ctx->failed = true; return false; }
+    ctx->last_text->data[ctx->last_text->used++] = *msg++;
+    ctx->text_size++;
   }
-  mi_dump_release_claims(&claims);
-  mi_hdump_buf_print(&ctx->hbuf, " }");
   return true;
+}
+
+static bool mi_dump_serialize(mi_dump_ctx_t* ctx) {
+  char tmp[256];
+  mi_dump_print(ctx, "{ \"heaps\": [\n");
+  bool first_heap = true;
+  for (mi_dump_heap_t* h = ctx->heaps; h != NULL && !ctx->failed; h = h->next) {
+    if (!first_heap) mi_dump_print(ctx, ",\n");
+    first_heap = false;
+    _mi_snprintf(tmp, sizeof(tmp), "  { \"seq\": %zu,\n    \"pages\": [\n", h->seq);
+    mi_dump_print(ctx, tmp);
+    bool first = true;
+    for (mi_dump_page_t* p = h->pages; p != NULL && !ctx->failed; p = p->next) {
+      if (!first) mi_dump_print(ctx, ",\n");
+      first = false;
+      _mi_snprintf(tmp, sizeof(tmp),
+        "      { \"id\": %zu, \"block_size\": %zu, \"used\": %zu, \"reserved\": %zu, \"thread_id\": %zu }",
+        mi_dump_id(ctx, p->id), p->block_size, p->used, p->reserved, (size_t)p->tid);
+      mi_dump_print(ctx, tmp);
+    }
+    mi_dump_print(ctx, "\n    ]");
+    if (ctx->include_blocks) {
+      mi_dump_print(ctx, ",\n    \"blocks\": [");
+      first = true;
+      for (mi_dump_page_t* p = h->pages; p != NULL && !ctx->failed; p = p->next) {
+        for (mi_dump_block_t* b = p->blocks; b != NULL && !ctx->failed; b = b->next) {
+          if (!first) mi_dump_print(ctx, ",");
+          first = false;
+          _mi_snprintf(tmp, sizeof(tmp), "[%zu,%zu]", mi_dump_id(ctx, b->id), b->size);
+          mi_dump_print(ctx, tmp);
+        }
+      }
+      mi_dump_print(ctx, "]");
+    }
+    mi_dump_print(ctx, " }");
+  }
+  _mi_snprintf(tmp, sizeof(tmp),
+    "\n], \"complete\": %s, \"skipped_pages\": %zu, \"busy_theaps\": %zu }\n",
+    ctx->coverage.skipped_pages == 0 && ctx->coverage.busy_theaps == 0 ? "true" : "false",
+    ctx->coverage.skipped_pages, ctx->coverage.busy_theaps);
+  return mi_dump_print(ctx, tmp);
 }
 
 char* mi_heap_dump_json(bool include_blocks, bool hash_addresses) mi_attr_noexcept {
-  // #366: be RUNNING for the whole dump (see `mi_dump_claim_theaps`): our own theaps are read
-  // below too, and a PARKED dumper could have them swept from under the walk.
-  mi_theap_t* self = _mi_theap_default();
+  mi_theap_t* self = mi_theap_get_default();
   MI_GATE_ENTER(self);
-  char* const result = mi_heap_dump_json_gated(include_blocks, hash_addresses);
+  mi_dump_ctx_t ctx;
+  _mi_memzero(&ctx, sizeof(ctx));
+  ctx.subproc = self->tld->subproc;
+  ctx.include_blocks = include_blocks;
+  ctx.hash_addresses = hash_addresses;
+  ctx.key = _mi_os_random_weak((uintptr_t)&ctx) | 1;
+  const bool captured = mi_subproc_visit_heaps(mi_subproc_current(), &mi_dump_capture_heap, &ctx);
   MI_GATE_LEAVE(self->tld);
-  #if !MI_OWNER_GATE
-  MI_UNUSED(self);
-  #endif
+  // No page/theap claims or registry locks remain. Format saved values only.
+  char* result = NULL;
+  if (captured && mi_dump_serialize(&ctx)) {
+    result = (char*)mi_malloc(ctx.text_size + 1);
+    if (result != NULL) {
+      size_t offset = 0;
+      for (mi_dump_text_t* text = ctx.text; text != NULL; text = text->next) {
+        _mi_memcpy(result + offset, text->data, text->used);
+        offset += text->used;
+      }
+      result[offset] = 0;
+    }
+  }
+  mi_dump_dispose(&ctx);
   return result;
 }
 
-static char* mi_heap_dump_json_gated(bool include_blocks, bool hash_addresses) {
-  mi_dump_ctx_t ctx;
-  _mi_memzero(&ctx, sizeof(ctx));
-  ctx.include_blocks = include_blocks;
-  ctx.hash_addresses = hash_addresses;
-  ctx.key             = _mi_os_random_weak((uintptr_t)&ctx) | 1;
-  if (!mi_hdump_buf_expand(&ctx.hbuf)) return NULL;
-  mi_hdump_buf_print(&ctx.hbuf, "{ \"heaps\": [\n");
-  ctx.first_heap = true;
-  mi_subproc_visit_heaps(mi_subproc_current(), &mi_dump_heap_visit, &ctx);
-  mi_hdump_buf_print(&ctx.hbuf, "\n] }\n");
-  if (ctx.hbuf.used >= ctx.hbuf.size) { mi_free(ctx.hbuf.buf); return NULL; }
-  return ctx.hbuf.buf;
-}
-
 size_t mi_heap_get_seq(mi_heap_t* heap) mi_attr_noexcept {
-  return (heap != NULL ? heap->heap_seq : 0);
+  return heap != NULL ? heap->heap_seq : 0;
 }

--- a/src/page-holes.c
+++ b/src/page-holes.c
@@ -126,6 +126,7 @@ terms of the MIT license. A copy of the license can be found in the file
 ----------------------------------------------------------- */
 
 #include "mimalloc.h"
+#include "mimalloc/prim.h"
 #include "mimalloc/internal.h"
 #include "mimalloc/prim-tls.h"   // _mi_theap_default
 
@@ -906,8 +907,8 @@ void _mi_purge_holes_of(mi_tld_t* tld, bool force) {
   overlapping it is free, so a single live block pins the whole OS page. This accounts for
   that, per size class, and says how many live blocks each pinned OS page is holding.
 
-  Read-only: it does not purge, un-purge, collect, or touch a free list. It walks the three
-  free lists in place instead of collecting them.
+  Read-only: it does not purge, un-purge, or collect. It reads the three free lists
+  in place and never mutates them.
 
   A block is exactly one of:
    - free-listed: on `free`, `local_free`, or `xthread_free`;
@@ -1217,20 +1218,35 @@ void _mi_page_holes_report_print(const mi_holes_report_t* rep) {
 // Report what hole punching leaves behind. Same traversal and same ownership rules as
 // `_mi_purge_holes_of` -- every theap of this thread, plus the abandoned pages of the heaps
 // behind them -- but read-only: it collects nothing, purges nothing, un-purges nothing, and
-// never touches a free list.
+// reads the three free lists in place and never mutates them.
 static bool mi_theap_page_holes_report(mi_theap_t* theap, mi_page_queue_t* pq, mi_page_t* page, void* arg1, void* arg2) {
   MI_UNUSED(theap); MI_UNUSED(pq); MI_UNUSED(arg2);
   _mi_page_holes_report_page(page, (mi_holes_report_t*)arg1);
   return true; // continue
 }
 
+#if MI_DEBUG > 0
+mi_decl_export _Atomic(uintptr_t) mi_debug_stall_in_holes_report;
+#endif
+
 void _mi_purge_holes_report_collect(mi_holes_report_t* rep) {
   if (rep == NULL) return;
   _mi_memzero(rep, sizeof(*rep));
-  mi_theap_t* const theap0 = _mi_theap_default();
+  mi_theap_t* theap0 = _mi_theap_default();
   if (theap0 == NULL || !mi_theap_is_initialized(theap0) || theap0->tld == NULL) return;
   mi_tld_t* const tld = theap0->tld;
   if (tld->thread_id != _mi_thread_id()) return;   // owner thread only, exactly as for the sweep
+
+  // #374: theaps_lock excludes the hole pass, not a claimed sweep's preceding collect.
+  // Be RUNNING before taking that lock so neither phase can race our free-list reads.
+  MI_GATE_ENTER(theap0);
+
+  #if MI_DEBUG > 0
+  if (mi_atomic_load_relaxed(&mi_debug_stall_in_holes_report) == 1) {
+    mi_atomic_store_release(&mi_debug_stall_in_holes_report, (uintptr_t)2);
+    while (mi_atomic_load_acquire(&mi_debug_stall_in_holes_report) == 2) { _mi_prim_thread_yield(); }
+  }
+  #endif
 
   mi_heap_t* heaps[MI_PURGE_HOLES_MAX_HEAPS];
   size_t heap_count = 0;
@@ -1254,6 +1270,7 @@ void _mi_purge_holes_report_collect(mi_holes_report_t* rep) {
     // once: every heap of this thread reaches the same arenas.
     if (heap_count > 0) { _mi_arenas_holes_committed(heaps[0], rep); }
   }
+  MI_GATE_LEAVE(tld);
 }
 
 void mi_purge_holes_report(void) mi_attr_noexcept {

--- a/test/test-diagnostic-walks.c
+++ b/test/test-diagnostic-walks.c
@@ -153,7 +153,7 @@ static void on_dump_resize(const mi_memory_change_t* change, void* arg) {
 }
 
 static void test_dump_growth(void) {
-  // More than a megabyte of JSON: exercise many raw-OS scratch chunks and the
+  // Hundreds of kilobytes of JSON: exercise many raw-OS scratch chunks and the
   // partial-page bitmap path that asserted in the plain Rust unit test (#374).
   enum { N = 40000 };
   void** blocks = (void**)mi_unwrapped_malloc(N * sizeof(void*), 0);
@@ -175,6 +175,140 @@ static void test_dump_growth(void) {
   puts("dump-growth: large capture, no hooked buffer resize");
 }
 
+enum { ABANDONED_N = 70 };
+static void* abandoned_blocks[ABANDONED_N];
+static THREAD_RET abandon_owner(void* arg) {
+  mi_heap_t* heap = (mi_heap_t*)arg;
+  for (size_t i = 0; i < ABANDONED_N; i++) {
+    // Singleton pages: >64 pages exercises more than one abandoned OS batch.
+    abandoned_blocks[i] = mi_heap_malloc(heap, MI_MiB);
+    assert(abandoned_blocks[i] != NULL);
+    assert(_mi_ptr_page(abandoned_blocks[i])->capacity == 1);
+  }
+  // Natural thread-exit teardown abandons these pages before the join returns.
+  return THREAD_OK;
+}
+
+static void test_dump_abandoned(void) {
+  mi_heap_t* heap = mi_heap_new();
+  assert(heap != NULL);
+  thread_t worker;
+  thread_start(&worker, &abandon_owner, heap);
+  thread_join(worker);
+  char* json = mi_heap_dump_json(true, false);
+  assert(json != NULL && strstr(json, "\"complete\": true") != NULL);
+  for (size_t i = 0; i < ABANDONED_N; i++) {
+    char needle[64];
+    // Guarded user pointers are offset from the reported block base.
+    snprintf(needle, sizeof(needle), "[%zu,", (size_t)mi_page_start(_mi_ptr_page(abandoned_blocks[i])));
+    assert(strstr(json, needle) != NULL);
+  }
+  mi_free(json);
+  #if MI_DEBUG > 0
+  // Under forced OS allocation, request 3 fails after the first 64 abandoned
+  // pages were claimed. All earlier claims must be released even on that path.
+  for (uintptr_t fail = 1; fail <= 12; fail++) {
+    mi_atomic_store_relaxed(&mi_debug_dump_fail_after, fail);
+    assert(mi_heap_dump_json(true, false) == NULL);
+    mi_atomic_store_relaxed(&mi_debug_dump_fail_after, (uintptr_t)0);
+    json = mi_heap_dump_json(true, false);
+    assert(json != NULL && strstr(json, "\"complete\": true") != NULL);
+    mi_free(json);
+  }
+  mi_atomic_store_relaxed(&mi_debug_dump_fail_after, UINTPTR_MAX);
+  assert(mi_heap_dump_json(true, false) == NULL);
+  mi_atomic_store_relaxed(&mi_debug_dump_fail_after, (uintptr_t)0);
+  #endif
+  // A leaked claim makes these cross-thread frees or heap teardown hang.
+  for (size_t i = 0; i < ABANDONED_N; i++) mi_free(abandoned_blocks[i]);
+  mi_heap_destroy(heap);
+  puts("dump-abandoned: all 70 pages captured; capture/serialization OOM cleanup");
+}
+
+typedef struct many_owner_s {
+  _Atomic(uintptr_t) phase;
+  void* block;
+} many_owner_t;
+
+static THREAD_RET many_owner(void* arg) {
+  many_owner_t* owner = (many_owner_t*)arg;
+  owner->block = mi_malloc(128);
+  assert(owner->block != NULL);
+  mi_tld_t* tld = _mi_theap_default()->tld;
+  mi_atomic_store_release(&tld->park_state, (size_t)MI_PARK_PARKED);
+  mi_atomic_store_release(&owner->phase, (uintptr_t)1);
+  while (mi_atomic_load_acquire(&owner->phase) == 1) _mi_prim_thread_yield();
+  _mi_park_leave_gate(tld);
+  mi_free(owner->block);
+  return THREAD_OK;
+}
+
+static void test_many_owners(void) {
+  enum { N = 70 };
+  many_owner_t owners[N];
+  thread_t threads[N];
+  for (size_t i = 0; i < N; i++) {
+    mi_atomic_store_relaxed(&owners[i].phase, (uintptr_t)0);
+    owners[i].block = NULL;
+    thread_start(&threads[i], &many_owner, &owners[i]);
+    while (mi_atomic_load_acquire(&owners[i].phase) != 1) _mi_prim_thread_yield();
+  }
+  char* json = mi_heap_dump_json(true, false);
+  assert(json != NULL && strstr(json, "\"complete\": true") != NULL);
+  for (size_t i = 0; i < N; i++) {
+    char needle[64];
+    mi_page_t* page = _mi_ptr_page(owners[i].block);
+    const uintptr_t start = (uintptr_t)mi_page_start(page);
+    const size_t bsize = mi_page_block_size(page);
+    const uintptr_t base = start + (((uintptr_t)owners[i].block - start) / bsize) * bsize;
+    snprintf(needle, sizeof(needle), "[%zu,", (size_t)base);
+    assert(strstr(json, needle) != NULL);
+    mi_atomic_store_release(&owners[i].phase, (uintptr_t)2);
+  }
+  mi_free(json);
+  for (size_t i = 0; i < N; i++) thread_join(threads[i]);
+  puts("dump-many-owners: 70 parked owners captured without a fixed claim cap");
+}
+
+static _Atomic(uintptr_t) churn_phase;
+static _Atomic(uintptr_t) churn_count;
+static THREAD_RET churn_owner(void* arg) {
+  MI_UNUSED(arg);
+  void* slots[64] = { NULL };
+  size_t count = 0;
+  mi_atomic_store_release(&churn_phase, (uintptr_t)1);
+  while (mi_atomic_load_acquire(&churn_phase) == 1) _mi_prim_thread_yield();
+  do {
+    const size_t slot = count % 64;
+    mi_free(slots[slot]);
+    slots[slot] = mi_malloc(count % 7 == 0 ? MI_MiB : 1024);
+    assert(slots[slot] != NULL);
+    count++;
+    mi_atomic_store_release(&churn_count, (uintptr_t)count);
+  } while (mi_atomic_load_acquire(&churn_phase) == 2);
+  for (size_t i = 0; i < 64; i++) mi_free(slots[i]);
+  return THREAD_OK;
+}
+
+static void test_retirement_churn(void) {
+  thread_t worker;
+  thread_start(&worker, &churn_owner, NULL);
+  while (mi_atomic_load_acquire(&churn_phase) != 1) _mi_prim_thread_yield();
+  mi_atomic_store_release(&churn_phase, (uintptr_t)2);
+  while (mi_atomic_load_acquire(&churn_count) < 128) _mi_prim_thread_yield();
+  for (size_t i = 0; i < 100; i++) {
+    char* json = mi_heap_dump_json(true, false);
+    assert(json != NULL && strstr(json, "\"complete\":") != NULL);
+    mi_free(json);
+    _mi_prim_thread_yield();
+  }
+  mi_atomic_store_release(&churn_phase, (uintptr_t)3);
+  thread_join(worker);
+  const size_t count = mi_atomic_load_acquire(&churn_count);
+  assert(count >= 128); // page-retiring frees really ran, not just initial allocs
+  printf("dump-retirement: 100 captures during %zu allocation/free cycles\n", count);
+}
+
 int main(void) {
   mi_thread_init();
 #if MI_OWNER_GATE && MI_DEBUG > 0
@@ -182,6 +316,9 @@ int main(void) {
 #endif
   test_dump_coverage();
   test_dump_growth();
+  test_dump_abandoned();
+  test_many_owners();
+  test_retirement_churn();
   puts("test-diagnostic-walks: ok");
   return 0;
 }

--- a/test/test-diagnostic-walks.c
+++ b/test/test-diagnostic-walks.c
@@ -1,0 +1,187 @@
+// #374: deterministic ownership regressions for diagnostic heap walks.
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "mimalloc.h"
+#include "mimalloc-stats.h"
+#include "mimalloc/internal.h"
+#include "mimalloc/prim.h"
+#include "mimalloc/prim-tls.h"
+#include "mimalloc/memory-events.h"
+
+#ifdef _WIN32
+#include <windows.h>
+typedef HANDLE thread_t;
+#define THREAD_RET DWORD WINAPI
+#define THREAD_OK 0
+static void thread_start(thread_t* t, LPTHREAD_START_ROUTINE fn, void* arg) {
+  *t = CreateThread(NULL, 0, fn, arg, 0, NULL);
+  assert(*t != NULL);
+}
+static void thread_join(thread_t t) {
+  DWORD code = 1;
+  assert(WaitForSingleObject(t, INFINITE) == WAIT_OBJECT_0);
+  assert(GetExitCodeThread(t, &code) && code == 0);
+  CloseHandle(t);
+}
+#else
+#include <pthread.h>
+typedef pthread_t thread_t;
+#define THREAD_RET void*
+#define THREAD_OK NULL
+static void thread_start(thread_t* t, void* (*fn)(void*), void* arg) {
+  assert(pthread_create(t, NULL, fn, arg) == 0);
+}
+static void thread_join(thread_t t) { assert(pthread_join(t, NULL) == 0); }
+#endif
+
+#if MI_OWNER_GATE && MI_DEBUG > 0
+static _Atomic(uintptr_t) report_phase;
+static mi_tld_t* reporter_tld;
+
+static THREAD_RET report_worker(void* arg) {
+  MI_UNUSED(arg);
+  void* keep = mi_malloc(1024);
+  assert(keep != NULL);
+  reporter_tld = _mi_theap_default()->tld;
+  mi_atomic_store_release(&mi_debug_stall_in_holes_report, (uintptr_t)1);
+  mi_holes_report_t rep;
+  _mi_purge_holes_report_collect(&rep);
+  mi_atomic_store_release(&report_phase, (uintptr_t)1);
+  while (mi_atomic_load_acquire(&report_phase) == 1) { _mi_prim_thread_yield(); }
+  mi_free(keep);
+  return THREAD_OK;
+}
+
+static void test_report_gate(void) {
+  thread_t worker;
+  thread_start(&worker, &report_worker, NULL);
+  while (mi_atomic_load_acquire(&mi_debug_stall_in_holes_report) != 2) { _mi_prim_thread_yield(); }
+  // RED before the fix: the reporter is PARKED at its first free-list walk.
+  assert(mi_atomic_load_acquire(&reporter_tld->park_state) == MI_PARK_RUNNING);
+  mi_purge_all_report_t during;
+  (void)mi_purge_all_ex(MI_PURGE_FORCE, 0, &during);
+  assert(during.theaps_pending > 0);
+  mi_atomic_store_release(&mi_debug_stall_in_holes_report, (uintptr_t)0);
+  while (mi_atomic_load_acquire(&report_phase) != 1) { _mi_prim_thread_yield(); }
+  assert(mi_atomic_load_acquire(&reporter_tld->park_state) == MI_PARK_PARKED);
+  mi_purge_all_report_t after;
+  (void)mi_purge_all_ex(MI_PURGE_FORCE, 0, &after);
+  // The same actual purge must now reach the reporter; not a vacuous no-sweeper test.
+  assert(after.theaps_pending == 0 && after.theaps_swept >= 2);
+  mi_atomic_store_release(&report_phase, (uintptr_t)2);
+  thread_join(worker);
+  puts("report-gate: excluded while reporting, foreign sweep completed afterward");
+}
+#endif
+
+static _Atomic(uintptr_t) dump_phase;
+static mi_heap_t* dump_heap;
+
+static THREAD_RET dump_owner(void* arg) {
+  MI_UNUSED(arg);
+  mi_thread_init();
+  mi_theap_t* self = _mi_theap_default();
+  MI_GATE_ENTER(self);
+  void* keep[32];
+  for (size_t i = 0; i < 32; i++) {
+    keep[i] = mi_heap_malloc(dump_heap, 1024);
+    assert(keep[i] != NULL);
+  }
+  mi_atomic_store_release(&dump_phase, (uintptr_t)1);
+  while (mi_atomic_load_acquire(&dump_phase) == 1) { _mi_prim_thread_yield(); }
+  MI_GATE_LEAVE(self->tld);
+  MI_UNUSED(self);
+  // Synthetic cooperative park for deterministic tests with the scavenger OFF.
+  // The public idle_start deliberately declines handoff without a live scavenger.
+  // No parked_count increment: pair this with the gate-form acquire below.
+  mi_atomic_store_release(&self->tld->park_state, (size_t)MI_PARK_PARKED);
+  mi_atomic_store_release(&dump_phase, (uintptr_t)3);
+  while (mi_atomic_load_acquire(&dump_phase) == 3) { _mi_prim_thread_yield(); }
+  _mi_park_leave_gate(self->tld);
+  for (size_t i = 0; i < 32; i++) { mi_free(keep[i]); }
+  return THREAD_OK;
+}
+
+static void test_dump_coverage(void) {
+  dump_heap = mi_heap_new();
+  assert(dump_heap != NULL);
+  thread_t worker;
+  thread_start(&worker, &dump_owner, NULL);
+  while (mi_atomic_load_acquire(&dump_phase) != 1) { _mi_prim_thread_yield(); }
+  char* busy = mi_heap_dump_json(true, false);
+  assert(busy != NULL);
+  // RED on the old unsafe RUNNING fallback, even when that race happens not to crash.
+  assert(strstr(busy, "\"complete\": false") != NULL);
+  mi_free(busy);
+  mi_atomic_store_release(&dump_phase, (uintptr_t)2);
+  while (mi_atomic_load_acquire(&dump_phase) != 3) { _mi_prim_thread_yield(); }
+  char* parked = mi_heap_dump_json(true, false);
+  assert(parked != NULL);
+  if (strstr(parked, "\"complete\": true") == NULL) {
+    const size_t len = strlen(parked);
+    fprintf(stderr, "parked dump tail: %s\n", parked + (len > 256 ? len - 256 : 0));
+  }
+  assert(strstr(parked, "\"complete\": true") != NULL);
+  char needle[64];
+  snprintf(needle, sizeof(needle), "\"seq\": %zu,", mi_heap_get_seq(dump_heap));
+  const char* begin = strstr(parked, needle);
+  assert(begin != NULL);
+  const char* end = strstr(begin + strlen(needle), "\"seq\":");
+  if (end == NULL) end = parked + strlen(parked);
+  size_t total_used = 0;
+  for (const char* p = begin; (p = strstr(p, "\"used\": ")) != NULL && p < end; p++) {
+    size_t used = 0;
+    assert(sscanf(p, "\"used\": %zu", &used) == 1);
+    total_used += used;
+  }
+  assert(total_used == 32);
+  mi_free(parked);
+  mi_atomic_store_release(&dump_phase, (uintptr_t)4);
+  thread_join(worker);
+  mi_heap_destroy(dump_heap);
+  puts("dump-coverage: busy owner reported, cooperative owner captured");
+}
+
+static size_t dump_resizes;
+static void on_dump_resize(const mi_memory_change_t* change, void* arg) {
+  MI_UNUSED(change); MI_UNUSED(arg);
+  dump_resizes++;
+}
+
+static void test_dump_growth(void) {
+  // More than a megabyte of JSON: exercise many raw-OS scratch chunks and the
+  // partial-page bitmap path that asserted in the plain Rust unit test (#374).
+  enum { N = 40000 };
+  void** blocks = (void**)mi_unwrapped_malloc(N * sizeof(void*), 0);
+  assert(blocks != NULL);
+  for (size_t i = 0; i < N; i++) { blocks[i] = mi_malloc(32); assert(blocks[i] != NULL); }
+  mi_memory_callbacks_t callbacks = { { NULL }, { NULL } };
+  callbacks.handlers[MI_MEMORY_RESIZE] = &on_dump_resize;
+  assert(mi_memory_set_callbacks(&callbacks));
+  assert(mi_memory_tracking_set_enabled(true));
+  dump_resizes = 0;
+  char* json = mi_heap_dump_json(true, false);
+  assert(json != NULL && strlen(json) > 500000);
+  assert(dump_resizes == 0); // the old mi_rezalloc-backed callback fails this
+  assert(mi_memory_set_callbacks(NULL));
+  assert(mi_memory_tracking_set_enabled(false));
+  mi_free(json);
+  for (size_t i = 0; i < N; i++) mi_free(blocks[i]);
+  mi_unwrapped_free(blocks);
+  puts("dump-growth: large capture, no hooked buffer resize");
+}
+
+int main(void) {
+  mi_thread_init();
+#if MI_OWNER_GATE && MI_DEBUG > 0
+  test_report_gate();
+#endif
+  test_dump_coverage();
+  test_dump_growth();
+  puts("test-diagnostic-walks: ok");
+  return 0;
+}

--- a/test/test-heap-dump-json.c
+++ b/test/test-heap-dump-json.c
@@ -3,10 +3,9 @@
    Spec is Bun's test/js/bun/jsc/heapStats-mimalloc.test.ts (oven-sh/bun): every JSON
    shape assertion it makes on `heapStats({ dump: true | "blocks" }).mimallocDump` is
    checked here at the C level -- `heaps[].seq`, `pages[].{id,block_size,used,reserved,
-   thread_id}`, `blocks` present only when requested, `blocks[[id,size]]` -- with one
-   exception: Bun's JS test also compares block sizes with page block sizes; the
-   public visitor reports usable block size, which excludes debug padding. #374
-   captures pages and their blocks together using raw-OS scratch storage.
+   thread_id}`, `blocks` present only when requested, `blocks[[id,size]]`, and each
+   block size matching a page size. #374 captures pages and their blocks together
+   using raw-OS scratch storage.
 
    Independent of MI_PPROF (src/heap-dump.c is unconditional), so this test is built and
    registered unconditionally too, like test-memory-events.c / test-dhat.c. */
@@ -137,6 +136,23 @@ static int check_field_min(const char* seg, size_t seg_len, const char* key, siz
 
 static void* heap1_blocks[N_ALLOC_HEAP1];
 
+static void check_block_page_sizes(const char* seg, size_t len) {
+  const char* p = find_bounded(seg, len, "\"blocks\": [");
+  assert(p != NULL);
+  p += strlen("\"blocks\": [");
+  while (p < seg + len && *p == '[') {
+    size_t id, size;
+    int consumed = 0;
+    assert(sscanf(p, "[%zu,%zu]%n", &id, &size, &consumed) == 2);
+    assert(consumed > 0 && p + consumed <= seg + len);
+    char needle[64];
+    snprintf(needle, sizeof(needle), "\"block_size\": %zu,", size);
+    assert(find_bounded(seg, len, needle) != NULL);
+    p += consumed;
+    if (*p == ',') p++;
+  }
+}
+
 static THREAD_RET dump_worker(void* arg) {
   (void)arg;
   for (int i = 0; i < DUMP_ITERATIONS; i++) {
@@ -228,6 +244,7 @@ int main(void) {
 
   const char* rseg1; size_t rseg1_len;
   assert(find_heap_segment(json_blocks_raw, seq1, &rseg1, &rseg1_len));
+  check_block_page_sizes(rseg1, rseg1_len);
   const char* blocks_prefix = "\"blocks\": [[";
   const char* blocks_at = find_bounded(rseg1, rseg1_len, blocks_prefix);
   assert(blocks_at != NULL);

--- a/test/test-heap-dump-json.c
+++ b/test/test-heap-dump-json.c
@@ -4,11 +4,9 @@
    shape assertion it makes on `heapStats({ dump: true | "blocks" }).mimallocDump` is
    checked here at the C level -- `heaps[].seq`, `pages[].{id,block_size,used,reserved,
    thread_id}`, `blocks` present only when requested, `blocks[[id,size]]` -- with one
-   exception: Bun's JS test also asserts every `blocks[]` size matches some `pages[]`
-   entry's `block_size`. That is best-effort here rather than a hard assertion, because
-   src/heap-dump.c's own JSON-buffer growth can mutate the heap being walked between the
-   pages pass and the blocks pass (see the SELF-MUTATION note there) -- the same
-   best-effort Bun's own implementation has.
+   exception: Bun's JS test also compares block sizes with page block sizes; the
+   public visitor reports usable block size, which excludes debug padding. #374
+   captures pages and their blocks together using raw-OS scratch storage.
 
    Independent of MI_PPROF (src/heap-dump.c is unconditional), so this test is built and
    registered unconditionally too, like test-memory-events.c / test-dhat.c. */
@@ -249,9 +247,8 @@ int main(void) {
 
   mi_free(json_pages);
 
-  /* --- dump from a second thread while the first thread frees (no crash); pages stay
-     non-empty (only half of heap1's blocks are freed) so this does not exercise the
-     documented page-retirement race in #78, just the common "read while write" case. --- */
+  /* #374: preserve concurrent frees, including guarded sample-rate-1, where these
+     frees can retire pages. The safe dump reports unclaimable owners as incomplete. */
   thread_t t;
   thread_start(&t, dump_worker, NULL);
   for (int i = 0; i < N_ALLOC_HEAP1 / 2; i++) {


### PR DESCRIPTION
Closes #374.

## Approved resolution

Implements the ownership-protected, explicitly incomplete diagnostic capture approved in [the issue discussion](https://github.com/zackees/mimalloc-pprof/issues/374#issuecomment-5650195758), with the [performance investigation and recommendation](https://github.com/zackees/mimalloc-pprof/issues/374#issuecomment-5650207065).

- Gate the holes reporter against foreign collection; correct the free-list-read comments and gate inventory.
- Replace heap-dump use of the general best-effort visitor with a dedicated ownership-protected capture. Never read an unclaimed RUNNING/SWEEPING owner's mutable fields. Cover arena pages, live OS pages, abandoned OS pages, and metadata ownership without changing retirement ordering.
- Report `complete`, `skipped_pages`, and `busy_theaps`. Complete means no observed omissions, not an atomic process-wide instant. Ungated foreign owners require successful cooperative parking for coverage; merely sleeping is insufficient. No new public complete-snapshot API and no mandatory owner gate.
- Capture page/block records and serialize using amortized raw-OS scratch. Allocate the `mi_free`-compatible result only after all capture claims and registry locks are released. Return NULL on allocation failure, never truncated JSON.
- Preserve exact visitor assertions, guarded concurrency tests, public generic visitor preconditions, and default allocation/free fast paths. Refresh Rust vendor and document its wrapper contract in separate Rust-only commits.

## Regression coverage

- Deterministic reporter-vs-sweeper exclusion, followed by an actual successful foreign purge (RED before gate fix, GREEN after).
- Busy-owner omissions vs exact parked-owner counts (old dump RED on explicit coverage assertion).
- Arena and forced-OS variants; concurrent allocation/free page-retirement churn.
- 40,000-block buffer growth with no hooked resize; 70 parked owners (no fixed 64-owner cap).
- 70 abandoned singleton pages, capture allocation failures including a partially claimed OS batch, formatting failure, successful retry, and cross-thread frees/cleanup.
- Existing JSON test retains guarded concurrent frees and now verifies block/page usable-size consistency.

The historical Rust assertion was not reproduced at its exact failing revision. That revision does contain a with-blocks heap-dump test, contrary to the original comment. This change removes both concrete hazards (unowned foreign reads and same-heap buffer growth during capture); the plain no-default-features Rust tests pass. No weakened assertion or skipped guarded test is used as a substitute for safety.

## Local evidence

- Final source `ef905c90`: gated Debug diagnostic/holes tests 5/5; ungated PPROF=OFF Debug diagnostic/JSON tests 3/3, including guarded sample rate 1; real Clang ASan gated tests 5/5; C++-compiled focused diagnostic/JSON tests 3/3.
- Rust plain lib tests 8/8 and default lib tests 9/9; `xtask check`, Rust binding surface check, internal-state inventory and positive controls, and `git diff --check` pass. `48467740` adds only the audited scratch/result allocation inventory and documentation.
- `ci/check_fastpath_identity.py --base 7d8e5e86` passes at final source: default `mi_malloc`, `mi_zalloc`, `mi_free`, `mi_heap_malloc_small`, `mi_malloc_small` are byte-identical after documented relocation normalization; gated positive control differs in all five. This is evidence for those five entry points, not a whole-program speed claim.
- Local GCC Release quiescent 40,000 x 32-byte target-heap benchmark, one warmup + 20 dumps, scavenger disabled: old median 5.361 ms; new 6.380 ms (~19% diagnostic-call cost). Both capture exactly 40,000/40,000 blocks. JSON sizes 763,503 vs 762,894 bytes. Timing is machine/workload-specific; no unreliable process RSS claim is made.
- Broader optional GCC Debug `MI_USE_CXX=ON` build encounters an existing untouched `test-purge-holes.c` goto-crossing-initialization error; focused C++ diagnostics pass. Required native MSVC and cross-platform gates must still pass before merge.

Independent pre-push review found and verified fixes for fresh-thread OOM handling, foreign gate-depth access ordering, OS-batch/error coverage, and the guarded block-address fixture. All findings resolved.

review agents launched: 1
clud-review: clean

## Merge gates

Awaiting this PR's Linux ON/OFF, ASan, native **cl** MSVC build/run, win-gnu and clang-cl Windows bundles, Rust, and both macOS cross-build architectures/selective decision checks. Do not merge by bypassing a required gate.
